### PR TITLE
fix: PVC起動時のpermission denied問題を修正

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -37,23 +37,50 @@ spec:
             - sh
             - -c
             - |
-              echo "Fixing PVC permissions for uid:gid 999:999..."
+              echo "Checking PVC permissions for uid:gid 999:999..."
+              NEED_FIX=false
+              
               {{- if .Values.persistence.enabled }}
-              if [ -d "/home/agentapi/workdir" ]; then
-                chown -R 999:999 /home/agentapi/workdir || echo "Warning: Failed to change ownership of workdir"
-                chmod -R 755 /home/agentapi/workdir || echo "Warning: Failed to change permissions of workdir"
-                echo "Fixed permissions for /home/agentapi/workdir"
+              echo "Testing write access to /home/agentapi/workdir..."
+              if ! su -s /bin/sh -c "touch /home/agentapi/workdir/.write_test && rm -f /home/agentapi/workdir/.write_test" 999 2>/dev/null; then
+                echo "Write test failed for /home/agentapi/workdir, need to fix permissions"
+                NEED_FIX=true
+              else
+                echo "Write test passed for /home/agentapi/workdir"
               fi
               {{- end }}
+              
               {{- if .Values.myclaudesPersistence.enabled }}
-              if [ -d "/home/agentapi/.agentapi-proxy/myclaudes" ]; then
-                mkdir -p /home/agentapi/.agentapi-proxy
-                chown -R 999:999 /home/agentapi/.agentapi-proxy || echo "Warning: Failed to change ownership of myclaudes"
-                chmod -R 755 /home/agentapi/.agentapi-proxy || echo "Warning: Failed to change permissions of myclaudes"
-                echo "Fixed permissions for /home/agentapi/.agentapi-proxy/myclaudes"
+              echo "Testing write access to /home/agentapi/.agentapi-proxy/myclaudes..."
+              mkdir -p /home/agentapi/.agentapi-proxy/myclaudes
+              if ! su -s /bin/sh -c "touch /home/agentapi/.agentapi-proxy/myclaudes/.write_test && rm -f /home/agentapi/.agentapi-proxy/myclaudes/.write_test" 999 2>/dev/null; then
+                echo "Write test failed for /home/agentapi/.agentapi-proxy/myclaudes, need to fix permissions"
+                NEED_FIX=true
+              else
+                echo "Write test passed for /home/agentapi/.agentapi-proxy/myclaudes"
               fi
               {{- end }}
-              echo "Permission fix completed"
+              
+              if [ "$NEED_FIX" = "true" ]; then
+                echo "Fixing PVC permissions..."
+                {{- if .Values.persistence.enabled }}
+                if [ -d "/home/agentapi/workdir" ]; then
+                  chown -R 999:999 /home/agentapi/workdir || echo "Warning: Failed to change ownership of workdir"
+                  chmod -R 755 /home/agentapi/workdir || echo "Warning: Failed to change permissions of workdir"
+                  echo "Fixed permissions for /home/agentapi/workdir"
+                fi
+                {{- end }}
+                {{- if .Values.myclaudesPersistence.enabled }}
+                if [ -d "/home/agentapi/.agentapi-proxy/myclaudes" ]; then
+                  chown -R 999:999 /home/agentapi/.agentapi-proxy || echo "Warning: Failed to change ownership of myclaudes"
+                  chmod -R 755 /home/agentapi/.agentapi-proxy || echo "Warning: Failed to change permissions of myclaudes"
+                  echo "Fixed permissions for /home/agentapi/.agentapi-proxy/myclaudes"
+                fi
+                {{- end }}
+                echo "Permission fix completed"
+              else
+                echo "No permission fix needed"
+              fi
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: data

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -29,8 +29,45 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and .Values.github.app.privateKey.secretName .Values.github.app.privateKey.key }}
       initContainers:
+        {{- if or .Values.persistence.enabled .Values.myclaudesPersistence.enabled }}
+        - name: fix-permissions
+          image: busybox:1.35
+          command:
+            - sh
+            - -c
+            - |
+              echo "Fixing PVC permissions for uid:gid 999:999..."
+              {{- if .Values.persistence.enabled }}
+              if [ -d "/home/agentapi/workdir" ]; then
+                chown -R 999:999 /home/agentapi/workdir || echo "Warning: Failed to change ownership of workdir"
+                chmod -R 755 /home/agentapi/workdir || echo "Warning: Failed to change permissions of workdir"
+                echo "Fixed permissions for /home/agentapi/workdir"
+              fi
+              {{- end }}
+              {{- if .Values.myclaudesPersistence.enabled }}
+              if [ -d "/home/agentapi/.agentapi-proxy/myclaudes" ]; then
+                mkdir -p /home/agentapi/.agentapi-proxy
+                chown -R 999:999 /home/agentapi/.agentapi-proxy || echo "Warning: Failed to change ownership of myclaudes"
+                chmod -R 755 /home/agentapi/.agentapi-proxy || echo "Warning: Failed to change permissions of myclaudes"
+                echo "Fixed permissions for /home/agentapi/.agentapi-proxy/myclaudes"
+              fi
+              {{- end }}
+              echo "Permission fix completed"
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /home/agentapi/workdir
+            {{- end }}
+            {{- if .Values.myclaudesPersistence.enabled }}
+            - name: myclaudes-data
+              mountPath: /home/agentapi/.agentapi-proxy/myclaudes
+            {{- end }}
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+        {{- end }}
+        {{- if and .Values.github.app.privateKey.secretName .Values.github.app.privateKey.key }}
         - name: setup-github-app-key
           image: busybox:1.35
           command:


### PR DESCRIPTION
## 概要
PVCが起動時にpermission deniedエラーが発生する問題を修正しました。

## 変更内容
- initContainerを追加してPVCマウント時にuid:gid 999:999の権限を設定
- persistence.enabled または myclaudesPersistence.enabled の場合にのみ実行
- 権限修正処理はroot権限で実行し、対象ディレクトリの所有者を999:999に変更

## 影響
- PVCの初回マウント時にもagentapi-proxyが正常に起動するようになります
- 既存の動作には影響しません

## テスト計画
- [ ] PVCを有効にしたKubernetes環境でのデプロイテスト
- [ ] 権限修正処理が正常に動作することを確認
- [ ] agentapi-proxyの起動が成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)