### PR TITLE
fix: playwright mcp の URL を @playwright/mcp@latest に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN mise global node@latest
 RUN mise exec -- npm install -g @anthropic-ai/claude-code
 
 # Install Playwright MCP server
-RUN mise exec -- npm install -g @modelcontextprotocol/server-playwright
+RUN mise exec -- npm install -g @playwright/mcp@latest
 
 # Setup Lightpanda Browser
 ENV LIGHTPANDA_BIN=/usr/local/bin/lightpanda


### PR DESCRIPTION
## 概要
Dockerfile で playwright mcp サーバーのパッケージ名を正しい URL に修正しました。

## 変更内容
- `@modelcontextprotocol/server-playwright` → `@playwright/mcp@latest`

## テスト計画
- [ ] Docker イメージのビルドが成功することを確認
- [ ] playwright mcp サーバーが正常にインストールされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)