### PR TITLE
feat: Use default service account and remove default security context settings

### DIFF
--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
   # Annotations to add to the service account
@@ -23,8 +23,7 @@ serviceAccount:
     # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT-ID:role/agentapi-s3-role
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  # If specified, it will use the existing service account instead of creating a new one
-  name: "default"
+  name: ""
 
 podAnnotations: {}
 podLabels: {}
@@ -68,7 +67,7 @@ resources:
 # Persistent Volume for session data
 persistence:
   enabled: true
-  storageClassName: "standard"
+  storageClassName: ""
   accessMode: ReadWriteOnce
   size: 10Gi
 

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -14,7 +14,7 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
   # Annotations to add to the service account
@@ -23,16 +23,13 @@ serviceAccount:
     # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT-ID:role/agentapi-s3-role
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  # If specified, it will use the existing service account instead of creating a new one
+  name: "default"
 
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext:
-  fsGroup: 1001
-  # runAsUser: 1001
-  # runAsGroup: 1001
-  # runAsNonRoot: true
+podSecurityContext: {}
 
 securityContext: {}
 


### PR DESCRIPTION
## 概要
- ServiceAccountの作成を無効化し、defaultのservice accountを使用するよう変更
- podSecurityContextのデフォルト設定を削除し、securityContextの設定を簡素化

## 変更内容
- `serviceAccount.create: false` に変更
- `serviceAccount.name: "default"` を設定
- `podSecurityContext` から `fsGroup: 1001` などのデフォルト設定を削除
- `securityContext` は引き続き空の設定を維持

## テスト計画
- [ ] Helmチャートのレンダリングが正しく動作することを確認
- [ ] デプロイ後にdefaultのservice accountが使用されることを確認
- [ ] アプリケーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)