### PR TITLE
Fix all golangci-lint errcheck issues

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -125,7 +125,7 @@ func runSend(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error sending message: %v\n", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -154,7 +154,7 @@ func runHistory(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error getting history: %v\n", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -186,7 +186,7 @@ func runStatus(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error getting status: %v\n", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -215,7 +215,7 @@ func runEvents(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error connecting to events: %v\n", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -177,7 +177,7 @@ func TestRunSendWithArgument(t *testing.T) {
 	runSend(&cobra.Command{}, []string{"test message"})
 
 	// Restore stdout and read output
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
@@ -234,7 +234,7 @@ func TestRunHistoryWithMockServer(t *testing.T) {
 	runHistory(&cobra.Command{}, []string{})
 
 	// Restore stdout and read output
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
@@ -283,7 +283,7 @@ func TestRunStatusWithMockServer(t *testing.T) {
 	runStatus(&cobra.Command{}, []string{})
 
 	// Restore stdout and read output
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
@@ -313,10 +313,10 @@ func TestRunEventsWithMockServer(t *testing.T) {
 		w.Header().Set("Connection", "keep-alive")
 
 		// Send a few test events
-		fmt.Fprintf(w, "data: {\"type\":\"message\",\"content\":\"Test event 1\"}\n\n")
+		_, _ = fmt.Fprintf(w, "data: {\"type\":\"message\",\"content\":\"Test event 1\"}\n\n")
 		w.(http.Flusher).Flush()
 
-		fmt.Fprintf(w, "data: {\"type\":\"status\",\"content\":\"Agent is thinking\"}\n\n")
+		_, _ = fmt.Fprintf(w, "data: {\"type\":\"status\",\"content\":\"Agent is thinking\"}\n\n")
 		w.(http.Flusher).Flush()
 
 		// Close connection after a short delay
@@ -349,7 +349,7 @@ func TestRunEventsWithMockServer(t *testing.T) {
 	}
 
 	// Restore stdout and read output
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
@@ -435,7 +435,7 @@ func TestRunSendInteractiveMode(t *testing.T) {
 	// Write test input and close
 	go func() {
 		_, _ = w.WriteString("interactive test message\n")
-		w.Close()
+		_ = w.Close()
 	}()
 
 	// Capture output
@@ -448,7 +448,7 @@ func TestRunSendInteractiveMode(t *testing.T) {
 
 	// Restore stdin and stdout
 	os.Stdin = oldStdin
-	outW.Close()
+	_ = outW.Close()
 	os.Stdout = oldStdout
 
 	// Read output

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -60,7 +60,7 @@ func TestGenerateTokenValidInputs(t *testing.T) {
 	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp("", "helpers-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	outputFile := filepath.Join(tmpDir, "test_api_keys.json")
 
@@ -111,7 +111,7 @@ func TestGenerateTokenMergeExisting(t *testing.T) {
 	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp("", "helpers-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	outputFile := filepath.Join(tmpDir, "existing_api_keys.json")
 
@@ -159,9 +159,10 @@ func TestGenerateTokenMergeExisting(t *testing.T) {
 	var existingKey, newKey map[string]interface{}
 	for _, k := range keys {
 		key := k.(map[string]interface{})
-		if key["user_id"] == "existing-user" {
+		switch key["user_id"] {
+		case "existing-user":
 			existingKey = key
-		} else if key["user_id"] == "new-user" {
+		case "new-user":
 			newKey = key
 		}
 	}
@@ -271,14 +272,14 @@ func TestRunSetupClaudeCodeNoCLAUDEDIR(t *testing.T) {
 	originalCLAUDEDIR := os.Getenv("CLAUDE_DIR")
 	defer func() {
 		if originalCLAUDEDIR != "" {
-			os.Setenv("CLAUDE_DIR", originalCLAUDEDIR)
+			_ = os.Setenv("CLAUDE_DIR", originalCLAUDEDIR)
 		} else {
-			os.Unsetenv("CLAUDE_DIR")
+			_ = os.Unsetenv("CLAUDE_DIR")
 		}
 	}()
 
 	// Unset CLAUDE_DIR
-	os.Unsetenv("CLAUDE_DIR")
+	_ = os.Unsetenv("CLAUDE_DIR")
 
 	// This test verifies the function handles missing CLAUDE_DIR
 	// We can't easily test os.Exit(1), but we can verify the error path is taken

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -105,12 +105,12 @@ func TestRunProxyWithInvalidConfig(t *testing.T) {
 	// Create a temporary invalid config file
 	tmpFile, err := os.CreateTemp("", "invalid-config-*.json")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
 	// Write invalid JSON
 	_, err = tmpFile.WriteString("{ invalid json }")
 	require.NoError(t, err)
-	tmpFile.Close()
+	_ = tmpFile.Close()
 
 	// Set the config flag to the invalid file
 	cfg = tmpFile.Name()

--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -102,7 +102,7 @@ func (p *GitHubAuthProvider) getUser(ctx context.Context, token string) (*GitHub
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
@@ -155,7 +155,7 @@ func (p *GitHubAuthProvider) getUserOrganizations(ctx context.Context, token str
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
@@ -185,7 +185,7 @@ func (p *GitHubAuthProvider) getUserTeamsInOrg(ctx context.Context, token, org, 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d for org %s", resp.StatusCode, org)
@@ -232,7 +232,7 @@ func (p *GitHubAuthProvider) checkTeamMembership(ctx context.Context, token, org
 	if err != nil {
 		return false, ""
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return false, ""

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -12,12 +12,12 @@ func TestLogger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	// Set LOG_DIR environment variable
 	originalLogDir := os.Getenv("LOG_DIR")
-	os.Setenv("LOG_DIR", tmpDir)
-	defer os.Setenv("LOG_DIR", originalLogDir)
+	_ = os.Setenv("LOG_DIR", tmpDir)
+	defer func() { _ = os.Setenv("LOG_DIR", originalLogDir) }()
 
 	logger := NewLogger()
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -227,7 +227,7 @@ func (p *Proxy) sessionToStorage(session *AgentSession) *storage.SessionData {
 		Tags:        session.Tags,
 		ProcessID:   processID,
 		Command:     command,
-		WorkingDir:  "", // Add working directory if needed
+		WorkingDir:  session.ID, // Session working directory is the session ID
 	}
 }
 
@@ -776,6 +776,9 @@ func (p *Proxy) runAgentAPIServer(ctx context.Context, session *AgentSession, sc
 	if repoInfo != nil {
 		templateData.RepoFullName = repoInfo.FullName
 		templateData.CloneDir = repoInfo.CloneDir
+	} else {
+		// Always set CloneDir to session ID, even when no repository is specified
+		templateData.CloneDir = session.ID
 	}
 
 	if scriptName != "" {

--- a/pkg/proxy/proxy_persistence_test.go
+++ b/pkg/proxy/proxy_persistence_test.go
@@ -23,7 +23,7 @@ func TestProxySessionPersistence(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 
@@ -75,7 +75,7 @@ func TestProxySessionPersistence(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 
@@ -120,7 +120,7 @@ func TestProxySessionPersistence(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 
@@ -198,7 +198,7 @@ func TestProxySessionRecovery(t *testing.T) {
 				t.Fatalf("Failed to save test session: %v", err)
 			}
 		}
-		initialStorage.Close()
+		_ = initialStorage.Close()
 
 		// Create proxy with persistence (should recover sessions)
 		cfg := createTestConfigWithPersistence(tmpDir)
@@ -207,7 +207,7 @@ func TestProxySessionRecovery(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 
@@ -278,7 +278,7 @@ func TestProxyPersistenceConfiguration(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 
@@ -297,7 +297,7 @@ func TestProxyPersistenceConfiguration(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 
@@ -339,7 +339,7 @@ func TestProxyPersistenceAPI(t *testing.T) {
 		proxy := NewProxy(cfg, false)
 		defer func() {
 			if proxy.storage != nil {
-				proxy.storage.Close()
+				_ = proxy.storage.Close()
 			}
 		}()
 

--- a/pkg/proxy/scripts/agentapi_default.sh
+++ b/pkg/proxy/scripts/agentapi_default.sh
@@ -26,6 +26,13 @@ if [[ -n "$GITHUB_REPO_FULLNAME" && -n "$GITHUB_CLONE_DIR" ]]; then
     cd "$GITHUB_CLONE_DIR"
 else
     echo "GitHub parameters not provided, skipping repository setup"
+    # Create session directory even when no repository is cloned
+    if [[ -n "$GITHUB_CLONE_DIR" ]]; then
+        echo "Creating session directory: $GITHUB_CLONE_DIR"
+        mkdir -p "$GITHUB_CLONE_DIR"
+        echo "Changing directory to $GITHUB_CLONE_DIR"
+        cd "$GITHUB_CLONE_DIR"
+    fi
 fi
 
 CLAUDE_DIR=. agentapi-proxy helpers setup-claude-code

--- a/pkg/storage/file.go
+++ b/pkg/storage/file.go
@@ -167,7 +167,7 @@ func (fs *FileStorage) syncToFile() error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	// Encode sessions
 	encoder := json.NewEncoder(file)
@@ -186,19 +186,19 @@ func (fs *FileStorage) syncToFile() error {
 	}
 
 	if err := encoder.Encode(&data); err != nil {
-		os.Remove(tempFile)
+		_ = os.Remove(tempFile)
 		return fmt.Errorf("failed to encode sessions: %w", err)
 	}
 
 	// Sync to disk
 	if err := file.Sync(); err != nil {
-		os.Remove(tempFile)
+		_ = os.Remove(tempFile)
 		return fmt.Errorf("failed to sync file: %w", err)
 	}
 
 	// Atomic rename
 	if err := os.Rename(tempFile, fs.filePath); err != nil {
-		os.Remove(tempFile)
+		_ = os.Remove(tempFile)
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 
@@ -211,7 +211,7 @@ func (fs *FileStorage) loadFromFile() error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	var data struct {
 		Sessions []*SessionData `json:"sessions"`

--- a/pkg/storage/storage_benchmark_test.go
+++ b/pkg/storage/storage_benchmark_test.go
@@ -124,7 +124,7 @@ func BenchmarkFileStorage(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create file storage: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	// Create test sessions
 	sessions := make([]*SessionData, 100) // Smaller set for file operations
@@ -200,7 +200,7 @@ func BenchmarkFileStorageWithEncryption(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create encrypted file storage: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	// Create test sessions with sensitive data
 	sessions := make([]*SessionData, 50) // Smaller set for encryption operations

--- a/pkg/storage/storage_integration_test.go
+++ b/pkg/storage/storage_integration_test.go
@@ -53,7 +53,7 @@ func TestFileStorageErrorHandling(t *testing.T) {
 		// Try to create storage in read-only directory
 		storage, err := NewFileStorage(tmpFile, 0, false)
 		if err == nil {
-			defer storage.Close()
+			defer func() { _ = storage.Close() }()
 
 			// Try to save session (should fail)
 			session := &SessionData{
@@ -80,7 +80,7 @@ func TestEncryptionErrorHandling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file storage: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	t.Run("EmptySensitiveValue", func(t *testing.T) {
 		session := &SessionData{
@@ -153,7 +153,7 @@ func TestStorageConcurrency(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create file storage: %v", err)
 		}
-		defer storage.Close()
+		defer func() { _ = storage.Close() }()
 
 		testConcurrentAccess(t, storage)
 	})
@@ -256,7 +256,7 @@ func TestStorageEdgeCases(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create file storage: %v", err)
 		}
-		defer storage.Close()
+		defer func() { _ = storage.Close() }()
 
 		// Create session with large environment data
 		largeValue := strings.Repeat("a", 100000) // 100KB string
@@ -384,7 +384,7 @@ func TestFileStoragePeriodicSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file storage: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	session := &SessionData{
 		ID:     "sync-test",
@@ -455,7 +455,7 @@ func TestStorageConfigValidation(t *testing.T) {
 			t.Errorf("Failed to create storage with empty file path: %v", err)
 		}
 		if storage != nil {
-			storage.Close()
+			_ = storage.Close()
 		}
 	})
 
@@ -472,7 +472,7 @@ func TestStorageConfigValidation(t *testing.T) {
 			t.Errorf("Failed to create storage with zero sync interval: %v", err)
 		}
 		if storage != nil {
-			storage.Close()
+			_ = storage.Close()
 		}
 	})
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -22,7 +22,7 @@ func TestFileStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file storage: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	testStorageInterface(t, storage)
 }
@@ -36,7 +36,7 @@ func TestFileStorageWithEncryption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file storage with encryption: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	// Test with sensitive environment variables
 	sessionData := &SessionData{
@@ -109,14 +109,14 @@ func TestFileStoragePersistence(t *testing.T) {
 		t.Fatalf("Failed to save session: %v", err)
 	}
 
-	storage1.Close()
+	_ = storage1.Close()
 
 	// Create second storage instance and verify data exists
 	storage2, err := NewFileStorage(tmpFile, 0, false)
 	if err != nil {
 		t.Fatalf("Failed to create second storage instance: %v", err)
 	}
-	defer storage2.Close()
+	defer func() { _ = storage2.Close() }()
 
 	loaded, err := storage2.Load(sessionData.ID)
 	if err != nil {
@@ -271,7 +271,7 @@ func TestStorageFactory(t *testing.T) {
 	if _, ok := fileStorage.(*FileStorage); !ok {
 		t.Errorf("Expected FileStorage, got %T", fileStorage)
 	}
-	fileStorage.Close()
+	_ = fileStorage.Close()
 
 	// Test unknown storage type
 	unknownConfig := &StorageConfig{Type: "unknown"}
@@ -290,7 +290,7 @@ func TestEncryptionDecryption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create file storage: %v", err)
 	}
-	defer storage.Close()
+	defer func() { _ = storage.Close() }()
 
 	// Test that encryption/decryption works by saving and loading sensitive data
 	sessionData := &SessionData{


### PR DESCRIPTION
## Summary
- **Fixed all golangci-lint errcheck issues** across the codebase (34 issues resolved)
- **Implemented session directory creation** when no repository is cloned
- Addressed unchecked error returns for file operations, HTTP responses, and environment variable manipulations
- Updated staticcheck issue in helpers_test.go by converting if-else chain to switch statement

## Changes Made

### Lint Fixes
- Fixed unchecked error returns using explicit error ignoring with `_ =` pattern
- Ensured all defer Close() calls properly handle return values
- Replaced if-else chain with switch statement for better code quality

### Directory Creation Feature
- Modified startup script to create session directory even when no GitHub repository is specified
- Ensured CloneDir template variable is always set to session ID
- Set WorkingDir in session storage to track session working directory properly
- **Now every session has its own dedicated directory regardless of whether a repository is cloned or not**

## Test plan
- [x] All linting issues resolved - `make lint` passes with 0 issues
- [x] Core functionality tests pass  
- [x] Unit tests for modified packages continue to pass
- [x] Build verification successful
- [x] Session directory creation works for both repository and non-repository sessions

🤖 Generated with [Claude Code](https://claude.ai/code)