### PR TITLE
fix: GitHub Enterprise URL フォーマット対応

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -245,8 +245,9 @@ func InitGitHubRepo(repoFullName, cloneDir string, ignoreMissingConfig bool) err
 		return fmt.Errorf("failed to get GitHub token: %w", err)
 	}
 
-	// Create repository URL
-	repoURL := fmt.Sprintf("https://github.com/%s", repoFullName)
+	// Create repository URL using the correct GitHub URL
+	githubURL := getGitHubURL()
+	repoURL := fmt.Sprintf("%s/%s", githubURL, repoFullName)
 
 	// Setup the repository with proper git clone
 	if err := setupRepository(repoURL, token, cloneDir); err != nil {
@@ -428,6 +429,11 @@ func createAuthenticatedURL(repoURL, token string) (string, error) {
 		parts := strings.TrimPrefix(repoURL, "git@"+githubHost+":")
 		parts = strings.TrimSuffix(parts, ".git")
 		return fmt.Sprintf("https://%s@%s/%s.git", token, githubHost, parts), nil
+	} else if strings.HasPrefix(repoURL, "https://github.com/") {
+		// Handle the case where repoURL starts with standard GitHub URL
+		// but we're using GitHub Enterprise
+		parts := strings.TrimPrefix(repoURL, "https://github.com/")
+		return fmt.Sprintf("https://%s@%s/%s", token, githubHost, parts), nil
 	}
 
 	return "", fmt.Errorf("unsupported repository URL format: %s", repoURL)


### PR DESCRIPTION
## 概要
GitHub Enterprise を使用している場合に発生していた「unsupported repository URL format」エラーを修正しました。

## 変更内容
- `InitGitHubRepo` 関数でリポジトリ URL を構築する際に、正しい GitHub URL（Enterprise 対応）を使用するよう修正
- `createAuthenticatedURL` 関数に標準 GitHub URL から Enterprise URL への変換ロジックを追加

## 修正前の問題
```
failed to create authenticated URL: unsupported repository URL format: https://github.com/org/repo
```

## 修正内容の詳細
1. **リポジトリ URL 構築の修正**: `getGitHubURL()` を使用して正しい GitHub ベース URL を取得
2. **URL フォーマット変換の追加**: `createAuthenticatedURL` 関数で `https://github.com/` で始まる URL も処理できるよう改善

## テスト計画
- [ ] GitHub Enterprise 環境での動作確認
- [ ] 標準 GitHub での動作確認（既存機能が破綻していないことを確認）

🤖 Generated with [Claude Code](https://claude.ai/code)