### PR TITLE
feat: convert agentapi_default.sh to Go template with embedded arguments

### DIFF
--- a/pkg/proxy/scripts/agentapi_default.sh
+++ b/pkg/proxy/scripts/agentapi_default.sh
@@ -18,4 +18,4 @@ else
 fi
 
 CLAUDE_DIR=. agentapi-agent helpers setup-claude-code
-exec agentapi server --port "$PORT" $AGENTAPI_ARGS -- claude $CLAUDE_ARGS
+exec agentapi server --port "$PORT" {{.AgentAPIArgs}} -- claude {{.ClaudeArgs}}


### PR DESCRIPTION
Resolves #55

Converted agentapi_default.sh from using environment variables to Go template format for better debuggability.

## Changes
- Replace environment variable usage with Go template variables {{.AgentAPIArgs}} and {{.ClaudeArgs}}
- Add ScriptTemplateData struct to hold template parameters
- Update extractScriptToTempFile to process script as template
- Modify runAgentAPIServer to pass template data
- Update logging to show embedded template arguments

## Benefits
- Improved debuggability by embedding arguments directly in script
- No more reliance on environment variables for script arguments
- All existing functionality preserved

Generated with [Claude Code](https://claude.ai/code)