### PR TITLE
セッション永続化時にユーザーの最初のメッセージをタグのdescriptionとして保存

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1333,6 +1333,19 @@ func extractRepoFullNameFromURL(repoURL string) (string, error) {
 
 // sendInitialMessage sends an initial message to the agentapi server after startup
 func (p *Proxy) sendInitialMessage(session *AgentSession, message string) {
+	// Save the first message as tag.description
+	if message != "" {
+		p.sessionsMutex.Lock()
+		if session.Tags == nil {
+			session.Tags = make(map[string]string)
+		}
+		session.Tags["description"] = message
+		p.sessionsMutex.Unlock()
+
+		// Update the persisted session with the new tag
+		p.updateSession(session)
+	}
+
 	// Wait a bit for the server to start up
 	time.Sleep(2 * time.Second)
 


### PR DESCRIPTION
## 概要
- セッション開始時にユーザーから送信される最初のメッセージを、タグのdescriptionフィールドに保存する機能を実装
- セッション一覧でユーザーの最初のリクエスト内容を確認できるようになる
- 永続化されたセッション情報にもdescriptionが含まれるため、セッション復元後も確認可能

## 実装内容
- `sendInitialMessage`関数内で、初期メッセージをtag.descriptionとして保存
- セッションのタグ情報を更新し、永続化ストレージにも反映

## テストプラン
- [x] make testが成功することを確認
- [x] make lintが成功することを確認
- [ ] セッション開始時に初期メッセージが送信された場合、tag.descriptionに保存されることを確認
- [ ] 永続化されたセッションを復元した際にもdescriptionが保持されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)