### PR TITLE
fix: Notification hookのメッセージを汎用的な文言に変更

### DIFF
--- a/config/managed-settings.json
+++ b/config/managed-settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 通知\" --body=\"ツールの使用許可が必要です。確認をお願いします。\""
+            "command": "agentapi-proxy helpers send-notification --title=\"Claude Code 通知\" --body=\"応答が必要です。確認をお願いします。\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Notification hookのメッセージを「ツールの使用許可が必要です」から「応答が必要です」に変更しました
- ツール利用許可に限定されない通知に対応するため、より汎用的な文言にしました

## Changes
- `config/managed-settings.json`: Notification hookのメッセージ文言を変更

## Test plan
- [ ] 設定ファイルの構文が正しいことを確認
- [ ] Claude Codeで通知が必要な状況で、新しいメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)