### PR TITLE
notification URLの引数形式を修正

### DIFF
--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -29,7 +29,7 @@ mise コマンドを利用することができます。言語のインタプリ
 agentapi-proxy helpers send-notification \
   --title "作業が完了しました" \
   --body "作業内容を確認してください" \
-  --url "$NOTIFICATION_BASE_URL"/agentapi?session={{ session ID }}"
+  --url "$NOTIFICATION_BASE_URL/agentapi?session={{ session ID }}"
 ```
 
 **重要**: 全ての作業が完了した時点で、**必ず**上記コマンドを実行してユーザーに通知を送信してください。


### PR DESCRIPTION
## 概要
- config/CLAUDE.md の通知コマンドの--url引数の形式を修正

## 変更内容
- `"$NOTIFICATION_BASE_URL"/agentapi` を `"$NOTIFICATION_BASE_URL/agentapi"` に修正
- ダブルクォート内でのパス区切りを正しい形式に変更

🤖 Generated with [Claude Code](https://claude.ai/code)