### PR TITLE
feat: DockerfileのWORKDIRを/home/agentapi/workdirに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN groupadd -r agentapi && useradd -r -g agentapi -d /home/agentapi -s /bin/bas
     echo 'agentapi ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Set working directory
-WORKDIR /app
+WORKDIR /home/agentapi/workdir
 
 # Copy binary from builder stage (agentapi-proxy binary only)
 COPY --from=builder /app/bin/agentapi-proxy /usr/local/bin/


### PR DESCRIPTION
## 概要
DockerfileのWORKDIRを`/app`から`/home/agentapi/workdir`に変更しました。

## 変更内容
- Dockerfile内のWORKDIR設定を`/home/agentapi/workdir`に更新
- コンテナ内での作業ディレクトリをより適切なパス構成に変更

## テスト結果
- make lintが正常に完了
- コードフォーマットに問題なし

🤖 Generated with [Claude Code](https://claude.ai/code)