### PR TITLE
CLAUDE.md を追記して通知の方法を教える

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -17,3 +17,15 @@ mise コマンドを利用することができます。言語のインタプリ
 ### CI の確認
 
 可能な限り、CI の結果を確認してその後のアクションにつなげてください。
+
+### ユーザーへの通知
+
+作業の終了を通知するために `agentapi-proxy helpers send-notification` というヘルパーが使用できます。  
+以下は実行例です。  
+
+```
+agentapi-proxy helpers send-notification \
+  --title "作業が完了しました" \
+  --body "作業内容を確認してください" \
+  --url "$NOTIFICATION_BASE_URL"/agentapi?session={{ session ID }}"
+```

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -233,6 +233,13 @@ spec:
             - name: GITHUB_APP_PEM_PATH
               value: "/etc/github-app/private-key"
             {{- end }}
+            {{- if .Values.config.notification.baseUrl }}
+            - name: NOTIFICATION_BASE_URL
+              value: {{ .Values.config.notification.baseUrl | quote }}
+            {{- else if .Values.config.hostname }}
+            - name: NOTIFICATION_BASE_URL
+              value: {{ printf "https://%s" .Values.config.hostname | quote }}
+            {{- end }}
             {{- range .Values.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -103,6 +103,9 @@ github:
 
 # Application Configuration
 config:
+  # ホスト名設定 (例: agentapi.example.com)
+  hostname: ""
+  
   # サーバー設定
   startPort: 9000
   
@@ -148,6 +151,12 @@ config:
     enabled: false
     path: "/etc/role-env-files"
     loadDefault: true
+  
+  # 通知設定
+  notification:
+    # 通知ベースURL (例: https://example.com)
+    # 末尾のスラッシュは含めない
+    baseUrl: ""
 
 # Environment variables
 env: []


### PR DESCRIPTION
- CLAUDE.md を追記する
- 既存の CLAUDE.md を最新のやつに随時置き換えるように変更する
- NOTIFICATION_BASE_URL を設定できるように helm chart を変更する。記法は `https://{hostname}` で末尾のスラッシュなし。