### PR TITLE
feat: Replace file-based config with hardcoded map in claude init

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -152,25 +152,13 @@ func mergeClaudeConfig() error {
 
 	targetPath := filepath.Join(homeDir, ".claude.json")
 
-	// Try to read config/claude.json
-	configPath := "config/claude.json"
-	configData, err := os.ReadFile(configPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// config/claude.json doesn't exist, nothing to merge
-			fmt.Printf("config/claude.json not found, skipping merge\n")
-			return nil
-		}
-		return fmt.Errorf("failed to read config/claude.json: %w", err)
+	// Define the configuration to merge as a map
+	configToMerge := map[string]interface{}{
+		"hasCompletedOnboarding":        true,
+		"bypassPermissionsModeAccepted": true,
 	}
 
-	// Parse config JSON
-	var configJSON map[string]interface{}
-	if err := json.Unmarshal(configData, &configJSON); err != nil {
-		return fmt.Errorf("failed to parse config/claude.json: %w", err)
-	}
-
-	fmt.Printf("Read config from config/claude.json\n")
+	fmt.Printf("Using hardcoded configuration map\n")
 
 	// Read existing ~/.claude.json if it exists
 	var targetJSON map[string]interface{}
@@ -188,8 +176,8 @@ func mergeClaudeConfig() error {
 		}
 	}
 
-	// Merge config into target (config values override existing values)
-	for key, value := range configJSON {
+	// Merge configuration map into target (config values override existing values)
+	for key, value := range configToMerge {
 		targetJSON[key] = value
 	}
 


### PR DESCRIPTION
## Summary

This PR replaces the file-based configuration reading from `config/claude.json` with a hardcoded map implementation in the `mergeClaudeConfig` function.

## Changes

- **Removed**: File reading logic for `config/claude.json`
- **Added**: Hardcoded configuration map with required settings
- **Simplified**: Deployment process by eliminating external file dependencies

## Implementation Details

The configuration is now defined as a hardcoded map:
```go
configToMerge := map[string]interface{}{
    "hasCompletedOnboarding":        true,
    "bypassPermissionsModeAccepted": true,
}
```

## Benefits

1. **Portability**: No external file dependencies
2. **Reliability**: Eliminates file reading errors
3. **Simplicity**: Cleaner, more maintainable code
4. **Performance**: Slightly faster initialization without file I/O

## Testing

- [x] Built successfully with `go build`
- [x] Tested `agentapi-proxy helpers init` command
- [x] Verified JSON merge into `~/.claude.json` works correctly
- [x] Confirmed both configuration values are properly applied

## Usage

```bash
# Initialize Claude configuration
agentapi-proxy helpers init

# Or using the original command
agentapi-proxy helpers setup-claude-code
```

🤖 Generated with [Claude Code](https://claude.ai/code)