### PR TITLE
作業完了後の通知に関する指示を強化

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -20,6 +20,8 @@ mise コマンドを利用することができます。言語のインタプリ
 
 ### ユーザーへの通知
 
+**作業完了後は必ずユーザーに通知を送信してください。**
+
 作業の終了を通知するために `agentapi-proxy helpers send-notification` というヘルパーが使用できます。  
 以下は実行例です。  
 
@@ -29,3 +31,5 @@ agentapi-proxy helpers send-notification \
   --body "作業内容を確認してください" \
   --url "$NOTIFICATION_BASE_URL"/agentapi?session={{ session ID }}"
 ```
+
+**重要**: 全ての作業が完了した時点で、**必ず**上記コマンドを実行してユーザーに通知を送信してください。


### PR DESCRIPTION
## 概要
- config/CLAUDE.md の通知セクションを更新し、作業完了後は必ずユーザーに通知を送信することを明記
- 重要性を強調するため太字での記載を追加
- 通知送信の重要性を再度強調するセクションを追加

## 変更内容
- 「作業完了後は必ずユーザーに通知を送信してください。」を太字で強調
- 重要性を示すための「重要」セクションを追加

🤖 Generated with [Claude Code](https://claude.ai/code)