### PR TITLE
feat: Add make to Dockerfile runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN set -ex && \
 # Runtime stage
 FROM debian:bookworm-slim
 
-# Install ca-certificates, curl, and bash for mise installation, plus GitHub CLI
-RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc && \
+# Install ca-certificates, curl, and bash for mise installation, plus GitHub CLI and make
+RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc make && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \


### PR DESCRIPTION
## Summary
- Add make package to the runtime stage of Dockerfile to enable build automation commands
- This allows the container to run make commands like `make lint` and `make test`

## Changes
- Updated Dockerfile line 45 to include `make` in the apt-get install command

## Test plan
- [ ] Build Docker image successfully with make package installed
- [ ] Verify make commands work within the container

🤖 Generated with [Claude Code](https://claude.ai/code)