### PR TITLE
fix: Netlifyビルドエラーの修正

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,6 @@
 [build]
+  # No build command needed for static files and functions
+  command = ""
   publish = "public"
   functions = "netlify/functions"
 

--- a/public/README.md
+++ b/public/README.md
@@ -32,7 +32,7 @@
 
 1. このリポジトリをNetlifyにデプロイ
 2. Build settingsで以下を設定:
-   - Build command: `npm run build` (または空欄)
+   - Build command: (空欄のまま)
    - Publish directory: `public`
    - Functions directory: `netlify/functions`
 


### PR DESCRIPTION
## 概要
Netlifyデプロイ時の`npm run build`エラーを修正します。

## 問題
- Netlifyがデフォルトで`npm run build`を実行しようとするが、package.jsonが存在しない
- 静的ファイルとFunctionsのみなのでビルドステップは不要

## 修正内容
- netlify.tomlに`command = ""`を明示的に設定
- ドキュメントを更新してビルドコマンドは空欄にするよう明記

## 確認事項
- [ ] Netlifyデプロイが成功すること
- [ ] ビルドエラーが発生しないこと

🤖 Generated with [Claude Code](https://claude.ai/code)