### PR TITLE
feat: extract user_id from authentication token instead of request parameters

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,6 @@
 #### リクエストボディ例
 ```json
 {
-  "user_id": "user123",
   "environment": {
     "CUSTOM_VAR": "value"
   },
@@ -25,6 +24,8 @@
   }
 }
 ```
+
+**注意**: `user_id` は認証されたユーザーのトークンから自動的に割り当てられます。
 
 ### /session_id/*
 - すべての `/session_id/*` へのリクエストは、該当セッションの `agentapi` へ転送されます。
@@ -38,16 +39,17 @@
 - タグによるフィルタリングが可能です（`tag.キー名=値` の形式）。
 
 #### サポートするクエリパラメータ
-- `user_id`: ユーザーIDでフィルタ
 - `status`: ステータスでフィルタ
 - `tag.{key}`: 指定したタグキーの値でフィルタ
 
 #### リクエスト例
 ```
-GET /search?user_id=123&status=active
+GET /search?status=active
 GET /search?tag.repository=agentapi-proxy&tag.env=production
-GET /search?user_id=123&tag.branch=main
+GET /search?tag.branch=main
 ```
+
+**注意**: セッションのフィルタリングは認証されたユーザーのコンテキストに基づいて自動的に行われます。管理者以外のユーザーは自分のセッションのみを表示できます。
 
 #### レスポンス例
 ```json

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,7 +28,6 @@ func NewClient(baseURL string) *Client {
 
 // StartRequest represents the request body for starting a new agentapi server
 type StartRequest struct {
-	UserID      string            `json:"user_id,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Tags        map[string]string `json:"tags,omitempty"`
 }
@@ -118,21 +117,18 @@ func (c *Client) Start(ctx context.Context, req *StartRequest) (*StartResponse, 
 }
 
 // Search lists and filters sessions
-func (c *Client) Search(ctx context.Context, userID, status string) (*SearchResponse, error) {
-	return c.SearchWithTags(ctx, userID, status, nil)
+func (c *Client) Search(ctx context.Context, status string) (*SearchResponse, error) {
+	return c.SearchWithTags(ctx, status, nil)
 }
 
 // SearchWithTags lists and filters sessions with tag support
-func (c *Client) SearchWithTags(ctx context.Context, userID, status string, tags map[string]string) (*SearchResponse, error) {
+func (c *Client) SearchWithTags(ctx context.Context, status string, tags map[string]string) (*SearchResponse, error) {
 	u, err := url.Parse(c.baseURL + "/search")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}
 
 	q := u.Query()
-	if userID != "" {
-		q.Set("user_id", userID)
-	}
 	if status != "" {
 		q.Set("status", status)
 	}


### PR DESCRIPTION
## Summary
- Remove user_id parameters from API endpoints and extract from authentication token
- Improve security by preventing user impersonation 
- Ensure proper session ownership based on authenticated user context

## Changes Made
- **POST /start**: Remove user_id query parameter and request body field
- **GET /search**: Remove user_id query parameter, auto-filter by authenticated user
- **StartRequest struct**: Remove UserID field from both proxy and client
- **Client API**: Update method signatures to remove user_id parameters
- **Tests**: Fix all integration and unit tests to work with new approach
- **Documentation**: Update API docs to reflect authentication-based behavior

## Security Improvements
- Users can only create sessions for themselves (no impersonation)
- Non-admin users can only view their own sessions
- Admin users can view all sessions
- Anonymous users get "anonymous" user_id when auth is disabled

## Test Status
✅ All integration tests pass
✅ All unit tests pass  
✅ Lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)