### PR TITLE
feat: refactor CLI structure using cobra with serverCmd

### DIFF
--- a/cmd/agentapi-proxy/main.go
+++ b/cmd/agentapi-proxy/main.go
@@ -5,58 +5,17 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/takutakahashi/agentapi-proxy/pkg/config"
-	"github.com/takutakahashi/agentapi-proxy/pkg/proxy"
-)
-
-var (
-	port    string
-	cfg     string
-	verbose bool
+	"github.com/takutakahashi/agentapi-proxy/cmd"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "agentapi-proxy",
 	Short: "AgentAPI Proxy Server",
 	Long:  "A reverse proxy server for AgentAPI that routes requests based on configuration",
-	Run:   runProxy,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&port, "port", "p", "8080", "Port to listen on")
-	rootCmd.PersistentFlags().StringVarP(&cfg, "config", "c", "config.json", "Configuration file path")
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
-
-	// Bind flags to viper
-	if err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port")); err != nil {
-		log.Printf("Failed to bind port flag: %v", err)
-	}
-	if err := viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config")); err != nil {
-		log.Printf("Failed to bind config flag: %v", err)
-	}
-	if err := viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose")); err != nil {
-		log.Printf("Failed to bind verbose flag: %v", err)
-	}
-}
-
-func runProxy(cmd *cobra.Command, args []string) {
-	if verbose {
-		log.SetFlags(log.LstdFlags | log.Lshortfile)
-	}
-
-	configData, err := config.LoadConfig(cfg)
-	if err != nil {
-		log.Printf("Failed to load config from %s, using defaults: %v", cfg, err)
-		configData = config.DefaultConfig()
-	}
-
-	proxyServer := proxy.NewProxy(configData, verbose)
-
-	log.Printf("Starting agentapi-proxy on port %s", port)
-	if err := proxyServer.GetEcho().Start(":" + port); err != nil {
-		log.Fatalf("Server failed to start: %v", err)
-	}
+	rootCmd.AddCommand(cmd.ServerCmd)
 }
 
 func main() {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/proxy"
+)
+
+var (
+	port    string
+	cfg     string
+	verbose bool
+)
+
+var ServerCmd = &cobra.Command{
+	Use:   "server",
+	Short: "Start the AgentAPI Proxy Server",
+	Long:  "Start the reverse proxy server for AgentAPI that routes requests based on configuration",
+	Run:   runProxy,
+}
+
+func init() {
+	ServerCmd.Flags().StringVarP(&port, "port", "p", "8080", "Port to listen on")
+	ServerCmd.Flags().StringVarP(&cfg, "config", "c", "config.json", "Configuration file path")
+	ServerCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+
+	// Bind flags to viper
+	if err := viper.BindPFlag("port", ServerCmd.Flags().Lookup("port")); err != nil {
+		log.Printf("Failed to bind port flag: %v", err)
+	}
+	if err := viper.BindPFlag("config", ServerCmd.Flags().Lookup("config")); err != nil {
+		log.Printf("Failed to bind config flag: %v", err)
+	}
+	if err := viper.BindPFlag("verbose", ServerCmd.Flags().Lookup("verbose")); err != nil {
+		log.Printf("Failed to bind verbose flag: %v", err)
+	}
+}
+
+func runProxy(cmd *cobra.Command, args []string) {
+	if verbose {
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
+
+	configData, err := config.LoadConfig(cfg)
+	if err != nil {
+		log.Printf("Failed to load config from %s, using defaults: %v", cfg, err)
+		configData = config.DefaultConfig()
+	}
+
+	proxyServer := proxy.NewProxy(configData, verbose)
+
+	log.Printf("Starting agentapi-proxy on port %s", port)
+	if err := proxyServer.GetEcho().Start(":" + port); err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}


### PR DESCRIPTION
Refactors the CLI structure to use cobra with a dedicated serverCmd as requested in issue #16.

## Changes
- Create cmd/server.go with ServerCmd for server functionality
- Refactor main.go to use cobra CLI structure with subcommands
- Move server logic from main.go to dedicated serverCmd
- CLI now supports 'agentapi-proxy server' command structure

## Testing
Please run `make lint` and `make test` before merging.

Closes #16

Generated with [Claude Code](https://claude.ai/code)