### PR TITLE
feat: add helpers command with subcommand support

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var HelpersCmd = &cobra.Command{
+	Use:   "helpers",
+	Short: "Helper utilities for agentapi-proxy",
+	Long:  "Collection of helper utilities and tools for working with agentapi-proxy",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Available helpers:")
+		fmt.Println("Use 'agentapi-proxy helpers --help' for more information about available subcommands.")
+	},
+}
+
+func init() {
+	// Subcommands will be added here in the future
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(cmd.ServerCmd)
+	rootCmd.AddCommand(cmd.HelpersCmd)
 }
 
 func main() {


### PR DESCRIPTION
Add new helpers command following existing CLI patterns. The command provides foundation for future helper utilities and is integrated with the Cobra CLI framework used by the project.

Fixes #39

Generated with [Claude Code](https://claude.ai/code)