### PR TITLE
fix(helm): Make volumeMount conditional based on persistence.enabled

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -79,8 +79,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /home/agentapi
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Summary
- Added conditional check for volumeMount in StatefulSet template
- volumeMount for data volume is now only included when `persistence.enabled` is true
- volumeClaimTemplates already had the conditional check, so no changes were needed there

## Test plan
- [x] Verified Helm template renders correctly with `persistence.enabled=false`
- [x] Helm lint passes without errors
- [x] Confirmed volumeMount is excluded when persistence is disabled

🤖 Generated with [Claude Code](https://claude.ai/code)