### PR TITLE
fix: Dockerコンテナでmiseコマンドが利用できるようにPATH設定を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,8 @@ COPY --from=agentapi-builder /agentapi /usr/local/bin/agentapi
 USER agentapi
 
 # Install mise
-RUN curl https://mise.run | sh
+RUN curl https://mise.run | sh && \
+    echo 'export PATH="/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:$PATH"' >> /home/agentapi/.bashrc
 ENV PATH="/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:$PATH"
 
 # Install claude code and Playwright MCP server via npm (Node.js is now installed directly)


### PR DESCRIPTION
## Summary
- Dockerコンテナ内でmiseコマンドが使えなかった問題を修正
- .bashrcにmiseのPATH設定を追加してシェルセッション間でPATHが維持されるように修正
- dockerコンテナ内でmiseを使った開発ツールのインストールが可能になる

## Test Plan
- [x] makeコマンドでlintとtestを実行し、全て成功することを確認
- [x] miseコマンドが正常に動作することを確認
- [x] .tool-versionsで定義されたツール（Go、golangci-lint、helm）のインストールができることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)