### PR TITLE
feat: add setup-claude-code subcommand to helpers

### DIFF
--- a/cmd/claude_code_settings.json
+++ b/cmd/claude_code_settings.json
@@ -1,0 +1,18 @@
+{
+  "workspaceSettings": {
+    "agentapiProxy": {
+      "defaultStartPort": 9000,
+      "enableVerboseLogging": false,
+      "configPath": "config.json"
+    }
+  },
+  "projectSettings": {
+    "lintCommand": "make lint",
+    "testCommand": "make test",
+    "buildCommand": "make build"
+  },
+  "preferences": {
+    "autoSaveOnEdit": true,
+    "showFileTreeByDefault": true
+  }
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,10 +1,17 @@
 package cmd
 
 import (
+	_ "embed"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
+
+//go:embed claude_code_settings.json
+var claudeCodeSettings string
 
 var HelpersCmd = &cobra.Command{
 	Use:   "helpers",
@@ -12,10 +19,49 @@ var HelpersCmd = &cobra.Command{
 	Long:  "Collection of helper utilities and tools for working with agentapi-proxy",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Available helpers:")
+		fmt.Println("  setup-claude-code - Setup Claude Code configuration")
 		fmt.Println("Use 'agentapi-proxy helpers --help' for more information about available subcommands.")
 	},
 }
 
+var setupClaudeCodeCmd = &cobra.Command{
+	Use:   "setup-claude-code",
+	Short: "Setup Claude Code configuration",
+	Long:  "Creates Claude Code configuration directory and settings file at $CLAUDE_DIR/.claude/settings.json",
+	Run:   runSetupClaudeCode,
+}
+
 func init() {
-	// Subcommands will be added here in the future
+	HelpersCmd.AddCommand(setupClaudeCodeCmd)
+}
+
+func runSetupClaudeCode(cmd *cobra.Command, args []string) {
+	claudeDir := os.Getenv("CLAUDE_DIR")
+	if claudeDir == "" {
+		fmt.Println("Error: CLAUDE_DIR environment variable is not set")
+		os.Exit(1)
+	}
+
+	// Create .claude directory
+	claudeConfigDir := filepath.Join(claudeDir, ".claude")
+	if err := os.MkdirAll(claudeConfigDir, 0755); err != nil {
+		fmt.Printf("Error creating directory %s: %v\n", claudeConfigDir, err)
+		os.Exit(1)
+	}
+
+	// Validate that the embedded JSON is valid
+	var tempSettings interface{}
+	if err := json.Unmarshal([]byte(claudeCodeSettings), &tempSettings); err != nil {
+		fmt.Printf("Error: Invalid embedded settings JSON: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write settings.json file
+	settingsPath := filepath.Join(claudeConfigDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(claudeCodeSettings), 0644); err != nil {
+		fmt.Printf("Error writing settings file %s: %v\n", settingsPath, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully created Claude Code configuration at %s\n", settingsPath)
 }


### PR DESCRIPTION
Fixes #42

Adds a new `setup-claude-code` subcommand to the helpers utility that:

- Creates `$CLAUDE_DIR/.claude/settings.json` with default configuration
- Uses Go embed to include extensible JSON settings
- Handles directory creation and error cases properly
- Follows existing code patterns and conventions

Generated with [Claude Code](https://claude.ai/code)