### PR TITLE
feat: Helm チャートに readinessProbe を追加

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -208,6 +208,10 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -178,6 +178,16 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 3
 
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 3
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## 概要
agentapi-proxy の Helm チャートに readinessProbe の設定を追加しました。

## 変更内容
- `values.yaml` に readinessProbe のデフォルト設定を追加
- `statefulset.yaml` テンプレートに readinessProbe の設定を適用

## 設定詳細
```yaml
readinessProbe:
  httpGet:
    path: /health
    port: http
  initialDelaySeconds: 10
  periodSeconds: 5
  timeoutSeconds: 3
  successThreshold: 1
  failureThreshold: 3
```

## 目的
現在、livenessProbe のみが設定されており、readinessProbe が設定されていませんでした。
readinessProbe を追加することで、以下のメリットがあります：

- Pod が起動直後に Service のエンドポイントに追加される前に、アプリケーションの準備状態を確認
- より安定したデプロイメントとトラフィック管理が可能

## テスト
- `make lint` : パス
- `make test` : パス

🤖 Generated with [Claude Code](https://claude.ai/code)