### PR TITLE
feat: 認証タイプと認証状況を取得するAPIエンドポイントを追加

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -83,7 +83,7 @@ func isOAuthEndpoint(path string) bool {
 		"/oauth/logout",
 		"/oauth/refresh",
 	}
-	
+
 	for _, oauthPath := range oauthPaths {
 		if strings.HasPrefix(path, oauthPath) {
 			return true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,11 +147,11 @@ func LoadConfig(filename string) (*Config, error) {
 	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
 		config.Auth.GitHub.OAuth.ClientID = expandEnvVars(config.Auth.GitHub.OAuth.ClientID)
 		config.Auth.GitHub.OAuth.ClientSecret = expandEnvVars(config.Auth.GitHub.OAuth.ClientSecret)
-		
+
 		// Log OAuth configuration status (without exposing secrets)
 		log.Printf("[CONFIG] OAuth ClientID configured: %v", config.Auth.GitHub.OAuth.ClientID != "")
 		log.Printf("[CONFIG] OAuth ClientSecret configured: %v", config.Auth.GitHub.OAuth.ClientSecret != "")
-		
+
 		// Warn if OAuth is configured but credentials are missing
 		if config.Auth.GitHub.OAuth.ClientID == "" || config.Auth.GitHub.OAuth.ClientSecret == "" {
 			log.Printf("[CONFIG] Warning: OAuth is configured but Client ID or Client Secret is missing")
@@ -173,18 +173,18 @@ func expandEnvVars(s string) string {
 	if s == "" {
 		return s
 	}
-	
+
 	// Match ${VAR_NAME} pattern
 	re := regexp.MustCompile(`\$\{([^}]+)\}`)
 	return re.ReplaceAllStringFunc(s, func(match string) string {
 		// Extract variable name (remove ${})
 		varName := strings.TrimPrefix(strings.TrimSuffix(match, "}"), "${")
-		
+
 		// Get environment variable value
 		if value := os.Getenv(varName); value != "" {
 			return value
 		}
-		
+
 		// Return original string if environment variable is not set
 		log.Printf("[CONFIG] Warning: Environment variable %s is not set", varName)
 		return match

--- a/pkg/proxy/auth_info_handlers.go
+++ b/pkg/proxy/auth_info_handlers.go
@@ -1,0 +1,99 @@
+package proxy
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+type AuthTypesResponse struct {
+	Enabled bool       `json:"enabled"`
+	Types   []AuthType `json:"types"`
+}
+
+type AuthType struct {
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Available bool   `json:"available"`
+}
+
+type AuthStatusResponse struct {
+	Authenticated bool                 `json:"authenticated"`
+	AuthType      string               `json:"auth_type,omitempty"`
+	UserID        string               `json:"user_id,omitempty"`
+	Role          string               `json:"role,omitempty"`
+	Permissions   []string             `json:"permissions,omitempty"`
+	GitHubUser    *auth.GitHubUserInfo `json:"github_user,omitempty"`
+}
+
+func NewAuthInfoHandlers(cfg *config.Config) *AuthInfoHandlers {
+	return &AuthInfoHandlers{cfg: cfg}
+}
+
+type AuthInfoHandlers struct {
+	cfg *config.Config
+}
+
+func (h *AuthInfoHandlers) GetAuthTypes(c echo.Context) error {
+	response := AuthTypesResponse{
+		Enabled: h.cfg.Auth.Enabled,
+		Types:   []AuthType{},
+	}
+
+	if !h.cfg.Auth.Enabled {
+		return c.JSON(http.StatusOK, response)
+	}
+
+	if h.cfg.Auth.Static != nil && h.cfg.Auth.Static.Enabled {
+		response.Types = append(response.Types, AuthType{
+			Type:      "api_key",
+			Name:      "API Key",
+			Available: true,
+		})
+	}
+
+	if h.cfg.Auth.GitHub != nil && h.cfg.Auth.GitHub.Enabled {
+		githubAuth := AuthType{
+			Type:      "github",
+			Name:      "GitHub",
+			Available: true,
+		}
+
+		if h.cfg.Auth.GitHub.OAuth != nil &&
+			h.cfg.Auth.GitHub.OAuth.ClientID != "" &&
+			h.cfg.Auth.GitHub.OAuth.ClientSecret != "" {
+			githubAuth.Type = "github_oauth"
+			githubAuth.Name = "GitHub OAuth"
+		}
+
+		response.Types = append(response.Types, githubAuth)
+	}
+
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *AuthInfoHandlers) GetAuthStatus(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+
+	if user == nil {
+		return c.JSON(http.StatusOK, AuthStatusResponse{
+			Authenticated: false,
+		})
+	}
+
+	response := AuthStatusResponse{
+		Authenticated: true,
+		AuthType:      user.AuthType,
+		UserID:        user.UserID,
+		Role:          user.Role,
+		Permissions:   user.Permissions,
+	}
+
+	if user.GitHubUser != nil {
+		response.GitHubUser = user.GitHubUser
+	}
+
+	return c.JSON(http.StatusOK, response)
+}

--- a/pkg/proxy/auth_info_handlers_test.go
+++ b/pkg/proxy/auth_info_handlers_test.go
@@ -1,0 +1,216 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+func TestGetAuthTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected AuthTypesResponse
+	}{
+		{
+			name: "auth disabled",
+			cfg: &config.Config{
+				Auth: config.AuthConfig{
+					Enabled: false,
+				},
+			},
+			expected: AuthTypesResponse{
+				Enabled: false,
+				Types:   []AuthType{},
+			},
+		},
+		{
+			name: "api key only",
+			cfg: &config.Config{
+				Auth: config.AuthConfig{
+					Enabled: true,
+					Static: &config.StaticAuthConfig{
+						Enabled: true,
+					},
+				},
+			},
+			expected: AuthTypesResponse{
+				Enabled: true,
+				Types: []AuthType{
+					{Type: "api_key", Name: "API Key", Available: true},
+				},
+			},
+		},
+		{
+			name: "github token only",
+			cfg: &config.Config{
+				Auth: config.AuthConfig{
+					Enabled: true,
+					GitHub: &config.GitHubAuthConfig{
+						Enabled: true,
+					},
+				},
+			},
+			expected: AuthTypesResponse{
+				Enabled: true,
+				Types: []AuthType{
+					{Type: "github", Name: "GitHub", Available: true},
+				},
+			},
+		},
+		{
+			name: "github oauth",
+			cfg: &config.Config{
+				Auth: config.AuthConfig{
+					Enabled: true,
+					GitHub: &config.GitHubAuthConfig{
+						Enabled: true,
+						OAuth: &config.GitHubOAuthConfig{
+							ClientID:     "test-client-id",
+							ClientSecret: "test-client-secret",
+						},
+					},
+				},
+			},
+			expected: AuthTypesResponse{
+				Enabled: true,
+				Types: []AuthType{
+					{Type: "github_oauth", Name: "GitHub OAuth", Available: true},
+				},
+			},
+		},
+		{
+			name: "all auth types",
+			cfg: &config.Config{
+				Auth: config.AuthConfig{
+					Enabled: true,
+					Static: &config.StaticAuthConfig{
+						Enabled: true,
+					},
+					GitHub: &config.GitHubAuthConfig{
+						Enabled: true,
+						OAuth: &config.GitHubOAuthConfig{
+							ClientID:     "test-client-id",
+							ClientSecret: "test-client-secret",
+						},
+					},
+				},
+			},
+			expected: AuthTypesResponse{
+				Enabled: true,
+				Types: []AuthType{
+					{Type: "api_key", Name: "API Key", Available: true},
+					{Type: "github_oauth", Name: "GitHub OAuth", Available: true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/auth/types", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			h := NewAuthInfoHandlers(tt.cfg)
+			err := h.GetAuthTypes(c)
+
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response AuthTypesResponse
+			err = json.Unmarshal(rec.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, response)
+		})
+	}
+}
+
+func TestGetAuthStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *auth.UserContext
+		expected AuthStatusResponse
+	}{
+		{
+			name: "not authenticated",
+			user: nil,
+			expected: AuthStatusResponse{
+				Authenticated: false,
+			},
+		},
+		{
+			name: "authenticated with api key",
+			user: &auth.UserContext{
+				UserID:      "test-user",
+				Role:        "user",
+				Permissions: []string{"session:create", "session:list"},
+				AuthType:    "api_key",
+			},
+			expected: AuthStatusResponse{
+				Authenticated: true,
+				AuthType:      "api_key",
+				UserID:        "test-user",
+				Role:          "user",
+				Permissions:   []string{"session:create", "session:list"},
+			},
+		},
+		{
+			name: "authenticated with github oauth",
+			user: &auth.UserContext{
+				UserID:      "github-user",
+				Role:        "admin",
+				Permissions: []string{"*"},
+				AuthType:    "github_oauth",
+				GitHubUser: &auth.GitHubUserInfo{
+					Login: "octocat",
+					Name:  "The Octocat",
+					Email: "octocat@github.com",
+				},
+			},
+			expected: AuthStatusResponse{
+				Authenticated: true,
+				AuthType:      "github_oauth",
+				UserID:        "github-user",
+				Role:          "admin",
+				Permissions:   []string{"*"},
+				GitHubUser: &auth.GitHubUserInfo{
+					Login: "octocat",
+					Name:  "The Octocat",
+					Email: "octocat@github.com",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/auth/status", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			if tt.user != nil {
+				c.Set("user", tt.user)
+			}
+
+			h := NewAuthInfoHandlers(&config.Config{})
+			err := h.GetAuthStatus(c)
+
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			var response AuthStatusResponse
+			err = json.Unmarshal(rec.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, response)
+		})
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -205,7 +205,7 @@ func NewProxy(cfg *config.Config, verbose bool) *Proxy {
 			log.Printf("[OAUTH_INIT] OAuth ClientSecret configured: %v", cfg.Auth.GitHub.OAuth.ClientSecret != "")
 		}
 	}
-	if cfg.Auth.GitHub != nil && cfg.Auth.GitHub.OAuth != nil && 
+	if cfg.Auth.GitHub != nil && cfg.Auth.GitHub.OAuth != nil &&
 		cfg.Auth.GitHub.OAuth.ClientID != "" && cfg.Auth.GitHub.OAuth.ClientSecret != "" {
 		log.Printf("[OAUTH_INIT] Initializing GitHub OAuth provider...")
 		p.oauthProvider = auth.NewGitHubOAuthProvider(cfg.Auth.GitHub.OAuth, cfg.Auth.GitHub)
@@ -359,6 +359,11 @@ func (p *Proxy) setupRoutes() {
 	p.echo.POST("/start", p.startAgentAPIServer, auth.RequirePermission("session:create"))
 	p.echo.GET("/search", p.searchSessions, auth.RequirePermission("session:list"))
 	p.echo.DELETE("/sessions/:sessionId", p.deleteSession, auth.RequirePermission("session:delete"))
+
+	// Add authentication info routes
+	authInfoHandlers := NewAuthInfoHandlers(p.config)
+	p.echo.GET("/auth/types", authInfoHandlers.GetAuthTypes)
+	p.echo.GET("/auth/status", authInfoHandlers.GetAuthStatus)
 
 	// Add OAuth routes if OAuth is configured
 	log.Printf("[ROUTES] OAuth provider configured: %v", p.oauthProvider != nil)


### PR DESCRIPTION
## Summary

- GET /auth/types: 利用可能な認証タイプ（APIキー、GitHub OAuth）を取得するエンドポイントを追加
- GET /auth/status: 現在の認証状況（認証済みか、ユーザー情報、権限等）を取得するエンドポイントを追加
- クライアント側から認証設定と状況を確認可能に

## Test plan

- [x] 認証が無効な場合のレスポンステスト
- [x] APIキー認証のみの場合のテスト
- [x] GitHub OAuth認証の場合のテスト  
- [x] 複数認証タイプが有効な場合のテスト
- [x] 認証済み/未認証状態のレスポンステスト
- [x] lint と test の実行確認

🤖 Generated with [Claude Code](https://claude.ai/code)