### PR TITLE
feat: GitHub OAuth スコープに admin:org 権限を追加

### DIFF
--- a/cmd/init_github_repo_test.go
+++ b/cmd/init_github_repo_test.go
@@ -1020,7 +1020,7 @@ func TestFindInstallationIDForRepo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clear cache before each test to ensure independence
 			installationCache.ClearCache()
-			
+
 			// Create test server
 			server := httptest.NewServer(tt.serverHandler)
 			defer server.Close()

--- a/config.oauth.development.example.json
+++ b/config.oauth.development.example.json
@@ -9,7 +9,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "repo workflow read:org admin:repo_hook notifications user:email",
+        "scope": "repo workflow admin:org admin:repo_hook notifications user:email",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/config.oauth.example.json
+++ b/config.oauth.example.json
@@ -9,7 +9,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "repo workflow read:org admin:repo_hook notifications user:email",
+        "scope": "repo workflow admin:org admin:repo_hook notifications user:email",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/config.oauth.public-only.example.json
+++ b/config.oauth.public-only.example.json
@@ -9,7 +9,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "public_repo workflow read:org notifications user:email",
+        "scope": "public_repo workflow admin:org notifications user:email",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -257,7 +257,7 @@ func TestAddMcpServer(t *testing.T) {
 		Args:      []string{"arg1", "arg2"},
 		Env:       map[string]string{"TEST_ENV": "test_value"},
 	}
-	
+
 	err := addMcpServer(tempDir, mcpConfig)
 	// This might succeed if claude command is available in the environment
 	if err != nil {
@@ -271,7 +271,7 @@ func TestAddMcpServer(t *testing.T) {
 		Transport: "http",
 		Endpoint:  "http://localhost:8080",
 	}
-	
+
 	err = addMcpServer(tempDir, mcpConfig2)
 	// This might succeed if claude command is available in the environment
 	if err != nil {
@@ -438,7 +438,7 @@ func TestGetGitHubToken(t *testing.T) {
 	_ = os.Unsetenv("GITHUB_PERSONAL_ACCESS_TOKEN")
 	_ = os.Setenv("GITHUB_APP_ID", "12345")
 	_ = os.Setenv("GITHUB_INSTALLATION_ID", "67890")
-	
+
 	// Create a dummy PEM file
 	tempDir := t.TempDir()
 	pemFile := filepath.Join(tempDir, "test.pem")
@@ -447,7 +447,7 @@ func TestGetGitHubToken(t *testing.T) {
 		t.Fatalf("Failed to create test PEM file: %v", err)
 	}
 	_ = os.Setenv("GITHUB_APP_PEM_PATH", pemFile)
-	
+
 	_, err = getGitHubToken("")
 	// This will fail because of invalid PEM, but tests the code path
 	if err == nil {
@@ -457,7 +457,7 @@ func TestGetGitHubToken(t *testing.T) {
 	// Test case 4: GitHub App auth with auto-discovery (no installation ID)
 	_ = os.Unsetenv("GITHUB_INSTALLATION_ID")
 	_ = os.Setenv("GITHUB_REPO_FULLNAME", "owner/repo")
-	
+
 	_, err = getGitHubToken("")
 	// This will fail because of invalid PEM, but tests the auto-discovery code path
 	if err == nil {
@@ -566,14 +566,14 @@ func TestGenerateGitHubAppToken(t *testing.T) {
 
 	// Test case 4: PEM file fallback to environment variable
 	originalPem := os.Getenv("GITHUB_APP_PEM")
-	defer func() { 
+	defer func() {
 		if originalPem != "" {
 			_ = os.Setenv("GITHUB_APP_PEM", originalPem)
 		} else {
 			_ = os.Unsetenv("GITHUB_APP_PEM")
 		}
 	}()
-	
+
 	// Set a dummy PEM content
 	_ = os.Setenv("GITHUB_APP_PEM", "dummy-pem-content")
 	_, err = generateGitHubAppToken("123", "456", nonExistentPem)
@@ -599,7 +599,7 @@ func TestAutoDiscoverInstallationID(t *testing.T) {
 	// Test case 3: Non-existent PEM file without env var
 	tempDir := t.TempDir()
 	nonExistentPem := filepath.Join(tempDir, "non-existent.pem")
-	
+
 	originalPem := os.Getenv("GITHUB_APP_PEM")
 	defer func() {
 		if originalPem != "" {
@@ -609,7 +609,7 @@ func TestAutoDiscoverInstallationID(t *testing.T) {
 		}
 	}()
 	_ = os.Unsetenv("GITHUB_APP_PEM")
-	
+
 	_, err = autoDiscoverInstallationID("123", nonExistentPem, "owner/repo")
 	if err == nil {
 		t.Error("Expected error for non-existent PEM file")
@@ -619,7 +619,7 @@ func TestAutoDiscoverInstallationID(t *testing.T) {
 func TestAuthenticateGHCLI(t *testing.T) {
 	// This function executes gh auth login command
 	// We can only test that it attempts to run the command
-	
+
 	// Test with mock environment
 	env := []string{"PATH=/usr/bin:/bin", "HOME=/tmp"}
 	err := authenticateGHCLI("github.enterprise.com", "test-token", env)
@@ -650,7 +650,7 @@ func TestSetupRepository(t *testing.T) {
 	if err := os.MkdirAll(gitDir, 0755); err != nil {
 		t.Fatalf("Failed to create .git directory: %v", err)
 	}
-	
+
 	// This will try to run git pull, which will fail in test environment
 	err = setupRepository("https://github.com/owner/repo", "test-token", tempDir)
 	if err == nil {


### PR DESCRIPTION
## 概要
OAuth でログインした際に所属する組織のリストを取得できるよう、OAuth スコープに `admin:org` 権限を追加しました。

## 変更内容
- `config.oauth.example.json`: `read:org` → `admin:org`
- `config.oauth.development.example.json`: `read:org` → `admin:org`  
- `config.oauth.public-only.example.json`: `read:org` → `admin:org`

## 理由
現在の設定では `read:org` スコープのみが設定されていますが、GitHub API で認証されたユーザーが所属する組織の詳細な一覧を取得するには `admin:org` スコープが必要です。

## テスト計画
- [ ] OAuth 認証後に組織リストが正常に取得できることを確認
- [ ] 既存の機能が正常に動作することを確認
- [ ] セキュリティ上の問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)