### PR TITLE
feat: Installation Tokenの4時間ごとの自動再認証機能を実装

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+	"github.com/takutakahashi/agentapi-proxy/pkg/startup"
 	"github.com/takutakahashi/agentapi-proxy/pkg/storage"
 	"github.com/takutakahashi/agentapi-proxy/pkg/userdir"
 )
@@ -1136,6 +1137,9 @@ func (p *Proxy) selectScript(c echo.Context, scriptCache map[string][]byte, tags
 // Shutdown gracefully stops all running sessions and waits for them to terminate
 func (p *Proxy) Shutdown(timeout time.Duration) error {
 	log.Printf("Shutting down proxy, terminating %d active sessions...", len(p.sessions))
+	
+	// Stop the re-authentication service
+	startup.StopReauthService()
 
 	// Get all session cancel functions
 	p.sessionsMutex.RLock()


### PR DESCRIPTION
## 概要

GitHub App Installation Tokenの有効期限が短い（1時間）問題に対応するため、4時間ごとに自動的に再認証を行う機能を実装しました。

## 主な変更点

### 新機能
- **再認証サービス**: 4時間間隔で自動的にGitHub App Installation Tokenを更新
- **gh CLI認証更新**: GitHub CLIの認証情報を定期的に更新
- **git remote更新**: git remoteのHTTPS URLに新しいトークンを自動設定
- **GitHub Enterprise対応**: GitHub Enterprise Serverでも動作

### 実装詳細
- `pkg/startup/startup.go`にReauthServiceを実装
- セッション開始時に自動的に再認証サービスを起動
- プロキシ終了時に再認証サービスを適切に停止
- エラーハンドリングとログ出力を改善

## テスト計画

- [x] GitHub App認証情報が設定されている場合の動作確認
- [x] 認証情報が設定されていない場合の適切なスキップ
- [x] GitHub Enterprise Serverでの動作確認
- [ ] 実際の4時間間隔での動作確認（長時間テスト）

## 影響範囲

- セッション開始時の処理に再認証サービスの起動を追加
- プロキシ終了時の処理に再認証サービスの停止を追加
- 既存の認証ロジックには影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)