### PR TITLE
feat: Add multi-architecture Docker build workflow

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -63,7 +63,7 @@ jobs:
             AGENTAPI_VERSION=v0.2.1
 
   build-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -74,9 +74,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -101,7 +98,7 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       
-      - name: Build and push ARM64 image
+      - name: Build and push ARM64 image (native)
         id: build
         uses: docker/build-push-action@v5
         with:
@@ -110,62 +107,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=arm64
-          cache-to: type=gha,mode=max,scope=arm64
+          cache-from: type=gha,scope=arm64-native
+          cache-to: type=gha,mode=max,scope=arm64-native
           build-args: |
             AGENTAPI_VERSION=v0.2.1
-
-  # GitHub Actions doesn't have native ARM64 runners yet
-  # If you have access to self-hosted ARM64 runners, uncomment and use this job instead
-  # build-arm64-native:
-  #   runs-on: [self-hosted, linux, arm64]
-  #   permissions:
-  #     contents: read
-  #     packages: write
-  #   outputs:
-  #     digest: ${{ steps.build.outputs.digest }}
-  #     metadata: ${{ steps.meta.outputs.json }}
-  #   
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #     
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
-  #     
-  #     - name: Log in to the Container registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-  #     
-  #     - name: Extract metadata
-  #       id: meta
-  #       uses: docker/metadata-action@v5
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-  #         tags: |
-  #           type=ref,event=branch
-  #           type=ref,event=pr
-  #           type=semver,pattern={{version}}
-  #           type=semver,pattern={{major}}.{{minor}}
-  #           type=semver,pattern={{major}}
-  #           type=sha
-  #     
-  #     - name: Build and push ARM64 image (native)
-  #       id: build
-  #       uses: docker/build-push-action@v5
-  #       with:
-  #         context: .
-  #         platforms: linux/arm64
-  #         push: true
-  #         tags: ${{ steps.meta.outputs.tags }}-arm64
-  #         labels: ${{ steps.meta.outputs.labels }}
-  #         cache-from: type=gha,scope=arm64-native
-  #         cache-to: type=gha,mode=max,scope=arm64-native
-  #         build-args: |
-  #           AGENTAPI_VERSION=v0.2.1
 
   merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -1,0 +1,214 @@
+name: Multi-Architecture Docker Build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-amd64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      metadata: ${{ steps.meta.outputs.json }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      
+      - name: Build and push AMD64 image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
+          build-args: |
+            AGENTAPI_VERSION=v0.2.1
+
+  build-arm64:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      metadata: ${{ steps.meta.outputs.json }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      
+      - name: Build and push ARM64 image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+          build-args: |
+            AGENTAPI_VERSION=v0.2.1
+
+  # GitHub Actions doesn't have native ARM64 runners yet
+  # If you have access to self-hosted ARM64 runners, uncomment and use this job instead
+  # build-arm64-native:
+  #   runs-on: [self-hosted, linux, arm64]
+  #   permissions:
+  #     contents: read
+  #     packages: write
+  #   outputs:
+  #     digest: ${{ steps.build.outputs.digest }}
+  #     metadata: ${{ steps.meta.outputs.json }}
+  #   
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #     
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     
+  #     - name: Extract metadata
+  #       id: meta
+  #       uses: docker/metadata-action@v5
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+  #         tags: |
+  #           type=ref,event=branch
+  #           type=ref,event=pr
+  #           type=semver,pattern={{version}}
+  #           type=semver,pattern={{major}}.{{minor}}
+  #           type=semver,pattern={{major}}
+  #           type=sha
+  #     
+  #     - name: Build and push ARM64 image (native)
+  #       id: build
+  #       uses: docker/build-push-action@v5
+  #       with:
+  #         context: .
+  #         platforms: linux/arm64
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}-arm64
+  #         labels: ${{ steps.meta.outputs.labels }}
+  #         cache-from: type=gha,scope=arm64-native
+  #         cache-to: type=gha,mode=max,scope=arm64-native
+  #         build-args: |
+  #           AGENTAPI_VERSION=v0.2.1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+      
+      - name: Create and push multi-arch manifest
+        run: |
+          # Get the tags from metadata
+          TAGS="${{ steps.meta.outputs.tags }}"
+          
+          # Create manifest for each tag
+          for tag in $TAGS; do
+            echo "Creating manifest for $tag"
+            docker buildx imagetools create \
+              --tag "$tag" \
+              "$tag-amd64" \
+              "$tag-arm64"
+          done


### PR DESCRIPTION
## Summary
- Docker image buildの高速化のため、AMD64とARM64のビルドを並列化
- 各アーキテクチャで独立したGitHub Actionsキャッシュを使用
- `docker buildx imagetools create`でマルチアーキテクチャマニフェストを統合

## Changes
- `.github/workflows/docker-multiarch.yml`を追加
- AMD64とARM64を別々のジョブで並列ビルド
- 将来のself-hosted ARM64 runner対応も準備済み（コメントアウト）

## Performance Impact
- クロスコンパイルを回避することでビルド時間を大幅短縮
- 並列実行によりCI全体の実行時間を最適化

## Test plan
- [ ] 新しいワークフローがmainブランチで正常に動作すること
- [ ] 生成されるマルチアーキテクチャイメージが両方のプラットフォームで動作すること
- [ ] 既存のdocker-build.ymlとの置き換えを検討

🤖 Generated with [Claude Code](https://claude.ai/code)