### PR TITLE
feat: Helmチャートにviper設定のデフォルト値を追加

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -45,6 +45,43 @@ spec:
           env:
             - name: HOME
               value: "/home/agentapi"
+            # Application configuration via environment variables (AGENTAPI_ prefix)
+            - name: AGENTAPI_START_PORT
+              value: {{ .Values.config.startPort | quote }}
+            - name: AGENTAPI_ENABLE_MULTIPLE_USERS
+              value: {{ .Values.config.enableMultipleUsers | quote }}
+            - name: AGENTAPI_PERSISTENCE_ENABLED
+              value: {{ .Values.config.persistence.enabled | quote }}
+            - name: AGENTAPI_PERSISTENCE_BACKEND
+              value: {{ .Values.config.persistence.backend | quote }}
+            - name: AGENTAPI_PERSISTENCE_FILE_PATH
+              value: {{ .Values.config.persistence.filePath | quote }}
+            - name: AGENTAPI_PERSISTENCE_SYNC_INTERVAL_SECONDS
+              value: {{ .Values.config.persistence.syncIntervalSeconds | quote }}
+            - name: AGENTAPI_PERSISTENCE_ENCRYPT_SENSITIVE_DATA
+              value: {{ .Values.config.persistence.encryptSensitiveData | quote }}
+            - name: AGENTAPI_PERSISTENCE_SESSION_RECOVERY_MAX_AGE_HOURS
+              value: {{ .Values.config.persistence.sessionRecoveryMaxAgeHours | quote }}
+            - name: AGENTAPI_AUTH_ENABLED
+              value: {{ .Values.config.auth.enabled | quote }}
+            - name: AGENTAPI_AUTH_STATIC_ENABLED
+              value: {{ .Values.config.auth.static.enabled | quote }}
+            - name: AGENTAPI_AUTH_STATIC_HEADER_NAME
+              value: {{ .Values.config.auth.static.headerName | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_ENABLED
+              value: {{ .Values.config.auth.github.enabled | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_BASE_URL
+              value: {{ .Values.config.auth.github.baseUrl | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_TOKEN_HEADER
+              value: {{ .Values.config.auth.github.tokenHeader | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID
+              value: {{ .Values.config.auth.github.oauth.clientId | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET
+              value: {{ .Values.config.auth.github.oauth.clientSecret | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_SCOPE
+              value: {{ .Values.config.auth.github.oauth.scope | quote }}
+            - name: AGENTAPI_AUTH_GITHUB_OAUTH_BASE_URL
+              value: {{ .Values.config.auth.github.oauth.baseUrl | quote }}
             {{- if .Values.github.enterprise.enabled }}
             {{- if .Values.github.enterprise.baseUrl }}
             - name: GITHUB_URL

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -97,6 +97,39 @@ github:
       # Secret 内のキー名
       key: "private-key"
 
+# Application Configuration
+config:
+  # サーバー設定
+  startPort: 9000
+  
+  # マルチユーザー設定
+  enableMultipleUsers: false
+  
+  # 永続化設定
+  persistence:
+    enabled: false
+    backend: "file"
+    filePath: "./sessions.json"
+    syncIntervalSeconds: 30
+    encryptSensitiveData: true
+    sessionRecoveryMaxAgeHours: 24
+  
+  # 認証設定
+  auth:
+    enabled: false
+    static:
+      enabled: false
+      headerName: "X-API-Key"
+    github:
+      enabled: false
+      baseUrl: "https://api.github.com"
+      tokenHeader: "Authorization"
+      oauth:
+        clientId: ""
+        clientSecret: ""
+        scope: "read:user read:org"
+        baseUrl: ""
+
 # Environment variables
 env: []
   # - name: GITHUB_TOKEN


### PR DESCRIPTION
## Summary
• Helmチャートのvalues.yamlにviper設定のデフォルト値を追加
• StatefulSetテンプレートで環境変数として設定を展開
• AGENTAPI_プレフィックス付き環境変数でviper設定を自動適用

## 変更内容
• `helm/agentapi-proxy/values.yaml`: 新しい`config`セクションを追加
  - サーバー設定 (startPort: 9000)
  - マルチユーザー設定 (enableMultipleUsers: false)
  - 永続化設定 (enabled: false, backend: file, etc.)
  - 認証設定 (GitHub OAuth, Static auth設定)

• `helm/agentapi-proxy/templates/statefulset.yaml`: 環境変数を追加
  - 全てのviper設定をAGENTAPI_プレフィックス付き環境変数として設定
  - values.yamlの設定値を動的に環境変数に変換

## Test plan
- [x] `helm template`でテンプレートレンダリング確認済み
- [x] 環境変数が正しく設定されることを確認済み
- [x] デフォルト値がviper設定と一致することを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)