### PR TITLE
feat: add verbose logging of script contents during start

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -644,6 +644,14 @@ func (p *Proxy) extractScriptToTempFile(scriptName string, templateData *ScriptT
 		processedContent = content
 	}
 
+	// Log script content when verbose mode is enabled
+	if p.verbose {
+		log.Printf("[VERBOSE] Script content for %s:", scriptName)
+		log.Printf("--- Script Start ---")
+		log.Printf("%s", string(processedContent))
+		log.Printf("--- Script End ---")
+	}
+
 	// Create temporary file
 	tmpFile, err := os.CreateTemp("", "agentapi-script-*.sh")
 	if err != nil {


### PR DESCRIPTION
When verbose mode is enabled (-v flag), the server now logs the complete script content before execution, including template variables resolved. This helps with debugging and understanding what scripts are being executed.

Fixes #57

Generated with [Claude Code](https://claude.ai/code)