### PR TITLE
feat: implement Go HTTP proxy server with configurable routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,154 @@
 # agentapi-proxy
+
 Proxy and Process Provisioner for coder/agentapi
+
+A configurable HTTP proxy server that routes requests based on URL patterns to different backend services. Designed specifically for proxying agentapi requests to appropriate backend services.
+
+## Features
+
+- **Flexible Routing**: Route requests based on URL patterns like `/api/{org}/{repo}`
+- **Configurable Backends**: Map different routes to different backend services
+- **Default Fallback**: Configure a default backend for unmatched routes
+- **Header Forwarding**: Automatically forwards `X-Forwarded-Host` and `X-Forwarded-Proto` headers
+- **Comprehensive Logging**: Optional verbose logging for debugging
+- **Health Checks**: Built-in support for health check endpoints
+- **Concurrent Request Handling**: Efficient handling of multiple simultaneous requests
+
+## Usage
+
+### Command Line Options
+
+```bash
+./agentapi-proxy [options]
+
+Options:
+  -port string
+        Port to listen on (default "8080")
+  -config string
+        Configuration file path (default "config.json")
+  -verbose
+        Enable verbose logging
+```
+
+### Configuration
+
+The proxy uses a JSON configuration file to define routing rules:
+
+```json
+{
+  "default_backend": "http://localhost:3000",
+  "routes": {
+    "/api/{org}/{repo}": "http://agentapi-backend:8080",
+    "/api/{org}/{repo}/issues": "http://issues-service:9000",
+    "/api/{org}/{repo}/pulls": "http://pr-service:9001",
+    "/health": "http://health-check:8080"
+  }
+}
+```
+
+#### Configuration Fields
+
+- `default_backend` (optional): Backend URL to use for routes that don't match any pattern
+- `routes`: Map of URL patterns to backend URLs
+
+#### URL Patterns
+
+- Use `{variable}` syntax for path variables (e.g., `{org}`, `{repo}`)
+- Patterns are matched using gorilla/mux router
+- More specific patterns take precedence over general ones
+
+## Examples
+
+### Basic Usage
+
+1. Create a configuration file:
+```bash
+cp config.json.example config.json
+# Edit config.json to match your backend services
+```
+
+2. Run the proxy:
+```bash
+go run .
+```
+
+3. The proxy will start on port 8080 and route requests according to your configuration.
+
+### Example Requests
+
+With the example configuration:
+
+```bash
+# Routes to agentapi-backend:8080
+curl http://localhost:8080/api/myorg/myrepo
+
+# Routes to issues-service:9000  
+curl http://localhost:8080/api/myorg/myrepo/issues
+
+# Routes to health-check:8080
+curl http://localhost:8080/health
+
+# Routes to default_backend (if configured)
+curl http://localhost:8080/some/other/path
+```
+
+## Development
+
+### Building
+
+```bash
+go build -o agentapi-proxy .
+```
+
+### Testing
+
+Run all tests:
+```bash
+go test -v ./...
+```
+
+Run specific test suites:
+```bash
+# Unit tests
+go test -v -run TestProxy
+go test -v -run TestConfig
+
+# Integration tests  
+go test -v -run TestIntegration
+```
+
+### Running Tests with Coverage
+
+```bash
+go test -v -cover ./...
+```
+
+## Docker Usage
+
+```dockerfile
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o agentapi-proxy .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/agentapi-proxy .
+COPY config.json .
+EXPOSE 8080
+CMD ["./agentapi-proxy"]
+```
+
+## Architecture
+
+The proxy consists of several key components:
+
+- **Router**: Uses gorilla/mux for URL pattern matching and routing
+- **Reverse Proxy**: Built on Go's `httputil.ReverseProxy` for efficient request forwarding
+- **Configuration Manager**: Handles loading and parsing of JSON configuration files
+- **Error Handling**: Proper error responses and logging for debugging
+
+## License
+
+See LICENSE file for details.

--- a/config.go
+++ b/config.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Config represents the proxy configuration
+type Config struct {
+	// DefaultBackend is used when no route matches
+	DefaultBackend string `json:"default_backend,omitempty"`
+	
+	// Routes maps path patterns to backend URLs
+	// Pattern can include variables like {org} and {repo}
+	Routes map[string]string `json:"routes"`
+}
+
+// LoadConfig loads configuration from a JSON file
+func LoadConfig(filename string) (*Config, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// DefaultConfig returns a default configuration
+func DefaultConfig() *Config {
+	return &Config{
+		DefaultBackend: "http://localhost:3000",
+		Routes: map[string]string{
+			"/api/{org}/{repo}": "http://localhost:3000",
+			"/health":           "http://localhost:3000",
+		},
+	}
+}

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,10 @@
+{
+  "default_backend": "http://localhost:3000",
+  "routes": {
+    "/api/{org}/{repo}": "http://agentapi-backend:8080",
+    "/api/{org}/{repo}/issues": "http://issues-service:9000",
+    "/api/{org}/{repo}/pulls": "http://pr-service:9001",
+    "/health": "http://health-check:8080",
+    "/metrics": "http://metrics-service:9090"
+  }
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	if config == nil {
+		t.Fatal("DefaultConfig returned nil")
+	}
+
+	if config.DefaultBackend == "" {
+		t.Error("DefaultBackend should not be empty")
+	}
+
+	if len(config.Routes) == 0 {
+		t.Error("Routes should not be empty")
+	}
+
+	// Check if expected routes exist
+	expectedRoutes := []string{"/api/{org}/{repo}", "/health"}
+	for _, route := range expectedRoutes {
+		if _, exists := config.Routes[route]; !exists {
+			t.Errorf("Expected route %s not found in default config", route)
+		}
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	// Create a temporary config file
+	tempConfig := &Config{
+		DefaultBackend: "http://example.com:8080",
+		Routes: map[string]string{
+			"/api/{org}/{repo}": "http://backend1.com",
+			"/v1/{service}":     "http://backend2.com",
+		},
+	}
+
+	configData, err := json.Marshal(tempConfig)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+
+	// Write to temporary file
+	tmpfile, err := os.CreateTemp("", "config*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write(configData); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+	tmpfile.Close()
+
+	// Load the config
+	loadedConfig, err := LoadConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Compare loaded config with original
+	if !reflect.DeepEqual(tempConfig, loadedConfig) {
+		t.Errorf("Loaded config doesn't match original.\nExpected: %+v\nGot: %+v", tempConfig, loadedConfig)
+	}
+}
+
+func TestLoadConfigNonexistentFile(t *testing.T) {
+	_, err := LoadConfig("nonexistent-file.json")
+	if err == nil {
+		t.Error("LoadConfig should return error for nonexistent file")
+	}
+}
+
+func TestLoadConfigInvalidJSON(t *testing.T) {
+	// Create a temporary file with invalid JSON
+	tmpfile, err := os.CreateTemp("", "invalid*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	invalidJSON := `{"invalid": json}`
+	if _, err := tmpfile.WriteString(invalidJSON); err != nil {
+		t.Fatalf("Failed to write invalid JSON: %v", err)
+	}
+	tmpfile.Close()
+
+	_, err = LoadConfig(tmpfile.Name())
+	if err == nil {
+		t.Error("LoadConfig should return error for invalid JSON")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/takutakahashi/agentapi-proxy
+
+go 1.21
+
+require (
+	github.com/gorilla/mux v1.8.1
+)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIntegrationFullProxy(t *testing.T) {
+	// Create multiple backend servers to simulate different services
+	backend1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Backend", "backend1")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Response from backend 1"))
+	}))
+	defer backend1.Close()
+
+	backend2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Backend", "backend2")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Response from backend 2"))
+	}))
+	defer backend2.Close()
+
+	config := &Config{
+		DefaultBackend: backend1.URL,
+		Routes: map[string]string{
+			"/api/{org}/{repo}":        backend1.URL,
+			"/api/{org}/{repo}/issues": backend2.URL,
+			"/health":                  backend1.URL,
+		},
+	}
+
+	proxy := NewProxy(config, true)
+
+	tests := []struct {
+		name             string
+		method           string
+		path             string
+		expectedStatus   int
+		expectedBackend  string
+		expectedResponse string
+	}{
+		{
+			name:             "API route to backend 1",
+			method:           "GET",
+			path:             "/api/myorg/myrepo",
+			expectedStatus:   http.StatusOK,
+			expectedBackend:  "backend1",
+			expectedResponse: "Response from backend 1",
+		},
+		{
+			name:             "Issues route to backend 2",
+			method:           "GET",
+			path:             "/api/myorg/myrepo/issues",
+			expectedStatus:   http.StatusOK,
+			expectedBackend:  "backend2",
+			expectedResponse: "Response from backend 2",
+		},
+		{
+			name:             "Health check",
+			method:           "GET",
+			path:             "/health",
+			expectedStatus:   http.StatusOK,
+			expectedBackend:  "backend1",
+			expectedResponse: "Response from backend 1",
+		},
+		{
+			name:             "Default route",
+			method:           "GET",
+			path:             "/some/unknown/path",
+			expectedStatus:   http.StatusOK,
+			expectedBackend:  "backend1",
+			expectedResponse: "Response from backend 1",
+		},
+		{
+			name:           "POST request",
+			method:         "POST",
+			path:           "/api/test/repo",
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			w := httptest.NewRecorder()
+
+			proxy.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+
+			if tt.expectedBackend != "" {
+				backend := w.Header().Get("X-Backend")
+				if backend != tt.expectedBackend {
+					t.Errorf("Expected backend %s, got %s", tt.expectedBackend, backend)
+				}
+			}
+
+			if tt.expectedResponse != "" {
+				body := w.Body.String()
+				if !strings.Contains(body, tt.expectedResponse) {
+					t.Errorf("Expected response to contain %s, got %s", tt.expectedResponse, body)
+				}
+			}
+		})
+	}
+}
+
+func TestProxyHeaders(t *testing.T) {
+	// Backend that returns request headers for inspection
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Echo back the forwarded headers
+		w.Header().Set("X-Forwarded-Host-Echo", r.Header.Get("X-Forwarded-Host"))
+		w.Header().Set("X-Forwarded-Proto-Echo", r.Header.Get("X-Forwarded-Proto"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	config := &Config{
+		Routes: map[string]string{
+			"/test": backend.URL,
+		},
+	}
+
+	proxy := NewProxy(config, false)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+
+	proxy.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Check if forwarded headers are set correctly
+	forwardedHost := w.Header().Get("X-Forwarded-Host-Echo")
+	if forwardedHost != "example.com" {
+		t.Errorf("Expected X-Forwarded-Host to be 'example.com', got '%s'", forwardedHost)
+	}
+
+	forwardedProto := w.Header().Get("X-Forwarded-Proto-Echo")
+	if forwardedProto != "http" {
+		t.Errorf("Expected X-Forwarded-Proto to be 'http', got '%s'", forwardedProto)
+	}
+}
+
+func TestConcurrentRequests(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate some processing time
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	config := &Config{
+		Routes: map[string]string{
+			"/api/{org}/{repo}": backend.URL,
+		},
+	}
+
+	proxy := NewProxy(config, false)
+
+	// Test concurrent requests
+	const numRequests = 10
+	results := make(chan int, numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		go func(id int) {
+			req := httptest.NewRequest("GET", "/api/org/repo", nil)
+			w := httptest.NewRecorder()
+			proxy.ServeHTTP(w, req)
+			results <- w.Code
+		}(i)
+	}
+
+	// Collect results
+	for i := 0; i < numRequests; i++ {
+		select {
+		case status := <-results:
+			if status != http.StatusOK {
+				t.Errorf("Request %d failed with status %d", i, status)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Request %d timed out", i)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	var (
+		port    = flag.String("port", "8080", "Port to listen on")
+		config  = flag.String("config", "config.json", "Configuration file path")
+		verbose = flag.Bool("verbose", false, "Enable verbose logging")
+	)
+	flag.Parse()
+
+	if *verbose {
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
+
+	cfg, err := LoadConfig(*config)
+	if err != nil {
+		log.Printf("Failed to load config from %s, using defaults: %v", *config, err)
+		cfg = DefaultConfig()
+	}
+
+	proxy := NewProxy(cfg, *verbose)
+	
+	log.Printf("Starting agentapi-proxy on port %s", *port)
+	if err := http.ListenAndServe(":"+*port, proxy); err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+// Proxy represents the HTTP proxy server
+type Proxy struct {
+	config  *Config
+	router  *mux.Router
+	verbose bool
+}
+
+// NewProxy creates a new proxy instance
+func NewProxy(config *Config, verbose bool) *Proxy {
+	p := &Proxy{
+		config:  config,
+		router:  mux.NewRouter(),
+		verbose: verbose,
+	}
+
+	p.setupRoutes()
+	return p
+}
+
+// ServeHTTP implements the http.Handler interface
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if p.verbose {
+		log.Printf("Request: %s %s from %s", r.Method, r.URL.Path, r.RemoteAddr)
+	}
+
+	p.router.ServeHTTP(w, r)
+}
+
+// setupRoutes configures the router with all defined routes
+func (p *Proxy) setupRoutes() {
+	for pattern, backend := range p.config.Routes {
+		p.addRoute(pattern, backend)
+	}
+
+	// Add default handler for unmatched routes
+	p.router.PathPrefix("/").HandlerFunc(p.defaultHandler)
+}
+
+// addRoute adds a single route to the router
+func (p *Proxy) addRoute(pattern, backend string) {
+	if p.verbose {
+		log.Printf("Adding route: %s -> %s", pattern, backend)
+	}
+
+	handler := p.createProxyHandler(backend)
+	p.router.Handle(pattern, handler)
+}
+
+// createProxyHandler creates a reverse proxy handler for the given backend
+func (p *Proxy) createProxyHandler(backendURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Parse the backend URL
+		target, err := url.Parse(backendURL)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid backend URL: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		// Create reverse proxy
+		proxy := httputil.NewSingleHostReverseProxy(target)
+		
+		// Customize the director to preserve the original path
+		originalDirector := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			originalDirector(req)
+			req.Header.Set("X-Forwarded-Host", req.Header.Get("Host"))
+			req.Header.Set("X-Forwarded-Proto", "http")
+			if req.TLS != nil {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			}
+		}
+
+		// Custom error handler
+		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("Proxy error for %s: %v", r.URL.Path, err)
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+		}
+
+		if p.verbose {
+			log.Printf("Proxying %s %s to %s", r.Method, r.URL.Path, target)
+		}
+
+		proxy.ServeHTTP(w, r)
+	}
+}
+
+// defaultHandler handles requests that don't match any configured routes
+func (p *Proxy) defaultHandler(w http.ResponseWriter, r *http.Request) {
+	if p.config.DefaultBackend != "" {
+		handler := p.createProxyHandler(p.config.DefaultBackend)
+		handler(w, r)
+		return
+	}
+
+	// No default backend configured, return 404
+	if p.verbose {
+		log.Printf("No route found for %s %s", r.Method, r.URL.Path)
+	}
+	http.NotFound(w, r)
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewProxy(t *testing.T) {
+	config := &Config{
+		DefaultBackend: "http://localhost:3000",
+		Routes: map[string]string{
+			"/api/{org}/{repo}": "http://localhost:3001",
+		},
+	}
+
+	proxy := NewProxy(config, false)
+	if proxy == nil {
+		t.Fatal("NewProxy returned nil")
+	}
+
+	if proxy.config != config {
+		t.Error("Proxy config not set correctly")
+	}
+
+	if proxy.router == nil {
+		t.Error("Router not initialized")
+	}
+}
+
+func TestProxyRouting(t *testing.T) {
+	// Create a test backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("backend response"))
+	}))
+	defer backend.Close()
+
+	config := &Config{
+		DefaultBackend: backend.URL,
+		Routes: map[string]string{
+			"/api/{org}/{repo}": backend.URL,
+			"/health":           backend.URL,
+		},
+	}
+
+	proxy := NewProxy(config, true)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedStatus int
+	}{
+		{
+			name:           "API route with org and repo",
+			path:           "/api/myorg/myrepo",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "Health endpoint",
+			path:           "/health",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "Unmatched route should use default backend",
+			path:           "/some/other/path",
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+
+			proxy.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestProxyWithoutDefaultBackend(t *testing.T) {
+	config := &Config{
+		Routes: map[string]string{
+			"/health": "http://localhost:3001",
+		},
+	}
+
+	proxy := NewProxy(config, false)
+
+	// Test unmatched route without default backend
+	req := httptest.NewRequest("GET", "/nonexistent", nil)
+	w := httptest.NewRecorder()
+
+	proxy.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestProxyErrorHandling(t *testing.T) {
+	config := &Config{
+		Routes: map[string]string{
+			"/api/{org}/{repo}": "http://invalid-backend:99999",
+		},
+	}
+
+	proxy := NewProxy(config, false)
+
+	req := httptest.NewRequest("GET", "/api/test/repo", nil)
+	w := httptest.NewRecorder()
+
+	proxy.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("Expected status %d for invalid backend, got %d", http.StatusBadGateway, w.Code)
+	}
+}


### PR DESCRIPTION
Implements a configurable HTTP proxy server for routing requests based on URL patterns to different backend services.

## Features
- Routes paths like `/api/{org}/{repo}` to specified host:port destinations
- JSON-based configuration with flexible routing rules
- Comprehensive test suite with unit and integration tests
- Header forwarding and proper error handling
- Verbose logging option for debugging

## Usage
```bash
go run . -port 8080 -config config.json -verbose
```

Resolves #2

Generated with [Claude Code](https://claude.ai/code)