### PR TITLE
feat: Add mock API server with GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: Deploy Mock API to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'public/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'public/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'
+      
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,10 +5,6 @@ on:
     branches: [ main ]
     paths:
       - 'public/**'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'public/**'
 
 permissions:
   contents: read

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,55 @@
+# AgentAPI Proxy - Mock API Server
+
+このディレクトリには、AgentAPI Proxyの動作をシミュレートするモックAPIサーバーが含まれています。
+
+## 概要
+
+このモックAPIサーバーは、実際のAgentAPI Proxyと同じエンドポイントを提供し、テストやデモンストレーション用のレスポンスを返します。
+
+## 利用可能なエンドポイント
+
+### セッション管理
+- `POST /api/start.json` - セッション作成
+- `POST /api/start-with-profile.json` - プロファイル使用セッション作成
+- `GET /api/search.json` - セッション検索
+
+### プロファイル管理
+- `POST /api/profiles/create.json` - プロファイル作成
+- `GET /api/profiles/list.json` - プロファイル一覧
+- `GET /api/profiles/detail.json` - プロファイル詳細
+- `PUT /api/profiles/update.json` - プロファイル更新
+- `DELETE /api/profiles/delete.json` - プロファイル削除
+- `POST /api/profiles/add-repository.json` - リポジトリ追加
+- `POST /api/profiles/add-template.json` - テンプレート追加
+
+### その他
+- `GET /api/sessions/example-session.json` - セッション例
+- `GET /api/error-examples.json` - エラーレスポンス例
+
+## GitHub Pages
+
+このモックAPIサーバーはGitHub Pagesでホストされ、以下のURLでアクセスできます：
+
+- メインページ: `https://takutakahashi.github.io/agentapi-proxy/`
+- APIエンドポイント: `https://takutakahashi.github.io/agentapi-proxy/api/[endpoint].json`
+
+## 使用方法
+
+```bash
+# セッション作成のレスポンス例を取得
+curl https://takutakahashi.github.io/agentapi-proxy/api/start.json
+
+# プロファイル一覧のレスポンス例を取得
+curl https://takutakahashi.github.io/agentapi-proxy/api/profiles/list.json
+```
+
+## 注意事項
+
+- これはモックサーバーであり、実際のAPIサーバーではありません
+- 実際のデータ操作は行われません
+- 認証や認可は実装されていません
+- 全てのレスポンスは静的なJSONファイルです
+
+## 実際のAPI
+
+本物のAgentAPI Proxyの使用方法については、[メインのREADME](../README.md)と[API仕様書](../docs/api.md)をご参照ください。

--- a/public/api/error-examples.json
+++ b/public/api/error-examples.json
@@ -1,0 +1,38 @@
+{
+  "error_responses": {
+    "session_not_found": {
+      "error": "Session not found",
+      "code": "SESSION_NOT_FOUND",
+      "message": "The specified session ID does not exist or has been terminated",
+      "status": 404
+    },
+    "profile_not_found": {
+      "error": "Profile not found",
+      "code": "PROFILE_NOT_FOUND", 
+      "message": "The specified profile ID does not exist or you don't have access to it",
+      "status": 404
+    },
+    "unauthorized": {
+      "error": "Unauthorized",
+      "code": "UNAUTHORIZED",
+      "message": "API key is missing or invalid",
+      "status": 401
+    },
+    "forbidden": {
+      "error": "Forbidden",
+      "code": "FORBIDDEN",
+      "message": "You don't have permission to access this resource",
+      "status": 403
+    },
+    "validation_error": {
+      "error": "Validation error",
+      "code": "VALIDATION_ERROR",
+      "message": "Request validation failed",
+      "details": {
+        "name": "Name is required",
+        "environment": "Environment must be an object"
+      },
+      "status": 400
+    }
+  }
+}

--- a/public/api/profiles/add-repository.json
+++ b/public/api/profiles/add-repository.json
@@ -1,0 +1,15 @@
+{
+  "message": "Repository added to profile successfully",
+  "repository": {
+    "id": "repo-550e8400-e29b-41d4-a716-446655440002",
+    "url": "https://github.com/example/new-project",
+    "name": "new-project",
+    "branch": "develop",
+    "last_commit": "def456abc789",
+    "metadata": {
+      "framework": "React",
+      "language": "TypeScript"
+    },
+    "added_at": "2024-01-01T12:50:00Z"
+  }
+}

--- a/public/api/profiles/add-template.json
+++ b/public/api/profiles/add-template.json
@@ -1,0 +1,15 @@
+{
+  "message": "Template added to profile successfully",
+  "template": {
+    "id": "template-550e8400-e29b-41d4-a716-446655440003",
+    "name": "バグ報告テンプレート",
+    "content": "## バグ報告\n\n**発生環境**: {{environment}}\n**再現手順**:\n1. {{step1}}\n2. {{step2}}\n\n**期待される動作**: {{expected}}\n**実際の動作**: {{actual}}",
+    "variables": ["environment", "step1", "step2", "expected", "actual"],
+    "category": "bug-report",
+    "metadata": {
+      "priority": "high",
+      "template_version": "1.0"
+    },
+    "created_at": "2024-01-01T12:55:00Z"
+  }
+}

--- a/public/api/profiles/create.json
+++ b/public/api/profiles/create.json
@@ -1,0 +1,27 @@
+{
+  "profile": {
+    "id": "profile-550e8400-e29b-41d4-a716-446655440000",
+    "user_id": "user-123",
+    "name": "開発環境プロファイル",
+    "description": "開発作業用の設定",
+    "environment": {
+      "NODE_ENV": "development",
+      "DEBUG": "true",
+      "API_BASE_URL": "https://dev-api.example.com"
+    },
+    "repository_history": [],
+    "system_prompt": "あなたは開発者のアシスタントです。コードレビューやデバッグを支援してください。",
+    "message_templates": [
+      {
+        "id": "template-550e8400-e29b-41d4-a716-446655440000",
+        "name": "コードレビュー依頼",
+        "content": "以下のコードをレビューしてください:\n\n{{code}}\n\n特に{{focus_area}}について確認をお願いします。",
+        "variables": ["code", "focus_area"],
+        "category": "review",
+        "created_at": "2024-01-01T12:00:00Z"
+      }
+    ],
+    "created_at": "2024-01-01T12:00:00Z",
+    "updated_at": "2024-01-01T12:00:00Z"
+  }
+}

--- a/public/api/profiles/delete.json
+++ b/public/api/profiles/delete.json
@@ -1,0 +1,5 @@
+{
+  "message": "Profile deleted successfully",
+  "profile_id": "profile-550e8400-e29b-41d4-a716-446655440000",
+  "deleted_at": "2024-01-01T12:45:00Z"
+}

--- a/public/api/profiles/detail.json
+++ b/public/api/profiles/detail.json
@@ -1,0 +1,54 @@
+{
+  "profile": {
+    "id": "profile-550e8400-e29b-41d4-a716-446655440000",
+    "user_id": "user-123",
+    "name": "開発環境プロファイル",
+    "description": "開発作業用の設定",
+    "environment": {
+      "NODE_ENV": "development",
+      "DEBUG": "true",
+      "API_BASE_URL": "https://dev-api.example.com",
+      "DATABASE_URL": "postgresql://localhost:5432/dev_db"
+    },
+    "repository_history": [
+      {
+        "id": "repo-550e8400-e29b-41d4-a716-446655440000",
+        "url": "https://github.com/example/project",
+        "name": "example-project",
+        "branch": "main",
+        "last_commit": "abc123def456",
+        "accessed_at": "2024-01-01T12:00:00Z"
+      },
+      {
+        "id": "repo-550e8400-e29b-41d4-a716-446655440001",
+        "url": "https://github.com/example/frontend",
+        "name": "frontend-app",
+        "branch": "develop",
+        "last_commit": "def456abc789",
+        "accessed_at": "2024-01-01T11:30:00Z"
+      }
+    ],
+    "system_prompt": "あなたは開発者のアシスタントです。コードレビューやデバッグを支援してください。常に最新のベストプラクティスを提案し、セキュリティを意識した実装を心がけてください。",
+    "message_templates": [
+      {
+        "id": "template-550e8400-e29b-41d4-a716-446655440000",
+        "name": "コードレビュー依頼",
+        "content": "以下のコードをレビューしてください:\n\n{{code}}\n\n特に{{focus_area}}について確認をお願いします。",
+        "variables": ["code", "focus_area"],
+        "category": "review",
+        "created_at": "2024-01-01T12:00:00Z"
+      },
+      {
+        "id": "template-550e8400-e29b-41d4-a716-446655440001",
+        "name": "バグ報告",
+        "content": "## バグ報告\n\n**発生環境**: {{environment}}\n**再現手順**:\n1. {{step1}}\n2. {{step2}}\n\n**期待される動作**: {{expected}}\n**実際の動作**: {{actual}}",
+        "variables": ["environment", "step1", "step2", "expected", "actual"],
+        "category": "bug-report",
+        "created_at": "2024-01-01T12:15:00Z"
+      }
+    ],
+    "created_at": "2024-01-01T12:00:00Z",
+    "updated_at": "2024-01-01T12:15:00Z",
+    "last_used_at": "2024-01-01T13:00:00Z"
+  }
+}

--- a/public/api/profiles/list.json
+++ b/public/api/profiles/list.json
@@ -1,0 +1,49 @@
+{
+  "profiles": [
+    {
+      "id": "profile-550e8400-e29b-41d4-a716-446655440000",
+      "user_id": "user-123",
+      "name": "開発環境プロファイル",
+      "description": "開発作業用の設定",
+      "environment": {
+        "NODE_ENV": "development",
+        "DEBUG": "true"
+      },
+      "repository_history": [],
+      "system_prompt": "開発者アシスタント",
+      "message_templates": [
+        {
+          "id": "template-550e8400-e29b-41d4-a716-446655440000",
+          "name": "コードレビュー依頼",
+          "category": "review"
+        }
+      ],
+      "created_at": "2024-01-01T12:00:00Z",
+      "updated_at": "2024-01-01T12:00:00Z"
+    },
+    {
+      "id": "profile-550e8400-e29b-41d4-a716-446655440001",
+      "user_id": "user-123",
+      "name": "本番環境プロファイル",
+      "description": "本番作業用の設定",
+      "environment": {
+        "NODE_ENV": "production",
+        "DEBUG": "false",
+        "API_BASE_URL": "https://api.example.com"
+      },
+      "repository_history": [
+        {
+          "id": "repo-550e8400-e29b-41d4-a716-446655440000",
+          "url": "https://github.com/example/production-app",
+          "name": "production-app",
+          "branch": "main"
+        }
+      ],
+      "system_prompt": "本番環境での慎重な作業を支援します",
+      "message_templates": [],
+      "created_at": "2024-01-01T10:00:00Z",
+      "updated_at": "2024-01-01T11:30:00Z"
+    }
+  ],
+  "total": 2
+}

--- a/public/api/profiles/update.json
+++ b/public/api/profiles/update.json
@@ -1,0 +1,38 @@
+{
+  "profile": {
+    "id": "profile-550e8400-e29b-41d4-a716-446655440000",
+    "user_id": "user-123",
+    "name": "更新された開発環境プロファイル",
+    "description": "開発作業用の設定（更新済み）",
+    "environment": {
+      "NODE_ENV": "development",
+      "DEBUG": "true",
+      "API_BASE_URL": "https://dev-api.example.com",
+      "NEW_VAR": "new_value",
+      "UPDATED_VAR": "updated_value"
+    },
+    "repository_history": [
+      {
+        "id": "repo-550e8400-e29b-41d4-a716-446655440000",
+        "url": "https://github.com/example/project",
+        "name": "example-project",
+        "branch": "main",
+        "last_commit": "abc123def456",
+        "accessed_at": "2024-01-01T12:00:00Z"
+      }
+    ],
+    "system_prompt": "更新されたシステムプロンプト - あなたは経験豊富な開発者のアシスタントです。",
+    "message_templates": [
+      {
+        "id": "template-550e8400-e29b-41d4-a716-446655440000",
+        "name": "コードレビュー依頼",
+        "content": "以下のコードをレビューしてください:\n\n{{code}}\n\n特に{{focus_area}}について確認をお願いします。",
+        "variables": ["code", "focus_area"],
+        "category": "review",
+        "created_at": "2024-01-01T12:00:00Z"
+      }
+    ],
+    "created_at": "2024-01-01T12:00:00Z",
+    "updated_at": "2024-01-01T12:30:00Z"
+  }
+}

--- a/public/api/search.json
+++ b/public/api/search.json
@@ -1,0 +1,47 @@
+{
+  "sessions": [
+    {
+      "session_id": "550e8400-e29b-41d4-a716-446655440000",
+      "user_id": "user-123",
+      "status": "active",
+      "started_at": "2024-01-01T12:00:00Z",
+      "port": 9000,
+      "tags": {
+        "repository": "agentapi-proxy",
+        "branch": "main",
+        "env": "production"
+      }
+    },
+    {
+      "session_id": "550e8400-e29b-41d4-a716-446655440001",
+      "user_id": "user-123",
+      "status": "active",
+      "started_at": "2024-01-01T12:05:00Z",
+      "port": 9001,
+      "tags": {
+        "repository": "another-repo",
+        "branch": "develop",
+        "env": "development"
+      }
+    },
+    {
+      "session_id": "550e8400-e29b-41d4-a716-446655440002",
+      "user_id": "user-456",
+      "status": "inactive",
+      "started_at": "2024-01-01T11:30:00Z",
+      "ended_at": "2024-01-01T11:45:00Z",
+      "port": 9002,
+      "tags": {
+        "repository": "test-repo",
+        "branch": "feature/test",
+        "env": "testing"
+      }
+    }
+  ],
+  "total": 3,
+  "filters_applied": {
+    "user_id": "user-123",
+    "status": null,
+    "tags": {}
+  }
+}

--- a/public/api/sessions/example-session.json
+++ b/public/api/sessions/example-session.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "active",
+  "agentapi_url": "http://localhost:9000",
+  "message": "This endpoint would normally proxy to the actual agentapi server",
+  "note": "In a real implementation, this would forward requests to the agentapi server running on the specified port"
+}

--- a/public/api/start-with-profile.json
+++ b/public/api/start-with-profile.json
@@ -1,0 +1,8 @@
+{
+  "session_id": "550e8400-e29b-41d4-a716-446655440001",
+  "message": "Session created successfully with profile",
+  "profile_id": "profile-uuid-here",
+  "port": 9001,
+  "started_at": "2024-01-01T12:05:00Z",
+  "status": "active"
+}

--- a/public/api/start.json
+++ b/public/api/start.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "message": "Session created successfully",
+  "port": 9000,
+  "started_at": "2024-01-01T12:00:00Z",
+  "status": "active"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AgentAPI Proxy - Mock API</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #fafafa;
+        }
+        .container {
+            background: white;
+            border-radius: 8px;
+            padding: 30px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            border-bottom: 3px solid #007acc;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #555;
+            margin-top: 30px;
+        }
+        .endpoint {
+            background: #f8f9fa;
+            border-left: 4px solid #007acc;
+            padding: 15px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .method {
+            font-weight: bold;
+            color: #007acc;
+        }
+        .url {
+            font-family: 'Monaco', 'Consolas', monospace;
+            background: #e9ecef;
+            padding: 2px 6px;
+            border-radius: 3px;
+        }
+        .description {
+            margin-top: 8px;
+            color: #666;
+        }
+        a {
+            color: #007acc;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .note {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            padding: 15px;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🤖 AgentAPI Proxy - Mock API Server</h1>
+        
+        <div class="note">
+            <strong>注意:</strong> これはモックAPIサーバーです。実際のagentapi-proxyの動作をシミュレートしています。
+        </div>
+
+        <h2>📝 利用可能なエンドポイント</h2>
+
+        <h3>セッション管理</h3>
+        
+        <div class="endpoint">
+            <div class="method">POST</div>
+            <div class="url"><a href="./api/start.json">/start</a></div>
+            <div class="description">新しいセッションを作成します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">POST</div>
+            <div class="url"><a href="./api/start-with-profile.json">/start-with-profile</a></div>
+            <div class="description">プロファイルを使用して新しいセッションを作成します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">GET</div>
+            <div class="url"><a href="./api/search.json">/search</a></div>
+            <div class="description">既存のセッション一覧を検索・取得します</div>
+        </div>
+
+        <h3>プロファイル管理</h3>
+
+        <div class="endpoint">
+            <div class="method">POST</div>
+            <div class="url"><a href="./api/profiles/create.json">/profiles</a></div>
+            <div class="description">新しいプロファイルを作成します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">GET</div>
+            <div class="url"><a href="./api/profiles/list.json">/profiles</a></div>
+            <div class="description">プロファイル一覧を取得します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">GET</div>
+            <div class="url"><a href="./api/profiles/detail.json">/profiles/:profileId</a></div>
+            <div class="description">特定のプロファイルの詳細を取得します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">PUT</div>
+            <div class="url"><a href="./api/profiles/update.json">/profiles/:profileId</a></div>
+            <div class="description">既存のプロファイルを更新します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">DELETE</div>
+            <div class="url"><a href="./api/profiles/delete.json">/profiles/:profileId</a></div>
+            <div class="description">プロファイルを削除します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">POST</div>
+            <div class="url"><a href="./api/profiles/add-repository.json">/profiles/:profileId/repositories</a></div>
+            <div class="description">プロファイルにリポジトリエントリを追加します</div>
+        </div>
+
+        <div class="endpoint">
+            <div class="method">POST</div>
+            <div class="url"><a href="./api/profiles/add-template.json">/profiles/:profileId/templates</a></div>
+            <div class="description">プロファイルにメッセージテンプレートを追加します</div>
+        </div>
+
+        <h2>📚 ドキュメント</h2>
+        <p>詳細なAPI仕様については、<a href="https://github.com/takutakahashi/agentapi-proxy/blob/main/docs/api.md">API仕様書</a>をご参照ください。</p>
+
+        <h2>🔗 関連リンク</h2>
+        <ul>
+            <li><a href="https://github.com/takutakahashi/agentapi-proxy">GitHub Repository</a></li>
+            <li><a href="https://github.com/coder/agentapi">AgentAPI (Backend)</a></li>
+        </ul>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create comprehensive mock HTTP responses for all AgentAPI Proxy endpoints
- Add GitHub Pages deployment workflow for hosting mock API
- Include session management endpoints (start, search, profile-based sessions)
- Include profile management endpoints (CRUD operations, repositories, templates)
- Add interactive HTML interface for exploring mock API responses

## Files Added
- `public/index.html` - Interactive web interface for the mock API
- `public/api/*.json` - Mock response files for all endpoints
- `public/README.md` - Documentation for the mock API
- `.github/workflows/pages.yml` - GitHub Pages deployment workflow

## Features
- **Session Management**: Mock responses for session creation, search, and routing
- **Profile Management**: Complete CRUD operations for user profiles
- **GitHub Pages**: Automated deployment workflow
- **Interactive Interface**: HTML page for exploring all available endpoints
- **Error Examples**: Sample error responses for common scenarios

## Test plan
- [x] Create mock responses for all documented API endpoints
- [x] Set up GitHub Pages deployment workflow
- [x] Verify all JSON responses are valid
- [x] Test HTML interface functionality
- [ ] Verify GitHub Pages deployment works after merge

🤖 Generated with [Claude Code](https://claude.ai/code)