### PR TITLE
fix: 永続化ボリュームの権限問題を修正

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,5 +11,20 @@ if [ ! -f /home/agentapi/.claude/CLAUDE.md ] || [ /tmp/config/CLAUDE.md -nt /hom
     echo "CLAUDE.md copied successfully"
 fi
 
+# Fix permissions for persistent volume directory
+if [ -d "$HOME/.agentapi-proxy" ]; then
+    echo "Fixing permissions for $HOME/.agentapi-proxy..."
+    # Change ownership to current user
+    sudo chown -R $(id -u):$(id -g) "$HOME/.agentapi-proxy" || chown -R $(id -u):$(id -g) "$HOME/.agentapi-proxy" 2>/dev/null || true
+    
+    # Create myclaudes directory if it doesn't exist
+    mkdir -p "$HOME/.agentapi-proxy/myclaudes"
+    
+    # Set proper permissions for myclaudes directory
+    chmod 755 "$HOME/.agentapi-proxy/myclaudes"
+    
+    echo "Permissions fixed successfully"
+fi
+
 # Execute the original command
 exec "$@"


### PR DESCRIPTION
## 概要
- Helmで永続化した`$HOME/.agentapi-proxy`ディレクトリの権限問題を修正
- `myclaudes`ディレクトリのパーミッションを適切に設定

## 変更内容
- `entrypoint.sh`に権限修正処理を追加
  - `$HOME/.agentapi-proxy`の所有者を現在のユーザーに変更
  - `myclaudes`ディレクトリのパーミッションを755に設定

## テスト計画
- [x] make lint の実行
- [x] make test の実行

🤖 Generated with [Claude Code](https://claude.ai/code)