### PR TITLE
feat: Add Playwright MCP configuration to Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,12 +86,18 @@ ENV PATH="/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:$PATH
 # Install claude code and Playwright MCP server via npm (Node.js is now installed directly)
 RUN sudo npm install -g @anthropic-ai/claude-code @playwright/mcp@latest
 
+# Install Playwright dependencies (without downloading browsers, using Lightpanda instead)
+RUN sudo npx playwright install-deps
+
 # Setup Lightpanda Browser
 ENV LIGHTPANDA_BIN=/usr/local/bin/lightpanda
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # Copy CLAUDE.md to temporary location for entrypoint script
 COPY config/CLAUDE.md /tmp/config/CLAUDE.md
+
+# Copy Claude Code MCP configuration
+COPY config/claude_code_config.json /tmp/config/claude_code_config.json
 
 # Copy entrypoint script
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/config/claude_code_config.json
+++ b/config/claude_code_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"],
+      "env": {
+        "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+        "LIGHTPANDA_BIN": "/usr/local/bin/lightpanda"
+      }
+    }
+  }
+}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,5 +11,14 @@ if [ ! -f /home/agentapi/.claude/CLAUDE.md ] || [ /tmp/config/CLAUDE.md -nt /hom
     echo "CLAUDE.md copied successfully"
 fi
 
+# Setup Claude Code configuration with MCP servers
+if [ -f /tmp/config/claude_code_config.json ]; then
+    echo "Setting up Claude Code MCP configuration..."
+    # Ensure claude-code config directory exists
+    mkdir -p /home/agentapi/.config/claude-code
+    cp /tmp/config/claude_code_config.json /home/agentapi/.config/claude-code/config.json
+    echo "Claude Code MCP configuration copied successfully"
+fi
+
 # Execute the original command
 exec "$@"


### PR DESCRIPTION
## Summary
- Add Playwright MCP server configuration for Claude Code integration
- Install Playwright system dependencies in Docker image
- Configure MCP server to use Lightpanda browser

## Changes
- **Dockerfile**: Added `npx playwright install-deps` to install Playwright system dependencies
- **config/claude_code_config.json**: New MCP configuration file for Playwright
- **scripts/entrypoint.sh**: Updated to copy MCP configuration to Claude Code config directory

## Test plan
- [ ] Build Docker image with changes
- [ ] Verify Playwright MCP is available in Claude Code
- [ ] Test basic Playwright functionality through MCP

🤖 Generated with [Claude Code](https://claude.ai/code)