### PR TITLE
feat: Add global gitignore configuration for .claude directory in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,10 @@ COPY --from=agentapi-builder /agentapi /usr/local/bin/agentapi
 # Switch to non-root user
 USER agentapi
 
+# Configure global gitignore for .claude directory
+RUN git config --global core.excludesfile ~/.gitignore_global && \
+    echo ".claude/" > ~/.gitignore_global
+
 # Install mise
 RUN curl https://mise.run | sh && \
     echo 'export PATH="/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:$PATH"' >> /home/agentapi/.bashrc

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -172,7 +172,7 @@ func tryStaticAuth(c echo.Context, staticCfg *config.StaticAuthConfig, cfg *conf
 
 	// First, try to get API key from the configured custom header
 	apiKey = c.Request().Header.Get(staticCfg.HeaderName)
-	
+
 	// If not found in custom header, try to extract from Authorization header (Bearer token)
 	if apiKey == "" {
 		authHeader := c.Request().Header.Get("Authorization")


### PR DESCRIPTION
## Summary
- Added global gitignore configuration in Dockerfile to automatically ignore `.claude/` directory
- This prevents Claude-specific configuration files from being accidentally committed to repositories

## Test plan
- [ ] Build the Docker image and verify it builds successfully
- [ ] Run a container from the image and verify git ignores `.claude/` directories
- [ ] Confirm existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)