### PR TITLE
remove: Skipping auth for health endpoint log message

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -49,7 +49,6 @@ func AuthMiddleware(cfg *config.Config, githubProvider *GitHubAuthProvider) echo
 
 			// Skip auth for health endpoint
 			if path == "/health" {
-				log.Printf("Skipping auth for health endpoint")
 				return next(c)
 			}
 


### PR DESCRIPTION
## Summary
- `Skipping auth for health endpoint` ログメッセージを削除

## 変更内容
- `pkg/auth/auth.go:52` の `log.Printf("Skipping auth for health endpoint")` を削除
- ヘルスエンドポイントの認証スキップ機能は正常に動作するため、ログ出力は不要

## Test plan
- [x] `make test` でテストが正常に通ることを確認
- [x] 機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)