### PR TITLE
CLAUDE_DIR環境変数の依存を削除

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -267,25 +267,12 @@ func TestInitCmdStructure(t *testing.T) {
 	assert.NotNil(t, initCmd.Run)
 }
 
-func TestRunSetupClaudeCodeNoCLAUDEDIR(t *testing.T) {
-	// Save original CLAUDE_DIR
-	originalCLAUDEDIR := os.Getenv("CLAUDE_DIR")
-	defer func() {
-		if originalCLAUDEDIR != "" {
-			_ = os.Setenv("CLAUDE_DIR", originalCLAUDEDIR)
-		} else {
-			_ = os.Unsetenv("CLAUDE_DIR")
-		}
-	}()
-
-	// Unset CLAUDE_DIR
-	_ = os.Unsetenv("CLAUDE_DIR")
-
-	// This test verifies the function handles missing CLAUDE_DIR
-	// We can't easily test os.Exit(1), but we can verify the error path is taken
-	// by checking that the function would exit early
-	claudeDir := os.Getenv("CLAUDE_DIR")
-	assert.Empty(t, claudeDir)
+func TestRunSetupClaudeCodeHomeDir(t *testing.T) {
+	// Test that the function can get the home directory
+	// We can't easily test the full function since it creates files,
+	// but we can verify the function exists and has the right structure
+	assert.NotNil(t, setupClaudeCodeCmd.Run)
+	assert.NotNil(t, initCmd.Run)
 }
 
 func TestClaudeCodeSettingsEmbedded(t *testing.T) {

--- a/pkg/proxy/scripts/agentapi_default.sh
+++ b/pkg/proxy/scripts/agentapi_default.sh
@@ -19,17 +19,17 @@ export GITHUB_APP_PEM_PATH="{{.GitHubAppPEMPath}}"
 export GITHUB_API="{{.GitHubAPI}}"
 export GITHUB_PERSONAL_ACCESS_TOKEN="{{.GitHubPersonalAccessToken}}"
 
-# Set user-specific CLAUDE_DIR if multiple users is enabled
+# Set user-specific .claude directory if multiple users is enabled
 if [[ "$ENABLE_MULTIPLE_USERS" == "true" && -n "$USER_HOME_DIR" ]]; then
-    # Set CLAUDE_DIR to ~/.claude/[username] pattern
+    # Set up user-specific .claude directory pattern
     USER_NAME=$(basename "$USER_HOME_DIR")
-    export CLAUDE_DIR="${HOME}/.claude/${USER_NAME}"
-    echo "Setting CLAUDE_DIR to user-specific directory: $CLAUDE_DIR"
+    USER_CLAUDE_DIR="${HOME}/.claude/${USER_NAME}"
+    echo "Setting up user-specific Claude directory: $USER_CLAUDE_DIR"
     
     # Ensure the Claude directory exists
-    if [[ ! -d "$CLAUDE_DIR" ]]; then
-        echo "Creating Claude user directory: $CLAUDE_DIR"
-        mkdir -p "$CLAUDE_DIR"
+    if [[ ! -d "$USER_CLAUDE_DIR" ]]; then
+        echo "Creating Claude user directory: $USER_CLAUDE_DIR"
+        mkdir -p "$USER_CLAUDE_DIR"
     fi
 fi
 
@@ -52,17 +52,14 @@ else
     fi
 fi
 
-# Use the CLAUDE_DIR if set, otherwise use current directory
-if [[ -z "$CLAUDE_DIR" ]]; then
-    CLAUDE_DIR=.
-fi
-CLAUDE_DIR="$CLAUDE_DIR" agentapi-proxy helpers setup-claude-code
+# Setup Claude configuration
+agentapi-proxy helpers setup-claude-code
 
 # Add MCP servers if configuration is provided
 MCP_CONFIGS="{{.MCPConfigs}}"
 if [[ -n "$MCP_CONFIGS" ]]; then
     echo "Setting up MCP servers from configuration"
-    if ! CLAUDE_DIR="$CLAUDE_DIR" agentapi-proxy helpers add-mcp-servers --config "$MCP_CONFIGS"; then
+    if ! agentapi-proxy helpers add-mcp-servers --config "$MCP_CONFIGS"; then
         echo "Warning: Failed to add MCP servers, continuing with session startup" >&2
     else
         echo "Successfully configured MCP servers"

--- a/pkg/userdir/userdir.go
+++ b/pkg/userdir/userdir.go
@@ -63,7 +63,7 @@ func (m *Manager) EnsureUserHomeDir(userID string) (string, error) {
 // GetUserClaudeDir returns the Claude directory for a specific user
 func (m *Manager) GetUserClaudeDir(userID string) (string, error) {
 	if !m.enabled {
-		// Return default CLAUDE_DIR location
+		// Return default .claude location
 		homeDir := os.Getenv("HOME")
 		if homeDir == "" {
 			homeDir = "/home/agentapi"
@@ -105,7 +105,7 @@ func (m *Manager) EnsureUserClaudeDir(userID string) (string, error) {
 	return claudeDir, nil
 }
 
-// GetUserEnvironment returns environment variables with user-specific CLAUDE_DIR set
+// GetUserEnvironment returns environment variables for user-specific directory setup
 func (m *Manager) GetUserEnvironment(userID string, baseEnv []string) ([]string, error) {
 	if !m.enabled {
 		return baseEnv, nil
@@ -118,32 +118,8 @@ func (m *Manager) GetUserEnvironment(userID string, baseEnv []string) ([]string,
 	}
 
 	// Create a copy of the base environment
-	env := make([]string, 0, len(baseEnv)+1)
-	homeDir := ""
-
-	// Copy existing environment variables, looking for HOME and CLAUDE_DIR
-	for _, envVar := range baseEnv {
-		if strings.HasPrefix(envVar, "CLAUDE_DIR=") {
-			// Skip the existing CLAUDE_DIR, we'll set our own
-		} else if strings.HasPrefix(envVar, "HOME=") {
-			homeDir = strings.TrimPrefix(envVar, "HOME=")
-			env = append(env, envVar)
-		} else {
-			env = append(env, envVar)
-		}
-	}
-
-	// If HOME wasn't set, use the system default
-	if homeDir == "" {
-		homeDir = os.Getenv("HOME")
-		if homeDir == "" {
-			homeDir = "/home/agentapi" // fallback
-		}
-	}
-
-	// Set CLAUDE_DIR to ~/.claude/[username]
-	claudeDir := filepath.Join(homeDir, ".claude", sanitizedUserID)
-	env = append(env, fmt.Sprintf("CLAUDE_DIR=%s", claudeDir))
+	env := make([]string, 0, len(baseEnv))
+	env = append(env, baseEnv...)
 
 	return env, nil
 }

--- a/pkg/userdir/userdir_test.go
+++ b/pkg/userdir/userdir_test.go
@@ -174,18 +174,11 @@ func TestGetUserEnvironment_EnabledMode(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Check that CLAUDE_DIR was added with user-specific directory
-	expectedClaudeDir := filepath.Join("/home/alice", ".claude", "bob")
-	claudeDirFound := false
+	// Check that environment variables are properly handled
 	homeFound := false
 
 	for _, envVar := range env {
-		if strings.HasPrefix(envVar, "CLAUDE_DIR=") {
-			if envVar != "CLAUDE_DIR="+expectedClaudeDir {
-				t.Errorf("Expected CLAUDE_DIR=%s, got %s", expectedClaudeDir, envVar)
-			}
-			claudeDirFound = true
-		} else if strings.HasPrefix(envVar, "HOME=") {
+		if strings.HasPrefix(envVar, "HOME=") {
 			// HOME should remain unchanged
 			if envVar != "HOME=/home/alice" {
 				t.Errorf("Expected HOME=/home/alice, got %s", envVar)
@@ -194,9 +187,6 @@ func TestGetUserEnvironment_EnabledMode(t *testing.T) {
 		}
 	}
 
-	if !claudeDirFound {
-		t.Error("CLAUDE_DIR environment variable not found")
-	}
 	if !homeFound {
 		t.Error("HOME environment variable not found")
 	}
@@ -213,22 +203,10 @@ func TestGetUserEnvironment_NoHomeInBase(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Check that CLAUDE_DIR was added with default HOME
-	claudeDirFound := false
-
-	for _, envVar := range env {
-		if strings.HasPrefix(envVar, "CLAUDE_DIR=") {
-			// When HOME is not set, it should use os.Getenv("HOME") or fallback to /home/agentapi
-			// The exact value depends on the test environment
-			if !strings.Contains(envVar, ".claude/bob") {
-				t.Errorf("Expected CLAUDE_DIR to contain '.claude/bob', got %s", envVar)
-			}
-			claudeDirFound = true
-		}
-	}
-
-	if !claudeDirFound {
-		t.Error("CLAUDE_DIR environment variable not found")
+	// Verify environment variables are handled properly
+	// The function should return the base environment when multiple users is enabled
+	if len(env) != len(baseEnv) {
+		t.Errorf("Expected env length to match base env length %d, got %d", len(baseEnv), len(env))
 	}
 }
 


### PR DESCRIPTION
## Summary
CLAUDE_DIR環境変数への依存を削除し、直接ホームディレクトリベースの設定に変更しました。

- CLAUDE_DIR環境変数を使用せず`~/.claude`ディレクトリを直接使用
- setup-claude-codeコマンドでユーザーのホームディレクトリ取得に変更
- userdir.goのGetUserEnvironment関数からCLAUDE_DIR設定を削除
- テストコードをCLAUDE_DIR非依存に更新
- スクリプトファイルでのCLAUDE_DIR設定を削除

## Test plan
- [x] make testでテストが通ることを確認
- [x] make lintでコード品質チェックが通ることを確認
- [x] CLAUDE_DIR関連のコードが完全に削除されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)