### PR TITLE
fix: Helmチャートでmiseコマンドが利用できるようにセキュリティコンテキストを修正

### DIFF
--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -30,9 +30,9 @@ podLabels: {}
 
 podSecurityContext:
   fsGroup: 1001
-  runAsUser: 1001
-  runAsGroup: 1001
-  runAsNonRoot: true
+  # runAsUser: 1001
+  # runAsGroup: 1001
+  # runAsNonRoot: true
 
 securityContext: {}
 


### PR DESCRIPTION
## Summary
- values.yamlでrunAsUser指定をコメントアウトしてrootで実行するように修正
- これによりmiseコマンドが正常に動作するようになる

## Test plan
- [ ] Helmチャートをデプロイしてmiseコマンドが実行できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)