### PR TITLE
fix: implement proper git clone functionality in InitGitHubRepo

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -1,13 +1,20 @@
 package startup
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/google/go-github/v57/github"
 )
 
 // SetupClaudeCode sets up Claude Code configuration
@@ -215,10 +222,8 @@ func addMcpServer(claudeDir string, mcpConfig MCPServerConfig) error {
 	return nil
 }
 
-// InitGitHubRepo initializes a GitHub repository (placeholder implementation)
+// InitGitHubRepo initializes a GitHub repository with proper git clone functionality
 func InitGitHubRepo(repoFullName, cloneDir string, ignoreMissingConfig bool) error {
-	// This is a simplified implementation for now
-	// In a real implementation, this would handle GitHub authentication and cloning
 	log.Printf("Initializing GitHub repository: %s to %s", repoFullName, cloneDir)
 
 	if repoFullName == "" {
@@ -234,8 +239,208 @@ func InitGitHubRepo(repoFullName, cloneDir string, ignoreMissingConfig bool) err
 		return fmt.Errorf("failed to create clone directory: %w", err)
 	}
 
-	// For now, just create a placeholder implementation
-	// TODO: Implement proper GitHub authentication and cloning
-	log.Printf("GitHub repository initialization completed (placeholder)")
+	// Get GitHub token for authentication
+	token, err := getGitHubToken()
+	if err != nil {
+		return fmt.Errorf("failed to get GitHub token: %w", err)
+	}
+
+	// Create repository URL
+	repoURL := fmt.Sprintf("https://github.com/%s", repoFullName)
+
+	// Setup the repository with proper git clone
+	if err := setupRepository(repoURL, token, cloneDir); err != nil {
+		return fmt.Errorf("failed to setup repository: %w", err)
+	}
+
+	log.Printf("GitHub repository initialization completed successfully")
 	return nil
+}
+
+// getGitHubToken retrieves the GitHub token for authentication
+func getGitHubToken() (string, error) {
+	// Check for personal access token first
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token, nil
+	}
+
+	// If no token available, try to use GitHub App authentication
+	appID := os.Getenv("GITHUB_APP_ID")
+	installationID := os.Getenv("GITHUB_INSTALLATION_ID")
+	pemPath := os.Getenv("GITHUB_APP_PEM_PATH")
+
+	if appID != "" && installationID != "" && pemPath != "" {
+		return generateGitHubAppToken(appID, installationID, pemPath)
+	}
+
+	// Check for GITHUB_PERSONAL_ACCESS_TOKEN as fallback
+	if token := os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN"); token != "" {
+		return token, nil
+	}
+
+	return "", fmt.Errorf("no GitHub authentication found: GITHUB_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, or GitHub App credentials (GITHUB_APP_ID, GITHUB_INSTALLATION_ID, GITHUB_APP_PEM_PATH) are required")
+}
+
+// generateGitHubAppToken generates a GitHub App installation token
+func generateGitHubAppToken(appIDStr, installationIDStr, pemPath string) (string, error) {
+	// Parse app ID
+	appID, err := strconv.ParseInt(appIDStr, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid GITHUB_APP_ID: %w", err)
+	}
+
+	// Parse installation ID
+	installationID, err := strconv.ParseInt(installationIDStr, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid GITHUB_INSTALLATION_ID: %w", err)
+	}
+
+	// Read private key file
+	pemData, err := os.ReadFile(pemPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read PEM file: %w", err)
+	}
+
+	// Create GitHub App transport
+	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, pemData)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GitHub App transport: %w", err)
+	}
+
+	// Set base URL if specified (for GitHub Enterprise)
+	if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" && githubAPI != "https://api.github.com" {
+		transport.BaseURL = githubAPI
+	}
+
+	// Create GitHub client
+	client := github.NewClient(&http.Client{Transport: transport})
+
+	// Handle GitHub Enterprise
+	if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" {
+		var err error
+		client, err = github.NewClient(&http.Client{Transport: transport}).WithEnterpriseURLs(githubAPI, githubAPI)
+		if err != nil {
+			return "", fmt.Errorf("failed to create GitHub Enterprise client: %w", err)
+		}
+	}
+
+	// Create installation token
+	ctx := context.Background()
+	token, _, err := client.Apps.CreateInstallationToken(
+		ctx,
+		installationID,
+		&github.InstallationTokenOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create installation token: %w", err)
+	}
+
+	return token.GetToken(), nil
+}
+
+// setupRepository sets up the git repository with proper cloning
+func setupRepository(repoURL, token, cloneDir string) error {
+	log.Printf("Setting up repository in: %s", cloneDir)
+
+	// Check if directory exists and is a git repository
+	gitDir := filepath.Join(cloneDir, ".git")
+	isGitRepo := false
+	if _, err := os.Stat(gitDir); err == nil {
+		isGitRepo = true
+	}
+
+	// Create authenticated URL
+	authURL, err := createAuthenticatedURL(repoURL, token)
+	if err != nil {
+		return fmt.Errorf("failed to create authenticated URL: %w", err)
+	}
+
+	if isGitRepo {
+		log.Printf("Git repository detected, updating...")
+		cmd := exec.Command("git", "pull")
+		cmd.Dir = cloneDir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to pull updates: %w", err)
+		}
+	} else {
+		log.Printf("Initializing new git repository...")
+
+		// Create directory if it doesn't exist
+		if err := os.MkdirAll(cloneDir, 0755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		// Initialize git
+		cmd := exec.Command("git", "init")
+		cmd.Dir = cloneDir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to initialize git: %w", err)
+		}
+
+		// Add remote
+		cmd = exec.Command("git", "remote", "add", "origin", authURL)
+		cmd.Dir = cloneDir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to add remote: %w", err)
+		}
+
+		// Fetch
+		cmd = exec.Command("git", "fetch")
+		cmd.Dir = cloneDir
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to fetch: %w", err)
+		}
+
+		// Try to checkout main, fall back to master
+		branches := []string{"main", "master"}
+		var checkoutErr error
+		for _, branch := range branches {
+			cmd = exec.Command("git", "checkout", branch)
+			cmd.Dir = cloneDir
+			if err := cmd.Run(); err != nil {
+				checkoutErr = err
+				continue
+			}
+			checkoutErr = nil
+			break
+		}
+
+		if checkoutErr != nil {
+			return fmt.Errorf("failed to checkout main or master branch: %w", checkoutErr)
+		}
+	}
+
+	log.Printf("Repository setup completed")
+	return nil
+}
+
+// createAuthenticatedURL creates an authenticated URL for git operations
+func createAuthenticatedURL(repoURL, token string) (string, error) {
+	githubURL := getGitHubURL()
+	githubHost := strings.TrimPrefix(githubURL, "https://")
+	githubHost = strings.TrimPrefix(githubHost, "http://")
+
+	// Parse the repository URL and insert the token
+	if strings.HasPrefix(repoURL, githubURL+"/") {
+		parts := strings.TrimPrefix(repoURL, githubURL+"/")
+		return fmt.Sprintf("https://%s@%s/%s", token, githubHost, parts), nil
+	} else if strings.HasPrefix(repoURL, "git@"+githubHost+":") {
+		parts := strings.TrimPrefix(repoURL, "git@"+githubHost+":")
+		parts = strings.TrimSuffix(parts, ".git")
+		return fmt.Sprintf("https://%s@%s/%s.git", token, githubHost, parts), nil
+	}
+
+	return "", fmt.Errorf("unsupported repository URL format: %s", repoURL)
+}
+
+// getGitHubURL returns the GitHub URL (supports enterprise)
+func getGitHubURL() string {
+	if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" {
+		// For enterprise GitHub, convert API URL to web URL
+		if strings.HasSuffix(githubAPI, "/api/v3") {
+			return strings.TrimSuffix(githubAPI, "/api/v3")
+		}
+		return githubAPI
+	}
+	return "https://github.com"
 }


### PR DESCRIPTION
## 問題の概要

PR #198 でシェルスクリプトからGo関数への移行が行われた際、`InitGitHubRepo` 関数がプレースホルダー実装のままで、実際のgit clone機能が失われていました。これにより、セッション開始時にgit cloneが成功する場合と失敗する場合が発生していました。

## 修正内容

- **実際のgit clone機能を実装**: `pkg/startup/startup.go` の `InitGitHubRepo` 関数を、プレースホルダーから実際のgit操作を行う実装に変更
- **GitHub認証サポート**: 個人アクセストークンとGitHub Appの両方をサポート
- **適切なリポジトリセットアップ**: git init, remote add, fetch, checkout の完全な実装
- **エラーハンドリング**: main/masterブランチへのフォールバック機能付き
- **GitHub Enterprise対応**: GitHub.comとGitHub Enterpriseの両方をサポート
- **後方互換性維持**: 既存の環境変数との互換性を保持

## 技術的詳細

実装は `cmd/init_github_repo.go` の動作するコードをベースにしており、循環インポートを避けるために startup パッケージに適応させました。

主な機能:
- GitHub認証（GITHUB_TOKEN、GITHUB_PERSONAL_ACCESS_TOKEN、GitHub App）
- 既存リポジトリの更新（git pull）と新規リポジトリの初期化
- main/masterブランチの自動検出とチェックアウト
- 詳細なエラーメッセージとログ出力

## テスト結果

- `make lint`: ✅ 通過
- `make test`: ✅ 全てのテストが通過
- 既存の機能に影響なし

## 動作確認

修正後、セッション開始時のGitHubリポジトリ初期化が安定して動作することを確認しました。

🤖 Generated with [Claude Code](https://claude.ai/code)