### PR TITLE
feat: Helm チャートに暗号化キーのシークレット設定を追加

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -60,6 +60,16 @@ spec:
               value: {{ .Values.config.persistence.syncIntervalSeconds | quote }}
             - name: AGENTAPI_PERSISTENCE_ENCRYPT_SENSITIVE_DATA
               value: {{ .Values.config.persistence.encryptSensitiveData | quote }}
+            {{- if .Values.config.persistence.encryptionKey.existingSecret.name }}
+            - name: AGENTAPI_PERSISTENCE_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.persistence.encryptionKey.existingSecret.name }}
+                  key: {{ .Values.config.persistence.encryptionKey.existingSecret.key | default "encryption-key" }}
+            {{- else if .Values.config.persistence.encryptionKey.value }}
+            - name: AGENTAPI_PERSISTENCE_ENCRYPTION_KEY
+              value: {{ .Values.config.persistence.encryptionKey.value | quote }}
+            {{- end }}
             - name: AGENTAPI_PERSISTENCE_SESSION_RECOVERY_MAX_AGE_HOURS
               value: {{ .Values.config.persistence.sessionRecoveryMaxAgeHours | quote }}
             {{- if .Values.config.persistence.s3.bucket }}

--- a/helm/agentapi-proxy/values-auth-example.yaml
+++ b/helm/agentapi-proxy/values-auth-example.yaml
@@ -67,3 +67,9 @@ ingress:
 persistence:
   enabled: true
   size: 50Gi
+  encryptSensitiveData: true
+  # 暗号化キーは既存のシークレットから参照
+  encryptionKey:
+    existingSecret:
+      name: "agentapi-encryption-secret"  # シークレット名
+      key: "encryption-key"  # シークレット内のキー名

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -118,6 +118,14 @@ config:
     syncIntervalSeconds: 30
     encryptSensitiveData: true
     sessionRecoveryMaxAgeHours: 24
+    # 暗号化キーの設定
+    encryptionKey:
+      # 既存のシークレットから暗号化キーを参照する場合
+      existingSecret:
+        name: ""  # シークレット名
+        key: "encryption-key"  # シークレット内のキー名
+      # 直接値を指定する場合（推奨されません）
+      value: ""  # 32文字の暗号化キー
     # S3設定（backend: "s3" の場合に使用）
     s3:
       bucket: ""


### PR DESCRIPTION
## Summary
- Helm チャートに暗号化キーをシークレットから参照できる機能を追加
- 既存のシークレットから暗号化キーを安全に管理できるように改善
- 環境変数 `AGENTAPI_PERSISTENCE_ENCRYPTION_KEY` として設定

## 変更内容
1. **values.yaml**
   - `persistence.encryptionKey` セクションを追加
   - 既存シークレットの参照と直接値の設定をサポート

2. **statefulset.yaml**
   - 暗号化キーを環境変数として設定するロジックを追加
   - シークレット参照時は `secretKeyRef` を使用

3. **values-auth-example.yaml**
   - 暗号化キーの使用例を追加

## 使用方法
```yaml
persistence:
  encryptSensitiveData: true
  encryptionKey:
    existingSecret:
      name: "my-encryption-secret"
      key: "encryption-key"
```

事前にシークレットを作成:
```bash
kubectl create secret generic my-encryption-secret \
  --from-literal=encryption-key=your-32-character-encryption-key
```

## Test plan
- [ ] Helm lint でエラーがないことを確認
- [ ] 暗号化キーがシークレットから正しく読み込まれることを確認
- [ ] 環境変数が正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)