### PR TITLE
Revert PR #125: Remove error handling strictness from GitHub repo initialization

### DIFF
--- a/pkg/proxy/scripts/agentapi_default.sh
+++ b/pkg/proxy/scripts/agentapi_default.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # AgentAPI startup script with GitHub integration
 # This script is executed when the github_repo parameter is present
@@ -18,7 +18,7 @@ export GITHUB_PERSONAL_ACCESS_TOKEN="{{.GitHubPersonalAccessToken}}"
 
 # Set up GitHub repository if parameters are provided
 if [[ -n "$GITHUB_REPO_FULLNAME" && -n "$GITHUB_CLONE_DIR" ]]; then
-    if ! agentapi-proxy helpers init-github-repository --repo-fullname "$GITHUB_REPO_FULLNAME" --clone-dir "$GITHUB_CLONE_DIR"; then
+    if ! agentapi-proxy helpers init-github-repository --ignore-missing-config --repo-fullname "$GITHUB_REPO_FULLNAME" --clone-dir "$GITHUB_CLONE_DIR"; then
         echo "Failed to initialize GitHub repository" >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Reverts changes from PR #125 that added strict error handling to the GitHub repository initialization script
- Removes the `-e` flag from the shebang line in `agentapi_default.sh`
- Restores the `--ignore-missing-config` flag to the `agentapi-proxy helpers init-github-repository` command

## Changes
- **Script behavior**: Script now continues execution even if individual commands fail (original behavior)
- **Configuration handling**: Missing configuration is ignored during GitHub repository initialization (original behavior)

## Reasoning
This revert restores the original, more permissive behavior of the GitHub repository initialization script, allowing the system to continue operating even when some configuration elements are missing or commands fail.

## Test plan
- [x] All existing tests pass
- [x] Script reverted to original behavior
- [x] No lint errors introduced

🤖 Generated with [Claude Code](https://claude.ai/code)