### PR TITLE
chore: Helm チャートの appVersion を v1.26.0 に更新

### DIFF
--- a/helm/agentapi-proxy/Chart.yaml
+++ b/helm/agentapi-proxy/Chart.yaml
@@ -3,7 +3,7 @@ name: agentapi-proxy
 description: A Helm chart for AgentAPI Proxy - a reverse proxy and process manager for agentapi server instances
 type: application
 version: 0.2.0
-appVersion: "1.23.0"
+appVersion: "1.26.0"
 home: https://github.com/takutakahashi/agentapi-proxy
 sources:
   - https://github.com/takutakahashi/agentapi-proxy


### PR DESCRIPTION
## 概要
- Helm チャートの appVersion を最新タグ v1.26.0 に更新しました

## 変更内容
- `helm/agentapi-proxy/Chart.yaml` の appVersion を "1.23.0" から "1.26.0" に更新

## テスト計画
- [ ] Helm チャートの lint が通ることを確認
- [ ] Helm install/upgrade が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)