### PR TITLE
Update Helm chart OCI registry path to charts namespace

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -58,12 +58,12 @@ jobs:
         run: |
           CHART_FILE=$(ls agentapi-proxy-*.tgz)
           echo "Pushing chart file: $CHART_FILE"
-          helm push "$CHART_FILE" oci://ghcr.io/${{ github.repository_owner }}
+          helm push "$CHART_FILE" oci://ghcr.io/${{ github.repository_owner }}/charts
 
       - name: Verify published chart
         run: |
           echo "Chart published successfully!"
-          echo "Install with: helm install agentapi-proxy oci://ghcr.io/${{ github.repository_owner }}/agentapi-proxy --version ${{ steps.version.outputs.version }}"
+          echo "Install with: helm install agentapi-proxy oci://ghcr.io/${{ github.repository_owner }}/charts/agentapi-proxy --version ${{ steps.version.outputs.version }}"
 
       - name: Create release notes
         run: |
@@ -73,20 +73,20 @@ jobs:
           ## Installation
           
           \`\`\`bash
-          helm install agentapi-proxy oci://ghcr.io/${{ github.repository_owner }}/agentapi-proxy --version ${{ steps.version.outputs.version }}
+          helm install agentapi-proxy oci://ghcr.io/${{ github.repository_owner }}/charts/agentapi-proxy --version ${{ steps.version.outputs.version }}
           \`\`\`
           
           ## Upgrade
           
           \`\`\`bash
-          helm upgrade agentapi-proxy oci://ghcr.io/${{ github.repository_owner }}/agentapi-proxy --version ${{ steps.version.outputs.version }}
+          helm upgrade agentapi-proxy oci://ghcr.io/${{ github.repository_owner }}/charts/agentapi-proxy --version ${{ steps.version.outputs.version }}
           \`\`\`
           
           ## Chart Information
           
           - **Chart Version**: ${{ steps.version.outputs.version }}
           - **App Version**: ${{ steps.version.outputs.version }}
-          - **Registry**: ghcr.io/${{ github.repository_owner }}/agentapi-proxy
+          - **Registry**: ghcr.io/${{ github.repository_owner }}/charts/agentapi-proxy
           
           ## Changes
           

--- a/HELM_RELEASE.md
+++ b/HELM_RELEASE.md
@@ -46,7 +46,7 @@ Once you push a tag matching `v*` or `helm-v*`, GitHub Actions will:
 3. ✅ Lint and validate the chart
 4. ✅ Package the chart into a `.tgz` file
 5. ✅ Login to `ghcr.io` using `GITHUB_TOKEN`
-6. ✅ Push the chart to `oci://ghcr.io/takutakahashi/agentapi-proxy`
+6. ✅ Push the chart to `oci://ghcr.io/takutakahashi/charts/agentapi-proxy`
 7. ✅ Create release notes and upload artifacts
 
 ### 4. Verify the Release
@@ -55,7 +55,7 @@ Once you push a tag matching `v*` or `helm-v*`, GitHub Actions will:
 2. **Check Packages**: Visit https://github.com/takutakahashi?tab=packages
 3. **Test Installation**:
    ```bash
-   helm install test oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0
+   helm install test oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0
    ```
 
 ## Version Strategy
@@ -149,7 +149,7 @@ helm package helm/agentapi-proxy/
 echo $GITHUB_TOKEN | helm registry login ghcr.io --username takutakahashi --password-stdin
 
 # 4. Push the chart
-helm push agentapi-proxy-0.1.0.tgz oci://ghcr.io/takutakahashi
+helm push agentapi-proxy-0.1.0.tgz oci://ghcr.io/takutakahashi/charts
 ```
 
 ## Best Practices

--- a/helm/OCI_REGISTRY.md
+++ b/helm/OCI_REGISTRY.md
@@ -35,7 +35,7 @@ echo $GITHUB_TOKEN | helm registry login ghcr.io --username YOUR_GITHUB_USERNAME
 ### 3. Push to OCI Registry
 
 ```bash
-helm push agentapi-proxy-0.1.0.tgz oci://ghcr.io/takutakahashi
+helm push agentapi-proxy-0.1.0.tgz oci://ghcr.io/takutakahashi/charts
 ```
 
 ### 4. Verify the Push
@@ -49,14 +49,14 @@ Once published, users can install the chart directly from the OCI registry:
 ### Method 1: Direct Install
 
 ```bash
-helm install agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0
+helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0
 ```
 
 ### Method 2: Pull and Install
 
 ```bash
 # Pull the chart
-helm pull oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0
+helm pull oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0
 
 # Extract and install
 tar -xzf agentapi-proxy-0.1.0.tgz
@@ -66,7 +66,7 @@ helm install agentapi-proxy ./agentapi-proxy
 ### Method 3: With Custom Values
 
 ```bash
-helm install agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy \
+helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy \
   --version 0.1.0 \
   --set ingress.enabled=true \
   --set ingress.hosts[0].host=agentapi.yourdomain.com
@@ -83,7 +83,7 @@ When updating the chart version:
 ```bash
 # Update Chart.yaml version to 0.2.0
 helm package helm/agentapi-proxy/
-helm push agentapi-proxy-0.2.0.tgz oci://ghcr.io/takutakahashi
+helm push agentapi-proxy-0.2.0.tgz oci://ghcr.io/takutakahashi/charts
 ```
 
 ## Automation with GitHub Actions
@@ -108,7 +108,7 @@ git push origin helm-v0.2.0
 - ✅ Triggers on `v*` or `helm-v*` tags
 - ✅ Automatically updates Chart.yaml version from git tag
 - ✅ Lints and validates the chart before publishing
-- ✅ Pushes to `oci://ghcr.io/[owner]/agentapi-proxy`
+- ✅ Pushes to `oci://ghcr.io/[owner]/charts/agentapi-proxy`
 - ✅ Creates release notes and artifacts
 - ✅ Uses `GITHUB_TOKEN` (no additional secrets needed)
 

--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -23,7 +23,7 @@ helm install my-agentapi-proxy ./helm/agentapi-proxy
 Once published to ghcr.io, you can install directly from the OCI registry:
 
 ```bash
-helm install my-agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0
+helm install my-agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0
 ```
 
 The command deploys AgentAPI Proxy on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -134,7 +134,7 @@ The command removes all the Kubernetes components associated with the chart and 
 helm install agentapi-proxy ./helm/agentapi-proxy
 
 # From OCI registry
-helm install agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0
+helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0
 ```
 
 ### With Custom Values
@@ -147,7 +147,7 @@ helm install agentapi-proxy ./helm/agentapi-proxy \
   --set persistence.size=20Gi
 
 # From OCI registry
-helm install agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy \
+helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy \
   --version 0.1.0 \
   --set image.tag=latest \
   --set replicaCount=2 \
@@ -177,7 +177,7 @@ ingress:
 helm install agentapi-proxy ./helm/agentapi-proxy -f values.yaml
 
 # From OCI registry
-helm install agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0 -f values.yaml
+helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0 -f values.yaml
 ```
 
 ### With Environment Variables
@@ -233,7 +233,7 @@ The chart uses StatefulSet for better session persistence. Each replica gets its
 helm upgrade agentapi-proxy ./helm/agentapi-proxy --set replicaCount=3
 
 # Scale to 3 replicas (OCI registry)
-helm upgrade agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0 --set replicaCount=3
+helm upgrade agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0 --set replicaCount=3
 ```
 
 ## Troubleshooting
@@ -277,7 +277,7 @@ To upgrade an existing release:
 helm upgrade agentapi-proxy ./helm/agentapi-proxy
 
 # Upgrade from OCI registry
-helm upgrade agentapi-proxy oci://ghcr.io/takutakahashi/agentapi-proxy --version 0.1.0
+helm upgrade agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0
 ```
 
 ## Values File Example


### PR DESCRIPTION
## Summary
- Updated all references to OCI registry from `ghcr.io/takutakahashi/agentapi-proxy` to `ghcr.io/takutakahashi/charts/agentapi-proxy`
- Provides better organization by grouping charts under a dedicated namespace
- Updated GitHub Actions workflow and all documentation to reflect the new path

## Test plan
- [x] Updated GitHub Actions workflow: `.github/workflows/helm-publish.yml`
- [x] Updated documentation files: `HELM_RELEASE.md`, `helm/OCI_REGISTRY.md`, `helm/agentapi-proxy/README.md`
- [x] Verified lint passes: `make lint`
- [ ] Test chart publishing workflow when PR is merged and tagged

🤖 Generated with [Claude Code](https://claude.ai/code)