### PR TITLE
chart内でconfigとsecretsを設定可能に

### DIFF
--- a/helm/agentapi-proxy/templates/configmap.yaml
+++ b/helm/agentapi-proxy/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-config
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/secret.yaml
+++ b/helm/agentapi-proxy/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-secrets
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -74,9 +74,19 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-          {{- with .Values.envFrom }}
+          {{- if or .Values.config .Values.secrets .Values.envFrom }}
           envFrom:
+            {{- if .Values.config }}
+            - configMapRef:
+                name: {{ include "agentapi-proxy.fullname" . }}-config
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "agentapi-proxy.fullname" . }}-secrets
+            {{- end }}
+            {{- with .Values.envFrom }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -116,6 +116,17 @@ envFrom: []
   # - secretRef:
   #     name: agentapi-secrets
 
+# Application configuration (non-sensitive)
+config: {}
+  # CLAUDE_ARGS: "--dangerously-skip-permissions"
+  # LOG_LEVEL: "info"
+  # SESSION_TIMEOUT: "3600"
+
+# Application secrets (sensitive data)
+secrets: {}
+  # GITHUB_TOKEN: "your-github-token"
+  # API_SECRET: "your-api-secret"
+
 # Liveness and readiness probes
 livenessProbe:
   httpGet:


### PR DESCRIPTION
## Summary
- ConfigMapテンプレートを追加してchart内で非機密設定を管理可能に
- Secretテンプレートを追加してchart内で機密情報を分離管理可能に
- values.yamlにconfigとsecretsセクションを追加
- StatefulSetでConfigMapとSecretを自動参照するよう修正

## Test plan
- [x] Helm lintでチャートの構文チェック完了
- [x] helm templateで正常にレンダリングされることを確認
- [x] configとsecretsが設定された場合のテンプレート出力を確認

🤖 Generated with [Claude Code](https://claude.ai/code)