### PR TITLE
feat: セッション復元時にプロセスも自動起動する機能を追加

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,6 +120,7 @@ type PersistenceConfig struct {
 	SyncInterval          int    `json:"sync_interval_seconds" mapstructure:"sync_interval_seconds"`
 	EncryptSecrets        bool   `json:"encrypt_sensitive_data" mapstructure:"encrypt_sensitive_data"`
 	SessionRecoveryMaxAge int    `json:"session_recovery_max_age_hours" mapstructure:"session_recovery_max_age_hours"` // Max age in hours for session recovery
+	RestoreProcesses      bool   `json:"restore_processes" mapstructure:"restore_processes"`                           // Whether to restore agentapi processes on recovery
 
 	// S3-specific configuration
 	S3Bucket    string `json:"s3_bucket" mapstructure:"s3_bucket"`
@@ -356,6 +357,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("persistence.sync_interval_seconds")
 	_ = v.BindEnv("persistence.encrypt_sensitive_data")
 	_ = v.BindEnv("persistence.session_recovery_max_age_hours")
+	_ = v.BindEnv("persistence.restore_processes")
 	_ = v.BindEnv("persistence.s3_bucket")
 	_ = v.BindEnv("persistence.s3_region")
 	_ = v.BindEnv("persistence.s3_prefix")
@@ -385,6 +387,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("persistence.sync_interval_seconds", 30)
 	v.SetDefault("persistence.encrypt_sensitive_data", true)
 	v.SetDefault("persistence.session_recovery_max_age_hours", 24)
+	v.SetDefault("persistence.restore_processes", true)
 
 	// S3 persistence defaults
 	v.SetDefault("persistence.s3_region", "us-east-1")

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1490,13 +1490,18 @@ func (p *Proxy) runAgentAPIServerForRestore(ctx context.Context, session *AgentS
 	}
 
 	// Start the AgentAPI session
-	err := startupManager.StartAgentAPISession(ctx, cfg)
+	cmd, err := startupManager.StartAgentAPISession(ctx, cfg)
 	if err != nil {
 		log.Printf("Failed to start restored AgentAPI session %s: %v", session.ID, err)
 		session.Status = "failed"
 		p.updateSession(session)
 		return
 	}
+
+	// Store the command in the session for proper cleanup
+	session.processMutex.Lock()
+	session.Process = cmd
+	session.processMutex.Unlock()
 
 	if p.verbose {
 		log.Printf("Successfully started restored AgentAPI session %s", session.ID)

--- a/pkg/proxy/startup.go
+++ b/pkg/proxy/startup.go
@@ -33,6 +33,7 @@ type StartupConfig struct {
 	Environment               map[string]string
 	Config                    *config.Config
 	Verbose                   bool
+	IsRestore                 bool // Whether this is a restored session
 }
 
 // StartupManager manages the startup process
@@ -159,6 +160,11 @@ func (sm *StartupManager) createAgentAPICommand(ctx context.Context, cfg *Startu
 	}
 
 	args = append(args, "--", "claude")
+
+	// Add -c option for restored sessions to continue previous conversation
+	if cfg.IsRestore {
+		args = append(args, "-c")
+	}
 
 	if cfg.ClaudeArgs != "" {
 		// TODO: Parse ClaudeArgs properly


### PR DESCRIPTION
## Summary
- セッション復元時にagentapiプロセスも自動起動するように機能拡張
- 設定項目 `persistence.restore_processes` を追加（デフォルト: true）
- ポート可用性チェック機能を実装
- 復元時のエラーハンドリングを追加

## 主な変更点
- `recoverSessions()` 関数の拡張: プロセス復元処理を追加
- `restoreSessionProcess()` 関数の新規実装: プロセス復元の核となる処理
- `isPortAvailable()` 関数の追加: ポート可用性チェック
- 設定項目 `PersistenceConfig.RestoreProcesses` の追加
- 環境変数 `AGENTAPI_PERSISTENCE_RESTORE_PROCESSES` でも制御可能

## Test plan
- [ ] セッション永続化が有効な環境でプロキシを起動
- [ ] セッションを作成してagentapiプロセスが起動することを確認
- [ ] プロキシを再起動
- [ ] セッション復元時にプロセスも自動起動することを確認
- [ ] `persistence.restore_processes=false` に設定して復元時にプロセスが起動しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)