### PR TITLE
fix: Make init_github_repo exit with status 1 when clone fails

### DIFF
--- a/cmd/init_github_repo.go
+++ b/cmd/init_github_repo.go
@@ -142,7 +142,8 @@ func runInitGitHubRepo(cmd *cobra.Command, args []string) error {
 
 	// Setup repository
 	if err := setupRepository(repoURL, token, cloneDir); err != nil {
-		return fmt.Errorf("failed to setup repository: %w", err)
+		fmt.Fprintf(os.Stderr, "failed to setup repository: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Setup MCP integration


### PR DESCRIPTION
## Summary
- Modified `init_github_repo` function to exit with status 1 when repository clone fails
- Changed error handling in `setupRepository` call to print error to stderr and call `os.Exit(1)`
- Ensures proper script termination with non-zero exit code when git operations fail

## Test plan
- [x] Code compiles without errors
- [x] Tests pass
- [ ] Manual testing with failing clone scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)