### PR TITLE
setup-gh実行時にGitリポジトリ情報を自動取得

### DIFF
--- a/pkg/userdir/userdir.go
+++ b/pkg/userdir/userdir.go
@@ -3,7 +3,6 @@ package userdir
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -206,17 +205,10 @@ eval "$(/home/agentapi/.local/bin/mise activate bash)"
 		fmt.Printf("Warning: Failed to copy CLAUDE.md to user home directory: %v\n", err)
 	}
 
-	// Get Git repository information
-	env := map[string]string{
+	// Return environment variables map
+	return map[string]string{
 		"HOME": userHomeDir,
-	}
-
-	// Try to get GITHUB_REPO_FULLNAME from git remote
-	if repoFullName := getGitHubRepoFullName(); repoFullName != "" {
-		env["GITHUB_REPO_FULLNAME"] = repoFullName
-	}
-
-	return env, nil
+	}, nil
 }
 
 // IsEnabled returns whether multiple users mode is enabled
@@ -299,50 +291,4 @@ func copyClaudeMdToUserHome(userHomeDir string) error {
 	}
 
 	return nil
-}
-
-// getGitHubRepoFullName extracts repository full name from git remote
-func getGitHubRepoFullName() string {
-	// Try to get the current working directory first
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-
-	// Use git to get the remote origin URL
-	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
-	cmd.Dir = cwd
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	remoteURL := strings.TrimSpace(string(output))
-	return extractRepoFullNameFromURL(remoteURL)
-}
-
-// extractRepoFullNameFromURL extracts owner/repo from various Git URL formats
-func extractRepoFullNameFromURL(url string) string {
-	// Handle SSH URLs: git@github.com:owner/repo.git
-	if strings.HasPrefix(url, "git@github.com:") {
-		path := strings.TrimPrefix(url, "git@github.com:")
-		path = strings.TrimSuffix(path, ".git")
-		return path
-	}
-
-	// Handle HTTPS URLs: https://github.com/owner/repo.git
-	if strings.HasPrefix(url, "https://github.com/") {
-		path := strings.TrimPrefix(url, "https://github.com/")
-		path = strings.TrimSuffix(path, ".git")
-		return path
-	}
-
-	// Handle git protocol URLs: git://github.com/owner/repo.git
-	if strings.HasPrefix(url, "git://github.com/") {
-		path := strings.TrimPrefix(url, "git://github.com/")
-		path = strings.TrimSuffix(path, ".git")
-		return path
-	}
-
-	return ""
 }

--- a/pkg/userdir/userdir.go
+++ b/pkg/userdir/userdir.go
@@ -3,6 +3,7 @@ package userdir
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -205,10 +206,17 @@ eval "$(/home/agentapi/.local/bin/mise activate bash)"
 		fmt.Printf("Warning: Failed to copy CLAUDE.md to user home directory: %v\n", err)
 	}
 
-	// Return environment variables map
-	return map[string]string{
+	// Get Git repository information
+	env := map[string]string{
 		"HOME": userHomeDir,
-	}, nil
+	}
+
+	// Try to get GITHUB_REPO_FULLNAME from git remote
+	if repoFullName := getGitHubRepoFullName(); repoFullName != "" {
+		env["GITHUB_REPO_FULLNAME"] = repoFullName
+	}
+
+	return env, nil
 }
 
 // IsEnabled returns whether multiple users mode is enabled
@@ -291,4 +299,50 @@ func copyClaudeMdToUserHome(userHomeDir string) error {
 	}
 
 	return nil
+}
+
+// getGitHubRepoFullName extracts repository full name from git remote
+func getGitHubRepoFullName() string {
+	// Try to get the current working directory first
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	// Use git to get the remote origin URL
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	cmd.Dir = cwd
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	remoteURL := strings.TrimSpace(string(output))
+	return extractRepoFullNameFromURL(remoteURL)
+}
+
+// extractRepoFullNameFromURL extracts owner/repo from various Git URL formats
+func extractRepoFullNameFromURL(url string) string {
+	// Handle SSH URLs: git@github.com:owner/repo.git
+	if strings.HasPrefix(url, "git@github.com:") {
+		path := strings.TrimPrefix(url, "git@github.com:")
+		path = strings.TrimSuffix(path, ".git")
+		return path
+	}
+
+	// Handle HTTPS URLs: https://github.com/owner/repo.git
+	if strings.HasPrefix(url, "https://github.com/") {
+		path := strings.TrimPrefix(url, "https://github.com/")
+		path = strings.TrimSuffix(path, ".git")
+		return path
+	}
+
+	// Handle git protocol URLs: git://github.com/owner/repo.git
+	if strings.HasPrefix(url, "git://github.com/") {
+		path := strings.TrimPrefix(url, "git://github.com/")
+		path = strings.TrimSuffix(path, ".git")
+		return path
+	}
+
+	return ""
 }


### PR DESCRIPTION
## 概要
setup-gh helper 実行時に、git remote から自動的にリポジトリ情報を取得する機能を追加しました。

## 変更内容
- Git remote からリポジトリ情報を取得する `getGitHubRepoFullName()` 関数を追加
- SSH、HTTPS、git プロトコルの URL 形式に対応した `extractRepoFullNameFromURL()` 関数を追加
- setup-gh 実行時にリポジトリ情報が未指定の場合、自動的に git config から取得

## 利用効果
- setup-gh helper でリポジトリ情報を手動入力する必要がなくなります
- `agentapi-proxy helpers setup-gh` を実行するだけで、自動的にリポジトリを検出してGitHub認証情報を更新可能
- 認証情報なしで git config から取得するため安全に動作

## テスト計画
- [x] 既存テストが正常に実行されることを確認
- [x] lint チェックが正常に実行されることを確認
- [ ] 実際のsetup-ghでリポジトリ情報が自動検出されることを確認
- [ ] SSH、HTTPS、git プロトコルの各URL形式で正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)