### PR TITLE
feat: Add MCP server configuration support to agentapi-proxy

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -58,6 +58,7 @@ type ScriptTemplateData struct {
 	UserID                    string
 	EnableMultipleUsers       string
 	UserHomeDir               string
+	MCPConfigs                string
 }
 
 // StartRequest represents the request body for starting a new agentapi server
@@ -853,6 +854,13 @@ func (p *Proxy) runAgentAPIServer(ctx context.Context, session *AgentSession, sc
 	} else {
 		// Always set CloneDir to session ID, even when no repository is specified
 		templateData.CloneDir = session.ID
+	}
+
+	// Extract MCP configurations from tags if available
+	if session.Tags != nil {
+		if mcpConfigs, exists := session.Tags["claude.mcp_configs"]; exists && mcpConfigs != "" {
+			templateData.MCPConfigs = mcpConfigs
+		}
 	}
 
 	if scriptName != "" {

--- a/pkg/proxy/scripts/agentapi_default.sh
+++ b/pkg/proxy/scripts/agentapi_default.sh
@@ -57,4 +57,16 @@ if [[ -z "$CLAUDE_DIR" ]]; then
     CLAUDE_DIR=.
 fi
 CLAUDE_DIR="$CLAUDE_DIR" agentapi-proxy helpers setup-claude-code
+
+# Add MCP servers if configuration is provided
+MCP_CONFIGS="{{.MCPConfigs}}"
+if [[ -n "$MCP_CONFIGS" ]]; then
+    echo "Setting up MCP servers from configuration"
+    if ! CLAUDE_DIR="$CLAUDE_DIR" agentapi-proxy helpers add-mcp-servers --config "$MCP_CONFIGS"; then
+        echo "Warning: Failed to add MCP servers, continuing with session startup" >&2
+    else
+        echo "Successfully configured MCP servers"
+    fi
+fi
+
 exec agentapi server --port "$PORT" {{.AgentAPIArgs}} -- claude {{.ClaudeArgs}}


### PR DESCRIPTION
## Summary
- Add backend support for Model Context Protocol (MCP) server configurations
- Process MCP configurations sent from frontend during session creation
- Automatically configure Claude with MCP servers during session startup

## Technical Details

### Backend Changes
- **Template Data Extension**: Added `MCPConfigs` field to `ScriptTemplateData`
- **Request Processing**: Extract `claude.mcp_configs` tag from session start requests
- **Helper Command**: New `add-mcp-servers` command for configuring Claude with MCP servers
- **Script Integration**: Updated `agentapi_default.sh` to automatically configure MCP servers

### MCP Configuration Flow
1. Frontend sends MCP configurations as base64-encoded JSON in `claude.mcp_configs` tag
2. Backend extracts the MCP configuration from session tags during session creation
3. Configuration is passed to the startup script via template data
4. Startup script calls `agentapi-proxy helpers add-mcp-servers` to configure Claude
5. Each MCP server is added via `claude mcp add` command with proper environment and arguments

### New Helper Command
```bash
agentapi-proxy helpers add-mcp-servers --config <base64-json> --claude-dir <dir>
```

Supports:
- Base64-encoded JSON MCP server configurations
- Multiple MCP servers in a single configuration
- stdio transport with command and arguments
- Custom environment variables per server
- Graceful error handling (continues on failure)

### Script Integration
The `agentapi_default.sh` script now includes:
```bash
# Add MCP servers if configuration is provided
MCP_CONFIGS="{{.MCPConfigs}}"
if [[ -n "$MCP_CONFIGS" ]]; then
    echo "Setting up MCP servers from configuration"
    if \! CLAUDE_DIR="$CLAUDE_DIR" agentapi-proxy helpers add-mcp-servers --config "$MCP_CONFIGS"; then
        echo "Warning: Failed to add MCP servers, continuing with session startup" >&2
    else
        echo "Successfully configured MCP servers"
    fi
fi
```

## Test Plan
- [x] Backend builds successfully
- [x] `add-mcp-servers` command works with test configurations
- [x] Base64 decoding functions correctly
- [x] Claude command integration works
- [x] Script template processing includes MCP configurations
- [x] All existing tests continue to pass
- [x] Integration with frontend MCP configuration encoding verified

🤖 Generated with [Claude Code](https://claude.ai/code)