### PR TITLE
feat: add Invalid API mock endpoint

### DIFF
--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -49,6 +49,17 @@ const mockResponses = {
       }
     }
   },
+  '/validate': {
+    POST: {
+      error: "Invalid API",
+      code: "INVALID_API_ERROR",
+      message: "Invalid API key or authentication token provided",
+      details: {
+        reason: "The API key format is invalid or has been revoked",
+        suggestion: "Please check your API key and ensure it's properly configured"
+      }
+    }
+  },
 };
 
 


### PR DESCRIPTION
## Summary
- Added a new `/validate` POST endpoint to the Netlify mock function
- Returns an error response containing 'Invalid API' message
- Useful for testing error handling scenarios in the frontend

## Test plan
- [x] Run `make lint` - all checks pass
- [x] Run `make test` - all tests pass
- [ ] Deploy to Netlify and test the new endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)