### PR TITLE
feat: GET /:session_id/messages エンドポイントのモック実装を追加

### DIFF
--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -203,6 +203,66 @@ const handleProfileEndpoint = (path, method) => {
 // Handle session-specific endpoints
 const handleSessionEndpoint = (path, method) => {
   const sessionMatch = path.match(/^\/sessions?\/([^\/]+)/);
+  const messagesMatch = path.match(/^\/([^\/]+)\/messages$/);
+  
+  if (messagesMatch && method === 'GET') {
+    const sessionId = messagesMatch[1];
+    return {
+      session_id: sessionId,
+      messages: [
+        {
+          id: "msg-550e8400-e29b-41d4-a716-446655440000",
+          session_id: sessionId,
+          role: "user",
+          content: "こんにちは、今日のタスクについて相談したいです。",
+          timestamp: "2024-01-01T12:00:00Z",
+          metadata: {
+            type: "text",
+            source: "web"
+          }
+        },
+        {
+          id: "msg-550e8400-e29b-41d4-a716-446655440001",
+          session_id: sessionId,
+          role: "assistant",
+          content: "こんにちは！喜んでお手伝いします。どのようなタスクについてご相談でしょうか？",
+          timestamp: "2024-01-01T12:00:30Z",
+          metadata: {
+            type: "text",
+            model: "claude-3.5-sonnet"
+          }
+        },
+        {
+          id: "msg-550e8400-e29b-41d4-a716-446655440002",
+          session_id: sessionId,
+          role: "user",
+          content: "プロジェクトのコードレビューをお願いします。",
+          timestamp: "2024-01-01T12:01:00Z",
+          metadata: {
+            type: "text",
+            source: "web"
+          }
+        },
+        {
+          id: "msg-550e8400-e29b-41d4-a716-446655440003",
+          session_id: sessionId,
+          role: "assistant",
+          content: "承知しました。コードレビューを実施いたします。対象のファイルを共有していただけますか？",
+          timestamp: "2024-01-01T12:01:15Z",
+          metadata: {
+            type: "text",
+            model: "claude-3.5-sonnet",
+            tools_used: ["code_analysis"]
+          }
+        }
+      ],
+      total: 4,
+      page: 1,
+      per_page: 50,
+      has_more: false
+    };
+  }
+  
   if (sessionMatch) {
     const sessionId = sessionMatch[1];
     return {


### PR DESCRIPTION
## 概要

`GET /:session_id/messages` エンドポイントのモック実装を追加しました。

## 主な変更点

- **セッションIDベースのメッセージ取得**: URLパラメータからセッションIDを動的に取得
- **日本語会話のサンプルデータ**: 実際の利用場面を想定したメッセージ履歴を提供
- **完全なレスポンス形式**: ページネーション情報やmetadataを含む構造化されたレスポンス
- **役割ベースの会話**: user/assistantの役割を明確に分けたメッセージ構造

## 実装詳細

- `/([^\/]+)/messages$` の正規表現パターンでセッションIDを取得
- 4つのメッセージ（ユーザー2件、アシスタント2件）を含むサンプルデータ
- timestamp、metadata（type、source、model、tools_used）などの詳細情報を含む
- ページネーション情報（total: 4, page: 1, per_page: 50, has_more: false）を提供

## テスト計画

- [x] 既存のモック実装との統合確認
- [x] URLパターンマッチングの動作確認
- [x] レスポンス形式の妥当性検証

🤖 Generated with [Claude Code](https://claude.ai/code)