### PR TITLE
feat: GitHub App Installation IDの自動検出機能を改善

### DIFF
--- a/docs/github-app-helm-authentication.md
+++ b/docs/github-app-helm-authentication.md
@@ -68,6 +68,7 @@ Webhook URL: https://your-agentapi.example.com/webhook (使用しない場合は
 2. 対象の組織を選択
 3. **All repositories** または **Selected repositories** を選択してインストール
 4. Installation IDをURLから取得（例：`/settings/installations/12345678` → `12345678`）
+   ※ Installation IDは省略可能で、指定しない場合は自動的に検出されます
 
 ## Helm設定
 
@@ -87,7 +88,7 @@ github:
   app:
     # GitHub App ID
     id: "123456"
-    # GitHub App Installation ID  
+    # GitHub App Installation ID (省略可能：指定しない場合は自動検出)
     installationId: "12345678"
     # GitHub App の秘密鍵を含むSecret
     privateKey:
@@ -173,7 +174,7 @@ github:
     apiUrl: "https://github.company.com/api/v3"
   app:
     id: "123456"
-    installationId: "12345678"
+    installationId: "12345678"  # 省略可能：指定しない場合は自動検出
     privateKey:
       secretName: "github-app-private-key"
       key: "private-key"
@@ -199,7 +200,7 @@ env:
   - name: GITHUB_APP_ID
     value: "123456"
   - name: GITHUB_INSTALLATION_ID  
-    value: "12345678"
+    value: "12345678"  # 省略可能：指定しない場合は自動検出
   - name: GITHUB_APP_PEM
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION
## 概要

GitHub App Installation IDの自動検出機能を改善し、Installation IDの入力を完全に省略可能にしました。

## 変更内容

### 1. findInstallationIDForRepo関数の改善
- `GITHUB_APP_PEM`環境変数のフォールバック処理を追加
- PEMファイルの読み取りエラー時に環境変数からの取得を試行
- エラーメッセージの改善

### 2. ドキュメントの更新
- Installation IDが省略可能であることを明記
- ヘルプメッセージの更新
- Helmチャートドキュメントの更新

## 実装の詳細

### 改善されたPEMファイル読み取り処理

```go
// Try to read from file first
pemData, err := os.ReadFile(pemPath)
if err \!= nil {
    // If file read fails, try to get from environment variable
    if pemContent := os.Getenv("GITHUB_APP_PEM"); pemContent \!= "" {
        pemData = []byte(pemContent)
    } else {
        return 0, fmt.Errorf("failed to read PEM file %s and GITHUB_APP_PEM environment variable not set: %w", pemPath, err)
    }
}
```

### 自動検出フロー

1. **GITHUB_INSTALLATION_ID**環境変数が設定されている場合：手動指定のInstallation IDを使用
2. **GITHUB_INSTALLATION_ID**環境変数が設定されていない場合：
   - GitHub App認証情報を使用してすべてのInstallationを取得
   - 指定されたリポジトリにアクセス可能なInstallationを検出
   - 最初に見つかったInstallation IDを使用

## テスト計画

- [ ] Installation IDを手動指定した場合の動作確認
- [ ] Installation IDを省略した場合の自動検出動作確認
- [ ] PEMファイルが存在しない場合の環境変数フォールバック確認
- [ ] 複数のInstallationが存在する場合の検出確認
- [ ] エラーハンドリングの確認

🤖 Generated with [Claude Code](https://claude.ai/code)