### PR TITLE
feat: ユーザーホームディレクトリに mise activate する .bashrc を追加

### DIFF
--- a/pkg/userdir/userdir.go
+++ b/pkg/userdir/userdir.go
@@ -157,6 +157,20 @@ func SetupUserHome(userID string) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to create user home directory %s: %w", userHomeDir, err)
 	}
 
+	// Create .bashrc with mise activation
+	bashrcPath := filepath.Join(userHomeDir, ".bashrc")
+	bashrcContent := `# Auto-generated .bashrc for agentapi user home
+# Activate mise (development tools version manager)
+eval "$(/home/agentapi/.local/bin/mise activate bash)"
+`
+
+	// Write .bashrc file if it doesn't exist
+	if _, err := os.Stat(bashrcPath); os.IsNotExist(err) {
+		if err := os.WriteFile(bashrcPath, []byte(bashrcContent), 0644); err != nil {
+			return nil, fmt.Errorf("failed to create .bashrc in user home directory %s: %w", userHomeDir, err)
+		}
+	}
+
 	// Return environment variables map
 	return map[string]string{
 		"HOME": userHomeDir,


### PR DESCRIPTION
## 概要
ユーザーごとのホームディレクトリ作成時に、mise を自動的に activate する .bashrc ファイルを作成する機能を追加しました。

## 変更内容
- `SetupUserHome` 関数で `.bashrc` ファイルを自動作成
- mise activate bash コマンドを含む `.bashrc` を生成  
- 絶対パス (`/home/agentapi/.local/bin/mise`) で mise を指定

## 問題の背景
ユーザーごとのホームディレクトリを用いた実行では、mise が使えなくなっていたため、userHomeDir を作成するときに mise を activate する `.bashrc` を配置する必要がありました。

## テスト結果
- `make lint` 実行済み
- `make test` 実行済み

🤖 Generated with [Claude Code](https://claude.ai/code)