### PR TITLE
feat: Use CLAUDE_DIR environment variable instead of modifying HOME

### DIFF
--- a/pkg/proxy/scripts/agentapi_default.sh
+++ b/pkg/proxy/scripts/agentapi_default.sh
@@ -19,15 +19,17 @@ export GITHUB_APP_PEM_PATH="{{.GitHubAppPEMPath}}"
 export GITHUB_API="{{.GitHubAPI}}"
 export GITHUB_PERSONAL_ACCESS_TOKEN="{{.GitHubPersonalAccessToken}}"
 
-# Set user-specific HOME directory if multiple users is enabled
+# Set user-specific CLAUDE_DIR if multiple users is enabled
 if [[ "$ENABLE_MULTIPLE_USERS" == "true" && -n "$USER_HOME_DIR" ]]; then
-    echo "Setting HOME to user-specific directory: $USER_HOME_DIR"
-    export HOME="$USER_HOME_DIR"
+    # Set CLAUDE_DIR to ~/.claude/[username] pattern
+    USER_NAME=$(basename "$USER_HOME_DIR")
+    export CLAUDE_DIR="${HOME}/.claude/${USER_NAME}"
+    echo "Setting CLAUDE_DIR to user-specific directory: $CLAUDE_DIR"
     
-    # Ensure the user home directory exists
-    if [[ ! -d "$USER_HOME_DIR" ]]; then
-        echo "Creating user home directory: $USER_HOME_DIR"
-        mkdir -p "$USER_HOME_DIR"
+    # Ensure the Claude directory exists
+    if [[ ! -d "$CLAUDE_DIR" ]]; then
+        echo "Creating Claude user directory: $CLAUDE_DIR"
+        mkdir -p "$CLAUDE_DIR"
     fi
 fi
 
@@ -50,5 +52,9 @@ else
     fi
 fi
 
-CLAUDE_DIR=. agentapi-proxy helpers setup-claude-code
+# Use the CLAUDE_DIR if set, otherwise use current directory
+if [[ -z "$CLAUDE_DIR" ]]; then
+    CLAUDE_DIR=.
+fi
+CLAUDE_DIR="$CLAUDE_DIR" agentapi-proxy helpers setup-claude-code
 exec agentapi server --port "$PORT" {{.AgentAPIArgs}} -- claude {{.ClaudeArgs}}


### PR DESCRIPTION
## Summary
- Replace HOME modification with CLAUDE_DIR environment variable for multi-user mode
- Set CLAUDE_DIR to ~/.claude/[username] pattern to give each user their own Claude configuration directory
- Keep HOME unchanged to avoid side effects on other processes

## Changes
- Updated `agentapi_default.sh` to set CLAUDE_DIR instead of HOME for multi-user mode
- Modified `userdir` package to manage CLAUDE_DIR environment variable
- Added new methods `GetUserClaudeDir` and `EnsureUserClaudeDir` for Claude directory management
- Updated tests to verify CLAUDE_DIR behavior

## Benefits
- Cleaner approach that doesn't modify the global HOME environment variable
- Each user gets their own Claude configuration directory at ~/.claude/[username]
- No side effects on other processes that depend on HOME

## Test plan
- [x] Run `make lint` - all checks pass
- [x] Run `make test` - all tests pass
- [x] Verify CLAUDE_DIR is set correctly in multi-user mode
- [x] Verify single-user mode continues to work as before

🤖 Generated with [Claude Code](https://claude.ai/code)