### PR TITLE
feat: SessionMonitorを無効化し、Claude Codeのhookで通知制御

### DIFF
--- a/cmd/claude_code_settings.json
+++ b/cmd/claude_code_settings.json
@@ -1,4 +1,26 @@
 {
   "dontCrawlDirectory": true,
-  "hasTrustDialogAccepted": true
+  "hasTrustDialogAccepted": true,
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 完了\" --body=\"セッションが正常に完了しました。お疲れ様でした！\""
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 通知\" --body=\"ツールの使用許可が必要です。確認をお願いします。\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -293,9 +293,7 @@ func NewProxy(cfg *config.Config, verbose bool) *Proxy {
 
 // StartMonitoring starts the session monitoring (called after proxy is fully initialized)
 func (p *Proxy) StartMonitoring() {
-	if p.sessionMonitor != nil && os.Getenv("AGENTAPI_TEST_MODE") == "" {
-		p.sessionMonitor.Start()
-	}
+	// Session monitoring disabled - notifications handled by Claude Code hooks
 }
 
 // loggingMiddleware returns Echo middleware for request logging

--- a/pkg/proxy/session_monitor.go
+++ b/pkg/proxy/session_monitor.go
@@ -206,7 +206,11 @@ func (sm *SessionMonitor) fetchAgentAPIStatus(port int) *AgentAPIStatus {
 		log.Printf("Failed to fetch status from port %d: %v", port, err)
 		return nil
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Failed to close response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("Non-OK status code from port %d: %d", port, resp.StatusCode)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,38 +14,6 @@ if [ ! -f /home/agentapi/.claude/CLAUDE.md ] || [ /tmp/config/CLAUDE.md -nt /hom
     echo "CLAUDE.md copied successfully"
 fi
 
-# Setup Claude Code hooks configuration
-echo "Setting up Claude Code hooks configuration..."
-cat > /home/agentapi/.claude/settings.json << 'EOF'
-{
-  "workspaceFolders": [],
-  "recentWorkspaces": [],
-  "settings": {},
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "curl -s -X POST http://localhost:8080/notifications/webhook -H 'Content-Type: application/json' -d '{\"session_id\":\"claude-code-session\",\"user_id\":\"anonymous\",\"event_type\":\"session_completed\",\"timestamp\":\"'$(date -Iseconds)'\",\"data\":{\"title\":\"Claude Code 完了\",\"body\":\"セッションが正常に完了しました。お疲れ様でした！\",\"type\":\"session_completed\"}}' || echo 'Claude Code セッションが完了しました。お疲れ様でした！'"
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "curl -s -X POST http://localhost:8080/notifications/webhook -H 'Content-Type: application/json' -d '{\"session_id\":\"claude-code-session\",\"user_id\":\"anonymous\",\"event_type\":\"permission_request\",\"timestamp\":\"'$(date -Iseconds)'\",\"data\":{\"title\":\"Claude Code 通知\",\"body\":\"ツールの使用許可が必要です。確認をお願いします。\",\"type\":\"permission_request\"}}' || echo 'Claude Code から通知: ツールの使用許可が必要です。'"
-          }
-        ]
-      }
-    ]
-  }
-}
-EOF
-echo "Claude Code hooks configuration setup completed"
 
 # Fix permissions for persistent volume directories only if needed
 if [ -d "$HOME/.agentapi-proxy" ]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -27,7 +27,7 @@ cat > /home/agentapi/.claude/settings.json << 'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 完了\" --body=\"セッションが正常に完了しました。お疲れ様でした！\" --type=\"session_completed\""
+            "command": "curl -s -X POST http://localhost:8080/notifications/webhook -H 'Content-Type: application/json' -d '{\"session_id\":\"claude-code-session\",\"user_id\":\"anonymous\",\"event_type\":\"session_completed\",\"timestamp\":\"'$(date -Iseconds)'\",\"data\":{\"title\":\"Claude Code 完了\",\"body\":\"セッションが正常に完了しました。お疲れ様でした！\",\"type\":\"session_completed\"}}' || echo 'Claude Code セッションが完了しました。お疲れ様でした！'"
           }
         ]
       }
@@ -37,7 +37,7 @@ cat > /home/agentapi/.claude/settings.json << 'EOF'
         "hooks": [
           {
             "type": "command",
-            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 通知\" --body=\"ツールの使用許可が必要です。確認をお願いします。\" --type=\"permission_request\""
+            "command": "curl -s -X POST http://localhost:8080/notifications/webhook -H 'Content-Type: application/json' -d '{\"session_id\":\"claude-code-session\",\"user_id\":\"anonymous\",\"event_type\":\"permission_request\",\"timestamp\":\"'$(date -Iseconds)'\",\"data\":{\"title\":\"Claude Code 通知\",\"body\":\"ツールの使用許可が必要です。確認をお願いします。\",\"type\":\"permission_request\"}}' || echo 'Claude Code から通知: ツールの使用許可が必要です。'"
           }
         ]
       }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,6 +14,39 @@ if [ ! -f /home/agentapi/.claude/CLAUDE.md ] || [ /tmp/config/CLAUDE.md -nt /hom
     echo "CLAUDE.md copied successfully"
 fi
 
+# Setup Claude Code hooks configuration
+echo "Setting up Claude Code hooks configuration..."
+cat > /home/agentapi/.claude/settings.json << 'EOF'
+{
+  "workspaceFolders": [],
+  "recentWorkspaces": [],
+  "settings": {},
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 完了\" --body=\"セッションが正常に完了しました。お疲れ様でした！\" --type=\"session_completed\""
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 通知\" --body=\"ツールの使用許可が必要です。確認をお願いします。\" --type=\"permission_request\""
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+echo "Claude Code hooks configuration setup completed"
+
 # Fix permissions for persistent volume directories only if needed
 if [ -d "$HOME/.agentapi-proxy" ]; then
     # Check if the directory ownership needs to be changed


### PR DESCRIPTION
## Summary
- SessionMonitorによるプッシュ通知を無効化
- Claude Codeのhook機能で通知制御を実装
- session_monitor.goのlintエラーを修正

## 変更内容
- `StartMonitoring()`でSessionMonitorの起動を無効化
- Claude Codeの`~/.claude/settings.json`にStop/Notificationhookを設定
- `agentapi-proxy helpers send-notification`を使用した通知実装

## Test plan
- [x] make lintでコード品質チェック完了
- [x] make testでテスト実行完了
- [x] SessionMonitorが起動されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)