### PR TITLE
GitHub認証プロバイダをシングルトンとして実装しキャッシュを有効化

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -23,7 +23,7 @@ func TestAuthMiddleware_Disabled(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	middleware := AuthMiddleware(cfg)
+	middleware := AuthMiddleware(cfg, nil)
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "success")
 	}
@@ -50,7 +50,7 @@ func TestAuthMiddleware_MissingAPIKey(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	middleware := AuthMiddleware(cfg)
+	middleware := AuthMiddleware(cfg, nil)
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "success")
 	}
@@ -88,7 +88,7 @@ func TestAuthMiddleware_InvalidAPIKey(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	middleware := AuthMiddleware(cfg)
+	middleware := AuthMiddleware(cfg, nil)
 	handler := func(c echo.Context) error {
 		return c.String(http.StatusOK, "success")
 	}
@@ -126,7 +126,7 @@ func TestAuthMiddleware_ValidAPIKey(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	middleware := AuthMiddleware(cfg)
+	middleware := AuthMiddleware(cfg, nil)
 	handler := func(c echo.Context) error {
 		user := GetUserFromContext(c)
 		assert.NotNil(t, user)


### PR DESCRIPTION
## 概要
GitHub認証のキャッシュが実際には動作していなかった問題を修正しました。

## 問題点
前回の実装でキャッシュ機能を追加しましたが、実際にはキャッシュが効いていませんでした。
原因は、毎回のリクエストで新しい`GitHubAuthProvider`インスタンスが作成されていたためです。

## 解決策
- `Proxy`構造体に`githubAuthProvider`フィールドを追加
- アプリケーション起動時に一度だけ`GitHubAuthProvider`を初期化
- `AuthMiddleware`がこのシングルトンインスタンスを使用するように変更

## 変更内容
1. `pkg/proxy/proxy.go`: 
   - `githubAuthProvider`フィールドを追加
   - 起動時にプロバイダを初期化

2. `pkg/auth/auth.go`:
   - `AuthMiddleware`がプロバイダインスタンスを受け取るように変更
   - `tryGitHubAuth`が渡されたプロバイダを使用するように変更

## テスト
- `make lint` - ✅ 成功
- `make test` (authパッケージ) - ✅ 成功

## 効果
これで実際にキャッシュが動作し、同一トークンでの認証時にGitHub APIへのリクエストが削減されます。

🤖 Generated with [Claude Code](https://claude.ai/code)