### PR TITLE
Fix Docker container ps command not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex && \
 FROM debian:bookworm-slim
 
 # Install ca-certificates, curl, and bash for mise installation, plus GitHub CLI and make
-RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc make && \
+RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc make procps && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \


### PR DESCRIPTION
## Summary
- Add procps package to Docker image to resolve 'spawn ps ENOENT' error
- This error occurs when bun tries to execute ps command internally during package installation
- The procps package provides ps, top, kill and other process management utilities

## Test plan
- [ ] Build Docker image and verify bun commands work without ps-related errors
- [ ] Test that bun install completes successfully
- [ ] Verify no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)