### PR TITLE
GitHub OAuth 認証フローの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ agentapi-proxy supports flexible authentication mechanisms:
 For detailed setup instructions:
 - [GitHub Token Authentication](docs/github-authentication.md)
 - [GitHub OAuth Flow](docs/github-oauth.md)
+- [GitHub OAuth Quick Start](docs/github-oauth-quickstart.md)
 - [RBAC Configuration](docs/rbac.md)
+
+### Try the OAuth Demo
+Check out the [OAuth Demo Application](examples/oauth-demo/) to see GitHub OAuth in action.
 
 ## Client Library
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,60 @@ curl http://localhost:8080/550e8400-e29b-41d4-a716-446655440000/api/workspaces
 
 For detailed API documentation, see [docs/api.md](docs/api.md).
 
+## Authentication
+
+agentapi-proxy supports flexible authentication mechanisms:
+
+- **Static API Keys**: Pre-configured API keys with role-based permissions
+- **GitHub Token Authentication**: Authenticate users via GitHub personal access tokens
+- **GitHub OAuth Flow**: Full OAuth2 flow for web applications
+- **Hybrid Mode**: Combine multiple authentication methods
+
+### Quick Start
+
+#### Static API Keys
+```json
+{
+  "auth": {
+    "enabled": true,
+    "static": {
+      "enabled": true,
+      "header_name": "X-API-Key",
+      "api_keys": [
+        {
+          "key": "your-api-key",
+          "user_id": "alice",
+          "role": "admin",
+          "permissions": ["*"]
+        }
+      ]
+    }
+  }
+}
+```
+
+#### GitHub OAuth Setup
+```json
+{
+  "auth": {
+    "enabled": true,
+    "github": {
+      "enabled": true,
+      "oauth": {
+        "client_id": "${GITHUB_CLIENT_ID}",
+        "client_secret": "${GITHUB_CLIENT_SECRET}",
+        "scope": "read:user read:org"
+      }
+    }
+  }
+}
+```
+
+For detailed setup instructions:
+- [GitHub Token Authentication](docs/github-authentication.md)
+- [GitHub OAuth Flow](docs/github-oauth.md)
+- [RBAC Configuration](docs/rbac.md)
+
 ## Client Library
 
 Use the Go client library for programmatic access:

--- a/config.oauth.example.json
+++ b/config.oauth.example.json
@@ -1,0 +1,43 @@
+{
+  "start_port": 9000,
+  "auth": {
+    "enabled": true,
+    "github": {
+      "enabled": true,
+      "base_url": "https://api.github.com",
+      "token_header": "Authorization",
+      "oauth": {
+        "client_id": "${GITHUB_CLIENT_ID}",
+        "client_secret": "${GITHUB_CLIENT_SECRET}",
+        "scope": "read:user read:org",
+        "base_url": "https://github.com"
+      },
+      "user_mapping": {
+        "default_role": "user",
+        "default_permissions": ["read", "session:create", "session:list"],
+        "team_role_mapping": {
+          "myorg/admins": {
+            "role": "admin",
+            "permissions": ["*"]
+          },
+          "myorg/developers": {
+            "role": "developer",
+            "permissions": ["read", "write", "execute", "session:create", "session:list", "session:delete", "session:access"]
+          },
+          "myorg/viewers": {
+            "role": "viewer",
+            "permissions": ["read", "session:list"]
+          }
+        }
+      }
+    }
+  },
+  "persistence": {
+    "enabled": true,
+    "backend": "file",
+    "file_path": "./sessions.json",
+    "sync_interval_seconds": 30,
+    "encrypt_sensitive_data": true,
+    "session_recovery_max_age_hours": 24
+  }
+}

--- a/docs/github-oauth-quickstart.md
+++ b/docs/github-oauth-quickstart.md
@@ -1,0 +1,519 @@
+# GitHub OAuth認証 クイックスタートガイド
+
+このガイドでは、agentapi-proxyでGitHub OAuth認証を素早くセットアップして使用する方法を説明します。
+
+## 目次
+
+1. [5分でセットアップ](#5分でセットアップ)
+2. [動作確認](#動作確認)
+3. [フロントエンド実装例](#フロントエンド実装例)
+4. [トラブルシューティング](#トラブルシューティング)
+
+## 5分でセットアップ
+
+### ステップ1: GitHub OAuth Appを作成
+
+1. GitHubにログインして [Settings > Developer settings > OAuth Apps](https://github.com/settings/developers) にアクセス
+2. **New OAuth App** をクリック
+3. 以下の情報を入力：
+   ```
+   Application name: AgentAPI Proxy Dev
+   Homepage URL: http://localhost:8080
+   Authorization callback URL: http://localhost:3000/callback
+   ```
+4. **Register application** をクリック
+5. Client IDをコピー
+6. **Generate a new client secret** をクリックしてClient Secretを生成・コピー
+
+### ステップ2: 環境変数を設定
+
+```bash
+# .envファイルを作成
+cat > .env << EOF
+GITHUB_CLIENT_ID=your_client_id_here
+GITHUB_CLIENT_SECRET=your_client_secret_here
+EOF
+
+# 環境変数をエクスポート
+export $(cat .env | xargs)
+```
+
+### ステップ3: 設定ファイルを作成
+
+```bash
+# config.oauth.example.jsonをコピー
+cp config.oauth.example.json config.json
+
+# 環境変数を使用するように設定されているか確認
+cat config.json | grep -E "(GITHUB_CLIENT_ID|GITHUB_CLIENT_SECRET)"
+```
+
+### ステップ4: プロキシサーバーを起動
+
+```bash
+# Dockerを使用する場合
+docker run -p 8080:8080 \
+  -e GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID \
+  -e GITHUB_CLIENT_SECRET=$GITHUB_CLIENT_SECRET \
+  -v $(pwd)/config.json:/app/config.json \
+  ghcr.io/takutakahashi/agentapi-proxy:latest server
+
+# または、ビルド済みバイナリを使用
+./bin/agentapi-proxy server --config config.json --port 8080
+```
+
+## 動作確認
+
+### 1. 認証フローのテスト（curlを使用）
+
+```bash
+# 1. 認証URLを取得
+curl -X POST http://localhost:8080/oauth/authorize \
+  -H "Content-Type: application/json" \
+  -d '{"redirect_uri": "http://localhost:3000/callback"}' \
+  | jq
+
+# レスポンス例:
+# {
+#   "auth_url": "https://github.com/login/oauth/authorize?client_id=xxx&redirect_uri=xxx&scope=xxx&state=xxx",
+#   "state": "secure-random-state"
+# }
+```
+
+### 2. ブラウザで認証
+
+1. 上記の `auth_url` をブラウザで開く
+2. GitHubにログインしてアプリケーションを承認
+3. `http://localhost:3000/callback?code=xxx&state=xxx` にリダイレクトされる
+
+### 3. アクセストークンを取得
+
+```bash
+# コールバックのcode と state を使用
+curl "http://localhost:8080/oauth/callback?code=YOUR_CODE&state=YOUR_STATE" | jq
+
+# レスポンス例:
+# {
+#   "session_id": "550e8400-e29b-41d4-a716-446655440000",
+#   "access_token": "gho_xxxxxxxxxxxx",
+#   "token_type": "Bearer",
+#   "expires_at": "2024-01-02T00:00:00Z",
+#   "user": {
+#     "user_id": "your-github-username",
+#     "role": "developer",
+#     "permissions": ["read", "write", "session:create"]
+#   }
+# }
+```
+
+### 4. 認証されたAPIリクエスト
+
+```bash
+# セッションIDを使用してAPIにアクセス
+SESSION_ID="550e8400-e29b-41d4-a716-446655440000"
+
+# 新しいagentapiセッションを作成
+curl -X POST http://localhost:8080/start \
+  -H "X-Session-ID: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"tags": {"project": "my-app"}}'
+
+# セッション一覧を取得
+curl http://localhost:8080/search \
+  -H "X-Session-ID: $SESSION_ID"
+```
+
+## フロントエンド実装例
+
+### React/Next.jsでの実装
+
+```jsx
+// components/GitHubLogin.jsx
+import { useState, useEffect } from 'react';
+
+const PROXY_URL = process.env.NEXT_PUBLIC_PROXY_URL || 'http://localhost:8080';
+const REDIRECT_URI = `${window.location.origin}/auth/callback`;
+
+export function GitHubLogin() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    // 既存のセッションをチェック
+    const sessionId = localStorage.getItem('agentapi_session_id');
+    if (sessionId) {
+      checkSession(sessionId);
+    }
+  }, []);
+
+  async function startOAuth() {
+    try {
+      const response = await fetch(`${PROXY_URL}/oauth/authorize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ redirect_uri: REDIRECT_URI })
+      });
+      
+      const data = await response.json();
+      
+      // stateを保存（CSRF対策）
+      sessionStorage.setItem('oauth_state', data.state);
+      
+      // GitHubにリダイレクト
+      window.location.href = data.auth_url;
+    } catch (error) {
+      console.error('OAuth start failed:', error);
+    }
+  }
+
+  async function checkSession(sessionId) {
+    try {
+      // セッションの有効性を確認（セッション情報を取得）
+      const response = await fetch(`${PROXY_URL}/search`, {
+        headers: { 'X-Session-ID': sessionId }
+      });
+      
+      if (response.ok) {
+        setIsAuthenticated(true);
+        // ユーザー情報を取得する追加のAPIコールが必要な場合
+      } else {
+        // セッションが無効な場合
+        localStorage.removeItem('agentapi_session_id');
+        setIsAuthenticated(false);
+      }
+    } catch (error) {
+      console.error('Session check failed:', error);
+    }
+  }
+
+  async function logout() {
+    const sessionId = localStorage.getItem('agentapi_session_id');
+    if (!sessionId) return;
+
+    try {
+      await fetch(`${PROXY_URL}/oauth/logout`, {
+        method: 'POST',
+        headers: { 'X-Session-ID': sessionId }
+      });
+    } finally {
+      localStorage.removeItem('agentapi_session_id');
+      setIsAuthenticated(false);
+      setUser(null);
+    }
+  }
+
+  if (isAuthenticated) {
+    return (
+      <div>
+        <p>ログイン済み: {user?.user_id}</p>
+        <button onClick={logout}>ログアウト</button>
+      </div>
+    );
+  }
+
+  return (
+    <button onClick={startOAuth}>
+      GitHubでログイン
+    </button>
+  );
+}
+```
+
+```jsx
+// pages/auth/callback.jsx (Next.js) または 
+// src/routes/auth/callback.jsx (React Router)
+import { useEffect } from 'react';
+import { useRouter } from 'next/router'; // または useNavigate (React Router)
+
+const PROXY_URL = process.env.NEXT_PUBLIC_PROXY_URL || 'http://localhost:8080';
+
+export default function OAuthCallback() {
+  const router = useRouter();
+
+  useEffect(() => {
+    handleCallback();
+  }, []);
+
+  async function handleCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
+    
+    // エラーチェック
+    if (!code || !state) {
+      console.error('Missing code or state');
+      router.push('/login?error=missing_params');
+      return;
+    }
+
+    // state検証
+    const savedState = sessionStorage.getItem('oauth_state');
+    if (state !== savedState) {
+      console.error('Invalid state parameter');
+      router.push('/login?error=invalid_state');
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `${PROXY_URL}/oauth/callback?code=${code}&state=${state}`
+      );
+      
+      if (!response.ok) {
+        throw new Error('OAuth callback failed');
+      }
+
+      const data = await response.json();
+      
+      // セッション情報を保存
+      localStorage.setItem('agentapi_session_id', data.session_id);
+      localStorage.setItem('agentapi_user', JSON.stringify(data.user));
+      
+      // クリーンアップ
+      sessionStorage.removeItem('oauth_state');
+      
+      // ダッシュボードにリダイレクト
+      router.push('/dashboard');
+    } catch (error) {
+      console.error('OAuth callback error:', error);
+      router.push('/login?error=callback_failed');
+    }
+  }
+
+  return (
+    <div>
+      <p>認証処理中...</p>
+    </div>
+  );
+}
+```
+
+### APIクライアントクラス
+
+```javascript
+// lib/agentapi-client.js
+export class AgentAPIClient {
+  constructor(proxyUrl = 'http://localhost:8080') {
+    this.proxyUrl = proxyUrl;
+    this.sessionId = null;
+  }
+
+  // 保存されたセッションIDを読み込み
+  loadSession() {
+    this.sessionId = localStorage.getItem('agentapi_session_id');
+    return this.sessionId;
+  }
+
+  // 認証済みリクエストを送信
+  async request(path, options = {}) {
+    if (!this.sessionId) {
+      throw new Error('Not authenticated');
+    }
+
+    const response = await fetch(`${this.proxyUrl}${path}`, {
+      ...options,
+      headers: {
+        ...options.headers,
+        'X-Session-ID': this.sessionId,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (response.status === 401) {
+      // セッション期限切れ
+      this.clearSession();
+      throw new Error('Session expired');
+    }
+
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  // 新しいagentapiセッションを開始
+  async createSession(data = {}) {
+    return this.request('/start', {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+  }
+
+  // セッション一覧を取得
+  async listSessions(filters = {}) {
+    const params = new URLSearchParams(filters);
+    return this.request(`/search?${params}`);
+  }
+
+  // agentapiサーバーにリクエストを転送
+  async proxyRequest(sessionId, path, options = {}) {
+    return this.request(`/${sessionId}${path}`, options);
+  }
+
+  // セッションをクリア
+  clearSession() {
+    this.sessionId = null;
+    localStorage.removeItem('agentapi_session_id');
+    localStorage.removeItem('agentapi_user');
+  }
+}
+
+// 使用例
+const client = new AgentAPIClient();
+client.loadSession();
+
+try {
+  // 新しいagentapiセッションを作成
+  const session = await client.createSession({
+    tags: { project: 'my-app' },
+    environment: { DEBUG: 'true' }
+  });
+  
+  console.log('Created session:', session.session_id);
+  
+  // agentapiサーバーにリクエスト
+  const workspaces = await client.proxyRequest(
+    session.session_id,
+    '/api/workspaces'
+  );
+} catch (error) {
+  if (error.message === 'Session expired') {
+    // 再ログインが必要
+    window.location.href = '/login';
+  }
+}
+```
+
+## Docker Composeでの開発環境
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+
+services:
+  agentapi-proxy:
+    image: ghcr.io/takutakahashi/agentapi-proxy:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+    volumes:
+      - ./config.json:/app/config.json
+      - ./sessions:/app/sessions
+    command: server --config /app/config.json
+
+  # 開発用のフロントエンド
+  frontend:
+    image: node:20
+    working_dir: /app
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+    environment:
+      - NEXT_PUBLIC_PROXY_URL=http://localhost:8080
+    command: npm run dev
+```
+
+```bash
+# 起動
+docker-compose up -d
+
+# ログ確認
+docker-compose logs -f agentapi-proxy
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+#### 1. "Invalid client" エラー
+
+**原因**: Client IDまたはClient Secretが正しくない
+
+**解決方法**:
+```bash
+# 環境変数を確認
+echo $GITHUB_CLIENT_ID
+echo $GITHUB_CLIENT_SECRET
+
+# 設定ファイルを確認
+cat config.json | jq '.auth.github.oauth'
+```
+
+#### 2. "Redirect URI mismatch" エラー
+
+**原因**: GitHub OAuth Appに登録したコールバックURLと一致しない
+
+**解決方法**:
+- GitHub OAuth Appの設定でAuthorization callback URLを確認
+- リクエストで送信している`redirect_uri`が完全に一致することを確認
+
+#### 3. CORS エラー
+
+**原因**: フロントエンドのオリジンが許可されていない
+
+**解決方法**:
+```bash
+# プロキシサーバーのCORS設定を確認
+# デフォルトでは全オリジンが許可されているはず
+```
+
+#### 4. セッションが見つからない
+
+**原因**: セッションが期限切れまたは無効
+
+**解決方法**:
+```javascript
+// セッションをリフレッシュ
+async function refreshSession() {
+  const sessionId = localStorage.getItem('agentapi_session_id');
+  
+  try {
+    const response = await fetch(`${PROXY_URL}/oauth/refresh`, {
+      method: 'POST',
+      headers: { 'X-Session-ID': sessionId }
+    });
+    
+    if (!response.ok) {
+      throw new Error('Refresh failed');
+    }
+    
+    const data = await response.json();
+    console.log('Session refreshed, expires at:', data.expires_at);
+  } catch (error) {
+    // 再ログインが必要
+    window.location.href = '/login';
+  }
+}
+```
+
+### デバッグモード
+
+```bash
+# 詳細なログを有効化
+./bin/agentapi-proxy server --config config.json --verbose
+
+# または環境変数で
+DEBUG=true ./bin/agentapi-proxy server
+```
+
+### ログの確認
+
+```bash
+# OAuth関連のログを確認
+tail -f logs/*.log | grep -E "(OAuth|GitHub|authentication)"
+
+# セッション関連のログ
+tail -f logs/*.log | grep -E "(session|Session)"
+```
+
+## 次のステップ
+
+1. [セキュリティのベストプラクティス](github-oauth.md#セキュリティのベストプラクティス)を確認
+2. [チーム権限の設定](github-authentication.md#チーム組織ベースの権限設定)
+3. [本番環境へのデプロイ](../README.md#deployment)
+
+質問や問題がある場合は、[GitHubのIssue](https://github.com/takutakahashi/agentapi-proxy/issues)で報告してください。

--- a/docs/github-oauth.md
+++ b/docs/github-oauth.md
@@ -1,0 +1,398 @@
+# GitHub OAuth認証セットアップガイド
+
+このガイドでは、agentapi-proxyでGitHub OAuth認証を設定する方法を説明します。OAuth認証により、ユーザーはGitHubアカウントでログインし、APIキーを管理する必要がなくなります。
+
+## 目次
+
+1. [前提条件](#前提条件)
+2. [GitHub OAuth Appの作成](#github-oauth-appの作成)
+3. [設定ファイルの作成](#設定ファイルの作成)
+4. [環境変数の設定](#環境変数の設定)
+5. [OAuthフローの使用](#oauthフローの使用)
+6. [APIエンドポイント](#apiエンドポイント)
+7. [セキュリティのベストプラクティス](#セキュリティのベストプラクティス)
+
+## 前提条件
+
+- GitHub アカウント
+- agentapi-proxy v2.x 以降
+- HTTPS対応のコールバックURL（本番環境の場合）
+
+## GitHub OAuth Appの作成
+
+### 1. GitHub.comでOAuth Appを作成
+
+1. GitHubにログインし、**Settings** → **Developer settings** → **OAuth Apps** に移動
+2. **New OAuth App** をクリック
+3. 以下の情報を入力：
+   - **Application name**: `AgentAPI Proxy` （任意の名前）
+   - **Homepage URL**: アプリケーションのURL
+   - **Authorization callback URL**: `https://your-domain.com/oauth/callback`
+   - **Description**: （オプション）アプリケーションの説明
+4. **Register application** をクリック
+5. 生成された **Client ID** と **Client Secret** を安全に保存
+
+### 2. GitHub Enterprise Serverの場合
+
+1. GHESインスタンスの **Settings** → **Developer settings** → **OAuth Apps** に移動
+2. 上記と同様の手順でOAuth Appを作成
+
+## 設定ファイルの作成
+
+### OAuth設定を含む設定ファイル
+
+`config.json`を以下のように設定します：
+
+```json
+{
+  "start_port": 9000,
+  "auth": {
+    "enabled": true,
+    "github": {
+      "enabled": true,
+      "base_url": "https://api.github.com",
+      "token_header": "Authorization",
+      "oauth": {
+        "client_id": "${GITHUB_CLIENT_ID}",
+        "client_secret": "${GITHUB_CLIENT_SECRET}",
+        "scope": "read:user read:org",
+        "base_url": "https://github.com"
+      },
+      "user_mapping": {
+        "default_role": "user",
+        "default_permissions": ["read", "session:create", "session:list"],
+        "team_role_mapping": {
+          "myorg/admins": {
+            "role": "admin",
+            "permissions": ["*"]
+          },
+          "myorg/developers": {
+            "role": "developer",
+            "permissions": ["read", "write", "execute", "session:create", "session:list", "session:delete", "session:access"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### GitHub Enterprise Server向け設定
+
+```json
+{
+  "auth": {
+    "github": {
+      "base_url": "https://github.enterprise.com/api/v3",
+      "oauth": {
+        "base_url": "https://github.enterprise.com",
+        "client_id": "${GHES_CLIENT_ID}",
+        "client_secret": "${GHES_CLIENT_SECRET}"
+      }
+    }
+  }
+}
+```
+
+## 環境変数の設定
+
+OAuth認証に必要な環境変数を設定します：
+
+```bash
+# GitHub OAuth App credentials
+export GITHUB_CLIENT_ID="your-client-id"
+export GITHUB_CLIENT_SECRET="your-client-secret"
+
+# オプション: GitHub Enterprise Server
+export GHES_CLIENT_ID="your-ghes-client-id"
+export GHES_CLIENT_SECRET="your-ghes-client-secret"
+```
+
+## OAuthフローの使用
+
+### 1. 認証URLの生成
+
+```bash
+# OAuth認証を開始
+curl -X POST https://your-proxy.com/oauth/authorize \
+  -H "Content-Type: application/json" \
+  -d '{
+    "redirect_uri": "https://your-app.com/callback"
+  }'
+```
+
+レスポンス例：
+```json
+{
+  "auth_url": "https://github.com/login/oauth/authorize?client_id=xxx&redirect_uri=xxx&scope=xxx&state=xxx",
+  "state": "secure-random-state"
+}
+```
+
+### 2. ユーザーのリダイレクト
+
+ユーザーを`auth_url`にリダイレクトします。ユーザーはGitHubでアプリケーションを承認します。
+
+### 3. コールバックの処理
+
+GitHubがユーザーをコールバックURLにリダイレクトします：
+
+```
+https://your-app.com/callback?code=xxx&state=xxx
+```
+
+### 4. アクセストークンの取得
+
+```bash
+# コールバックパラメータでトークンを取得
+curl -X GET "https://your-proxy.com/oauth/callback?code=xxx&state=xxx"
+```
+
+レスポンス例：
+```json
+{
+  "session_id": "uuid-session-id",
+  "access_token": "gho_xxxxxxxxxxxx",
+  "token_type": "Bearer",
+  "expires_at": "2024-01-01T00:00:00Z",
+  "user": {
+    "user_id": "github-username",
+    "role": "developer",
+    "permissions": ["read", "write", "session:create"],
+    "github_user": {
+      "login": "github-username",
+      "id": 123456,
+      "email": "user@example.com"
+    }
+  }
+}
+```
+
+### 5. セッションを使用したAPIアクセス
+
+```bash
+# セッションIDを使用してAPIにアクセス
+curl -H "X-Session-ID: uuid-session-id" \
+     https://your-proxy.com/search
+
+# または Bearer tokenとして使用
+curl -H "Authorization: Bearer uuid-session-id" \
+     https://your-proxy.com/search
+```
+
+## APIエンドポイント
+
+### OAuth認証エンドポイント
+
+#### POST /oauth/authorize
+OAuth認証フローを開始します。
+
+**リクエスト:**
+```json
+{
+  "redirect_uri": "https://your-app.com/callback"
+}
+```
+
+**レスポンス:**
+```json
+{
+  "auth_url": "https://github.com/login/oauth/authorize?...",
+  "state": "secure-state-parameter"
+}
+```
+
+#### GET /oauth/callback
+GitHubからのコールバックを処理し、セッションを作成します。
+
+**パラメータ:**
+- `code`: GitHubから提供される認証コード
+- `state`: 認証リクエストで生成されたstate
+
+**レスポンス:**
+```json
+{
+  "session_id": "uuid",
+  "access_token": "gho_xxx",
+  "token_type": "Bearer",
+  "expires_at": "2024-01-01T00:00:00Z",
+  "user": {...}
+}
+```
+
+#### POST /oauth/logout
+セッションをログアウトし、GitHubトークンを無効化します。
+
+**ヘッダー:**
+- `X-Session-ID: uuid` または
+- `Authorization: Bearer uuid`
+
+**レスポンス:**
+```json
+{
+  "message": "Successfully logged out"
+}
+```
+
+#### POST /oauth/refresh
+セッションの有効期限を延長します。
+
+**ヘッダー:**
+- `X-Session-ID: uuid`
+
+**レスポンス:**
+```json
+{
+  "access_token": "gho_xxx",
+  "token_type": "Bearer",
+  "expires_at": "2024-01-02T00:00:00Z",
+  "user": {...}
+}
+```
+
+## JavaScriptでの実装例
+
+```javascript
+// OAuth認証フローの実装
+class GitHubOAuthClient {
+  constructor(proxyUrl) {
+    this.proxyUrl = proxyUrl;
+    this.sessionId = localStorage.getItem('oauth_session_id');
+  }
+
+  async startAuth(redirectUri) {
+    const response = await fetch(`${this.proxyUrl}/oauth/authorize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uri: redirectUri })
+    });
+    
+    const data = await response.json();
+    // stateを保存（CSRF対策）
+    sessionStorage.setItem('oauth_state', data.state);
+    // GitHubにリダイレクト
+    window.location.href = data.auth_url;
+  }
+
+  async handleCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
+    
+    // state検証
+    const savedState = sessionStorage.getItem('oauth_state');
+    if (state !== savedState) {
+      throw new Error('Invalid state parameter');
+    }
+    
+    const response = await fetch(
+      `${this.proxyUrl}/oauth/callback?code=${code}&state=${state}`
+    );
+    
+    const data = await response.json();
+    // セッションIDを保存
+    localStorage.setItem('oauth_session_id', data.session_id);
+    this.sessionId = data.session_id;
+    
+    return data;
+  }
+
+  async makeAuthenticatedRequest(endpoint, options = {}) {
+    if (!this.sessionId) {
+      throw new Error('Not authenticated');
+    }
+    
+    return fetch(`${this.proxyUrl}${endpoint}`, {
+      ...options,
+      headers: {
+        ...options.headers,
+        'X-Session-ID': this.sessionId
+      }
+    });
+  }
+
+  async logout() {
+    if (!this.sessionId) return;
+    
+    await fetch(`${this.proxyUrl}/oauth/logout`, {
+      method: 'POST',
+      headers: { 'X-Session-ID': this.sessionId }
+    });
+    
+    localStorage.removeItem('oauth_session_id');
+    this.sessionId = null;
+  }
+}
+
+// 使用例
+const client = new GitHubOAuthClient('https://your-proxy.com');
+
+// 認証開始
+await client.startAuth('https://your-app.com/callback');
+
+// コールバックページで
+await client.handleCallback();
+
+// 認証済みリクエスト
+const sessions = await client.makeAuthenticatedRequest('/search');
+```
+
+## セキュリティのベストプラクティス
+
+### 1. HTTPS の使用
+- 本番環境では必ずHTTPSを使用
+- コールバックURLもHTTPSを使用
+
+### 2. State パラメータの検証
+- CSRF攻撃を防ぐため、必ずstateパラメータを検証
+- stateは予測不可能なランダム値を使用
+
+### 3. クライアントシークレットの保護
+- クライアントシークレットは環境変数で管理
+- 設定ファイルに直接記述しない
+- バージョン管理システムにコミットしない
+
+### 4. スコープの最小化
+- 必要最小限のGitHubスコープのみを要求
+- `read:user`と`read:org`で十分な場合が多い
+
+### 5. セッション管理
+- セッションには適切な有効期限を設定（デフォルト24時間）
+- 定期的に期限切れセッションをクリーンアップ
+- ログアウト時はGitHubトークンも無効化
+
+### 6. エラーハンドリング
+```javascript
+try {
+  await client.handleCallback();
+} catch (error) {
+  if (error.message.includes('Invalid state')) {
+    // CSRF攻撃の可能性
+    console.error('Security error: Invalid state');
+  } else if (error.message.includes('expired')) {
+    // セッション期限切れ
+    await client.startAuth(redirectUri);
+  }
+}
+```
+
+### 7. 監査ログ
+- すべての認証イベントをログに記録
+- 異常なアクセスパターンを監視
+- 定期的にログを確認
+
+## トラブルシューティング
+
+### 認証エラー（401）
+- Client IDとClient Secretが正しいか確認
+- コールバックURLがOAuth Appの設定と一致しているか確認
+
+### CORS エラー
+- プロキシのCORS設定を確認
+- フロントエンドのオリジンが許可されているか確認
+
+### セッション期限切れ
+- `/oauth/refresh`エンドポイントを使用してセッションを更新
+- または再度認証フローを実行
+
+このガイドに従うことで、安全で使いやすいGitHub OAuth認証を実装できます。

--- a/examples/oauth-demo/README.md
+++ b/examples/oauth-demo/README.md
@@ -1,0 +1,131 @@
+# GitHub OAuth デモアプリケーション
+
+このディレクトリには、agentapi-proxyのGitHub OAuth認証を試すための簡単なデモアプリケーションが含まれています。
+
+## セットアップ
+
+### 1. GitHub OAuth Appを作成
+
+1. [GitHub Developer Settings](https://github.com/settings/developers)にアクセス
+2. "New OAuth App"をクリック
+3. 以下の情報を入力：
+   - **Application name**: AgentAPI OAuth Demo
+   - **Homepage URL**: http://localhost:3000
+   - **Authorization callback URL**: http://localhost:3000/examples/oauth-demo/index.html
+4. Client IDとClient Secretを保存
+
+### 2. 環境変数を設定
+
+```bash
+export GITHUB_CLIENT_ID=your_client_id_here
+export GITHUB_CLIENT_SECRET=your_client_secret_here
+```
+
+### 3. agentapi-proxyを起動
+
+```bash
+# プロジェクトルートから
+./bin/agentapi-proxy server --config config.oauth.example.json --port 8080
+```
+
+### 4. デモアプリケーションを開く
+
+#### 方法1: ローカルサーバーを使用
+
+```bash
+# Python 3を使用
+cd examples/oauth-demo
+python3 -m http.server 3000
+
+# またはNode.jsを使用
+npx http-server -p 3000
+```
+
+ブラウザで http://localhost:3000/index.html を開く
+
+#### 方法2: ファイルを直接開く
+
+ブラウザで `file:///path/to/agentapi-proxy/examples/oauth-demo/index.html` を開く
+
+**注意**: この場合、Authorization callback URLを`file://`プロトコルに合わせて変更する必要があります。
+
+## 使い方
+
+1. **プロキシサーバーURL**を確認（デフォルト: http://localhost:8080）
+2. **GitHubでログイン**ボタンをクリック
+3. GitHubにリダイレクトされるので、アプリケーションを承認
+4. 認証成功後、自動的にデモページに戻ります
+5. 認証済みの状態で以下が可能：
+   - 新しいAgentAPIセッションの作成
+   - アクティブなセッション一覧の表示
+   - セッショントークンの更新
+   - ログアウト
+
+## デモの機能
+
+### 認証フロー
+- OAuth認証の開始
+- GitHubコールバックの処理
+- セキュアなstate検証
+- セッション情報の保存
+
+### セッション管理
+- セッションの作成
+- セッション一覧の取得
+- セッションの更新
+- ログアウト処理
+
+### デバッグ機能
+- リアルタイムログ表示
+- エラーハンドリング
+- セッション情報の表示
+
+## トラブルシューティング
+
+### "Invalid client"エラー
+- Client IDとClient Secretが正しく設定されているか確認
+- 環境変数が正しくエクスポートされているか確認
+
+### "Redirect URI mismatch"エラー
+- GitHub OAuth Appの設定でAuthorization callback URLを確認
+- デモアプリケーションのURLと完全に一致することを確認
+
+### CORSエラー
+- agentapi-proxyが起動していることを確認
+- プロキシサーバーのURLが正しいことを確認
+
+## カスタマイズ
+
+### プロダクション環境での使用
+
+このデモコードをベースに、以下の改善を加えることを推奨：
+
+1. **セキュリティ強化**
+   - HTTPSの使用
+   - CSRFトークンの追加検証
+   - セッション情報の安全な保存
+
+2. **エラーハンドリング**
+   - ネットワークエラーの再試行
+   - より詳細なエラーメッセージ
+
+3. **UI/UX改善**
+   - ローディング状態の表示
+   - より洗練されたデザイン
+   - 多言語対応
+
+4. **機能拡張**
+   - セッションの詳細情報表示
+   - AgentAPIへのプロキシリクエスト
+   - リアルタイムステータス更新
+
+## ソースコード
+
+デモのソースコードは単一のHTMLファイル（`index.html`）に含まれています。以下の技術を使用：
+
+- バニラJavaScript（フレームワーク不使用）
+- Fetch API（HTTPリクエスト）
+- LocalStorage/SessionStorage（データ保存）
+- シンプルなCSS（スタイリング）
+
+プロダクション環境では、React、Vue、Angular等のフレームワークを使用することを推奨します。

--- a/examples/oauth-demo/index.html
+++ b/examples/oauth-demo/index.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AgentAPI Proxy - GitHub OAuth デモ</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            border-radius: 8px;
+            padding: 30px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            margin-bottom: 30px;
+        }
+        .section {
+            margin-bottom: 30px;
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 6px;
+        }
+        button {
+            background-color: #0366d6;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 6px;
+            font-size: 16px;
+            cursor: pointer;
+            margin-right: 10px;
+        }
+        button:hover {
+            background-color: #0256c7;
+        }
+        button:disabled {
+            background-color: #94a3b8;
+            cursor: not-allowed;
+        }
+        .error {
+            color: #dc2626;
+            background-color: #fee;
+            padding: 10px;
+            border-radius: 4px;
+            margin-top: 10px;
+        }
+        .success {
+            color: #059669;
+            background-color: #d1fae5;
+            padding: 10px;
+            border-radius: 4px;
+            margin-top: 10px;
+        }
+        .info {
+            background-color: #e0e7ff;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+        }
+        .code {
+            font-family: 'Consolas', 'Monaco', monospace;
+            background-color: #f3f4f6;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-size: 14px;
+        }
+        .hidden {
+            display: none;
+        }
+        .session-info {
+            background: #f0f9ff;
+            padding: 15px;
+            border-radius: 6px;
+            margin-top: 20px;
+        }
+        pre {
+            background: #1e293b;
+            color: #e2e8f0;
+            padding: 15px;
+            border-radius: 6px;
+            overflow-x: auto;
+            font-size: 14px;
+        }
+        input[type="text"] {
+            width: 100%;
+            padding: 8px 12px;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            font-size: 14px;
+            margin-bottom: 10px;
+        }
+        .flex {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+        .flex input {
+            flex: 1;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🔐 AgentAPI Proxy - GitHub OAuth デモ</h1>
+        
+        <div class="info">
+            <strong>使い方:</strong>
+            <ol>
+                <li>プロキシサーバーのURLを設定（デフォルト: http://localhost:8080）</li>
+                <li>「GitHubでログイン」をクリック</li>
+                <li>GitHubで認証を承認</li>
+                <li>認証後、AgentAPIセッションを作成できます</li>
+            </ol>
+        </div>
+
+        <!-- 設定セクション -->
+        <div class="section">
+            <h2>⚙️ 設定</h2>
+            <label for="proxyUrl">プロキシサーバーURL:</label>
+            <input type="text" id="proxyUrl" value="http://localhost:8080" />
+            <label for="redirectUri">リダイレクトURI（このページのURL）:</label>
+            <input type="text" id="redirectUri" value="" />
+        </div>
+
+        <!-- 認証セクション -->
+        <div class="section">
+            <h2>🔑 認証状態</h2>
+            <div id="authStatus">
+                <p>未認証</p>
+                <button onclick="startOAuth()">GitHubでログイン</button>
+            </div>
+            <div id="userInfo" class="session-info hidden"></div>
+        </div>
+
+        <!-- セッション作成セクション -->
+        <div id="sessionSection" class="section hidden">
+            <h2>🚀 AgentAPIセッション</h2>
+            <div class="flex">
+                <input type="text" id="sessionTag" placeholder="タグ（例: project-name）" />
+                <button onclick="createSession()">新規セッション作成</button>
+            </div>
+            <button onclick="listSessions()">セッション一覧</button>
+            <div id="sessionList" class="session-info hidden"></div>
+        </div>
+
+        <!-- ログセクション -->
+        <div class="section">
+            <h2>📝 ログ</h2>
+            <pre id="logs">ログがここに表示されます...</pre>
+        </div>
+    </div>
+
+    <script>
+        // グローバル変数
+        let sessionId = null;
+        let userContext = null;
+
+        // ページ読み込み時の初期化
+        window.onload = function() {
+            // リダイレクトURIを自動設定
+            const redirectUri = window.location.origin + window.location.pathname;
+            document.getElementById('redirectUri').value = redirectUri;
+
+            // URLパラメータをチェック（OAuthコールバック）
+            const params = new URLSearchParams(window.location.search);
+            if (params.has('code') && params.has('state')) {
+                handleOAuthCallback(params.get('code'), params.get('state'));
+            } else {
+                // 保存されたセッションをチェック
+                checkExistingSession();
+            }
+        };
+
+        // ログ出力
+        function log(message, type = 'info') {
+            const logs = document.getElementById('logs');
+            const timestamp = new Date().toLocaleTimeString();
+            const color = type === 'error' ? '#ef4444' : type === 'success' ? '#10b981' : '#6b7280';
+            logs.innerHTML += `<span style="color: ${color}">[${timestamp}] ${message}</span>\n`;
+            logs.scrollTop = logs.scrollHeight;
+        }
+
+        // OAuth認証開始
+        async function startOAuth() {
+            const proxyUrl = document.getElementById('proxyUrl').value;
+            const redirectUri = document.getElementById('redirectUri').value;
+
+            log('OAuth認証を開始します...');
+
+            try {
+                const response = await fetch(`${proxyUrl}/oauth/authorize`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ redirect_uri: redirectUri })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                log('認証URLを取得しました', 'success');
+                log(`State: ${data.state}`);
+
+                // stateを保存
+                sessionStorage.setItem('oauth_state', data.state);
+
+                // GitHubにリダイレクト
+                log('GitHubにリダイレクトします...');
+                window.location.href = data.auth_url;
+
+            } catch (error) {
+                log(`エラー: ${error.message}`, 'error');
+            }
+        }
+
+        // OAuthコールバック処理
+        async function handleOAuthCallback(code, state) {
+            log('OAuthコールバックを処理中...');
+
+            // state検証
+            const savedState = sessionStorage.getItem('oauth_state');
+            if (state !== savedState) {
+                log('セキュリティエラー: stateパラメータが一致しません', 'error');
+                return;
+            }
+
+            const proxyUrl = document.getElementById('proxyUrl').value;
+
+            try {
+                const response = await fetch(`${proxyUrl}/oauth/callback?code=${code}&state=${state}`);
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                log('認証成功！', 'success');
+                log(`セッションID: ${data.session_id}`);
+                log(`ユーザー: ${data.user.user_id} (${data.user.role})`);
+
+                // セッション情報を保存
+                sessionId = data.session_id;
+                userContext = data.user;
+                localStorage.setItem('agentapi_session_id', sessionId);
+                localStorage.setItem('agentapi_user', JSON.stringify(userContext));
+
+                // UIを更新
+                updateAuthUI(true);
+
+                // URLパラメータをクリア
+                window.history.replaceState({}, document.title, window.location.pathname);
+                sessionStorage.removeItem('oauth_state');
+
+            } catch (error) {
+                log(`認証エラー: ${error.message}`, 'error');
+            }
+        }
+
+        // 既存セッションをチェック
+        async function checkExistingSession() {
+            const savedSessionId = localStorage.getItem('agentapi_session_id');
+            const savedUser = localStorage.getItem('agentapi_user');
+
+            if (savedSessionId && savedUser) {
+                sessionId = savedSessionId;
+                userContext = JSON.parse(savedUser);
+
+                log('保存されたセッションを確認中...');
+
+                // セッションの有効性を確認
+                const proxyUrl = document.getElementById('proxyUrl').value;
+                try {
+                    const response = await fetch(`${proxyUrl}/search`, {
+                        headers: { 'X-Session-ID': sessionId }
+                    });
+
+                    if (response.ok) {
+                        log('セッションは有効です', 'success');
+                        updateAuthUI(true);
+                    } else {
+                        log('セッションが無効です', 'error');
+                        clearSession();
+                    }
+                } catch (error) {
+                    log(`セッション確認エラー: ${error.message}`, 'error');
+                    clearSession();
+                }
+            }
+        }
+
+        // UI更新
+        function updateAuthUI(authenticated) {
+            const authStatus = document.getElementById('authStatus');
+            const userInfo = document.getElementById('userInfo');
+            const sessionSection = document.getElementById('sessionSection');
+
+            if (authenticated && userContext) {
+                authStatus.innerHTML = `
+                    <p>✅ 認証済み</p>
+                    <button onclick="logout()">ログアウト</button>
+                    <button onclick="refreshSession()">セッション更新</button>
+                `;
+
+                userInfo.innerHTML = `
+                    <h3>ユーザー情報</h3>
+                    <p><strong>ユーザーID:</strong> ${userContext.user_id}</p>
+                    <p><strong>ロール:</strong> ${userContext.role}</p>
+                    <p><strong>権限:</strong> ${userContext.permissions.join(', ')}</p>
+                    <p><strong>セッションID:</strong> <span class="code">${sessionId}</span></p>
+                `;
+                userInfo.classList.remove('hidden');
+                sessionSection.classList.remove('hidden');
+            } else {
+                authStatus.innerHTML = `
+                    <p>未認証</p>
+                    <button onclick="startOAuth()">GitHubでログイン</button>
+                `;
+                userInfo.classList.add('hidden');
+                sessionSection.classList.add('hidden');
+            }
+        }
+
+        // ログアウト
+        async function logout() {
+            const proxyUrl = document.getElementById('proxyUrl').value;
+
+            log('ログアウト中...');
+
+            try {
+                await fetch(`${proxyUrl}/oauth/logout`, {
+                    method: 'POST',
+                    headers: { 'X-Session-ID': sessionId }
+                });
+                log('ログアウトしました', 'success');
+            } catch (error) {
+                log(`ログアウトエラー: ${error.message}`, 'error');
+            }
+
+            clearSession();
+        }
+
+        // セッション更新
+        async function refreshSession() {
+            const proxyUrl = document.getElementById('proxyUrl').value;
+
+            log('セッションを更新中...');
+
+            try {
+                const response = await fetch(`${proxyUrl}/oauth/refresh`, {
+                    method: 'POST',
+                    headers: { 'X-Session-ID': sessionId }
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                log('セッションを更新しました', 'success');
+                log(`有効期限: ${new Date(data.expires_at).toLocaleString()}`);
+
+            } catch (error) {
+                log(`セッション更新エラー: ${error.message}`, 'error');
+            }
+        }
+
+        // セッションクリア
+        function clearSession() {
+            sessionId = null;
+            userContext = null;
+            localStorage.removeItem('agentapi_session_id');
+            localStorage.removeItem('agentapi_user');
+            updateAuthUI(false);
+        }
+
+        // AgentAPIセッション作成
+        async function createSession() {
+            const proxyUrl = document.getElementById('proxyUrl').value;
+            const tag = document.getElementById('sessionTag').value;
+
+            log('AgentAPIセッションを作成中...');
+
+            try {
+                const response = await fetch(`${proxyUrl}/start`, {
+                    method: 'POST',
+                    headers: {
+                        'X-Session-ID': sessionId,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        tags: tag ? { name: tag } : {},
+                        environment: { DEBUG: 'true' }
+                    })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                log('AgentAPIセッションを作成しました', 'success');
+                log(`セッションID: ${data.session_id}`);
+
+                // タグフィールドをクリア
+                document.getElementById('sessionTag').value = '';
+
+                // セッション一覧を更新
+                await listSessions();
+
+            } catch (error) {
+                log(`セッション作成エラー: ${error.message}`, 'error');
+            }
+        }
+
+        // セッション一覧取得
+        async function listSessions() {
+            const proxyUrl = document.getElementById('proxyUrl').value;
+
+            log('セッション一覧を取得中...');
+
+            try {
+                const response = await fetch(`${proxyUrl}/search`, {
+                    headers: { 'X-Session-ID': sessionId }
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                log(`${data.sessions.length}個のセッションが見つかりました`, 'success');
+
+                // セッション一覧を表示
+                const sessionList = document.getElementById('sessionList');
+                if (data.sessions.length > 0) {
+                    sessionList.innerHTML = '<h3>アクティブなセッション</h3>';
+                    data.sessions.forEach(session => {
+                        const startTime = new Date(session.started_at).toLocaleString();
+                        const tags = session.tags ? Object.entries(session.tags).map(([k, v]) => `${k}=${v}`).join(', ') : '';
+                        sessionList.innerHTML += `
+                            <div style="margin-bottom: 10px; padding: 10px; background: #f9fafb; border-radius: 4px;">
+                                <p><strong>ID:</strong> <span class="code">${session.session_id}</span></p>
+                                <p><strong>ステータス:</strong> ${session.status}</p>
+                                <p><strong>開始時刻:</strong> ${startTime}</p>
+                                <p><strong>ポート:</strong> ${session.port}</p>
+                                ${tags ? `<p><strong>タグ:</strong> ${tags}</p>` : ''}
+                            </div>
+                        `;
+                    });
+                    sessionList.classList.remove('hidden');
+                } else {
+                    sessionList.innerHTML = '<p>アクティブなセッションはありません</p>';
+                    sessionList.classList.remove('hidden');
+                }
+
+            } catch (error) {
+                log(`セッション一覧取得エラー: ${error.message}`, 'error');
+            }
+        }
+    </script>
+</body>
+</html>

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -17,6 +17,7 @@ type UserContext struct {
 	APIKey      string
 	AuthType    string          // "api_key" or "github_oauth"
 	GitHubUser  *GitHubUserInfo // GitHub user info when using GitHub auth
+	AccessToken string          // OAuth access token (not serialized)
 }
 
 // AuthMiddleware creates authentication middleware

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -1,0 +1,214 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+// OAuthState represents a pending OAuth authentication state
+type OAuthState struct {
+	State       string    `json:"state"`
+	RedirectURI string    `json:"redirect_uri"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// OAuthTokenResponse represents the GitHub OAuth token response
+type OAuthTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+// GitHubOAuthProvider handles GitHub OAuth2 authentication flow
+type GitHubOAuthProvider struct {
+	config         *config.GitHubOAuthConfig
+	client         *http.Client
+	stateStore     map[string]*OAuthState // In production, use Redis or similar
+	githubProvider *GitHubAuthProvider
+}
+
+// NewGitHubOAuthProvider creates a new GitHub OAuth provider
+func NewGitHubOAuthProvider(cfg *config.GitHubOAuthConfig, githubCfg *config.GitHubAuthConfig) *GitHubOAuthProvider {
+	return &GitHubOAuthProvider{
+		config: cfg,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		stateStore:     make(map[string]*OAuthState),
+		githubProvider: NewGitHubAuthProvider(githubCfg),
+	}
+}
+
+// GenerateAuthURL generates the GitHub OAuth authorization URL
+func (p *GitHubOAuthProvider) GenerateAuthURL(redirectURI string) (string, string, error) {
+	// Generate secure random state
+	state, err := p.generateState()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	// Store state with expiration (15 minutes)
+	p.stateStore[state] = &OAuthState{
+		State:       state,
+		RedirectURI: redirectURI,
+		CreatedAt:   time.Now(),
+	}
+
+	// Clean up expired states
+	p.cleanupExpiredStates()
+
+	// Build authorization URL
+	params := url.Values{
+		"client_id":    {p.config.ClientID},
+		"redirect_uri": {redirectURI},
+		"scope":        {p.config.Scope},
+		"state":        {state},
+	}
+
+	authURL := fmt.Sprintf("%s/login/oauth/authorize?%s",
+		strings.TrimSuffix(p.config.BaseURL, "/"),
+		params.Encode())
+
+	return authURL, state, nil
+}
+
+// ExchangeCode exchanges the authorization code for an access token
+func (p *GitHubOAuthProvider) ExchangeCode(ctx context.Context, code, state string) (*UserContext, error) {
+	// Verify state
+	oauthState, exists := p.stateStore[state]
+	if !exists {
+		return nil, fmt.Errorf("invalid state parameter")
+	}
+
+	// Check if state is expired (15 minutes)
+	if time.Since(oauthState.CreatedAt) > 15*time.Minute {
+		delete(p.stateStore, state)
+		return nil, fmt.Errorf("state expired")
+	}
+
+	// Remove state after use
+	delete(p.stateStore, state)
+
+	// Exchange code for token
+	token, err := p.exchangeCodeForToken(ctx, code, oauthState.RedirectURI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code: %w", err)
+	}
+
+	// Use the existing GitHub provider to authenticate with the token
+	userContext, err := p.githubProvider.Authenticate(ctx, token.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to authenticate with token: %w", err)
+	}
+
+	// Add OAuth-specific metadata
+	userContext.AuthType = "github_oauth"
+	userContext.AccessToken = token.AccessToken
+
+	return userContext, nil
+}
+
+// exchangeCodeForToken exchanges authorization code for access token
+func (p *GitHubOAuthProvider) exchangeCodeForToken(ctx context.Context, code, redirectURI string) (*OAuthTokenResponse, error) {
+	tokenURL := fmt.Sprintf("%s/login/oauth/access_token",
+		strings.TrimSuffix(p.config.BaseURL, "/"))
+
+	params := url.Values{
+		"client_id":     {p.config.ClientID},
+		"client_secret": {p.config.ClientSecret},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token exchange failed with status %d", resp.StatusCode)
+	}
+
+	var tokenResp OAuthTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, err
+	}
+
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("no access token in response")
+	}
+
+	return &tokenResp, nil
+}
+
+// generateState generates a secure random state parameter
+func (p *GitHubOAuthProvider) generateState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// cleanupExpiredStates removes expired states from the store
+func (p *GitHubOAuthProvider) cleanupExpiredStates() {
+	now := time.Now()
+	for state, oauthState := range p.stateStore {
+		if now.Sub(oauthState.CreatedAt) > 15*time.Minute {
+			delete(p.stateStore, state)
+		}
+	}
+}
+
+// RevokeToken revokes a GitHub access token
+func (p *GitHubOAuthProvider) RevokeToken(ctx context.Context, token string) error {
+	revokeURL := fmt.Sprintf("%s/applications/%s/token",
+		strings.TrimSuffix(p.config.BaseURL, "/"),
+		p.config.ClientID)
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", revokeURL, nil)
+	if err != nil {
+		return err
+	}
+
+	// Use basic auth with client ID and secret
+	req.SetBasicAuth(p.config.ClientID, p.config.ClientSecret)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add the token to revoke in the body
+	body := fmt.Sprintf(`{"access_token":"%s"}`, token)
+	req.Body = io.NopCloser(strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to revoke token: status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -1,0 +1,200 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+func TestGitHubOAuthProvider_GenerateAuthURL(t *testing.T) {
+	cfg := &config.GitHubOAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Scope:        "read:user read:org",
+		BaseURL:      "https://github.com",
+	}
+
+	githubCfg := &config.GitHubAuthConfig{
+		Enabled:     true,
+		BaseURL:     "https://api.github.com",
+		TokenHeader: "Authorization",
+	}
+
+	provider := NewGitHubOAuthProvider(cfg, githubCfg)
+
+	redirectURI := "http://localhost:3000/callback"
+	authURL, state, err := provider.GenerateAuthURL(redirectURI)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, authURL)
+	assert.NotEmpty(t, state)
+	assert.Contains(t, authURL, "https://github.com/login/oauth/authorize")
+	assert.Contains(t, authURL, "client_id=test-client-id")
+	assert.Contains(t, authURL, "redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback")
+	assert.Contains(t, authURL, "scope=read%3Auser+read%3Aorg")
+	assert.Contains(t, authURL, "state="+state)
+}
+
+func TestGitHubOAuthProvider_ExchangeCode(t *testing.T) {
+	// Mock GitHub OAuth server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			// Mock token exchange response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org"}`))
+		case "/user":
+			// Mock user API response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"login":"testuser","id":123456,"email":"test@example.com","name":"Test User"}`))
+		case "/user/orgs":
+			// Mock organizations API response
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"login":"test-org","id":789}]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer mockServer.Close()
+
+	cfg := &config.GitHubOAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Scope:        "read:user read:org",
+		BaseURL:      mockServer.URL,
+	}
+
+	githubCfg := &config.GitHubAuthConfig{
+		Enabled:     true,
+		BaseURL:     mockServer.URL,
+		TokenHeader: "Authorization",
+		UserMapping: config.GitHubUserMapping{
+			DefaultRole:        "user",
+			DefaultPermissions: []string{"read"},
+			TeamRoleMapping:    map[string]config.TeamRoleRule{},
+		},
+	}
+
+	provider := NewGitHubOAuthProvider(cfg, githubCfg)
+
+	// Generate state first
+	_, state, err := provider.GenerateAuthURL("http://localhost:3000/callback")
+	assert.NoError(t, err)
+
+	// Exchange code
+	ctx := context.Background()
+	userContext, err := provider.ExchangeCode(ctx, "test-code", state)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, userContext)
+	assert.Equal(t, "testuser", userContext.UserID)
+	assert.Equal(t, "user", userContext.Role)
+	assert.Equal(t, "github_oauth", userContext.AuthType)
+	assert.Equal(t, "gho_test_token", userContext.AccessToken)
+	assert.NotNil(t, userContext.GitHubUser)
+	assert.Equal(t, "testuser", userContext.GitHubUser.Login)
+}
+
+func TestGitHubOAuthProvider_ExchangeCode_InvalidState(t *testing.T) {
+	cfg := &config.GitHubOAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Scope:        "read:user read:org",
+		BaseURL:      "https://github.com",
+	}
+
+	githubCfg := &config.GitHubAuthConfig{
+		Enabled:     true,
+		BaseURL:     "https://api.github.com",
+		TokenHeader: "Authorization",
+	}
+
+	provider := NewGitHubOAuthProvider(cfg, githubCfg)
+
+	ctx := context.Background()
+	_, err := provider.ExchangeCode(ctx, "test-code", "invalid-state")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid state parameter")
+}
+
+func TestGitHubOAuthProvider_ExchangeCode_ExpiredState(t *testing.T) {
+	cfg := &config.GitHubOAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		Scope:        "read:user read:org",
+		BaseURL:      "https://github.com",
+	}
+
+	githubCfg := &config.GitHubAuthConfig{
+		Enabled:     true,
+		BaseURL:     "https://api.github.com",
+		TokenHeader: "Authorization",
+	}
+
+	provider := NewGitHubOAuthProvider(cfg, githubCfg)
+
+	// Manually create an expired state
+	state := "expired-state"
+	provider.stateStore[state] = &OAuthState{
+		State:       state,
+		RedirectURI: "http://localhost:3000/callback",
+		CreatedAt:   time.Now().Add(-20 * time.Minute), // 20 minutes ago
+	}
+
+	ctx := context.Background()
+	_, err := provider.ExchangeCode(ctx, "test-code", state)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "state expired")
+}
+
+func TestGitHubOAuthProvider_generateState(t *testing.T) {
+	provider := &GitHubOAuthProvider{}
+
+	state1, err1 := provider.generateState()
+	state2, err2 := provider.generateState()
+
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEmpty(t, state1)
+	assert.NotEmpty(t, state2)
+	assert.NotEqual(t, state1, state2) // States should be unique
+}
+
+func TestGitHubOAuthProvider_cleanupExpiredStates(t *testing.T) {
+	provider := &GitHubOAuthProvider{
+		stateStore: make(map[string]*OAuthState),
+	}
+
+	// Add valid state
+	validState := "valid-state"
+	provider.stateStore[validState] = &OAuthState{
+		State:       validState,
+		RedirectURI: "http://localhost:3000/callback",
+		CreatedAt:   time.Now(),
+	}
+
+	// Add expired state
+	expiredState := "expired-state"
+	provider.stateStore[expiredState] = &OAuthState{
+		State:       expiredState,
+		RedirectURI: "http://localhost:3000/callback",
+		CreatedAt:   time.Now().Add(-20 * time.Minute),
+	}
+
+	// Clean up
+	provider.cleanupExpiredStates()
+
+	// Check results
+	assert.Contains(t, provider.stateStore, validState)
+	assert.NotContains(t, provider.stateStore, expiredState)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,10 +24,19 @@ type StaticAuthConfig struct {
 
 // GitHubAuthConfig represents GitHub OAuth authentication
 type GitHubAuthConfig struct {
-	Enabled     bool              `json:"enabled" mapstructure:"enabled"`
-	BaseURL     string            `json:"base_url" mapstructure:"base_url"`
-	TokenHeader string            `json:"token_header" mapstructure:"token_header"`
-	UserMapping GitHubUserMapping `json:"user_mapping" mapstructure:"user_mapping"`
+	Enabled     bool               `json:"enabled" mapstructure:"enabled"`
+	BaseURL     string             `json:"base_url" mapstructure:"base_url"`
+	TokenHeader string             `json:"token_header" mapstructure:"token_header"`
+	UserMapping GitHubUserMapping  `json:"user_mapping" mapstructure:"user_mapping"`
+	OAuth       *GitHubOAuthConfig `json:"oauth,omitempty" mapstructure:"oauth"`
+}
+
+// GitHubOAuthConfig represents GitHub OAuth2 configuration
+type GitHubOAuthConfig struct {
+	ClientID     string `json:"client_id" mapstructure:"client_id"`
+	ClientSecret string `json:"client_secret" mapstructure:"client_secret"`
+	Scope        string `json:"scope" mapstructure:"scope"`
+	BaseURL      string `json:"base_url,omitempty" mapstructure:"base_url"`
 }
 
 // GitHubUserMapping represents user role mapping configuration
@@ -120,6 +129,14 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 	if config.Auth.GitHub != nil && config.Auth.GitHub.TokenHeader == "" {
 		config.Auth.GitHub.TokenHeader = "Authorization"
+	}
+	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
+		if config.Auth.GitHub.OAuth.BaseURL == "" {
+			config.Auth.GitHub.OAuth.BaseURL = config.Auth.GitHub.BaseURL
+		}
+		if config.Auth.GitHub.OAuth.Scope == "" {
+			config.Auth.GitHub.OAuth.Scope = "read:user read:org"
+		}
 	}
 
 	// Load API keys from external file if specified

--- a/pkg/proxy/oauth_handlers.go
+++ b/pkg/proxy/oauth_handlers.go
@@ -1,0 +1,257 @@
+package proxy
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// OAuthLoginRequest represents the request body for OAuth login
+type OAuthLoginRequest struct {
+	RedirectURI string `json:"redirect_uri"`
+}
+
+// OAuthLoginResponse represents the response for OAuth login
+type OAuthLoginResponse struct {
+	AuthURL string `json:"auth_url"`
+	State   string `json:"state"`
+}
+
+// OAuthCallbackRequest represents the OAuth callback parameters
+type OAuthCallbackRequest struct {
+	Code  string `query:"code"`
+	State string `query:"state"`
+}
+
+// OAuthTokenResponse represents the response after successful OAuth
+type OAuthTokenResponse struct {
+	AccessToken string            `json:"access_token"`
+	TokenType   string            `json:"token_type"`
+	ExpiresAt   time.Time         `json:"expires_at"`
+	User        *auth.UserContext `json:"user"`
+}
+
+// OAuthSessionResponse represents the response with session information
+type OAuthSessionResponse struct {
+	SessionID   string            `json:"session_id"`
+	AccessToken string            `json:"access_token"`
+	TokenType   string            `json:"token_type"`
+	ExpiresAt   time.Time         `json:"expires_at"`
+	User        *auth.UserContext `json:"user"`
+}
+
+// handleOAuthLogin initiates the OAuth flow
+func (p *Proxy) handleOAuthLogin(c echo.Context) error {
+	var req OAuthLoginRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	// Validate redirect URI
+	if req.RedirectURI == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "redirect_uri is required")
+	}
+
+	// Validate redirect URI format
+	redirectURL, err := url.Parse(req.RedirectURI)
+	if err != nil || redirectURL.Scheme == "" || redirectURL.Host == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid redirect_uri format")
+	}
+
+	// Generate OAuth URL
+	authURL, state, err := p.oauthProvider.GenerateAuthURL(req.RedirectURI)
+	if err != nil {
+		log.Printf("Failed to generate OAuth URL: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to generate authorization URL")
+	}
+
+	return c.JSON(http.StatusOK, OAuthLoginResponse{
+		AuthURL: authURL,
+		State:   state,
+	})
+}
+
+// handleOAuthCallback handles the OAuth callback
+func (p *Proxy) handleOAuthCallback(c echo.Context) error {
+	var req OAuthCallbackRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid callback parameters")
+	}
+
+	// Validate required parameters
+	if req.Code == "" || req.State == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Missing code or state parameter")
+	}
+
+	// Exchange code for token
+	userContext, err := p.oauthProvider.ExchangeCode(c.Request().Context(), req.Code, req.State)
+	if err != nil {
+		log.Printf("OAuth code exchange failed: %v", err)
+		return echo.NewHTTPError(http.StatusUnauthorized, "OAuth authentication failed")
+	}
+
+	// Create a new session for the authenticated user
+	sessionID := uuid.New().String()
+	expiresAt := time.Now().Add(24 * time.Hour) // Token expires in 24 hours
+
+	// Store session information (in production, use a proper session store)
+	p.oauthSessions.Store(sessionID, &OAuthSession{
+		ID:          sessionID,
+		UserContext: userContext,
+		CreatedAt:   time.Now(),
+		ExpiresAt:   expiresAt,
+	})
+
+	// Return session information
+	return c.JSON(http.StatusOK, OAuthSessionResponse{
+		SessionID:   sessionID,
+		AccessToken: userContext.AccessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   expiresAt,
+		User:        userContext,
+	})
+}
+
+// handleOAuthLogout handles OAuth logout
+func (p *Proxy) handleOAuthLogout(c echo.Context) error {
+	// Get the session ID from the Authorization header or query parameter
+	sessionID := c.Request().Header.Get("X-Session-ID")
+	if sessionID == "" {
+		sessionID = c.QueryParam("session_id")
+	}
+
+	if sessionID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Session ID required")
+	}
+
+	// Get session from store
+	sessionValue, ok := p.oauthSessions.Load(sessionID)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+	}
+
+	session := sessionValue.(*OAuthSession)
+
+	// Revoke the GitHub token
+	if err := p.oauthProvider.RevokeToken(c.Request().Context(), session.UserContext.AccessToken); err != nil {
+		log.Printf("Failed to revoke GitHub token: %v", err)
+		// Continue with logout even if revocation fails
+	}
+
+	// Remove session from store
+	p.oauthSessions.Delete(sessionID)
+
+	return c.JSON(http.StatusOK, map[string]string{
+		"message": "Successfully logged out",
+	})
+}
+
+// handleOAuthRefresh handles token refresh (if needed in the future)
+func (p *Proxy) handleOAuthRefresh(c echo.Context) error {
+	// GitHub OAuth tokens don't expire, so this is a placeholder
+	// In a real implementation, you might want to validate the token is still valid
+	sessionID := c.Request().Header.Get("X-Session-ID")
+	if sessionID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Session ID required")
+	}
+
+	sessionValue, ok := p.oauthSessions.Load(sessionID)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+	}
+
+	session := sessionValue.(*OAuthSession)
+
+	// Check if session is expired
+	if time.Now().After(session.ExpiresAt) {
+		p.oauthSessions.Delete(sessionID)
+		return echo.NewHTTPError(http.StatusUnauthorized, "Session expired")
+	}
+
+	// Extend session expiration
+	session.ExpiresAt = time.Now().Add(24 * time.Hour)
+
+	return c.JSON(http.StatusOK, OAuthTokenResponse{
+		AccessToken: session.UserContext.AccessToken,
+		TokenType:   "Bearer",
+		ExpiresAt:   session.ExpiresAt,
+		User:        session.UserContext,
+	})
+}
+
+// OAuthSession represents an authenticated OAuth session
+type OAuthSession struct {
+	ID          string
+	UserContext *auth.UserContext
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
+}
+
+// validateOAuthSession validates an OAuth session from the request
+func (p *Proxy) validateOAuthSession(c echo.Context) (*auth.UserContext, error) {
+	// Try to get session ID from header first, then from query parameter
+	sessionID := c.Request().Header.Get("X-Session-ID")
+	if sessionID == "" {
+		sessionID = c.QueryParam("session_id")
+	}
+
+	if sessionID == "" {
+		// Try to extract from Authorization header as Bearer token
+		authHeader := c.Request().Header.Get("Authorization")
+		if authHeader != "" && len(authHeader) > 7 && authHeader[:7] == "Bearer " {
+			sessionID = authHeader[7:]
+		}
+	}
+
+	if sessionID == "" {
+		return nil, fmt.Errorf("no session ID provided")
+	}
+
+	// Get session from store
+	sessionValue, ok := p.oauthSessions.Load(sessionID)
+	if !ok {
+		return nil, fmt.Errorf("session not found")
+	}
+
+	session := sessionValue.(*OAuthSession)
+
+	// Check if session is expired
+	if time.Now().After(session.ExpiresAt) {
+		p.oauthSessions.Delete(sessionID)
+		return nil, fmt.Errorf("session expired")
+	}
+
+	return session.UserContext, nil
+}
+
+// cleanupExpiredOAuthSessions periodically cleans up expired OAuth sessions
+func (p *Proxy) cleanupExpiredOAuthSessions() {
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		now := time.Now()
+		var toDelete []string
+
+		p.oauthSessions.Range(func(key, value interface{}) bool {
+			sessionID := key.(string)
+			session := value.(*OAuthSession)
+
+			if now.After(session.ExpiresAt) {
+				toDelete = append(toDelete, sessionID)
+			}
+			return true
+		})
+
+		for _, sessionID := range toDelete {
+			p.oauthSessions.Delete(sessionID)
+			log.Printf("Cleaned up expired OAuth session: %s", sessionID)
+		}
+	}
+}

--- a/pkg/proxy/oauth_handlers_test.go
+++ b/pkg/proxy/oauth_handlers_test.go
@@ -1,0 +1,285 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+func setupTestProxyWithOAuth(t *testing.T) (*Proxy, *httptest.Server) {
+	// Mock GitHub OAuth server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org"}`))
+		case "/user":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"login":"testuser","id":123456,"email":"test@example.com","name":"Test User"}`))
+		case "/user/orgs":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[{"login":"test-org","id":789}]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	cfg := &config.Config{
+		StartPort: 9000,
+		Auth: config.AuthConfig{
+			Enabled: true,
+			GitHub: &config.GitHubAuthConfig{
+				Enabled:     true,
+				BaseURL:     mockServer.URL,
+				TokenHeader: "Authorization",
+				UserMapping: config.GitHubUserMapping{
+					DefaultRole:        "user",
+					DefaultPermissions: []string{"read", "session:create", "session:list"},
+				},
+				OAuth: &config.GitHubOAuthConfig{
+					ClientID:     "test-client-id",
+					ClientSecret: "test-client-secret",
+					Scope:        "read:user read:org",
+					BaseURL:      mockServer.URL,
+				},
+			},
+		},
+	}
+
+	proxy := NewProxy(cfg, false)
+	return proxy, mockServer
+}
+
+func TestHandleOAuthLogin(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// Test valid request
+	reqBody := OAuthLoginRequest{
+		RedirectURI: "http://localhost:3000/callback",
+	}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := proxy.handleOAuthLogin(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp OAuthLoginResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resp.AuthURL)
+	assert.NotEmpty(t, resp.State)
+	assert.Contains(t, resp.AuthURL, mockServer.URL+"/login/oauth/authorize")
+}
+
+func TestHandleOAuthLogin_InvalidRequest(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// Test missing redirect_uri
+	reqBody := OAuthLoginRequest{}
+	body, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := proxy.handleOAuthLogin(c)
+	assert.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}
+
+func TestHandleOAuthCallback(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// First generate a valid state
+	_, state, _ := proxy.oauthProvider.GenerateAuthURL("http://localhost:3000/callback")
+
+	// Test valid callback
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?code=test-code&state="+state, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := proxy.handleOAuthCallback(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp OAuthSessionResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resp.SessionID)
+	assert.Equal(t, "gho_test_token", resp.AccessToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.NotNil(t, resp.User)
+	assert.Equal(t, "testuser", resp.User.UserID)
+}
+
+func TestHandleOAuthCallback_MissingParameters(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// Test missing code
+	req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state=test-state", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := proxy.handleOAuthCallback(c)
+	assert.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}
+
+func TestHandleOAuthLogout(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// Create a test session
+	testSession := &OAuthSession{
+		ID: "test-session-id",
+		UserContext: &auth.UserContext{
+			UserID:      "testuser",
+			AccessToken: "gho_test_token",
+		},
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	proxy.oauthSessions.Store(testSession.ID, testSession)
+
+	// Test logout with session ID in header
+	req := httptest.NewRequest(http.MethodPost, "/oauth/logout", nil)
+	req.Header.Set("X-Session-ID", testSession.ID)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := proxy.handleOAuthLogout(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify session was removed
+	_, exists := proxy.oauthSessions.Load(testSession.ID)
+	assert.False(t, exists)
+}
+
+func TestHandleOAuthRefresh(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// Create a test session
+	testSession := &OAuthSession{
+		ID: "test-session-id",
+		UserContext: &auth.UserContext{
+			UserID:      "testuser",
+			AccessToken: "gho_test_token",
+		},
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	proxy.oauthSessions.Store(testSession.ID, testSession)
+
+	// Test refresh
+	req := httptest.NewRequest(http.MethodPost, "/oauth/refresh", nil)
+	req.Header.Set("X-Session-ID", testSession.ID)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := proxy.handleOAuthRefresh(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp OAuthTokenResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "gho_test_token", resp.AccessToken)
+	assert.True(t, resp.ExpiresAt.After(time.Now().Add(23*time.Hour)))
+}
+
+func TestValidateOAuthSession(t *testing.T) {
+	proxy, mockServer := setupTestProxyWithOAuth(t)
+	defer mockServer.Close()
+
+	e := echo.New()
+
+	// Create a test session
+	testSession := &OAuthSession{
+		ID: "test-session-id",
+		UserContext: &auth.UserContext{
+			UserID:      "testuser",
+			AccessToken: "gho_test_token",
+		},
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	proxy.oauthSessions.Store(testSession.ID, testSession)
+
+	// Test with session ID in header
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("X-Session-ID", testSession.ID)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	userContext, err := proxy.validateOAuthSession(c)
+	assert.NoError(t, err)
+	assert.NotNil(t, userContext)
+	assert.Equal(t, "testuser", userContext.UserID)
+
+	// Test with session ID in query parameter
+	req2 := httptest.NewRequest(http.MethodGet, "/test?session_id="+testSession.ID, nil)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+
+	userContext2, err2 := proxy.validateOAuthSession(c2)
+	assert.NoError(t, err2)
+	assert.NotNil(t, userContext2)
+	assert.Equal(t, "testuser", userContext2.UserID)
+
+	// Test with expired session
+	expiredSession := &OAuthSession{
+		ID: "expired-session-id",
+		UserContext: &auth.UserContext{
+			UserID: "expireduser",
+		},
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	}
+	proxy.oauthSessions.Store(expiredSession.ID, expiredSession)
+
+	req3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req3.Header.Set("X-Session-ID", expiredSession.ID)
+	rec3 := httptest.NewRecorder()
+	c3 := e.NewContext(req3, rec3)
+
+	_, err3 := proxy.validateOAuthSession(c3)
+	assert.Error(t, err3)
+	assert.Contains(t, err3.Error(), "session expired")
+}

--- a/pkg/proxy/oauth_handlers_test.go
+++ b/pkg/proxy/oauth_handlers_test.go
@@ -21,15 +21,15 @@ func setupTestProxyWithOAuth(t *testing.T) (*Proxy, *httptest.Server) {
 		case "/login/oauth/access_token":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org"}`))
+			_, _ = w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org"}`))
 		case "/user":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"login":"testuser","id":123456,"email":"test@example.com","name":"Test User"}`))
+			_, _ = w.Write([]byte(`{"login":"testuser","id":123456,"email":"test@example.com","name":"Test User"}`))
 		case "/user/orgs":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`[{"login":"test-org","id":789}]`))
+			_, _ = w.Write([]byte(`[{"login":"test-org","id":789}]`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION
## 概要
GitHub OAuth2 認証フローを実装し、Webアプリケーションからの安全な認証を可能にしました。

## 変更内容
### 新機能
- **OAuth認証プロバイダー** (`pkg/auth/oauth.go`)
  - GitHub OAuth2フローの完全な実装
  - 安全なstate管理による CSRF 対策
  - アクセストークンの取得と管理

- **OAuth エンドポイント** (`pkg/proxy/oauth_handlers.go`)
  - `POST /oauth/authorize` - 認証フロー開始
  - `GET /oauth/callback` - GitHub からのコールバック処理
  - `POST /oauth/logout` - ログアウトとトークン無効化
  - `POST /oauth/refresh` - セッション延長

- **セッション管理**
  - 有効期限付きセッション（デフォルト24時間）
  - 定期的な期限切れセッションのクリーンアップ
  - メモリベースのセッションストア

### 設定
- `config.oauth.example.json` - OAuth設定のサンプル
- 環境変数サポート (`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`)
- 既存の GitHub 認証との互換性維持

### セキュリティ
- CSRF 対策のための state パラメータ検証
- セッションの有効期限管理
- GitHub トークンの適切な無効化

### ドキュメント
- `docs/github-oauth.md` - 詳細な設定・使用方法
- README.md に認証セクションを追加

## テスト計画
- [x] OAuth プロバイダーのユニットテスト
- [x] OAuth ハンドラーのユニットテスト
- [x] 既存のテストへの影響なし
- [ ] 実際の GitHub OAuth App での動作確認

## 使用例
```javascript
// OAuth認証フローの開始
const response = await fetch('/oauth/authorize', {
  method: 'POST',
  body: JSON.stringify({ redirect_uri: 'https://app.com/callback' })
});
const { auth_url } = await response.json();
window.location.href = auth_url;

// コールバック処理
const params = new URLSearchParams(window.location.search);
const session = await fetch(`/oauth/callback?code=${params.get('code')}&state=${params.get('state')}`);
```

## 今後の改善案
- Redis等を使用した分散セッション管理
- リフレッシュトークンのサポート
- セッションの永続化オプション

🤖 Generated with [Claude Code](https://claude.ai/code)