### PR TITLE
Add GitHub CLI installation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,14 @@ RUN set -ex && \
 # Runtime stage
 FROM debian:bookworm-slim
 
-# Install ca-certificates, curl, and bash for mise installation
-RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc && rm -rf /var/lib/apt/lists/*
+# Install ca-certificates, curl, and bash for mise installation, plus GitHub CLI
+RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y gh && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
 RUN groupadd -g 1001 agentapi && \


### PR DESCRIPTION
## Summary
- Add GitHub CLI (gh) installation to Dockerfile using official Debian repository
- Set up GPG keyring and repository configuration for secure installation
- Ensure gh CLI is available in the runtime environment

## Test plan
- [x] Dockerfile builds successfully
- [x] Linting passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)