### PR TITLE
feat: Disable heartbeat checking by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,7 @@ func DefaultConfig() *Config {
 			EncryptSecrets:        true,
 			SessionRecoveryMaxAge: 24, // Default 24 hours
 		},
-		DisableHeartbeat:     false,
+		DisableHeartbeat:     true,
 		DisableZombieCleanup: false,
 	}
 }


### PR DESCRIPTION
## Summary
- Changed the default configuration to disable heartbeat checking (`DisableHeartbeat: true`)
- This prevents sessions from being automatically disconnected due to heartbeat timeouts

## Test plan
- [ ] Verify that sessions no longer disconnect automatically when heartbeat is disabled
- [ ] Confirm that existing configurations with explicit `DisableHeartbeat: false` still work as expected
- [ ] Test that all other session management features continue to work normally

🤖 Generated with [Claude Code](https://claude.ai/code)