### PR TITLE
feat: viper設定管理の実装

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,49 @@
+# Example configuration file for agentapi-proxy
+# This file demonstrates all available configuration options
+# Values can be overridden by environment variables with AGENTAPI_ prefix
+# Example: AGENTAPI_START_PORT=8080
+
+# Starting port for agentapi servers
+start_port: 9000
+
+# Authentication configuration
+auth:
+  enabled: false
+  
+  # Static API key authentication
+  static:
+    enabled: false
+    header_name: "X-API-Key"
+    keys_file: ""  # Path to external API keys file
+    api_keys: []
+  
+  # GitHub OAuth authentication
+  github:
+    enabled: false
+    base_url: "https://api.github.com"
+    token_header: "Authorization"
+    
+    # User role mapping
+    user_mapping:
+      default_role: "user"
+      default_permissions: ["session:create"]
+      team_role_mapping: {}
+    
+    # OAuth configuration
+    oauth:
+      client_id: "${AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID}"
+      client_secret: "${AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET}"
+      scope: "read:user read:org"
+      base_url: ""  # Defaults to auth.github.base_url
+
+# Session persistence configuration
+persistence:
+  enabled: false
+  backend: "file"  # Options: file, sqlite, postgres
+  file_path: "./sessions.json"
+  sync_interval_seconds: 30
+  encrypt_sensitive_data: true
+  session_recovery_max_age_hours: 24
+
+# Enable user-specific directory isolation
+enable_multiple_users: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,25 @@
+// Package config provides configuration management for agentapi-proxy using viper.
+//
+// Configuration can be loaded from:
+//   - JSON files (backward compatibility)
+//   - YAML files
+//   - Environment variables with AGENTAPI_ prefix
+//
+// Environment variable examples:
+//
+//	AGENTAPI_START_PORT=8080
+//	AGENTAPI_AUTH_ENABLED=true
+//	AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID=your_client_id
+//	AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET=your_client_secret
+//	AGENTAPI_PERSISTENCE_ENABLED=true
+//	AGENTAPI_PERSISTENCE_BACKEND=file
+//
+// Configuration file search paths:
+//   - Current directory
+//   - $HOME/.agentapi/
+//   - /etc/agentapi/
+//
+// Configuration file names: config.json, config.yaml, config.yml
 package config
 
 import (
@@ -7,6 +29,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 // AuthConfig represents authentication configuration
@@ -86,8 +110,149 @@ type Config struct {
 	EnableMultipleUsers bool `json:"enable_multiple_users" mapstructure:"enable_multiple_users"`
 }
 
-// LoadConfig loads configuration from a JSON file
+// LoadConfig loads configuration using viper with support for JSON, YAML, and environment variables
 func LoadConfig(filename string) (*Config, error) {
+	v := viper.New()
+
+	// Set up configuration file
+	if filename != "" {
+		v.SetConfigFile(filename)
+	} else {
+		v.SetConfigName("config")
+		v.AddConfigPath(".")
+		v.AddConfigPath("$HOME/.agentapi")
+		v.AddConfigPath("/etc/agentapi/")
+	}
+
+	// Enable environment variable support
+	v.AutomaticEnv()
+	v.SetEnvPrefix("AGENTAPI")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+	// Set defaults
+	setDefaults(v)
+
+	// Read config file
+	if err := v.ReadInConfig(); err != nil {
+		// If no config file is found, use defaults
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, err
+		}
+		log.Printf("[CONFIG] No config file found, using defaults and environment variables")
+	} else {
+		log.Printf("[CONFIG] Using config file: %s", v.ConfigFileUsed())
+	}
+
+	var config Config
+	if err := v.Unmarshal(&config); err != nil {
+		return nil, err
+	}
+
+	// Apply defaults for any fields that weren't set in config file
+	applyConfigDefaults(&config)
+
+	// Apply post-processing
+	if err := postProcessConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// setDefaults sets default values for viper configuration
+func setDefaults(v *viper.Viper) {
+	v.SetDefault("start_port", 9000)
+
+	// Persistence defaults
+	v.SetDefault("persistence.enabled", false)
+	v.SetDefault("persistence.backend", "file")
+	v.SetDefault("persistence.file_path", "./sessions.json")
+	v.SetDefault("persistence.sync_interval_seconds", 30)
+	v.SetDefault("persistence.encrypt_sensitive_data", true)
+	v.SetDefault("persistence.session_recovery_max_age_hours", 24)
+
+	// Auth defaults
+	v.SetDefault("auth.enabled", false)
+	v.SetDefault("auth.static.enabled", false)
+	v.SetDefault("auth.static.header_name", "X-API-Key")
+	v.SetDefault("auth.github.base_url", "https://api.github.com")
+	v.SetDefault("auth.github.token_header", "Authorization")
+	v.SetDefault("auth.github.oauth.scope", "read:user read:org")
+
+	// Multiple users default
+	v.SetDefault("enable_multiple_users", false)
+}
+
+// applyConfigDefaults applies default values to any unset configuration fields
+func applyConfigDefaults(config *Config) {
+	// Apply defaults for persistence if the entire struct is uninitialized
+	if config.Persistence.Backend == "" {
+		config.Persistence.Backend = "file"
+	}
+	if config.Persistence.FilePath == "" {
+		config.Persistence.FilePath = "./sessions.json"
+	}
+	if config.Persistence.SyncInterval == 0 {
+		config.Persistence.SyncInterval = 30
+	}
+	if !config.Persistence.Enabled {
+		config.Persistence.EncryptSecrets = true
+		config.Persistence.SessionRecoveryMaxAge = 24
+	}
+
+	// Apply auth defaults
+	if config.Auth.Static != nil && config.Auth.Static.HeaderName == "" {
+		config.Auth.Static.HeaderName = "X-API-Key"
+	}
+	if config.Auth.GitHub != nil {
+		if config.Auth.GitHub.BaseURL == "" {
+			config.Auth.GitHub.BaseURL = "https://api.github.com"
+		}
+		if config.Auth.GitHub.TokenHeader == "" {
+			config.Auth.GitHub.TokenHeader = "Authorization"
+		}
+		if config.Auth.GitHub.OAuth != nil && config.Auth.GitHub.OAuth.Scope == "" {
+			config.Auth.GitHub.OAuth.Scope = "read:user read:org"
+		}
+	}
+}
+
+// postProcessConfig applies post-processing logic to the configuration
+func postProcessConfig(config *Config) error {
+	// Set default auth configuration
+	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
+		if config.Auth.GitHub.OAuth.BaseURL == "" {
+			config.Auth.GitHub.OAuth.BaseURL = config.Auth.GitHub.BaseURL
+		}
+	}
+
+	// Expand environment variables in OAuth configuration
+	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
+		config.Auth.GitHub.OAuth.ClientID = expandEnvVars(config.Auth.GitHub.OAuth.ClientID)
+		config.Auth.GitHub.OAuth.ClientSecret = expandEnvVars(config.Auth.GitHub.OAuth.ClientSecret)
+
+		// Log OAuth configuration status (without exposing secrets)
+		log.Printf("[CONFIG] OAuth ClientID configured: %v", config.Auth.GitHub.OAuth.ClientID != "")
+		log.Printf("[CONFIG] OAuth ClientSecret configured: %v", config.Auth.GitHub.OAuth.ClientSecret != "")
+
+		// Warn if OAuth is configured but credentials are missing
+		if config.Auth.GitHub.OAuth.ClientID == "" || config.Auth.GitHub.OAuth.ClientSecret == "" {
+			log.Printf("[CONFIG] Warning: OAuth is configured but Client ID or Client Secret is missing")
+		}
+	}
+
+	// Load API keys from external file if specified
+	if config.Auth.Enabled && config.Auth.Static != nil && config.Auth.Static.KeysFile != "" {
+		if err := config.loadAPIKeysFromFile(); err != nil {
+			log.Printf("Warning: Failed to load API keys from %s: %v", config.Auth.Static.KeysFile, err)
+		}
+	}
+
+	return nil
+}
+
+// LoadConfigLegacy loads configuration from a JSON file (legacy method)
+func LoadConfigLegacy(filename string) (*Config, error) {
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -124,45 +289,9 @@ func LoadConfig(filename string) (*Config, error) {
 		config.Persistence.SessionRecoveryMaxAge = 24
 	}
 
-	// Set default auth configuration
-	if config.Auth.Static != nil && config.Auth.Static.HeaderName == "" {
-		config.Auth.Static.HeaderName = "X-API-Key"
-	}
-	if config.Auth.GitHub != nil && config.Auth.GitHub.BaseURL == "" {
-		config.Auth.GitHub.BaseURL = "https://api.github.com"
-	}
-	if config.Auth.GitHub != nil && config.Auth.GitHub.TokenHeader == "" {
-		config.Auth.GitHub.TokenHeader = "Authorization"
-	}
-	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
-		if config.Auth.GitHub.OAuth.BaseURL == "" {
-			config.Auth.GitHub.OAuth.BaseURL = config.Auth.GitHub.BaseURL
-		}
-		if config.Auth.GitHub.OAuth.Scope == "" {
-			config.Auth.GitHub.OAuth.Scope = "read:user read:org"
-		}
-	}
-
-	// Expand environment variables in OAuth configuration
-	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
-		config.Auth.GitHub.OAuth.ClientID = expandEnvVars(config.Auth.GitHub.OAuth.ClientID)
-		config.Auth.GitHub.OAuth.ClientSecret = expandEnvVars(config.Auth.GitHub.OAuth.ClientSecret)
-
-		// Log OAuth configuration status (without exposing secrets)
-		log.Printf("[CONFIG] OAuth ClientID configured: %v", config.Auth.GitHub.OAuth.ClientID != "")
-		log.Printf("[CONFIG] OAuth ClientSecret configured: %v", config.Auth.GitHub.OAuth.ClientSecret != "")
-
-		// Warn if OAuth is configured but credentials are missing
-		if config.Auth.GitHub.OAuth.ClientID == "" || config.Auth.GitHub.OAuth.ClientSecret == "" {
-			log.Printf("[CONFIG] Warning: OAuth is configured but Client ID or Client Secret is missing")
-		}
-	}
-
-	// Load API keys from external file if specified
-	if config.Auth.Enabled && config.Auth.Static != nil && config.Auth.Static.KeysFile != "" {
-		if err := config.loadAPIKeysFromFile(); err != nil {
-			log.Printf("Warning: Failed to load API keys from %s: %v", config.Auth.Static.KeysFile, err)
-		}
+	// Apply post-processing
+	if err := postProcessConfig(&config); err != nil {
+		return nil, err
 	}
 
 	return &config, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,9 +175,13 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("auth.enabled", false)
 	v.SetDefault("auth.static.enabled", false)
 	v.SetDefault("auth.static.header_name", "X-API-Key")
+	v.SetDefault("auth.github.enabled", false)
 	v.SetDefault("auth.github.base_url", "https://api.github.com")
 	v.SetDefault("auth.github.token_header", "Authorization")
+	v.SetDefault("auth.github.oauth.client_id", "")
+	v.SetDefault("auth.github.oauth.client_secret", "")
 	v.SetDefault("auth.github.oauth.scope", "read:user read:org")
+	v.SetDefault("auth.github.oauth.base_url", "")
 
 	// Multiple users default
 	v.SetDefault("enable_multiple_users", false)
@@ -226,12 +230,14 @@ func postProcessConfig(config *Config) error {
 		}
 	}
 
-	// Expand environment variables in OAuth configuration
+	// Expand environment variables in OAuth configuration (for ${VAR_NAME} syntax in config files)
 	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
 		config.Auth.GitHub.OAuth.ClientID = expandEnvVars(config.Auth.GitHub.OAuth.ClientID)
 		config.Auth.GitHub.OAuth.ClientSecret = expandEnvVars(config.Auth.GitHub.OAuth.ClientSecret)
+	}
 
-		// Log OAuth configuration status (without exposing secrets)
+	// Log OAuth configuration status (after expansion)
+	if config.Auth.GitHub != nil && config.Auth.GitHub.OAuth != nil {
 		log.Printf("[CONFIG] OAuth ClientID configured: %v", config.Auth.GitHub.OAuth.ClientID != "")
 		log.Printf("[CONFIG] OAuth ClientSecret configured: %v", config.Auth.GitHub.OAuth.ClientSecret != "")
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -309,3 +309,239 @@ func TestLoadConfig_EnableMultipleUsers(t *testing.T) {
 		t.Errorf("Expected EnableMultipleUsers to be true, got %t", loadedConfig.EnableMultipleUsers)
 	}
 }
+
+func TestExpandEnvVars(t *testing.T) {
+	// Set up test environment variables
+	_ = os.Setenv("TEST_VAR", "test_value")
+	_ = os.Setenv("CLIENT_ID", "my_client_id")
+	defer func() {
+		_ = os.Unsetenv("TEST_VAR")
+		_ = os.Unsetenv("CLIENT_ID")
+	}()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple variable expansion",
+			input:    "${TEST_VAR}",
+			expected: "test_value",
+		},
+		{
+			name:     "Variable in string",
+			input:    "prefix_${TEST_VAR}_suffix",
+			expected: "prefix_test_value_suffix",
+		},
+		{
+			name:     "Multiple variables",
+			input:    "${TEST_VAR}_${CLIENT_ID}",
+			expected: "test_value_my_client_id",
+		},
+		{
+			name:     "Non-existent variable",
+			input:    "${NON_EXISTENT_VAR}",
+			expected: "${NON_EXISTENT_VAR}",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "No variables",
+			input:    "plain_string",
+			expected: "plain_string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := expandEnvVars(tt.input)
+			if result != tt.expected {
+				t.Errorf("expandEnvVars(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoadConfigWithEnvVarExpansion(t *testing.T) {
+	// Set up test environment variables
+	_ = os.Setenv("TEST_CLIENT_ID", "github_client_123")
+	_ = os.Setenv("TEST_CLIENT_SECRET", "github_secret_456")
+	defer func() {
+		_ = os.Unsetenv("TEST_CLIENT_ID")
+		_ = os.Unsetenv("TEST_CLIENT_SECRET")
+	}()
+
+	// Create config with environment variable references
+	configJSON := `{
+		"start_port": 8000,
+		"auth": {
+			"enabled": true,
+			"github": {
+				"enabled": true,
+				"oauth": {
+					"client_id": "${TEST_CLIENT_ID}",
+					"client_secret": "${TEST_CLIENT_SECRET}",
+					"scope": "read:user read:org"
+				}
+			}
+		}
+	}`
+
+	// Write to temporary file
+	tmpfile, err := os.CreateTemp("", "config*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+
+	if _, err := tmpfile.WriteString(configJSON); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+	_ = tmpfile.Close()
+
+	// Load the config
+	loadedConfig, err := LoadConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Verify environment variables were expanded
+	if loadedConfig.Auth.GitHub == nil || loadedConfig.Auth.GitHub.OAuth == nil {
+		t.Fatal("GitHub OAuth config should not be nil")
+	}
+
+	if loadedConfig.Auth.GitHub.OAuth.ClientID != "github_client_123" {
+		t.Errorf("Expected ClientID to be 'github_client_123', got '%s'", loadedConfig.Auth.GitHub.OAuth.ClientID)
+	}
+
+	if loadedConfig.Auth.GitHub.OAuth.ClientSecret != "github_secret_456" {
+		t.Errorf("Expected ClientSecret to be 'github_secret_456', got '%s'", loadedConfig.Auth.GitHub.OAuth.ClientSecret)
+	}
+}
+
+func TestLoadConfigWithYAML(t *testing.T) {
+	// Create YAML config
+	yamlConfig := `
+start_port: 8000
+auth:
+  enabled: true
+  github:
+    enabled: true
+    oauth:
+      client_id: "yaml_client_id"
+      client_secret: "yaml_client_secret"
+      scope: "read:user read:org"
+persistence:
+  enabled: true
+  backend: "file"
+  file_path: "./test_sessions.json"
+enable_multiple_users: true
+`
+
+	// Write to temporary YAML file
+	tmpfile, err := os.CreateTemp("", "config*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+
+	if _, err := tmpfile.WriteString(yamlConfig); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+	_ = tmpfile.Close()
+
+	// Load the config
+	loadedConfig, err := LoadConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Verify YAML was loaded correctly
+	if loadedConfig.StartPort != 8000 {
+		t.Errorf("Expected StartPort to be 8000, got %d", loadedConfig.StartPort)
+	}
+
+	if !loadedConfig.EnableMultipleUsers {
+		t.Errorf("Expected EnableMultipleUsers to be true, got %t", loadedConfig.EnableMultipleUsers)
+	}
+
+	if !loadedConfig.Persistence.Enabled {
+		t.Errorf("Expected Persistence.Enabled to be true, got %t", loadedConfig.Persistence.Enabled)
+	}
+
+	if loadedConfig.Persistence.FilePath != "./test_sessions.json" {
+		t.Errorf("Expected Persistence.FilePath to be './test_sessions.json', got '%s'", loadedConfig.Persistence.FilePath)
+	}
+
+	if loadedConfig.Auth.GitHub == nil || loadedConfig.Auth.GitHub.OAuth == nil {
+		t.Fatal("GitHub OAuth config should not be nil")
+	}
+
+	if loadedConfig.Auth.GitHub.OAuth.ClientID != "yaml_client_id" {
+		t.Errorf("Expected ClientID to be 'yaml_client_id', got '%s'", loadedConfig.Auth.GitHub.OAuth.ClientID)
+	}
+}
+
+func TestLoadConfigWithEnvironmentVariables(t *testing.T) {
+	// Set up test environment variables (viper format)
+	_ = os.Setenv("AGENTAPI_START_PORT", "9999")
+	_ = os.Setenv("AGENTAPI_AUTH_ENABLED", "true")
+	_ = os.Setenv("AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID", "env_client_id")
+	_ = os.Setenv("AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET", "env_client_secret")
+	_ = os.Setenv("AGENTAPI_PERSISTENCE_ENABLED", "true")
+	_ = os.Setenv("AGENTAPI_PERSISTENCE_BACKEND", "sqlite")
+	_ = os.Setenv("AGENTAPI_ENABLE_MULTIPLE_USERS", "true")
+
+	defer func() {
+		_ = os.Unsetenv("AGENTAPI_START_PORT")
+		_ = os.Unsetenv("AGENTAPI_AUTH_ENABLED")
+		_ = os.Unsetenv("AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID")
+		_ = os.Unsetenv("AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET")
+		_ = os.Unsetenv("AGENTAPI_PERSISTENCE_ENABLED")
+		_ = os.Unsetenv("AGENTAPI_PERSISTENCE_BACKEND")
+		_ = os.Unsetenv("AGENTAPI_ENABLE_MULTIPLE_USERS")
+	}()
+
+	// Load config without specifying a file (should use env vars and defaults)
+	loadedConfig, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	// Verify environment variables were loaded
+	if loadedConfig.StartPort != 9999 {
+		t.Errorf("Expected StartPort to be 9999, got %d", loadedConfig.StartPort)
+	}
+
+	if !loadedConfig.Auth.Enabled {
+		t.Errorf("Expected Auth.Enabled to be true, got %t", loadedConfig.Auth.Enabled)
+	}
+
+	if !loadedConfig.EnableMultipleUsers {
+		t.Errorf("Expected EnableMultipleUsers to be true, got %t", loadedConfig.EnableMultipleUsers)
+	}
+
+	if !loadedConfig.Persistence.Enabled {
+		t.Errorf("Expected Persistence.Enabled to be true, got %t", loadedConfig.Persistence.Enabled)
+	}
+
+	if loadedConfig.Persistence.Backend != "sqlite" {
+		t.Errorf("Expected Persistence.Backend to be 'sqlite', got '%s'", loadedConfig.Persistence.Backend)
+	}
+
+	if loadedConfig.Auth.GitHub == nil || loadedConfig.Auth.GitHub.OAuth == nil {
+		t.Fatal("GitHub OAuth config should not be nil")
+	}
+
+	if loadedConfig.Auth.GitHub.OAuth.ClientID != "env_client_id" {
+		t.Errorf("Expected ClientID to be 'env_client_id', got '%s'", loadedConfig.Auth.GitHub.OAuth.ClientID)
+	}
+
+	if loadedConfig.Auth.GitHub.OAuth.ClientSecret != "env_client_secret" {
+		t.Errorf("Expected ClientSecret to be 'env_client_secret', got '%s'", loadedConfig.Auth.GitHub.OAuth.ClientSecret)
+	}
+}


### PR DESCRIPTION
## Summary
- config.jsonの値をviperを使用して環境変数やYAMLファイルから読み込めるように実装
- 既存のJSON設定ファイルとの後方互換性を維持
- 環境変数サポート（AGENTAPI_プレフィックス）とYAML設定ファイルサポートを追加

## 主な変更点
- LoadConfig関数をviperベースに変更
- 環境変数サポート（例: AGENTAPI_START_PORT=8080）
- YAML設定ファイルサポート
- 設定ファイル検索パス追加（., $HOME/.agentapi, /etc/agentapi）
- config.example.yaml追加
- テストを更新してviper実装に対応

## 環境変数の例
```bash
AGENTAPI_START_PORT=8080
AGENTAPI_AUTH_ENABLED=true
AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID=your_client_id
AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET=your_client_secret
AGENTAPI_PERSISTENCE_ENABLED=true
```

## Test plan
- [x] 既存のJSONファイル読み込みが正常に動作することを確認
- [x] 環境変数からの設定読み込みが正常に動作することを確認
- [x] YAMLファイルからの設定読み込みが正常に動作することを確認
- [x] デフォルト値が正しく適用されることを確認
- [x] 全テストが合格することを確認
- [x] lintが合格することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)