### PR TITLE
feat: ロールベース環境変数のマッピング設定を簡素化

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -255,14 +255,26 @@ config:
     path: "/etc/role-env-files"
     loadDefault: true
 
+# Simple mapping: filename -> secret configuration
 roleEnvFiles:
   enabled: true
-  secretNames:
-    default: "agentapi-env-default"
-    admin: "agentapi-env-admin"
-    developer: "agentapi-env-developer"
-    user: "agentapi-env-user"
-    guest: "agentapi-env-guest"
+  files:
+    "default.env":
+      secretName: "agentapi-env-default"
+      key: "default.env"
+    "admin.env":
+      secretName: "agentapi-env-admin"
+      key: "admin.env"
+    "developer.env":
+      secretName: "agentapi-env-developer"
+      key: "developer.env"
+    "user.env":
+      secretName: "agentapi-env-user"
+      key: "user.env"
+    # You can also map files with different names:
+    "database.env":
+      secretName: "db-config-secret"
+      key: "production.env"
 ```
 
 Create secrets for each role:
@@ -292,6 +304,41 @@ kubectl create secret generic agentapi-env-user \
 FEATURE_FLAGS=production
 API_RATE_LIMIT=100"
 ```
+
+#### Flexible File Mapping
+
+The new configuration format allows you to map any filename to any secret and key:
+
+```yaml
+roleEnvFiles:
+  enabled: true
+  files:
+    # Standard role files
+    "default.env":
+      secretName: "common-config"
+      key: "default.env"
+    "admin.env":
+      secretName: "admin-secrets"
+      key: "admin-config"
+    
+    # Custom files from different secrets
+    "database.env":
+      secretName: "db-config"
+      key: "production.env"
+    "api-keys.env":
+      secretName: "third-party-secrets"
+      key: "api-credentials"
+    "monitoring.env":
+      secretName: "observability-config"
+      key: "metrics.env"
+```
+
+This creates files in `/etc/role-env-files/`:
+- `default.env` (from `common-config` secret, key `default.env`)
+- `admin.env` (from `admin-secrets` secret, key `admin-config`)
+- `database.env` (from `db-config` secret, key `production.env`)
+- `api-keys.env` (from `third-party-secrets` secret, key `api-credentials`)
+- `monitoring.env` (from `observability-config` secret, key `metrics.env`)
 
 See [values-role-env-example.yaml](values-role-env-example.yaml) for a complete example with all secrets.
 

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -188,44 +188,18 @@ spec:
           configMap:
             name: {{ include "agentapi-proxy.fullname" . }}-auth-config
         {{- end }}
-        {{- if .Values.roleEnvFiles.enabled }}
+        {{- if and .Values.roleEnvFiles.enabled .Values.roleEnvFiles.files }}
         - name: role-env-files
           projected:
             sources:
-            {{- if .Values.roleEnvFiles.secretNames.default }}
+            {{- range $filename, $config := .Values.roleEnvFiles.files }}
+            {{- if and $config.secretName $config.key }}
             - secret:
-                name: {{ .Values.roleEnvFiles.secretNames.default }}
+                name: {{ $config.secretName }}
                 items:
-                - key: default.env
-                  path: default.env
+                - key: {{ $config.key }}
+                  path: {{ $filename }}
             {{- end }}
-            {{- if .Values.roleEnvFiles.secretNames.admin }}
-            - secret:
-                name: {{ .Values.roleEnvFiles.secretNames.admin }}
-                items:
-                - key: admin.env
-                  path: admin.env
-            {{- end }}
-            {{- if .Values.roleEnvFiles.secretNames.developer }}
-            - secret:
-                name: {{ .Values.roleEnvFiles.secretNames.developer }}
-                items:
-                - key: developer.env
-                  path: developer.env
-            {{- end }}
-            {{- if .Values.roleEnvFiles.secretNames.user }}
-            - secret:
-                name: {{ .Values.roleEnvFiles.secretNames.user }}
-                items:
-                - key: user.env
-                  path: user.env
-            {{- end }}
-            {{- if .Values.roleEnvFiles.secretNames.guest }}
-            - secret:
-                name: {{ .Values.roleEnvFiles.secretNames.guest }}
-                items:
-                - key: guest.env
-                  path: guest.env
             {{- end }}
         {{- end }}
         {{- with .Values.volumes }}

--- a/helm/agentapi-proxy/values-role-env-example.yaml
+++ b/helm/agentapi-proxy/values-role-env-example.yaml
@@ -8,15 +8,33 @@ config:
     path: "/etc/role-env-files"
     loadDefault: true
 
-# Configure secrets for each role
+# Simple mapping: filename -> secret configuration
+# ファイル名とSecretの設定を直接マッピング
 roleEnvFiles:
   enabled: true
-  secretNames:
-    default: "agentapi-env-default"
-    admin: "agentapi-env-admin"
-    developer: "agentapi-env-developer"
-    user: "agentapi-env-user"
-    guest: "agentapi-env-guest"
+  files:
+    "default.env":
+      secretName: "agentapi-env-default"
+      key: "default.env"
+    "admin.env":
+      secretName: "agentapi-env-admin"
+      key: "admin.env"
+    "developer.env":
+      secretName: "agentapi-env-developer"
+      key: "developer.env"
+    "user.env":
+      secretName: "agentapi-env-user"
+      key: "user.env"
+    "guest.env":
+      secretName: "agentapi-env-guest"
+      key: "guest.env"
+    # You can also map files with different names:
+    # "special-config.env":
+    #   secretName: "custom-secret"
+    #   key: "special-key"
+    # "database.env":
+    #   secretName: "db-config"
+    #   key: "production.env"
 
 ---
 # Example secrets for role-based environment variables

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -238,30 +238,40 @@ authConfig:
   #           - "session:list"
 
 # Role-based environment files configuration
-# This stores environment variables for each role in separate secrets
+# Map environment files to secrets - this creates the appropriate projected volume automatically
 roleEnvFiles:
   # Configuration for role-based environment variables
-  # 各ロール用の環境変数をSecretで管理するための設定
   enabled: false
   
-  # Secret names for each role
-  # Each secret should contain environment variables in KEY=VALUE format
-  # 各ロール用のSecret名を指定
-  secretNames:
-    default: ""    # Secret name for default environment variables (all roles)
-    admin: ""      # Secret name for admin role environment variables
-    developer: ""  # Secret name for developer role environment variables
-    user: ""       # Secret name for user role environment variables
-    guest: ""      # Secret name for guest role environment variables
+  # Simple mapping: filename -> secret configuration
+  # ファイル名とSecretの設定を直接マッピング
+  files:
+    # "default.env":
+    #   secretName: "agentapi-env-default"
+    #   key: "default.env"
+    # "admin.env":
+    #   secretName: "agentapi-env-admin" 
+    #   key: "admin.env"
+    # "developer.env":
+    #   secretName: "agentapi-env-developer"
+    #   key: "developer.env"
+    # "user.env":
+    #   secretName: "agentapi-env-user"
+    #   key: "user.env"
+    # "guest.env":
+    #   secretName: "agentapi-env-guest"
+    #   key: "guest.env"
   
-  # Example secret structure:
-  # apiVersion: v1
-  # kind: Secret
-  # metadata:
-  #   name: agentapi-env-admin
-  # type: Opaque
-  # data:
-  #   admin.env: |
-  #     LOG_LEVEL=debug
-  #     ADMIN_ACCESS=true
-  #     SECRET_KEY=admin-secret-123
+  # Example usage:
+  # roleEnvFiles:
+  #   enabled: true
+  #   files:
+  #     "default.env":
+  #       secretName: "common-env-vars"
+  #       key: "default.env"
+  #     "admin.env":
+  #       secretName: "admin-secrets"
+  #       key: "admin-config"
+  #     "developer.env":
+  #       secretName: "dev-config"
+  #       key: "development.env"


### PR DESCRIPTION
## 概要
values.yamlでシンプルにファイル名とSecretの対応を定義するだけで、projected volumeが自動的に構成されるように改善しました。

## 変更内容
- 🔧 `roleEnvFiles.files` でファイル名とSecret設定を直接マッピング
- 🔄 StatefulSet テンプレートを動的生成に変更（`range` ループ使用）
- 🎯 柔軟なファイル名とSecret名・キー名の組み合わせをサポート
- 📝 設定例を新しい形式に更新
- 📚 README に詳細な使用例を追加

## Before（旧形式）
```yaml
roleEnvFiles:
  enabled: true
  secretNames:
    default: "agentapi-env-default"
    admin: "agentapi-env-admin"
    developer: "agentapi-env-developer"
```

## After（新形式）
```yaml
roleEnvFiles:
  enabled: true
  files:
    "default.env":
      secretName: "agentapi-env-default"
      key: "default.env"
    "admin.env":
      secretName: "agentapi-env-admin"
      key: "admin.env"
    # 柔軟なマッピングも可能
    "database.env":
      secretName: "db-config"
      key: "production.env"
```

## メリット
1. **シンプルな設定**: ファイル名とSecretを直接対応付け
2. **柔軟性向上**: 任意のファイル名、Secret名、キー名の組み合わせが可能
3. **自動構成**: StatefulSetのprojected volumeが自動生成
4. **拡張性**: 新しいファイルマッピングを簡単に追加可能

## 使用例
```yaml
roleEnvFiles:
  enabled: true
  files:
    "default.env":
      secretName: "common-config"
      key: "default.env"
    "admin.env":
      secretName: "admin-secrets"
      key: "admin-config"
    "database.env":
      secretName: "db-config"
      key: "production.env"
    "api-keys.env":
      secretName: "third-party-secrets"
      key: "api-credentials"
```

これにより `/etc/role-env-files/` に以下のファイルが作成されます：
- `default.env`
- `admin.env`
- `database.env`
- `api-keys.env`

🤖 Generated with [Claude Code](https://claude.ai/code)