### PR TITLE
fix: OAuth CORS プリフライトリクエストに対応

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -121,10 +121,10 @@ func NewProxy(cfg *config.Config, verbose bool) *Proxy {
 			path := c.Request().URL.Path
 			pathParts := strings.Split(path, "/")
 			// Skip CORS only for proxy routes that match /:sessionId/* pattern
-			// (at least 3 parts, not starting with "start", "search", or "sessions")
+			// (at least 3 parts, not starting with "start", "search", "sessions", or "oauth")
 			if len(pathParts) >= 3 && pathParts[1] != "" {
 				firstSegment := pathParts[1]
-				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions"
+				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth"
 			}
 			return false
 		},


### PR DESCRIPTION
## 概要
- `/oauth/authorize` エンドポイントで OPTIONS 404 エラーが発生していた問題を修正
- CORSプリフライトリクエストが正常に処理されるように変更

## 変更内容
- `pkg/proxy/proxy.go` のCORSミドルウェアスキッパー関数を修正
- `/oauth/*` パスでCORSミドルウェアが適用されるように "oauth" をスキップ対象から除外

## 修正前の問題
- ブラウザからのCORSプリフライト（OPTIONS）リクエストが 404 エラーになっていた
- OAuth認証フローがブラウザから開始できない状況

## 修正後
- `/oauth/authorize` エンドポイントでOPTIONSメソッドが正常に処理される
- ブラウザからのOAuth認証フローが正常に動作する

## テスト計画
- [ ] `/oauth/authorize` エンドポイントへのOPTIONSリクエストが 200 で応答することを確認
- [ ] ブラウザからのOAuth認証フローが正常に動作することを確認
- [ ] 他のエンドポイントのCORS動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)