### PR TITLE
feat: add arbitrary key-value tagging functionality

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,22 @@
 - 新しいセッションを作成します。
 - レスポンスとして、作成されたセッションIDを返します。
 - 各セッションごとに `agentapi` が新規に起動されます。
+- リクエストボディで任意のタグ（key-value）を指定できます。
+
+#### リクエストボディ例
+```json
+{
+  "user_id": "user123",
+  "environment": {
+    "CUSTOM_VAR": "value"
+  },
+  "tags": {
+    "repository": "agentapi-proxy",
+    "branch": "main",
+    "env": "production"
+  }
+}
+```
 
 ### /session_id/*
 - すべての `/session_id/*` へのリクエストは、該当セッションの `agentapi` へ転送されます。
@@ -19,18 +35,48 @@
 - クエリパラメータでフィルタリングが可能です。
 - 全体のセッション情報を取得するためのエンドポイントです。
 - レスポンスはJSON形式で、セッションのリストを返します。
+- タグによるフィルタリングが可能です（`tag.キー名=値` の形式）。
+
+#### サポートするクエリパラメータ
+- `user_id`: ユーザーIDでフィルタ
+- `status`: ステータスでフィルタ
+- `tag.{key}`: 指定したタグキーの値でフィルタ
 
 #### リクエスト例
 ```
 GET /search?user_id=123&status=active
+GET /search?tag.repository=agentapi-proxy&tag.env=production
+GET /search?user_id=123&tag.branch=main
 ```
 
 #### レスポンス例
 ```json
 {
   "sessions": [
-    { "session_id": "abc123", "user_id": "123", "status": "active" },
-    { "session_id": "def456", "user_id": "123", "status": "active" }
+    {
+      "session_id": "abc123",
+      "user_id": "123",
+      "status": "active",
+      "started_at": "2023-06-08T12:00:00Z",
+      "port": 9000,
+      "tags": {
+        "repository": "agentapi-proxy",
+        "branch": "main",
+        "env": "production"
+      }
+    },
+    {
+      "session_id": "def456",
+      "user_id": "123",
+      "status": "active",
+      "started_at": "2023-06-08T12:05:00Z",
+      "port": 9001,
+      "tags": {
+        "repository": "another-repo",
+        "branch": "develop",
+        "env": "production"
+      }
+    }
   ]
 }
 ```


### PR DESCRIPTION
Resolves #35

Implemented arbitrary key-value tagging functionality for agentapi-proxy:

## Features Added
- Added Tags field to StartRequest and AgentSession structs
- Implemented tag filtering in /search endpoint with tag.key=value query params
- Updated client library with SearchWithTags method
- Added comprehensive test coverage for tag functionality
- Updated API documentation with tag examples

## Usage Examples
```bash
# Start session with tags
curl -X POST /start -d '{"tags": {"repository": "agentapi-proxy", "env": "prod"}}'

# Search by tags
curl "/search?tag.repository=agentapi-proxy&tag.env=prod"
```

This enables filtering sessions by arbitrary metadata such as:
- Repository name: tag.repository=agentapi-proxy
- Environment: tag.env=production
- Branch: tag.branch=main

🤖 Generated with [Claude Code](https://claude.ai/code)