### PR TITLE
feat: add detailed logging for exit 1 errors

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +45,6 @@ var initCmd = &cobra.Command{
 	Long:  "Creates Claude Code configuration directory and settings file at $CLAUDE_DIR/.claude/settings.json, and merges config/claude.json into ~/.claude.json",
 	Run:   runSetupClaudeCode,
 }
-
 
 var generateTokenCmd = &cobra.Command{
 	Use:   "generate-token",
@@ -96,6 +96,7 @@ func runSetupClaudeCode(cmd *cobra.Command, args []string) {
 	claudeDir := os.Getenv("CLAUDE_DIR")
 	if claudeDir == "" {
 		fmt.Println("Error: CLAUDE_DIR environment variable is not set")
+		log.Printf("Fatal error: CLAUDE_DIR environment variable is not set")
 		os.Exit(1)
 	}
 
@@ -103,6 +104,7 @@ func runSetupClaudeCode(cmd *cobra.Command, args []string) {
 	claudeConfigDir := filepath.Join(claudeDir, ".claude")
 	if err := os.MkdirAll(claudeConfigDir, 0755); err != nil {
 		fmt.Printf("Error creating directory %s: %v\n", claudeConfigDir, err)
+		log.Printf("Fatal error creating directory %s: %v", claudeConfigDir, err)
 		os.Exit(1)
 	}
 
@@ -110,6 +112,7 @@ func runSetupClaudeCode(cmd *cobra.Command, args []string) {
 	var tempSettings interface{}
 	if err := json.Unmarshal([]byte(claudeCodeSettings), &tempSettings); err != nil {
 		fmt.Printf("Error: Invalid embedded settings JSON: %v\n", err)
+		log.Printf("Fatal error: Invalid embedded settings JSON: %v", err)
 		os.Exit(1)
 	}
 
@@ -117,6 +120,7 @@ func runSetupClaudeCode(cmd *cobra.Command, args []string) {
 	settingsPath := filepath.Join(claudeConfigDir, "settings.json")
 	if err := os.WriteFile(settingsPath, []byte(claudeCodeSettings), 0644); err != nil {
 		fmt.Printf("Error writing settings file %s: %v\n", settingsPath, err)
+		log.Printf("Fatal error writing settings file %s: %v", settingsPath, err)
 		os.Exit(1)
 	}
 
@@ -136,6 +140,7 @@ func runSetupClaudeCode(cmd *cobra.Command, args []string) {
 		claudeCmd := exec.Command("claude", "config", "set", key, value)
 		if err := claudeCmd.Run(); err != nil {
 			fmt.Printf("Error setting Claude config: %v\n", err)
+			log.Printf("Fatal error setting Claude config for key '%s': %v", key, err)
 			os.Exit(1)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Println(err)
+		log.Printf("Fatal error executing command: %v", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

スクリプトがexit 1したときに何もわからなくなる問題を解決するため、exit(1)が発生する箇所すべてに詳細なログ出力を追加しました。

### 変更内容

- **main.go**: rootCommandのエラー時に詳細ログを追加
- **cmd/helpers.go**: 以下の箇所にエラーログを追加
  - CLAUDE_DIR環境変数未設定時
  - ディレクトリ作成失敗時 
  - 埋め込みJSON無効時
  - 設定ファイル書き込み失敗時
  - Claude設定セット失敗時（キー名も含む）

### 効果

これにより、exit 1が発生した際の原因を特定しやすくなり、デバッグが容易になります。

## Test plan

- [x] テストが正常に通ることを確認
- [x] go vet および go fmt でコード品質をチェック
- [x] 既存の機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)