### PR TITLE
feat: add verbose logging for OAuth and authentication endpoints

### DIFF
--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -219,12 +219,15 @@ func (p *GitHubAuthProvider) getUser(ctx context.Context, token string) (*GitHub
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
+	logVerbose("Making GitHub API request: GET %s", url)
 	resp, err := p.client.Do(req)
 	if err != nil {
+		logVerbose("GitHub API request failed: %v", err)
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	logVerbose("GitHub API response: %d %s", resp.StatusCode, resp.Status)
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
 	}
@@ -327,12 +330,15 @@ func (p *GitHubAuthProvider) getUserOrganizations(ctx context.Context, token str
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
+	logVerbose("Making GitHub API request: GET %s", url)
 	resp, err := p.client.Do(req)
 	if err != nil {
+		logVerbose("GitHub API request failed: %v", err)
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	logVerbose("GitHub API response: %d %s", resp.StatusCode, resp.Status)
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
 	}
@@ -358,12 +364,15 @@ func (p *GitHubAuthProvider) checkTeamMembership(ctx context.Context, token, org
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
+	logVerbose("Making GitHub API request: GET %s", url)
 	resp, err := p.client.Do(req)
 	if err != nil {
+		logVerbose("GitHub API request failed: %v", err)
 		return false, ""
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	logVerbose("GitHub API response: %d %s", resp.StatusCode, resp.Status)
 	if resp.StatusCode == http.StatusNotFound {
 		return false, ""
 	}


### PR DESCRIPTION
Add comprehensive verbose logging for OAuth and authentication flows:

- OAuth endpoints: authorization URL generation, token exchange, token revocation
- GitHub API endpoints: user info, organizations, team memberships
- Environment variable control: AGENTAPI_OAUTH_VERBOSE_LOGGING or AGENTAPI_VERBOSE_LOGGING
- Logs include HTTP method, full URL, response status codes, and error details

Fixes #193

Generated with [Claude Code](https://claude.ai/code)