### PR TITLE
feat: Helm チャートにロールベース環境変数の設定を追加

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -243,6 +243,58 @@ serviceAccount:
 helm install agentapi-proxy ./helm/agentapi-proxy -f values.yaml
 ```
 
+### With Role-based Environment Variables
+
+AgentAPI Proxy supports loading different environment variables based on the authenticated user's role. This allows for fine-grained configuration per user type.
+
+```yaml
+# values.yaml
+config:
+  roleEnvFiles:
+    enabled: true
+    path: "/etc/role-env-files"
+    loadDefault: true
+
+roleEnvFiles:
+  enabled: true
+  secretNames:
+    default: "agentapi-env-default"
+    admin: "agentapi-env-admin"
+    developer: "agentapi-env-developer"
+    user: "agentapi-env-user"
+    guest: "agentapi-env-guest"
+```
+
+Create secrets for each role:
+
+```bash
+# Default environment variables (applied to all roles)
+kubectl create secret generic agentapi-env-default \
+  --from-literal=default.env="LOG_LEVEL=info
+DB_HOST=postgresql.default.svc.cluster.local
+DB_PORT=5432"
+
+# Admin-specific environment variables
+kubectl create secret generic agentapi-env-admin \
+  --from-literal=admin.env="LOG_LEVEL=debug
+ADMIN_ACCESS=true
+SECRET_KEY=admin-secret-123"
+
+# Developer-specific environment variables
+kubectl create secret generic agentapi-env-developer \
+  --from-literal=developer.env="LOG_LEVEL=debug
+DEV_ACCESS=true
+FEATURE_FLAGS=dev,staging"
+
+# User-specific environment variables
+kubectl create secret generic agentapi-env-user \
+  --from-literal=user.env="USER_ACCESS=true
+FEATURE_FLAGS=production
+API_RATE_LIMIT=100"
+```
+
+See [values-role-env-example.yaml](values-role-env-example.yaml) for a complete example with all secrets.
+
 ### Create Required Secrets
 
 ```bash

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -114,6 +114,13 @@ spec:
             - name: AGENTAPI_AUTH_CONFIG_FILE
               value: "/etc/auth-config/auth-config.yaml"
             {{- end }}
+            # Role-based environment files configuration
+            - name: AGENTAPI_ROLE_ENV_FILES_ENABLED
+              value: {{ .Values.config.roleEnvFiles.enabled | quote }}
+            - name: AGENTAPI_ROLE_ENV_FILES_PATH
+              value: {{ .Values.config.roleEnvFiles.path | quote }}
+            - name: AGENTAPI_ROLE_ENV_FILES_LOAD_DEFAULT
+              value: {{ .Values.config.roleEnvFiles.loadDefault | quote }}
             {{- if .Values.github.enterprise.enabled }}
             {{- if .Values.github.enterprise.baseUrl }}
             - name: GITHUB_URL
@@ -161,6 +168,11 @@ spec:
               mountPath: /etc/auth-config
               readOnly: true
             {{- end }}
+            {{- if .Values.roleEnvFiles.enabled }}
+            - name: role-env-files
+              mountPath: {{ .Values.config.roleEnvFiles.path }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -175,6 +187,46 @@ spec:
         - name: auth-config
           configMap:
             name: {{ include "agentapi-proxy.fullname" . }}-auth-config
+        {{- end }}
+        {{- if .Values.roleEnvFiles.enabled }}
+        - name: role-env-files
+          projected:
+            sources:
+            {{- if .Values.roleEnvFiles.secretNames.default }}
+            - secret:
+                name: {{ .Values.roleEnvFiles.secretNames.default }}
+                items:
+                - key: default.env
+                  path: default.env
+            {{- end }}
+            {{- if .Values.roleEnvFiles.secretNames.admin }}
+            - secret:
+                name: {{ .Values.roleEnvFiles.secretNames.admin }}
+                items:
+                - key: admin.env
+                  path: admin.env
+            {{- end }}
+            {{- if .Values.roleEnvFiles.secretNames.developer }}
+            - secret:
+                name: {{ .Values.roleEnvFiles.secretNames.developer }}
+                items:
+                - key: developer.env
+                  path: developer.env
+            {{- end }}
+            {{- if .Values.roleEnvFiles.secretNames.user }}
+            - secret:
+                name: {{ .Values.roleEnvFiles.secretNames.user }}
+                items:
+                - key: user.env
+                  path: user.env
+            {{- end }}
+            {{- if .Values.roleEnvFiles.secretNames.guest }}
+            - secret:
+                name: {{ .Values.roleEnvFiles.secretNames.guest }}
+                items:
+                - key: guest.env
+                  path: guest.env
+            {{- end }}
         {{- end }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/helm/agentapi-proxy/values-role-env-example.yaml
+++ b/helm/agentapi-proxy/values-role-env-example.yaml
@@ -1,0 +1,101 @@
+# Example configuration for role-based environment variables
+# ロールベース環境変数の設定例
+
+# Enable role-based environment files feature
+config:
+  roleEnvFiles:
+    enabled: true
+    path: "/etc/role-env-files"
+    loadDefault: true
+
+# Configure secrets for each role
+roleEnvFiles:
+  enabled: true
+  secretNames:
+    default: "agentapi-env-default"
+    admin: "agentapi-env-admin"
+    developer: "agentapi-env-developer"
+    user: "agentapi-env-user"
+    guest: "agentapi-env-guest"
+
+---
+# Example secrets for role-based environment variables
+# 各ロール用のSecret例
+
+# Default environment variables (applied to all roles)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentapi-env-default
+type: Opaque
+stringData:
+  default.env: |
+    # Default environment variables for all roles
+    LOG_LEVEL=info
+    DB_HOST=postgresql.default.svc.cluster.local
+    DB_PORT=5432
+    REDIS_HOST=redis.default.svc.cluster.local
+    REDIS_PORT=6379
+
+---
+# Admin role environment variables
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentapi-env-admin
+type: Opaque
+stringData:
+  admin.env: |
+    # Admin-specific environment variables
+    LOG_LEVEL=debug
+    ADMIN_ACCESS=true
+    SECRET_KEY=admin-secret-123
+    DEBUG_MODE=true
+    FEATURE_FLAGS=all
+
+---
+# Developer role environment variables
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentapi-env-developer
+type: Opaque
+stringData:
+  developer.env: |
+    # Developer-specific environment variables
+    LOG_LEVEL=debug
+    DEV_ACCESS=true
+    FEATURE_FLAGS=dev,staging
+    DEBUG_TOOLS=enabled
+    API_RATE_LIMIT=1000
+
+---
+# User role environment variables
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentapi-env-user
+type: Opaque
+stringData:
+  user.env: |
+    # User-specific environment variables
+    USER_ACCESS=true
+    FEATURE_FLAGS=production
+    API_RATE_LIMIT=100
+    SESSION_TIMEOUT=3600
+
+---
+# Guest role environment variables
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentapi-env-guest
+type: Opaque
+stringData:
+  guest.env: |
+    # Guest-specific environment variables
+    GUEST_ACCESS=true
+    FEATURE_FLAGS=basic
+    API_RATE_LIMIT=10
+    SESSION_TIMEOUT=1800
+    READ_ONLY=true

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -143,6 +143,12 @@ config:
         clientSecret: ""
         scope: "read:user read:org"
         baseUrl: ""
+  
+  # ロールベース環境変数ファイル設定
+  roleEnvFiles:
+    enabled: false
+    path: "/etc/role-env-files"
+    loadDefault: true
 
 # Environment variables
 env: []
@@ -230,3 +236,32 @@ authConfig:
   #         permissions:
   #           - "read"
   #           - "session:list"
+
+# Role-based environment files configuration
+# This stores environment variables for each role in separate secrets
+roleEnvFiles:
+  # Configuration for role-based environment variables
+  # 各ロール用の環境変数をSecretで管理するための設定
+  enabled: false
+  
+  # Secret names for each role
+  # Each secret should contain environment variables in KEY=VALUE format
+  # 各ロール用のSecret名を指定
+  secretNames:
+    default: ""    # Secret name for default environment variables (all roles)
+    admin: ""      # Secret name for admin role environment variables
+    developer: ""  # Secret name for developer role environment variables
+    user: ""       # Secret name for user role environment variables
+    guest: ""      # Secret name for guest role environment variables
+  
+  # Example secret structure:
+  # apiVersion: v1
+  # kind: Secret
+  # metadata:
+  #   name: agentapi-env-admin
+  # type: Opaque
+  # data:
+  #   admin.env: |
+  #     LOG_LEVEL=debug
+  #     ADMIN_ACCESS=true
+  #     SECRET_KEY=admin-secret-123


### PR DESCRIPTION
## 概要
Secretから環境変数ファイルを読み込むロールベース環境変数機能をHelmチャートに追加しました。

## 変更内容
- 🔧 `values.yaml` にロールベース環境変数の設定項目を追加
- 📦 StatefulSet テンプレートに環境変数設定とボリュームマウントを追加
- 🔐 projected volume を使用してSecretから環境変数ファイルをマウント
- 👥 各ロール（admin, developer, user, guest）用のSecret設定をサポート
- 📖 `values-role-env-example.yaml` で完全な使用例を提供
- 📚 README.md に詳細な設定方法を追加

## 設定方法

### 1. values.yaml で機能を有効化
```yaml
config:
  roleEnvFiles:
    enabled: true
    path: "/etc/role-env-files"
    loadDefault: true

roleEnvFiles:
  enabled: true
  secretNames:
    default: "agentapi-env-default"
    admin: "agentapi-env-admin"
    developer: "agentapi-env-developer"
    user: "agentapi-env-user"
    guest: "agentapi-env-guest"
```

### 2. 各ロール用のSecretを作成
```bash
# Default環境変数（全ロール共通）
kubectl create secret generic agentapi-env-default \
  --from-literal=default.env="LOG_LEVEL=info
DB_HOST=postgresql.default.svc.cluster.local"

# Admin専用環境変数
kubectl create secret generic agentapi-env-admin \
  --from-literal=admin.env="LOG_LEVEL=debug
ADMIN_ACCESS=true"
```

## 技術的詳細
- **projected volume**: 複数のSecretを単一のボリュームにマウント
- **Secret管理**: 環境変数は暗号化されたSecretで安全に管理
- **動的ロード**: ユーザーのロールに基づいて適切な環境変数を自動選択
- **階層構造**: default.env → role.env の順で読み込み、後者が優先

## テスト計画
- [x] values.yaml の設定項目検証
- [x] StatefulSet テンプレートの構文チェック
- [x] Secret マウントの動作確認
- [x] 完全な使用例の提供

完全な設定例は `values-role-env-example.yaml` を参照してください。

🤖 Generated with [Claude Code](https://claude.ai/code)