### PR TITLE
feat(helm): Remove readiness probe from StatefulSet

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -88,10 +88,6 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe }}
-          readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
-          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.volumes }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -126,15 +126,6 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 3
 
-readinessProbe:
-  httpGet:
-    path: /health
-    port: http
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  timeoutSeconds: 3
-  failureThreshold: 3
-
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## Summary
- Remove readiness probe configuration from Helm chart StatefulSet
- Clean up readiness probe settings from values.yaml

## Changes
- Removed readiness probe section from `helm/agentapi-proxy/templates/statefulset.yaml`
- Removed readiness probe configuration from `helm/agentapi-proxy/values.yaml`

## Test plan
- [x] Helm lint passes successfully
- [x] Verify StatefulSet template renders without readiness probe
- [ ] Deploy to test environment and confirm pods start correctly without readiness checks

🤖 Generated with [Claude Code](https://claude.ai/code)