### PR TITLE
feat: ConfigMapから認可設定を読み込み可能にする機能を追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,5 +67,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helm/agentapi-proxy/templates/configmap.yaml
+++ b/helm/agentapi-proxy/templates/configmap.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.authConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-auth-config
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+data:
+  auth-config.yaml: |
+    {{- if .Values.authConfig.github }}
+    github:
+      {{- if .Values.authConfig.github.user_mapping }}
+      user_mapping:
+        {{- if .Values.authConfig.github.user_mapping.default_role }}
+        default_role: {{ .Values.authConfig.github.user_mapping.default_role | quote }}
+        {{- end }}
+        {{- if .Values.authConfig.github.user_mapping.default_permissions }}
+        default_permissions:
+        {{- range .Values.authConfig.github.user_mapping.default_permissions }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.authConfig.github.user_mapping.team_role_mapping }}
+        team_role_mapping:
+        {{- range $teamKey, $teamRule := .Values.authConfig.github.user_mapping.team_role_mapping }}
+          {{ $teamKey | quote }}:
+            {{- if $teamRule.role }}
+            role: {{ $teamRule.role | quote }}
+            {{- end }}
+            {{- if $teamRule.permissions }}
+            permissions:
+            {{- range $teamRule.permissions }}
+              - {{ . | quote }}
+            {{- end }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -110,6 +110,10 @@ spec:
               value: {{ .Values.config.auth.github.oauth.scope | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_BASE_URL
               value: {{ .Values.config.auth.github.oauth.baseUrl | quote }}
+            {{- if .Values.authConfig }}
+            - name: AGENTAPI_AUTH_CONFIG_FILE
+              value: "/etc/auth-config/auth-config.yaml"
+            {{- end }}
             {{- if .Values.github.enterprise.enabled }}
             {{- if .Values.github.enterprise.baseUrl }}
             - name: GITHUB_URL
@@ -148,6 +152,11 @@ spec:
             - name: data
               mountPath: /home/agentapi/workdir
             {{- end }}
+            {{- if .Values.authConfig }}
+            - name: auth-config
+              mountPath: /etc/auth-config
+              readOnly: true
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -157,10 +166,15 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.volumes }}
       volumes:
+        {{- if .Values.authConfig }}
+        - name: auth-config
+          configMap:
+            name: {{ include "agentapi-proxy.fullname" . }}-auth-config
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/agentapi-proxy/values-auth-example.yaml
+++ b/helm/agentapi-proxy/values-auth-example.yaml
@@ -1,0 +1,69 @@
+# Example values file showing auth configuration with ConfigMap
+# This demonstrates how to configure GitHub OAuth with team-based permissions
+
+replicaCount: 1
+
+config:
+  auth:
+    enabled: true
+    github:
+      enabled: true
+      oauth:
+        clientId: "your-github-client-id"
+        clientSecret: "your-github-client-secret"
+        scope: "repo workflow read:org admin:repo_hook notifications user:email"
+
+# Auth configuration - stored in ConfigMap and mounted to container
+# This allows complex authorization rules that cannot be expressed as environment variables
+authConfig:
+  github:
+    user_mapping:
+      default_role: "user"
+      default_permissions:
+        - "read"
+        - "session:create"
+        - "session:list"
+      team_role_mapping:
+        "myorg/admins":
+          role: "admin"
+          permissions:
+            - "*"
+        "myorg/developers":
+          role: "developer"
+          permissions:
+            - "read"
+            - "write"
+            - "execute"
+            - "session:create"
+            - "session:list"
+            - "session:delete"
+            - "session:access"
+        "myorg/qa-team":
+          role: "tester"
+          permissions:
+            - "read"
+            - "session:create"
+            - "session:list"
+            - "session:access"
+        "myorg/viewers":
+          role: "viewer"
+          permissions:
+            - "read"
+            - "session:list"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: agentapi.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: agentapi-proxy-tls
+      hosts:
+        - agentapi.example.com
+
+persistence:
+  enabled: true
+  size: 50Gi

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -191,3 +191,35 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Auth configuration (stored in ConfigMap and mounted to the container)
+# This allows complex authorization rules that cannot be easily expressed as environment variables
+authConfig:
+  # Example configuration structure:
+  # github:
+  #   user_mapping:
+  #     default_role: "user"
+  #     default_permissions:
+  #       - "read"
+  #       - "session:create"
+  #       - "session:list"
+  #     team_role_mapping:
+  #       "myorg/admins":
+  #         role: "admin"
+  #         permissions:
+  #           - "*"
+  #       "myorg/developers":
+  #         role: "developer"
+  #         permissions:
+  #           - "read"
+  #           - "write"
+  #           - "execute"
+  #           - "session:create"
+  #           - "session:list"
+  #           - "session:delete"
+  #           - "session:access"
+  #       "myorg/viewers":
+  #         role: "viewer"
+  #         permissions:
+  #           - "read"
+  #           - "session:list"

--- a/pkg/config/config_auth_test.go
+++ b/pkg/config/config_auth_test.go
@@ -1,0 +1,245 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAuthConfigFromFile(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "auth-config-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name        string
+		fileContent string
+		fileName    string
+		expectError bool
+		validate    func(*Config) bool
+	}{
+		{
+			name: "valid YAML auth config",
+			fileContent: `github:
+  user_mapping:
+    default_role: "user"
+    default_permissions:
+      - "read"
+      - "session:create"
+    team_role_mapping:
+      "myorg/admins":
+        role: "admin"
+        permissions:
+          - "*"
+      "myorg/developers":
+        role: "developer"
+        permissions:
+          - "read"
+          - "write"`,
+			fileName:    "auth-config.yaml",
+			expectError: false,
+			validate: func(c *Config) bool {
+				if c.Auth.GitHub == nil {
+					t.Logf("GitHub config is nil")
+					return false
+				}
+				if c.Auth.GitHub.UserMapping.DefaultRole != "user" {
+					t.Logf("Expected default role 'user', got '%s'", c.Auth.GitHub.UserMapping.DefaultRole)
+					return false
+				}
+				if len(c.Auth.GitHub.UserMapping.DefaultPermissions) != 2 {
+					t.Logf("Expected 2 default permissions, got %d: %v", len(c.Auth.GitHub.UserMapping.DefaultPermissions), c.Auth.GitHub.UserMapping.DefaultPermissions)
+					return false
+				}
+				if len(c.Auth.GitHub.UserMapping.TeamRoleMapping) != 2 {
+					t.Logf("Expected 2 team role mappings, got %d", len(c.Auth.GitHub.UserMapping.TeamRoleMapping))
+					return false
+				}
+				adminRule, exists := c.Auth.GitHub.UserMapping.TeamRoleMapping["myorg/admins"]
+				if !exists {
+					t.Logf("myorg/admins rule not found")
+					return false
+				}
+				if adminRule.Role != "admin" {
+					t.Logf("Expected admin role, got '%s'", adminRule.Role)
+					return false
+				}
+				return true
+			},
+		},
+		{
+			name: "valid JSON auth config",
+			fileContent: `{
+  "github": {
+    "user_mapping": {
+      "default_role": "viewer",
+      "default_permissions": ["read"],
+      "team_role_mapping": {
+        "myorg/testers": {
+          "role": "tester",
+          "permissions": ["read", "session:create"]
+        }
+      }
+    }
+  }
+}`,
+			fileName:    "auth-config.json",
+			expectError: false,
+			validate: func(c *Config) bool {
+				return c.Auth.GitHub != nil &&
+					c.Auth.GitHub.UserMapping.DefaultRole == "viewer" &&
+					len(c.Auth.GitHub.UserMapping.DefaultPermissions) == 1 &&
+					c.Auth.GitHub.UserMapping.DefaultPermissions[0] == "read" &&
+					c.Auth.GitHub.UserMapping.TeamRoleMapping["myorg/testers"].Role == "tester"
+			},
+		},
+		{
+			name:        "invalid YAML",
+			fileContent: "invalid: yaml: content: [",
+			fileName:    "invalid.yaml",
+			expectError: true,
+			validate:    nil,
+		},
+		{
+			name:        "invalid JSON",
+			fileContent: `{"invalid": json}`,
+			fileName:    "invalid.json",
+			expectError: true,
+			validate:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test file
+			filePath := filepath.Join(tempDir, tt.fileName)
+			err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			// Create a basic config
+			config := &Config{
+				Auth: AuthConfig{
+					Enabled: true,
+				},
+			}
+
+			// Load auth config from file
+			err = loadAuthConfigFromFile(config, filePath)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Validate the result
+			if tt.validate != nil && !tt.validate(config) {
+				t.Errorf("Validation failed for test case: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestLoadConfigWithAuthConfigFile(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "config-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create auth config file
+	authConfigContent := `github:
+  user_mapping:
+    default_role: "user"
+    default_permissions:
+      - "read"
+    team_role_mapping:
+      "myorg/admins":
+        role: "admin"
+        permissions:
+          - "*"`
+
+	authConfigPath := filepath.Join(tempDir, "auth-config.yaml")
+	err = os.WriteFile(authConfigPath, []byte(authConfigContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write auth config file: %v", err)
+	}
+
+	// Create main config with path to auth config
+	mainConfigWithPath := `{
+  "start_port": 8080,
+  "auth_config_file": "` + authConfigPath + `",
+  "auth": {
+    "enabled": true,
+    "github": {
+      "enabled": true,
+      "base_url": "https://api.github.com"
+    }
+  }
+}`
+
+	mainConfigPath := filepath.Join(tempDir, "config.json")
+	err = os.WriteFile(mainConfigPath, []byte(mainConfigWithPath), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write main config file: %v", err)
+	}
+
+	// Load config
+	config, err := LoadConfig(mainConfigPath)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Validate
+	if config.StartPort != 8080 {
+		t.Errorf("Expected start_port 8080, got %d", config.StartPort)
+	}
+
+	if config.AuthConfigFile != authConfigPath {
+		t.Errorf("Expected auth_config_file %s, got %s", authConfigPath, config.AuthConfigFile)
+	}
+
+	if !config.Auth.Enabled {
+		t.Errorf("Expected auth to be enabled")
+	}
+
+	if config.Auth.GitHub == nil {
+		t.Fatalf("Expected GitHub config to be initialized")
+	}
+
+	if !config.Auth.GitHub.Enabled {
+		t.Errorf("Expected GitHub auth to be enabled")
+	}
+
+	if config.Auth.GitHub.UserMapping.DefaultRole != "user" {
+		t.Errorf("Expected default role 'user', got '%s'", config.Auth.GitHub.UserMapping.DefaultRole)
+	}
+
+	if len(config.Auth.GitHub.UserMapping.TeamRoleMapping) != 1 {
+		t.Errorf("Expected 1 team role mapping, got %d", len(config.Auth.GitHub.UserMapping.TeamRoleMapping))
+	}
+
+	adminRule, exists := config.Auth.GitHub.UserMapping.TeamRoleMapping["myorg/admins"]
+	if !exists {
+		t.Errorf("Expected 'myorg/admins' team role mapping to exist")
+	} else {
+		if adminRule.Role != "admin" {
+			t.Errorf("Expected admin role, got '%s'", adminRule.Role)
+		}
+		if len(adminRule.Permissions) != 1 || adminRule.Permissions[0] != "*" {
+			t.Errorf("Expected admin permissions ['*'], got %v", adminRule.Permissions)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

GitHubのOAuth認証における認可設定（user_mapping、team_role_mapping）をConfigMapから読み込み可能にする機能を追加しました。

## 変更内容

### 🔧 コア機能
- `AGENTAPI_AUTH_CONFIG_FILE` 環境変数を追加し、外部設定ファイルからの認可設定読み込みに対応
- YAML と JSON 形式の認可設定ファイルに対応
- `LoadAuthConfigFromFile` 関数を追加してConfigMap経由での設定読み込みを実現

### 📦 Helm Chart拡張
- `helm/agentapi-proxy/templates/configmap.yaml` を追加してConfigMapテンプレートを作成
- `values.yaml` に `authConfig` セクションを追加
- StatefulSetテンプレートにConfigMapのマウント設定を追加
- 使用例を含む `values-auth-example.yaml` を作成

### 🧪 テスト
- `pkg/config/config_auth_test.go` を追加して新機能の包括的なテストを実装
- YAML/JSON形式のテスト、統合テストを含む

## 使用方法

### values.yamlでの設定例
```yaml
authConfig:
  github:
    user_mapping:
      default_role: "user"
      default_permissions:
        - "read"
        - "session:create"
      team_role_mapping:
        "myorg/admins":
          role: "admin"
          permissions:
            - "*"
        "myorg/developers":
          role: "developer"
          permissions:
            - "read"
            - "write"
            - "session:create"
            - "session:access"
```

### 環境変数での設定
```bash
AGENTAPI_AUTH_CONFIG_FILE="/etc/auth-config/auth-config.yaml"
```

## テスト結果
- 全ての既存テストが通過
- 新しい認可設定機能のテストが通過
- Lintエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)