### PR TITLE
feat: gh repo clone を使用したリポジトリクローン機能の実装

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -423,29 +423,6 @@ func extractRepoName(repoURL string) (string, error) {
 	return "", fmt.Errorf("unable to extract repository name from URL: %s", repoURL)
 }
 
-// createAuthenticatedURL creates an authenticated URL for git operations
-func createAuthenticatedURL(repoURL, token string) (string, error) {
-	githubURL := getGitHubURL()
-	githubHost := strings.TrimPrefix(githubURL, "https://")
-	githubHost = strings.TrimPrefix(githubHost, "http://")
-
-	// Parse the repository URL and insert the token
-	if strings.HasPrefix(repoURL, githubURL+"/") {
-		parts := strings.TrimPrefix(repoURL, githubURL+"/")
-		return fmt.Sprintf("https://%s@%s/%s", token, githubHost, parts), nil
-	} else if strings.HasPrefix(repoURL, "git@"+githubHost+":") {
-		parts := strings.TrimPrefix(repoURL, "git@"+githubHost+":")
-		parts = strings.TrimSuffix(parts, ".git")
-		return fmt.Sprintf("https://%s@%s/%s.git", token, githubHost, parts), nil
-	} else if strings.HasPrefix(repoURL, "https://github.com/") {
-		// Handle the case where repoURL starts with standard GitHub URL
-		// but we're using GitHub Enterprise
-		parts := strings.TrimPrefix(repoURL, "https://github.com/")
-		return fmt.Sprintf("https://%s@%s/%s", token, githubHost, parts), nil
-	}
-
-	return "", fmt.Errorf("unsupported repository URL format: %s", repoURL)
-}
 
 // getGitHubURL returns the GitHub URL (supports enterprise)
 func getGitHubURL() string {


### PR DESCRIPTION
## 概要
init 時のリポジトリクローン処理を `gh repo clone` コマンドを使用するよう改善しました。

## 変更内容
- **setupRepository 関数の改善**: 手動の git コマンドシーケンス（init/remote add/fetch/checkout）を `gh repo clone` で置き換え
- **extractRepoName 関数の追加**: 様々な GitHub URL 形式から owner/repo 形式を抽出
- **GitHub Enterprise 対応**: `GH_HOST` 環境変数の設定により Enterprise 環境をサポート

## 修正前の処理
```bash
git init
git remote add origin <url>
git fetch
git checkout main/master
```

## 修正後の処理
```bash
gh repo clone owner/repo target_directory
```

## メリット
1. **認証の簡素化**: `gh` コマンドが自動的に適切な認証を処理
2. **GitHub Enterprise 対応の向上**: `GH_HOST` 環境変数により Enterprise 環境での動作が改善
3. **エラーハンドリングの改善**: `gh repo clone` が適切なエラーメッセージを提供
4. **コードの簡素化**: 複数の git コマンドを単一の `gh` コマンドで置き換え

## テスト計画
- [ ] 標準 GitHub での動作確認
- [ ] GitHub Enterprise 環境での動作確認
- [ ] 既存のリポジトリが存在する場合の `git pull` 動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)