### PR TITLE
fix: GitHub Enterprise Server認証エラーの修正

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -379,7 +379,7 @@ func setupRepository(repoURL, token, cloneDir string) error {
 			env = append(env, fmt.Sprintf("GH_HOST=%s", githubHost))
 			
 			// Authenticate gh CLI for GitHub Enterprise Server
-			if err := authenticateGHCLI(githubHost, token); err != nil {
+			if err := authenticateGHCLI(githubHost, token, env); err != nil {
 				log.Printf("Warning: Failed to authenticate gh CLI for %s: %v", githubHost, err)
 			}
 		}
@@ -408,12 +408,19 @@ func setupRepository(repoURL, token, cloneDir string) error {
 }
 
 // authenticateGHCLI authenticates gh CLI for GitHub Enterprise Server
-func authenticateGHCLI(githubHost, token string) error {
+func authenticateGHCLI(githubHost, token string, env []string) error {
 	log.Printf("Authenticating gh CLI for Enterprise Server: %s", githubHost)
 
 	// Use gh auth login with token for Enterprise Server
 	cmd := exec.Command("gh", "auth", "login", "--hostname", githubHost, "--with-token")
 	cmd.Stdin = strings.NewReader(token)
+	
+	// Set environment variables to use user-specific home directory
+	if len(env) > 0 {
+		cmd.Env = env
+	} else {
+		cmd.Env = os.Environ()
+	}
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -373,8 +373,14 @@ func setupRepository(repoURL, token, cloneDir string) error {
 		// Set GitHub Enterprise host if applicable
 		if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" && githubAPI != "https://api.github.com" {
 			githubHost := strings.TrimPrefix(githubAPI, "https://")
+			githubHost = strings.TrimPrefix(githubHost, "http://")
 			githubHost = strings.TrimSuffix(githubHost, "/api/v3")
 			env = append(env, fmt.Sprintf("GH_HOST=%s", githubHost))
+			
+			// Authenticate gh CLI for GitHub Enterprise Server
+			if err := authenticateGHCLI(githubHost, token); err != nil {
+				log.Printf("Warning: Failed to authenticate gh CLI for %s: %v", githubHost, err)
+			}
 		}
 
 		// Create parent directory
@@ -397,6 +403,25 @@ func setupRepository(repoURL, token, cloneDir string) error {
 	}
 
 	log.Printf("Repository setup completed")
+	return nil
+}
+
+// authenticateGHCLI authenticates gh CLI for GitHub Enterprise Server
+func authenticateGHCLI(githubHost, token string) error {
+	log.Printf("Authenticating gh CLI for Enterprise Server: %s", githubHost)
+
+	// Use gh auth login with token for Enterprise Server
+	cmd := exec.Command("gh", "auth", "login", "--hostname", githubHost, "--with-token")
+	cmd.Stdin = strings.NewReader(token)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh auth login failed: %w, stderr: %s", err, stderr.String())
+	}
+
+	log.Printf("Successfully authenticated gh CLI for %s", githubHost)
 	return nil
 }
 

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -1,6 +1,7 @@
 package startup
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"


### PR DESCRIPTION
## 概要
GitHub Enterprise Serverへの認証が失敗していた問題を修正しました。

## 修正内容
- **認証エラーの修正**: GitHub Enterprise Server用のgh CLI認証を自動化
- **URL処理の改善**: GITHUB_API環境変数からホスト名を正しく抽出
- **認証関数の追加**: `authenticateGHCLI`関数を追加し、自動認証を実現
- **プロトコル処理**: HTTP/HTTPSプロトコルの適切な処理を追加

## 変更したファイル
- `pkg/startup/startup.go`: GitHub Enterprise Server認証ロジックの追加

## 動作確認
この修正により、以下のエラーが解決されます：
```
HTTP 401: Must authenticate to access this API.
```

## テスト計画
- [ ] GitHub Enterprise Server環境での動作確認
- [ ] 従来のGitHub.com環境での動作確認
- [ ] 認証エラーハンドリングの確認

🤖 Generated with [Claude Code](https://claude.ai/code)