### PR TITLE
feat: Preserve CLAUDE.md when mounting .claude directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,11 +80,16 @@ RUN mise global node@latest
 # Install claude code via npm
 RUN mise exec -- npm install -g @anthropic-ai/claude-code
 
-# Copy CLAUDE.md to user's home directory
-COPY --chown=agentapi:agentapi config/CLAUDE.md /home/agentapi/.claude/CLAUDE.md
+# Copy CLAUDE.md to temporary location for entrypoint script
+COPY --chown=agentapi:agentapi config/CLAUDE.md /tmp/config/CLAUDE.md
+
+# Copy entrypoint script
+COPY --chown=agentapi:agentapi scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Expose port
 EXPOSE 8080
 
-# Run the application
+# Run the application with entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["mise", "exec", "--", "agentapi-proxy", "server"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Create .claude directory if it doesn't exist
+mkdir -p /home/agentapi/.claude
+
+# Copy CLAUDE.md if it doesn't exist or if it's older than the source
+if [ ! -f /home/agentapi/.claude/CLAUDE.md ] || [ /tmp/config/CLAUDE.md -nt /home/agentapi/.claude/CLAUDE.md ]; then
+    echo "Copying CLAUDE.md to .claude directory..."
+    cp /tmp/config/CLAUDE.md /home/agentapi/.claude/CLAUDE.md
+    echo "CLAUDE.md copied successfully"
+fi
+
+# Execute the original command
+exec "$@"


### PR DESCRIPTION
## Summary
- Add entrypoint script to handle CLAUDE.md copying at container startup
- Ensure CLAUDE.md is available even when .claude directory is mounted
- Fix issue where mounting .claude directory would overwrite CLAUDE.md

## Changes
- Created `scripts/entrypoint.sh` that copies CLAUDE.md if missing or outdated
- Modified Dockerfile to use entrypoint script
- CLAUDE.md is now stored in `/tmp/config/` and copied to `.claude/` at startup

## Test plan
- [ ] Build Docker image with changes
- [ ] Test container startup without .claude mount (should work as before)
- [ ] Test container startup with .claude mount (CLAUDE.md should be preserved)
- [ ] Verify CLAUDE.md content is correct after mount

🤖 Generated with [Claude Code](https://claude.ai/code)