### PR TITLE
feat: DockerfileにPlaywright MCPと軽量ブラウザを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,23 @@ RUN set -ex && \
 FROM debian:bookworm-slim
 
 # Install ca-certificates, curl, and bash for mise installation, plus GitHub CLI and make
-RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc make procps && \
+# Also install dependencies for Chromium browser
+RUN apt-get update && apt-get install -y ca-certificates curl bash git python3 gcc make procps \
+    # Chromium and its dependencies
+    chromium \
+    chromium-driver \
+    # Additional dependencies for headless browser operation
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libatspi2.0-0 \
+    libxshmfence1 && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
@@ -79,6 +95,14 @@ RUN mise global node@latest
 
 # Install claude code via npm
 RUN mise exec -- npm install -g @anthropic-ai/claude-code
+
+# Install Playwright MCP server
+RUN mise exec -- npm install -g @modelcontextprotocol/server-playwright
+
+# Setup Chromium for Playwright
+ENV CHROME_BIN=/usr/bin/chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # Copy CLAUDE.md to temporary location for entrypoint script
 COPY --chown=agentapi:agentapi config/CLAUDE.md /tmp/config/CLAUDE.md


### PR DESCRIPTION
## 概要
DockerfileにPlaywright MCPサーバーと軽量ブラウザ（Chromium）を標準搭載しました。

## 変更内容
- Chromiumブラウザとドライバーのインストール
- ヘッドレスブラウザ動作に必要な依存関係（libnss3、libgbm1など）の追加
- `@modelcontextprotocol/server-playwright` をnpmでインストール
- Playwrightがシステムにインストールされたブラウザを使用するための環境変数設定

## テスト計画
- [x] 既存のテストスイートが正常に動作することを確認
- [x] Dockerイメージのビルドが成功することを確認
- [ ] Playwright MCPサーバーが正常に起動することを確認（CI/CDでの確認）

🤖 Generated with [Claude Code](https://claude.ai/code)