### PR TITLE
refactor: conform to docs/api.md specification

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,10 +1,3 @@
 {
-  "default_backend": "http://localhost:3000",
-  "routes": {
-    "/api/{org}/{repo}": "http://agentapi-backend:8080",
-    "/api/{org}/{repo}/issues": "http://issues-service:9000",
-    "/api/{org}/{repo}/pulls": "http://pr-service:9001",
-    "/health": "http://health-check:8080",
-    "/metrics": "http://metrics-service:9090"
-  }
+  "start_port": 9000
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,12 +8,8 @@ import (
 
 // Config represents the proxy configuration
 type Config struct {
-	// DefaultBackend is used when no route matches
-	DefaultBackend string `json:"DefaultBackend" mapstructure:"default_backend"`
-
-	// Routes maps path patterns to backend URLs
-	// Pattern can include variables like {org} and {repo}
-	Routes map[string]string `json:"Routes" mapstructure:"routes"`
+	// StartPort is the starting port for agentapi servers
+	StartPort int `json:"start_port" mapstructure:"start_port"`
 }
 
 // LoadConfig loads configuration from a JSON file
@@ -34,16 +30,17 @@ func LoadConfig(filename string) (*Config, error) {
 		return nil, err
 	}
 
+	// Set default values if not specified
+	if config.StartPort == 0 {
+		config.StartPort = 9000
+	}
+
 	return &config, nil
 }
 
 // DefaultConfig returns a default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		DefaultBackend: "http://localhost:3000",
-		Routes: map[string]string{
-			"/api/{org}/{repo}": "http://localhost:3000",
-			"/health":           "http://localhost:3000",
-		},
+		StartPort: 9000,
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,31 +14,20 @@ func TestDefaultConfig(t *testing.T) {
 		t.Fatal("DefaultConfig returned nil")
 	}
 
-	if config.DefaultBackend == "" {
-		t.Error("DefaultBackend should not be empty")
+	if config.StartPort == 0 {
+		t.Error("StartPort should not be zero")
 	}
 
-	if len(config.Routes) == 0 {
-		t.Error("Routes should not be empty")
-	}
-
-	// Check if expected routes exist
-	expectedRoutes := []string{"/api/{org}/{repo}", "/health"}
-	for _, route := range expectedRoutes {
-		if _, exists := config.Routes[route]; !exists {
-			t.Errorf("Expected route %s not found in default config", route)
-		}
+	expectedStartPort := 9000
+	if config.StartPort != expectedStartPort {
+		t.Errorf("Expected StartPort to be %d, got %d", expectedStartPort, config.StartPort)
 	}
 }
 
 func TestLoadConfig(t *testing.T) {
 	// Create a temporary config file
 	tempConfig := &Config{
-		DefaultBackend: "http://example.com:8080",
-		Routes: map[string]string{
-			"/api/{org}/{repo}": "http://backend1.com",
-			"/v1/{service}":     "http://backend2.com",
-		},
+		StartPort: 8000,
 	}
 
 	configData, err := json.Marshal(tempConfig)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -10,10 +10,7 @@ import (
 
 func TestNewProxy(t *testing.T) {
 	cfg := &config.Config{
-		DefaultBackend: "http://localhost:3000",
-		Routes: map[string]string{
-			"/api/{org}/{repo}": "http://localhost:3001",
-		},
+		StartPort: 9000,
 	}
 
 	proxy := NewProxy(cfg, false)
@@ -28,118 +25,49 @@ func TestNewProxy(t *testing.T) {
 	if proxy.echo == nil {
 		t.Error("Echo instance not initialized")
 	}
-}
 
-func TestProxyRouting(t *testing.T) {
-	// Create a test backend server
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("backend response"))
-	}))
-	defer backend.Close()
-
-	cfg := &config.Config{
-		DefaultBackend: backend.URL,
-		Routes: map[string]string{
-			"/api/{org}/{repo}": backend.URL,
-			"/health":           backend.URL,
-		},
-	}
-
-	proxy := NewProxy(cfg, true)
-
-	tests := []struct {
-		name           string
-		path           string
-		expectedStatus int
-	}{
-		{
-			name:           "API route with org and repo",
-			path:           "/api/myorg/myrepo",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "Health endpoint",
-			path:           "/health",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "Unmatched route should use default backend",
-			path:           "/some/other/path",
-			expectedStatus: http.StatusOK,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", tt.path, nil)
-			w := httptest.NewRecorder()
-
-			proxy.GetEcho().ServeHTTP(w, req)
-
-			if w.Code != tt.expectedStatus {
-				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
-			}
-		})
+	if proxy.nextPort != cfg.StartPort {
+		t.Errorf("Expected nextPort to be %d, got %d", cfg.StartPort, proxy.nextPort)
 	}
 }
 
-func TestProxyWithoutDefaultBackend(t *testing.T) {
-	cfg := &config.Config{
-		Routes: map[string]string{
-			"/health": "http://localhost:3001",
-		},
-	}
-
-	proxy := NewProxy(cfg, false)
-
-	// Test unmatched route without default backend
-	req := httptest.NewRequest("GET", "/nonexistent", nil)
-	w := httptest.NewRecorder()
-
-	proxy.GetEcho().ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Errorf("Expected status %d, got %d", http.StatusNotFound, w.Code)
-	}
-}
-
-func TestProxyErrorHandling(t *testing.T) {
-	cfg := &config.Config{
-		Routes: map[string]string{
-			"/api/{org}/{repo}": "http://invalid-backend:99999",
-		},
-	}
-
-	proxy := NewProxy(cfg, false)
-
-	req := httptest.NewRequest("GET", "/api/test/repo", nil)
-	w := httptest.NewRecorder()
-
-	proxy.GetEcho().ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadGateway {
-		t.Errorf("Expected status %d for invalid backend, got %d", http.StatusBadGateway, w.Code)
-	}
-}
-
-func TestStartAgentAPIServer(t *testing.T) {
+func TestStartEndpoint(t *testing.T) {
 	cfg := config.DefaultConfig()
 	proxy := NewProxy(cfg, false)
 
-	req := httptest.NewRequest("POST", "/sessions/start", nil)
+	req := httptest.NewRequest("POST", "/start", nil)
 	w := httptest.NewRecorder()
 
 	proxy.GetEcho().ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("Expected status %d for /sessions/start endpoint, got %d", http.StatusOK, w.Code)
+		t.Errorf("Expected status %d for /start endpoint, got %d", http.StatusOK, w.Code)
 	}
 
 	// Check if response contains session_id
 	response := w.Body.String()
 	if response == "" {
-		t.Error("Expected non-empty response from /sessions/start endpoint")
+		t.Error("Expected non-empty response from /start endpoint")
+	}
+}
+
+func TestSearchEndpoint(t *testing.T) {
+	cfg := config.DefaultConfig()
+	proxy := NewProxy(cfg, false)
+
+	req := httptest.NewRequest("GET", "/search", nil)
+	w := httptest.NewRecorder()
+
+	proxy.GetEcho().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d for /search endpoint, got %d", http.StatusOK, w.Code)
+	}
+
+	// Check if response contains sessions array
+	response := w.Body.String()
+	if response == "" {
+		t.Error("Expected non-empty response from /search endpoint")
 	}
 }
 
@@ -148,7 +76,7 @@ func TestSessionRoutingNotFound(t *testing.T) {
 	proxy := NewProxy(cfg, false)
 
 	// Test routing to non-existent session
-	req := httptest.NewRequest("GET", "/sessions/nonexistent-session-id/health", nil)
+	req := httptest.NewRequest("GET", "/nonexistent-session-id/health", nil)
 	w := httptest.NewRecorder()
 
 	proxy.GetEcho().ServeHTTP(w, req)


### PR DESCRIPTION
Fixes #27

## Summary

Refactored the agentapi-proxy to conform to the API specification defined in docs/api.md:

- Updated API endpoints to match specification
- Simplified configuration structure
- Added missing /search endpoint
- Removed unnecessary general proxy functionality
- Enhanced session management with filtering
- Fixed race conditions and updated tests

## Changes

1. **API Endpoints:**
   - `POST /sessions/start` → `POST /start`
   - `ANY /sessions/:sessionId/*` → `ANY /:session_id/*`
   - Added `GET /search` with session filtering

2. **Configuration:**
   - Simplified from complex routing to just `start_port`
   - Removed unnecessary `routes` and `default_backend`

3. **Code Quality:**
   - Fixed race conditions in port allocation
   - Updated all tests to match new structure
   - Removed unused proxy routing functions

## Test Results

✅ All tests passing with race detection enabled

Generated with [Claude Code](https://claude.ai/code)