### PR TITLE
feat: ロールベースの環境変数ファイル読み込み機能を追加

### DIFF
--- a/pkg/config/env_loader.go
+++ b/pkg/config/env_loader.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnvVar represents a single environment variable
+type EnvVar struct {
+	Key   string
+	Value string
+}
+
+// LoadRoleEnvVars loads environment variables for a specific role
+func LoadRoleEnvVars(config *RoleEnvFilesConfig, role string) ([]EnvVar, error) {
+	if !config.Enabled {
+		return nil, nil
+	}
+
+	var envVars []EnvVar
+
+	// Load default.env if enabled
+	if config.LoadDefault {
+		defaultPath := filepath.Join(config.Path, "default.env")
+		if vars, err := loadEnvFile(defaultPath); err == nil {
+			envVars = append(envVars, vars...)
+			log.Printf("[ENV] Loaded %d environment variables from default.env", len(vars))
+		} else if !os.IsNotExist(err) {
+			log.Printf("[ENV] Warning: Failed to load default.env: %v", err)
+		}
+	}
+
+	// Load role-specific env file
+	if role != "" {
+		rolePath := filepath.Join(config.Path, fmt.Sprintf("%s.env", role))
+		if vars, err := loadEnvFile(rolePath); err == nil {
+			envVars = append(envVars, vars...)
+			log.Printf("[ENV] Loaded %d environment variables for role '%s'", len(vars), role)
+		} else if !os.IsNotExist(err) {
+			log.Printf("[ENV] Warning: Failed to load env file for role '%s': %v", role, err)
+		}
+	}
+
+	return envVars, nil
+}
+
+// loadEnvFile reads environment variables from a file
+func loadEnvFile(filepath string) ([]EnvVar, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var envVars []EnvVar
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Parse KEY=VALUE format
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			log.Printf("[ENV] Warning: Invalid format at line %d in %s: %s", lineNum, filepath, line)
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		// Remove surrounding quotes if present
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+
+		// Validate key
+		if key == "" || strings.ContainsAny(key, " \t\n") {
+			log.Printf("[ENV] Warning: Invalid key at line %d in %s: '%s'", lineNum, filepath, key)
+			continue
+		}
+
+		envVars = append(envVars, EnvVar{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	return envVars, nil
+}
+
+// ApplyEnvVars sets environment variables in the current process
+// Returns the list of variables that were set
+func ApplyEnvVars(envVars []EnvVar) []string {
+	var applied []string
+
+	for _, env := range envVars {
+		// Check if value already exists
+		_, existed := os.LookupEnv(env.Key)
+
+		// Set the new value
+		if err := os.Setenv(env.Key, env.Value); err != nil {
+			log.Printf("[ENV] Error setting environment variable %s: %v", env.Key, err)
+			continue
+		}
+
+		// Log the change
+		if existed {
+			log.Printf("[ENV] Updated %s (previous value existed)", env.Key)
+		} else {
+			log.Printf("[ENV] Set %s", env.Key)
+		}
+
+		applied = append(applied, env.Key)
+	}
+
+	return applied
+}
+
+// GetRoleFromContext extracts the user's role from the authentication context
+// This is a helper function that should be called from the auth package
+func GetRoleFromContext(userID string, role string) string {
+	if role == "" {
+		return "guest"
+	}
+	return role
+}

--- a/pkg/config/env_loader_test.go
+++ b/pkg/config/env_loader_test.go
@@ -1,0 +1,336 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRoleEnvVars(t *testing.T) {
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "env_loader_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create test environment files
+	defaultEnvContent := `# Default environment variables
+DB_HOST=localhost
+DB_PORT=5432
+LOG_LEVEL=info
+`
+	adminEnvContent := `# Admin-specific environment variables
+LOG_LEVEL=debug
+ADMIN_ACCESS=true
+SECRET_KEY="admin-secret-123"
+`
+	userEnvContent := `# User-specific environment variables
+USER_ACCESS=true
+FEATURE_FLAG_A=enabled
+`
+
+	// Write test files
+	if err := os.WriteFile(filepath.Join(tempDir, "default.env"), []byte(defaultEnvContent), 0644); err != nil {
+		t.Fatalf("Failed to write default.env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "admin.env"), []byte(adminEnvContent), 0644); err != nil {
+		t.Fatalf("Failed to write admin.env: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "user.env"), []byte(userEnvContent), 0644); err != nil {
+		t.Fatalf("Failed to write user.env: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		config       *RoleEnvFilesConfig
+		role         string
+		expectedVars map[string]string
+		expectError  bool
+	}{
+		{
+			name: "disabled config returns empty",
+			config: &RoleEnvFilesConfig{
+				Enabled:     false,
+				Path:        tempDir,
+				LoadDefault: true,
+			},
+			role:         "admin",
+			expectedVars: map[string]string{},
+		},
+		{
+			name: "load only role-specific env",
+			config: &RoleEnvFilesConfig{
+				Enabled:     true,
+				Path:        tempDir,
+				LoadDefault: false,
+			},
+			role: "admin",
+			expectedVars: map[string]string{
+				"LOG_LEVEL":    "debug",
+				"ADMIN_ACCESS": "true",
+				"SECRET_KEY":   "admin-secret-123",
+			},
+		},
+		{
+			name: "load default and role-specific env",
+			config: &RoleEnvFilesConfig{
+				Enabled:     true,
+				Path:        tempDir,
+				LoadDefault: true,
+			},
+			role: "admin",
+			expectedVars: map[string]string{
+				"DB_HOST":      "localhost",
+				"DB_PORT":      "5432",
+				"LOG_LEVEL":    "debug", // Overridden by role-specific
+				"ADMIN_ACCESS": "true",
+				"SECRET_KEY":   "admin-secret-123",
+			},
+		},
+		{
+			name: "load default only for unknown role",
+			config: &RoleEnvFilesConfig{
+				Enabled:     true,
+				Path:        tempDir,
+				LoadDefault: true,
+			},
+			role: "unknown",
+			expectedVars: map[string]string{
+				"DB_HOST":   "localhost",
+				"DB_PORT":   "5432",
+				"LOG_LEVEL": "info",
+			},
+		},
+		{
+			name: "empty role loads only default",
+			config: &RoleEnvFilesConfig{
+				Enabled:     true,
+				Path:        tempDir,
+				LoadDefault: true,
+			},
+			role: "",
+			expectedVars: map[string]string{
+				"DB_HOST":   "localhost",
+				"DB_PORT":   "5432",
+				"LOG_LEVEL": "info",
+			},
+		},
+		{
+			name: "user role env vars",
+			config: &RoleEnvFilesConfig{
+				Enabled:     true,
+				Path:        tempDir,
+				LoadDefault: true,
+			},
+			role: "user",
+			expectedVars: map[string]string{
+				"DB_HOST":        "localhost",
+				"DB_PORT":        "5432",
+				"LOG_LEVEL":      "info",
+				"USER_ACCESS":    "true",
+				"FEATURE_FLAG_A": "enabled",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars, err := LoadRoleEnvVars(tt.config, tt.role)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Convert envVars slice to map for easier comparison
+			actualVars := make(map[string]string)
+			for _, env := range envVars {
+				actualVars[env.Key] = env.Value
+			}
+
+			// Check expected variables
+			for key, expectedValue := range tt.expectedVars {
+				if actualValue, exists := actualVars[key]; !exists {
+					t.Errorf("Expected key %s not found", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("Key %s: expected value %s, got %s", key, expectedValue, actualValue)
+				}
+			}
+
+			// Check for unexpected variables
+			for key := range actualVars {
+				if _, expected := tt.expectedVars[key]; !expected {
+					t.Errorf("Unexpected key %s found", key)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadEnvFile(t *testing.T) {
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "env_file_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name         string
+		content      string
+		expectedVars map[string]string
+		expectError  bool
+	}{
+		{
+			name: "valid env file",
+			content: `# Comment line
+KEY1=value1
+KEY2=value2
+
+# Another comment
+KEY3="quoted value"
+KEY4='single quoted'
+KEY5=value with spaces
+`,
+			expectedVars: map[string]string{
+				"KEY1": "value1",
+				"KEY2": "value2",
+				"KEY3": "quoted value",
+				"KEY4": "single quoted",
+				"KEY5": "value with spaces",
+			},
+		},
+		{
+			name: "empty file",
+			content: `# Only comments
+
+# Nothing else
+`,
+			expectedVars: map[string]string{},
+		},
+		{
+			name: "invalid format lines are skipped",
+			content: `VALID_KEY=valid_value
+INVALID LINE WITHOUT EQUALS
+ANOTHER_VALID=test
+=NO_KEY
+KEY_WITHOUT_VALUE=
+FINAL_KEY=final_value
+`,
+			expectedVars: map[string]string{
+				"VALID_KEY":         "valid_value",
+				"ANOTHER_VALID":     "test",
+				"KEY_WITHOUT_VALUE": "",
+				"FINAL_KEY":         "final_value",
+			},
+		},
+		{
+			name: "special characters in values",
+			content: `DATABASE_URL=postgres://user:pass@localhost:5432/db
+API_KEY=abc123!@#$%^&*()
+PATH=/usr/local/bin:/usr/bin:/bin
+EMPTY=
+`,
+			expectedVars: map[string]string{
+				"DATABASE_URL": "postgres://user:pass@localhost:5432/db",
+				"API_KEY":      "abc123!@#$%^&*()",
+				"PATH":         "/usr/local/bin:/usr/bin:/bin",
+				"EMPTY":        "",
+			},
+		},
+		{
+			name: "equals sign in value",
+			content: `EQUATION=a=b+c
+CONFIG=key1=value1,key2=value2
+`,
+			expectedVars: map[string]string{
+				"EQUATION": "a=b+c",
+				"CONFIG":   "key1=value1,key2=value2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Write test file
+			testFile := filepath.Join(tempDir, "test.env")
+			if err := os.WriteFile(testFile, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			envVars, err := loadEnvFile(testFile)
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Convert envVars slice to map for easier comparison
+			actualVars := make(map[string]string)
+			for _, env := range envVars {
+				actualVars[env.Key] = env.Value
+			}
+
+			// Check expected variables
+			for key, expectedValue := range tt.expectedVars {
+				if actualValue, exists := actualVars[key]; !exists {
+					t.Errorf("Expected key %s not found", key)
+				} else if actualValue != expectedValue {
+					t.Errorf("Key %s: expected value %q, got %q", key, expectedValue, actualValue)
+				}
+			}
+
+			// Check for unexpected variables
+			for key := range actualVars {
+				if _, expected := tt.expectedVars[key]; !expected {
+					t.Errorf("Unexpected key %s found", key)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyEnvVars(t *testing.T) {
+	// Save original environment to restore later
+	originalEnv := os.Environ()
+	defer func() {
+		// Restore original environment
+		os.Clearenv()
+		for _, env := range originalEnv {
+			if idx := strings.Index(env, "="); idx > 0 {
+				os.Setenv(env[:idx], env[idx+1:])
+			}
+		}
+	}()
+
+	// Set up test environment
+	os.Setenv("EXISTING_VAR", "original_value")
+
+	envVars := []EnvVar{
+		{Key: "NEW_VAR", Value: "new_value"},
+		{Key: "EXISTING_VAR", Value: "updated_value"},
+		{Key: "EMPTY_VAR", Value: ""},
+	}
+
+	applied := ApplyEnvVars(envVars)
+
+	// Check that all variables were applied
+	if len(applied) != len(envVars) {
+		t.Errorf("Expected %d applied vars, got %d", len(envVars), len(applied))
+	}
+
+	// Verify environment variables were set correctly
+	if val := os.Getenv("NEW_VAR"); val != "new_value" {
+		t.Errorf("NEW_VAR: expected 'new_value', got '%s'", val)
+	}
+	if val := os.Getenv("EXISTING_VAR"); val != "updated_value" {
+		t.Errorf("EXISTING_VAR: expected 'updated_value', got '%s'", val)
+	}
+	if val := os.Getenv("EMPTY_VAR"); val != "" {
+		t.Errorf("EMPTY_VAR: expected empty string, got '%s'", val)
+	}
+}


### PR DESCRIPTION
## 概要
認証されたユーザーのロールに基づいて、環境変数を自動的に読み込む機能を実装しました。

## 変更内容
- 🆕 `RoleEnvFilesConfig` 構造体を追加して、ロールベースの環境変数設定を管理
- 📁 `pkg/config/env_loader.go` に環境変数ファイルの読み込みロジックを実装
- 🔧 セッション作成時にユーザーのロールに基づいて環境変数を自動適用
- 📄 `default.env` とロール別の環境変数ファイル（`admin.env`, `user.env` など）をサポート

## 設定方法
以下の環境変数で機能を設定できます：

```bash
# 機能の有効化
AGENTAPI_ROLE_ENV_FILES_ENABLED=true

# 環境変数ファイルのディレクトリパス
AGENTAPI_ROLE_ENV_FILES_PATH=/etc/agentapi/env

# default.env を読み込むかどうか（デフォルト: true）
AGENTAPI_ROLE_ENV_FILES_LOAD_DEFAULT=true
```

## 使用例
1. 環境変数ファイルを準備：
   ```
   /etc/agentapi/env/
   ├── default.env    # 全ロール共通の環境変数
   ├── admin.env      # admin ロール用の環境変数
   ├── developer.env  # developer ロール用の環境変数
   └── user.env       # user ロール用の環境変数
   ```

2. 環境変数ファイルの例（`admin.env`）：
   ```bash
   # Admin-specific environment variables
   LOG_LEVEL=debug
   ADMIN_ACCESS=true
   SECRET_KEY="admin-secret-123"
   ```

3. ユーザーがセッションを作成すると、そのロールに基づいて環境変数が自動的に適用されます

## テスト計画
- [x] 環境変数ファイルの読み込みテスト
- [x] ロール別環境変数の適用テスト
- [x] default.env とロール別ファイルの優先順位テスト
- [x] 無効な環境変数ファイルのエラーハンドリングテスト

🤖 Generated with [Claude Code](https://claude.ai/code)