### PR TITLE
feat: use GITHUB_URL and GITHUB_API environment variables as default values for auth configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,14 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// getEnvWithDefault returns the value of environment variable or default value
+func getEnvWithDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
 // AuthConfig represents authentication configuration
 type AuthConfig struct {
 	Enabled bool              `json:"enabled" mapstructure:"enabled"`
@@ -376,12 +384,12 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("auth.static.enabled", false)
 	v.SetDefault("auth.static.header_name", "X-API-Key")
 	v.SetDefault("auth.github.enabled", false)
-	v.SetDefault("auth.github.base_url", "https://api.github.com")
+	v.SetDefault("auth.github.base_url", getEnvWithDefault("GITHUB_API", "https://api.github.com"))
 	v.SetDefault("auth.github.token_header", "Authorization")
 	v.SetDefault("auth.github.oauth.client_id", "")
 	v.SetDefault("auth.github.oauth.client_secret", "")
 	v.SetDefault("auth.github.oauth.scope", "read:user read:org")
-	v.SetDefault("auth.github.oauth.base_url", "")
+	v.SetDefault("auth.github.oauth.base_url", getEnvWithDefault("GITHUB_URL", "https://github.com"))
 
 	// Multiple users default
 	v.SetDefault("enable_multiple_users", false)
@@ -410,7 +418,7 @@ func applyConfigDefaults(config *Config) {
 	}
 	if config.Auth.GitHub != nil {
 		if config.Auth.GitHub.BaseURL == "" {
-			config.Auth.GitHub.BaseURL = "https://api.github.com"
+			config.Auth.GitHub.BaseURL = getEnvWithDefault("GITHUB_API", "https://api.github.com")
 		}
 		if config.Auth.GitHub.TokenHeader == "" {
 			config.Auth.GitHub.TokenHeader = "Authorization"


### PR DESCRIPTION
## Summary
• Add support for GITHUB_URL and GITHUB_API environment variables as default values for auth configuration
• Reduce hardcoded GitHub URLs in authentication setup
• Improve compatibility with GitHub Enterprise setups

## Changes Made
• Added `getEnvWithDefault` helper function to support environment variable fallbacks
• Updated `auth.github.base_url` default to use `GITHUB_API` environment variable (fallback: https://api.github.com)
• Updated `auth.github.oauth.base_url` default to use `GITHUB_URL` environment variable (fallback: https://github.com)
• Applied consistent environment variable handling across auth configuration

## Test plan
- [ ] Verify default behavior works when environment variables are not set
- [ ] Test with GITHUB_API and GITHUB_URL environment variables set to custom values
- [ ] Confirm GitHub Enterprise Server configurations work correctly
- [ ] Validate OAuth flow works with both default and custom GitHub URLs

🤖 Generated with [Claude Code](https://claude.ai/code)