### PR TITLE
startup関数でuserdir管理のhomeDirを使用するように修正

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -23,11 +23,13 @@ import (
 var installationCache = github_pkg.NewInstallationCache()
 
 // SetupClaudeCode sets up Claude Code configuration
-func SetupClaudeCode() error {
-	// Get home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+func SetupClaudeCode(homeDir string) error {
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
 	}
 
 	// Create .claude directory
@@ -58,7 +60,7 @@ func SetupClaudeCode() error {
 	}
 
 	// Merge config into ~/.claude.json
-	if err := mergeClaudeConfig(); err != nil {
+	if err := mergeClaudeConfig(homeDir); err != nil {
 		log.Printf("Warning: Failed to merge claude config: %v", err)
 		// Don't return error, just warn
 	}
@@ -81,11 +83,13 @@ func SetupClaudeCode() error {
 	return nil
 }
 
-func mergeClaudeConfig() error {
-	// Get home directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+func mergeClaudeConfig(homeDir string) error {
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
 	}
 
 	targetPath := filepath.Join(homeDir, ".claude.json")
@@ -144,11 +148,13 @@ type MCPServerConfig struct {
 }
 
 // SetupMCPServers sets up MCP servers from configuration
-func SetupMCPServers(configFlag string) error {
-	// Get Claude directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+func SetupMCPServers(homeDir, configFlag string) error {
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
 	}
 	claudeDir := filepath.Join(homeDir, ".claude")
 

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -29,7 +29,7 @@ func TestSetupClaudeCode(t *testing.T) {
 	}
 
 	// Mock userHomeDir function by creating a test that works with temp directory
-	err = SetupClaudeCode()
+	err = SetupClaudeCode(tempDir)
 	if err != nil {
 		t.Fatalf("SetupClaudeCode failed: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestMergeClaudeConfig(t *testing.T) {
 	}
 
 	// Test case 1: No existing .claude.json file
-	err = mergeClaudeConfig()
+	err = mergeClaudeConfig(tempDir)
 	if err != nil {
 		t.Fatalf("mergeClaudeConfig failed with no existing file: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestMergeClaudeConfig(t *testing.T) {
 	}
 
 	// Merge config again
-	err = mergeClaudeConfig()
+	err = mergeClaudeConfig(tempDir)
 	if err != nil {
 		t.Fatalf("mergeClaudeConfig failed with existing file: %v", err)
 	}
@@ -215,13 +215,13 @@ func TestSetupMCPServers(t *testing.T) {
 	_ = os.Setenv("HOME", tempDir)
 
 	// Test case 1: Empty config flag
-	err = SetupMCPServers("")
+	err = SetupMCPServers(tempDir, "")
 	if err == nil {
 		t.Error("Expected error for empty config flag")
 	}
 
 	// Test case 2: Invalid JSON
-	err = SetupMCPServers("invalid json")
+	err = SetupMCPServers(tempDir, "invalid json")
 	if err == nil {
 		t.Error("Expected error for invalid JSON")
 	}
@@ -248,13 +248,13 @@ func TestSetupMCPServers(t *testing.T) {
 
 	// Note: This test will fail because it tries to execute the claude command
 	// which is not available in the test environment. This is expected behavior.
-	_ = SetupMCPServers(string(configJson))
+	_ = SetupMCPServers(tempDir, string(configJson))
 	// We don't check for error here because the claude command will fail
 	// but we can verify that the config was parsed correctly
 
 	// Test case 4: Base64 encoded config
 	base64Config := base64.StdEncoding.EncodeToString(configJson)
-	_ = SetupMCPServers(base64Config)
+	_ = SetupMCPServers(tempDir, base64Config)
 }
 
 func TestAddMcpServer(t *testing.T) {


### PR DESCRIPTION
## 概要

- `pkg/startup/startup.go` の `SetupClaudeCode`、`SetupMCPServers`、`mergeClaudeConfig` 関数に `homeDir` パラメータを追加
- 呼び出し元の `pkg/proxy/startup.go` で `userdir.SetupUserHome` を使用してユーザー固有のホームディレクトリを取得
- テストファイルを新しい関数シグネチャに合わせて更新

## 変更内容

### pkg/startup/startup.go
- `SetupClaudeCode(homeDir string)` に変更
- `SetupMCPServers(homeDir, configFlag string)` に変更  
- `mergeClaudeConfig(homeDir string)` に変更
- 各関数で `homeDir` パラメータが空の場合は従来通り `os.UserHomeDir()` を使用

### pkg/proxy/startup.go
- `setupClaudeCode(cfg *StartupConfig)` で `userdir.SetupUserHome(cfg.UserID)` を使用
- `setupMCPServers(cfg *StartupConfig, mcpConfigs string)` で `userdir.SetupUserHome(cfg.UserID)` を使用

## テスト結果

- `make lint`: 正常終了
- `make test`: 全テスト通過

## 効果

これにより、マルチユーザー環境でのユーザー固有のホームディレクトリ管理が適切に行われ、各ユーザーのClaude Code設定とMCPサーバー設定が正しく分離されます。

🤖 Generated with [Claude Code](https://claude.ai/code)