### PR TITLE
fix: Helm チャートの設定を修正

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -146,7 +146,7 @@ spec:
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: data
-              mountPath: /home/agentapi
+              mountPath: /home/agentapi/workdir
             {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/takutakahashi/agentapi-proxy
   pullPolicy: IfNotPresent
-  tag: "1.23.0"
+  tag: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## 概要
- Helm チャートの設定を修正しました

## 変更内容
1. イメージタグのデフォルト値を削除（空文字列に設定）
   - `values.yaml` の `image.tag` を `"1.23.0"` から `""` に変更
   - リリース時に自動的にタグバージョンが設定されるようになります

2. volumeMount 先を変更
   - `statefulset.yaml` の volumeMount パスを `/home/agentapi` から `/home/agentapi/workdir` に変更

## 背景
- リリース時に自動的に appVersion がタグバージョンと同期される仕組みは既に実装済みでした（`helm-publish.yml`）
- イメージタグのデフォルト値が設定されていると、リリース時の自動更新と競合する可能性があったため削除しました
- volumeMount の変更により、作業ディレクトリが明確に分離されます

## テスト計画
- [ ] Helm チャートの lint が通ることを確認
- [ ] Helm install/upgrade が正常に動作することを確認
- [ ] ボリュームが正しくマウントされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)