### PR TITLE
feat: Add profile persistence feature with filesystem and S3 storage

### DIFF
--- a/docs/profile-api.md
+++ b/docs/profile-api.md
@@ -1,0 +1,458 @@
+# Profile API Documentation
+
+## Overview
+
+The Profile API allows users to manage their persistent profiles with customizable settings and preferences. Profiles support both filesystem and S3 storage backends.
+
+## Configuration
+
+Add profile configuration to your `config.yaml`:
+
+```yaml
+profile:
+  type: filesystem  # or "s3"
+  # Filesystem configuration
+  base_path: ~/.agentapi-proxy/profiles
+  
+  # S3 configuration (when type: s3)
+  s3_bucket: my-profiles-bucket
+  s3_region: us-east-1
+  s3_endpoint: ""  # Optional, for S3-compatible services
+  s3_prefix: profiles  # Optional prefix for keys
+```
+
+## Environment Variables
+
+- `AGENTAPI_PROFILE_TYPE` - Storage type (filesystem or s3)
+- `AGENTAPI_PROFILE_BASE_PATH` - Base path for filesystem storage
+- `AGENTAPI_PROFILE_S3_BUCKET` - S3 bucket name
+- `AGENTAPI_PROFILE_S3_REGION` - S3 region
+- `AGENTAPI_PROFILE_S3_ENDPOINT` - S3 endpoint (optional)
+- `AGENTAPI_PROFILE_S3_PREFIX` - S3 key prefix (optional)
+
+## Authentication & Permissions
+
+All profile endpoints require authentication. The following permissions are used:
+- `profile:read` - Read profile data
+- `profile:write` - Create/update profile data  
+- `profile:delete` - Delete profiles
+- `profile:admin` - Administrative access to all profiles
+
+## Profile Data Structure
+
+```json
+{
+  "user_id": "user123",
+  "username": "johndoe",
+  "email": "john@example.com", 
+  "display_name": "John Doe",
+  "preferences": {
+    "theme": "dark",
+    "language": "en",
+    "notifications": true
+  },
+  "settings": {
+    "timeout": 30,
+    "max_sessions": 5
+  },
+  "metadata": {
+    "organization": "acme-corp",
+    "role": "developer"
+  },
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T14:20:00Z",
+  "last_login_at": "2024-01-15T14:20:00Z"
+}
+```
+
+## API Endpoints
+
+### User Profile Management
+
+#### Get Current User Profile
+
+```http
+GET /profile
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "user_id": "user123",
+  "username": "johndoe",
+  "email": "john@example.com",
+  "display_name": "John Doe",
+  "preferences": {},
+  "settings": {},
+  "metadata": {},
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T14:20:00Z",
+  "last_login_at": "2024-01-15T14:20:00Z"
+}
+```
+
+**Status Codes:**
+- `200` - Profile retrieved successfully
+- `401` - Authentication required
+- `404` - Profile not found
+
+#### Create Profile
+
+```http
+POST /profile
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "username": "johndoe",
+  "email": "john@example.com",
+  "display_name": "John Doe"
+}
+```
+
+**Response:**
+```json
+{
+  "user_id": "user123",
+  "username": "johndoe",
+  "email": "john@example.com",
+  "display_name": "John Doe",
+  "preferences": {},
+  "settings": {},
+  "metadata": {},
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T10:30:00Z"
+}
+```
+
+**Status Codes:**
+- `201` - Profile created successfully
+- `400` - Invalid request body
+- `401` - Authentication required
+- `409` - Profile already exists
+
+#### Update Profile
+
+```http
+PUT /profile
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "username": "johndoe",
+  "email": "john@example.com",
+  "display_name": "John Doe",
+  "preferences": {
+    "theme": "dark",
+    "language": "en"
+  },
+  "settings": {
+    "timeout": 30
+  },
+  "metadata": {
+    "role": "developer"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "user_id": "user123",
+  "username": "johndoe",
+  "email": "john@example.com",
+  "display_name": "John Doe",
+  "preferences": {
+    "theme": "dark",
+    "language": "en"
+  },
+  "settings": {
+    "timeout": 30
+  },
+  "metadata": {
+    "role": "developer"
+  },
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T14:20:00Z"
+}
+```
+
+**Status Codes:**
+- `200` - Profile updated successfully
+- `400` - Invalid request body
+- `401` - Authentication required
+- `404` - Profile not found
+
+#### Delete Profile
+
+```http
+DELETE /profile
+Authorization: Bearer <token>
+```
+
+**Status Codes:**
+- `204` - Profile deleted successfully
+- `401` - Authentication required
+- `404` - Profile not found
+
+### Preference Management
+
+#### Set Preference
+
+```http
+POST /profile/preference
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "key": "theme",
+  "value": "dark"
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Preference set successfully",
+  "key": "theme",
+  "value": "dark"
+}
+```
+
+**Status Codes:**
+- `200` - Preference set successfully
+- `400` - Invalid request body or missing key
+- `401` - Authentication required
+- `404` - Profile not found
+
+#### Get Preference
+
+```http
+GET /profile/preference/{key}
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "key": "theme",
+  "value": "dark"
+}
+```
+
+**Status Codes:**
+- `200` - Preference retrieved successfully
+- `401` - Authentication required
+- `404` - Profile or preference not found
+
+### Setting Management
+
+#### Set Setting
+
+```http
+POST /profile/setting
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "key": "timeout",
+  "value": 30
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Setting set successfully",
+  "key": "timeout",
+  "value": 30
+}
+```
+
+**Status Codes:**
+- `200` - Setting set successfully
+- `400` - Invalid request body or missing key
+- `401` - Authentication required
+- `404` - Profile not found
+
+#### Get Setting
+
+```http
+GET /profile/setting/{key}
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "key": "timeout",
+  "value": 30
+}
+```
+
+**Status Codes:**
+- `200` - Setting retrieved successfully
+- `401` - Authentication required
+- `404` - Profile or setting not found
+
+### Administrative Endpoints
+
+#### List All Profiles (Admin Only)
+
+```http
+GET /profiles
+Authorization: Bearer <admin-token>
+```
+
+**Response:**
+```json
+{
+  "profiles": ["user123", "user456", "user789"],
+  "count": 3
+}
+```
+
+**Status Codes:**
+- `200` - Profiles listed successfully
+- `401` - Authentication required
+- `403` - Insufficient permissions
+
+#### Get User Profile (Admin Only)
+
+```http
+GET /profiles/{userID}
+Authorization: Bearer <admin-token>
+```
+
+**Response:**
+```json
+{
+  "user_id": "user123",
+  "username": "johndoe",
+  "email": "john@example.com",
+  "display_name": "John Doe",
+  "preferences": {},
+  "settings": {},
+  "metadata": {},
+  "created_at": "2024-01-15T10:30:00Z",
+  "updated_at": "2024-01-15T14:20:00Z",
+  "last_login_at": "2024-01-15T14:20:00Z"
+}
+```
+
+**Status Codes:**
+- `200` - Profile retrieved successfully
+- `401` - Authentication required
+- `403` - Insufficient permissions
+- `404` - Profile not found
+
+#### Delete User Profile (Admin Only)
+
+```http
+DELETE /profiles/{userID}
+Authorization: Bearer <admin-token>
+```
+
+**Status Codes:**
+- `204` - Profile deleted successfully
+- `401` - Authentication required
+- `403` - Insufficient permissions
+- `404` - Profile not found
+
+## Storage Options
+
+### Filesystem Storage
+
+Profiles are stored as JSON files in user-specific directories:
+- Path: `{base_path}/{userID}/profile.json`
+- Default base path: `~/.agentapi-proxy/profiles`
+- Uses atomic writes for data safety
+
+### S3 Storage
+
+Profiles are stored as JSON objects in S3:
+- Key format: `{prefix}/{userID}/profile.json`
+- Supports S3-compatible services via custom endpoint
+- Automatic encryption at rest (when S3 bucket configured)
+
+## Error Handling
+
+All endpoints return consistent error responses:
+
+```json
+{
+  "message": "Error description",
+  "status": 400
+}
+```
+
+Common error responses:
+- `400 Bad Request` - Invalid request format or missing required fields
+- `401 Unauthorized` - Authentication required or invalid credentials
+- `403 Forbidden` - Insufficient permissions for the requested operation
+- `404 Not Found` - Profile or resource not found
+- `409 Conflict` - Profile already exists (on creation)
+- `500 Internal Server Error` - Server-side error
+
+## Examples
+
+### Complete Profile Management Flow
+
+1. **Create a profile:**
+```bash
+curl -X POST /profile \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "johndoe", "email": "john@example.com", "display_name": "John Doe"}'
+```
+
+2. **Set preferences:**
+```bash
+curl -X POST /profile/preference \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "theme", "value": "dark"}'
+```
+
+3. **Update profile:**
+```bash
+curl -X PUT /profile \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"display_name": "John Smith", "preferences": {"theme": "light"}}'
+```
+
+4. **Get profile:**
+```bash
+curl -X GET /profile \
+  -H "Authorization: Bearer <token>"
+```
+
+### Configuration Examples
+
+#### Filesystem Configuration
+```yaml
+profile:
+  type: filesystem
+  base_path: /app/data/profiles
+```
+
+#### S3 Configuration  
+```yaml
+profile:
+  type: s3
+  s3_bucket: agentapi-profiles
+  s3_region: us-west-2
+  s3_prefix: prod/profiles
+```
+
+#### MinIO Configuration
+```yaml
+profile:
+  type: s3
+  s3_bucket: profiles
+  s3_region: us-east-1
+  s3_endpoint: http://minio:9000
+  s3_prefix: profiles
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"github.com/takutakahashi/agentapi-proxy/pkg/profile"
 	"gopkg.in/yaml.v2"
 )
 
@@ -145,6 +146,8 @@ type Config struct {
 	AuthConfigFile string `json:"auth_config_file" mapstructure:"auth_config_file"`
 	// RoleEnvFiles is the configuration for role-based environment files
 	RoleEnvFiles RoleEnvFilesConfig `json:"role_env_files" mapstructure:"role_env_files"`
+	// Profile represents profile persistence configuration
+	Profile profile.Config `json:"profile" mapstructure:"profile"`
 }
 
 // LoadConfig loads configuration using viper with support for JSON, YAML, and environment variables

--- a/pkg/profile/factory.go
+++ b/pkg/profile/factory.go
@@ -1,0 +1,27 @@
+package profile
+
+import (
+	"fmt"
+)
+
+// NewStorage creates a new profile storage instance based on the configuration
+func NewStorage(cfg *Config) (Storage, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("profile storage config is nil")
+	}
+
+	switch cfg.Type {
+	case StorageTypeFilesystem, "":
+		// Default to filesystem if no type specified
+		return NewFilesystemStorage(cfg.BasePath)
+
+	case StorageTypeS3:
+		if cfg.S3Bucket == "" {
+			return nil, fmt.Errorf("S3 bucket is required for S3 storage")
+		}
+		return NewS3Storage(cfg.S3Bucket, cfg.S3Region, cfg.S3Endpoint, cfg.S3Prefix)
+
+	default:
+		return nil, fmt.Errorf("unsupported storage type: %s", cfg.Type)
+	}
+}

--- a/pkg/profile/filesystem.go
+++ b/pkg/profile/filesystem.go
@@ -1,0 +1,245 @@
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// FilesystemStorage implements profile storage using the local filesystem
+type FilesystemStorage struct {
+	basePath string
+	mu       sync.RWMutex
+}
+
+// NewFilesystemStorage creates a new filesystem-based profile storage
+func NewFilesystemStorage(basePath string) (*FilesystemStorage, error) {
+	if basePath == "" {
+		// Use default base path in user's home directory
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get home directory: %w", err)
+		}
+		basePath = filepath.Join(homeDir, ".agentapi-proxy", "profiles")
+	}
+
+	// Ensure base directory exists
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create profile directory: %w", err)
+	}
+
+	return &FilesystemStorage{
+		basePath: basePath,
+	}, nil
+}
+
+// getProfilePath returns the path to a user's profile file
+func (fs *FilesystemStorage) getProfilePath(userID string) string {
+	// Sanitize userID to prevent directory traversal
+	safeUserID := strings.ReplaceAll(userID, "..", "")
+	safeUserID = strings.ReplaceAll(safeUserID, "/", "_")
+	safeUserID = strings.ReplaceAll(safeUserID, "\\", "_")
+
+	// Use base path for profile storage
+	userDir := filepath.Join(fs.basePath, safeUserID)
+	_ = os.MkdirAll(userDir, 0755) // Ensure directory exists
+	return filepath.Join(userDir, "profile.json")
+}
+
+// Save stores a profile to the filesystem
+func (fs *FilesystemStorage) Save(ctx context.Context, profile *Profile) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if profile == nil || profile.UserID == "" {
+		return ErrInvalidProfile
+	}
+
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal profile: %w", err)
+	}
+
+	profilePath := fs.getProfilePath(profile.UserID)
+
+	// Write to temporary file first
+	tmpPath := profilePath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write profile: %w", err)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, profilePath); err != nil {
+		_ = os.Remove(tmpPath) // Clean up
+		return fmt.Errorf("failed to save profile: %w", err)
+	}
+
+	return nil
+}
+
+// Load retrieves a profile from the filesystem
+func (fs *FilesystemStorage) Load(ctx context.Context, userID string) (*Profile, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if userID == "" {
+		return nil, ErrInvalidProfile
+	}
+
+	profilePath := fs.getProfilePath(userID)
+
+	file, err := os.Open(profilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrProfileNotFound
+		}
+		return nil, fmt.Errorf("failed to open profile: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read profile: %w", err)
+	}
+
+	var profile Profile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal profile: %w", err)
+	}
+
+	return &profile, nil
+}
+
+// Update updates an existing profile
+func (fs *FilesystemStorage) Update(ctx context.Context, userID string, update *ProfileUpdate) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if userID == "" || update == nil {
+		return ErrInvalidProfile
+	}
+
+	// Load existing profile
+	profilePath := fs.getProfilePath(userID)
+
+	file, err := os.Open(profilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ErrProfileNotFound
+		}
+		return fmt.Errorf("failed to open profile: %w", err)
+	}
+
+	data, err := io.ReadAll(file)
+	_ = file.Close()
+	if err != nil {
+		return fmt.Errorf("failed to read profile: %w", err)
+	}
+
+	var profile Profile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return fmt.Errorf("failed to unmarshal profile: %w", err)
+	}
+
+	// Apply updates
+	profile.Update(update)
+
+	// Save updated profile
+	updatedData, err := json.MarshalIndent(&profile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated profile: %w", err)
+	}
+
+	// Write to temporary file first
+	tmpPath := profilePath + ".tmp"
+	if err := os.WriteFile(tmpPath, updatedData, 0644); err != nil {
+		return fmt.Errorf("failed to write updated profile: %w", err)
+	}
+
+	// Atomic rename
+	if err := os.Rename(tmpPath, profilePath); err != nil {
+		_ = os.Remove(tmpPath) // Clean up
+		return fmt.Errorf("failed to save updated profile: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a profile from the filesystem
+func (fs *FilesystemStorage) Delete(ctx context.Context, userID string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if userID == "" {
+		return ErrInvalidProfile
+	}
+
+	profilePath := fs.getProfilePath(userID)
+
+	if err := os.Remove(profilePath); err != nil {
+		if os.IsNotExist(err) {
+			return ErrProfileNotFound
+		}
+		return fmt.Errorf("failed to delete profile: %w", err)
+	}
+
+	return nil
+}
+
+// Exists checks if a profile exists
+func (fs *FilesystemStorage) Exists(ctx context.Context, userID string) (bool, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if userID == "" {
+		return false, ErrInvalidProfile
+	}
+
+	profilePath := fs.getProfilePath(userID)
+
+	_, err := os.Stat(profilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check profile existence: %w", err)
+	}
+
+	return true, nil
+}
+
+// List returns all profile IDs
+func (fs *FilesystemStorage) List(ctx context.Context) ([]string, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	var userIDs []string
+
+	// List all directories in base path
+	entries, err := os.ReadDir(fs.basePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to list profiles: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// Check if profile.json exists in this directory
+		profilePath := filepath.Join(fs.basePath, entry.Name(), "profile.json")
+		if _, err := os.Stat(profilePath); err == nil {
+			userIDs = append(userIDs, entry.Name())
+		}
+	}
+
+	return userIDs, nil
+}

--- a/pkg/profile/filesystem_test.go
+++ b/pkg/profile/filesystem_test.go
@@ -1,0 +1,271 @@
+package profile
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilesystemStorageBasicOperations(t *testing.T) {
+	// Create temporary directory
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create filesystem storage
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	ctx := context.Background()
+	userID := "test-user-123"
+
+	// Test Exists - should return false initially
+	exists, err := storage.Exists(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to check existence: %v", err)
+	}
+	if exists {
+		t.Error("Profile should not exist initially")
+	}
+
+	// Test Load - should return ErrProfileNotFound
+	_, err = storage.Load(ctx, userID)
+	if err != ErrProfileNotFound {
+		t.Errorf("Expected ErrProfileNotFound, got %v", err)
+	}
+
+	// Create and save a profile
+	profile := NewProfile(userID)
+	profile.Username = "testuser"
+	profile.Email = "test@example.com"
+	profile.Preferences["theme"] = "dark"
+
+	err = storage.Save(ctx, profile)
+	if err != nil {
+		t.Fatalf("Failed to save profile: %v", err)
+	}
+
+	// Test Exists - should return true now
+	exists, err = storage.Exists(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to check existence: %v", err)
+	}
+	if !exists {
+		t.Error("Profile should exist after saving")
+	}
+
+	// Test Load - should return the profile
+	loadedProfile, err := storage.Load(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to load profile: %v", err)
+	}
+
+	if loadedProfile.UserID != userID {
+		t.Errorf("Expected UserID %s, got %s", userID, loadedProfile.UserID)
+	}
+
+	if loadedProfile.Username != "testuser" {
+		t.Errorf("Expected Username 'testuser', got %s", loadedProfile.Username)
+	}
+
+	if loadedProfile.Email != "test@example.com" {
+		t.Errorf("Expected Email 'test@example.com', got %s", loadedProfile.Email)
+	}
+
+	if loadedProfile.Preferences["theme"] != "dark" {
+		t.Errorf("Expected theme 'dark', got %v", loadedProfile.Preferences["theme"])
+	}
+
+	// Test Update
+	update := &ProfileUpdate{
+		DisplayName: "Test User",
+		Preferences: map[string]interface{}{
+			"lang": "en",
+		},
+	}
+
+	err = storage.Update(ctx, userID, update)
+	if err != nil {
+		t.Fatalf("Failed to update profile: %v", err)
+	}
+
+	// Load and verify update
+	updatedProfile, err := storage.Load(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to load updated profile: %v", err)
+	}
+
+	if updatedProfile.DisplayName != "Test User" {
+		t.Errorf("Expected DisplayName 'Test User', got %s", updatedProfile.DisplayName)
+	}
+
+	if updatedProfile.Preferences["lang"] != "en" {
+		t.Errorf("Expected lang 'en', got %v", updatedProfile.Preferences["lang"])
+	}
+
+	// Original preference should still exist
+	if updatedProfile.Preferences["theme"] != "dark" {
+		t.Errorf("Expected theme 'dark' to be preserved, got %v", updatedProfile.Preferences["theme"])
+	}
+
+	// Test List
+	userIDs, err := storage.List(ctx)
+	if err != nil {
+		t.Fatalf("Failed to list profiles: %v", err)
+	}
+
+	if len(userIDs) != 1 {
+		t.Errorf("Expected 1 profile, got %d", len(userIDs))
+	}
+
+	if userIDs[0] != userID {
+		t.Errorf("Expected userID %s in list, got %s", userID, userIDs[0])
+	}
+
+	// Test Delete
+	err = storage.Delete(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to delete profile: %v", err)
+	}
+
+	// Test Exists - should return false after deletion
+	exists, err = storage.Exists(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to check existence after deletion: %v", err)
+	}
+	if exists {
+		t.Error("Profile should not exist after deletion")
+	}
+
+	// Test Load - should return ErrProfileNotFound again
+	_, err = storage.Load(ctx, userID)
+	if err != ErrProfileNotFound {
+		t.Errorf("Expected ErrProfileNotFound after deletion, got %v", err)
+	}
+}
+
+func TestFilesystemStorageInvalidInputs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Test Save with nil profile
+	err = storage.Save(ctx, nil)
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for nil profile, got %v", err)
+	}
+
+	// Test Save with empty UserID
+	profile := &Profile{}
+	err = storage.Save(ctx, profile)
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test Load with empty UserID
+	_, err = storage.Load(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test Update with empty UserID
+	err = storage.Update(ctx, "", &ProfileUpdate{})
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test Update with nil update
+	err = storage.Update(ctx, "user123", nil)
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for nil update, got %v", err)
+	}
+
+	// Test Delete with empty UserID
+	err = storage.Delete(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test Exists with empty UserID
+	_, err = storage.Exists(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+}
+
+func TestFilesystemStorageDefaultPath(t *testing.T) {
+	// Test creating storage with empty path (should use default)
+	storage, err := NewFilesystemStorage("")
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage with default path: %v", err)
+	}
+
+	// Verify storage was created (we can't easily test the exact path without
+	// accessing internal fields, but we can test basic functionality)
+	ctx := context.Background()
+	exists, err := storage.Exists(ctx, "test-user")
+	if err != nil {
+		t.Fatalf("Failed to check existence with default path: %v", err)
+	}
+
+	// Should return false (profile doesn't exist)
+	if exists {
+		t.Error("Profile should not exist")
+	}
+}
+
+func TestFilesystemStorageFileOperations(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	ctx := context.Background()
+	userID := "test-user-123"
+
+	// Create and save profile
+	profile := NewProfile(userID)
+	profile.Username = "testuser"
+
+	err = storage.Save(ctx, profile)
+	if err != nil {
+		t.Fatalf("Failed to save profile: %v", err)
+	}
+
+	// Verify file was created
+	profilePath := filepath.Join(tmpDir, userID, "profile.json")
+	if _, err := os.Stat(profilePath); os.IsNotExist(err) {
+		t.Error("Profile file should exist")
+	}
+
+	// Delete profile
+	err = storage.Delete(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to delete profile: %v", err)
+	}
+
+	// Verify file was deleted
+	if _, err := os.Stat(profilePath); !os.IsNotExist(err) {
+		t.Error("Profile file should be deleted")
+	}
+}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,0 +1,132 @@
+package profile
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Profile represents a user's profile with customizable settings and preferences
+type Profile struct {
+	UserID      string                 `json:"user_id"`
+	Username    string                 `json:"username"`
+	Email       string                 `json:"email"`
+	DisplayName string                 `json:"display_name"`
+	Preferences map[string]interface{} `json:"preferences"`
+	Settings    map[string]interface{} `json:"settings"`
+	Metadata    map[string]string      `json:"metadata"`
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+	LastLoginAt *time.Time             `json:"last_login_at,omitempty"`
+}
+
+// NewProfile creates a new profile with the given user ID
+func NewProfile(userID string) *Profile {
+	now := time.Now()
+	return &Profile{
+		UserID:      userID,
+		Preferences: make(map[string]interface{}),
+		Settings:    make(map[string]interface{}),
+		Metadata:    make(map[string]string),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+}
+
+// Update updates the profile fields with non-empty values from the update
+func (p *Profile) Update(update *ProfileUpdate) {
+	if update.Username != "" {
+		p.Username = update.Username
+	}
+	if update.Email != "" {
+		p.Email = update.Email
+	}
+	if update.DisplayName != "" {
+		p.DisplayName = update.DisplayName
+	}
+	if update.Preferences != nil {
+		for k, v := range update.Preferences {
+			p.Preferences[k] = v
+		}
+	}
+	if update.Settings != nil {
+		for k, v := range update.Settings {
+			p.Settings[k] = v
+		}
+	}
+	if update.Metadata != nil {
+		for k, v := range update.Metadata {
+			p.Metadata[k] = v
+		}
+	}
+	p.UpdatedAt = time.Now()
+}
+
+// ProfileUpdate represents fields that can be updated in a profile
+type ProfileUpdate struct {
+	Username    string                 `json:"username,omitempty"`
+	Email       string                 `json:"email,omitempty"`
+	DisplayName string                 `json:"display_name,omitempty"`
+	Preferences map[string]interface{} `json:"preferences,omitempty"`
+	Settings    map[string]interface{} `json:"settings,omitempty"`
+	Metadata    map[string]string      `json:"metadata,omitempty"`
+}
+
+// MarshalJSON implements custom JSON marshaling
+func (p *Profile) MarshalJSON() ([]byte, error) {
+	type Alias Profile
+	return json.Marshal(&struct {
+		*Alias
+		CreatedAt   string  `json:"created_at"`
+		UpdatedAt   string  `json:"updated_at"`
+		LastLoginAt *string `json:"last_login_at,omitempty"`
+	}{
+		Alias:     (*Alias)(p),
+		CreatedAt: p.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: p.UpdatedAt.Format(time.RFC3339),
+		LastLoginAt: func() *string {
+			if p.LastLoginAt != nil {
+				s := p.LastLoginAt.Format(time.RFC3339)
+				return &s
+			}
+			return nil
+		}(),
+	})
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling
+func (p *Profile) UnmarshalJSON(data []byte) error {
+	type Alias Profile
+	aux := &struct {
+		*Alias
+		CreatedAt   string  `json:"created_at"`
+		UpdatedAt   string  `json:"updated_at"`
+		LastLoginAt *string `json:"last_login_at,omitempty"`
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	var err error
+	p.CreatedAt, err = time.Parse(time.RFC3339, aux.CreatedAt)
+	if err != nil {
+		return err
+	}
+
+	p.UpdatedAt, err = time.Parse(time.RFC3339, aux.UpdatedAt)
+	if err != nil {
+		return err
+	}
+
+	if aux.LastLoginAt != nil {
+		t, err := time.Parse(time.RFC3339, *aux.LastLoginAt)
+		if err != nil {
+			return err
+		}
+		p.LastLoginAt = &t
+	}
+
+	return nil
+}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,0 +1,209 @@
+package profile
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNewProfile(t *testing.T) {
+	userID := "test-user-123"
+	profile := NewProfile(userID)
+
+	if profile.UserID != userID {
+		t.Errorf("Expected UserID %s, got %s", userID, profile.UserID)
+	}
+
+	if profile.Preferences == nil {
+		t.Error("Expected Preferences to be initialized")
+	}
+
+	if profile.Settings == nil {
+		t.Error("Expected Settings to be initialized")
+	}
+
+	if profile.Metadata == nil {
+		t.Error("Expected Metadata to be initialized")
+	}
+
+	if profile.CreatedAt.IsZero() {
+		t.Error("Expected CreatedAt to be set")
+	}
+
+	if profile.UpdatedAt.IsZero() {
+		t.Error("Expected UpdatedAt to be set")
+	}
+}
+
+func TestProfileUpdate(t *testing.T) {
+	profile := NewProfile("test-user")
+	originalUpdatedAt := profile.UpdatedAt
+
+	// Sleep a bit to ensure timestamp difference
+	time.Sleep(10 * time.Millisecond)
+
+	update := &ProfileUpdate{
+		Username:    "newusername",
+		Email:       "new@example.com",
+		DisplayName: "New Display Name",
+		Preferences: map[string]interface{}{
+			"theme": "dark",
+			"lang":  "en",
+		},
+		Settings: map[string]interface{}{
+			"timeout": 300,
+		},
+		Metadata: map[string]string{
+			"role": "admin",
+		},
+	}
+
+	profile.Update(update)
+
+	if profile.Username != "newusername" {
+		t.Errorf("Expected Username to be updated to 'newusername', got %s", profile.Username)
+	}
+
+	if profile.Email != "new@example.com" {
+		t.Errorf("Expected Email to be updated to 'new@example.com', got %s", profile.Email)
+	}
+
+	if profile.DisplayName != "New Display Name" {
+		t.Errorf("Expected DisplayName to be updated to 'New Display Name', got %s", profile.DisplayName)
+	}
+
+	if profile.Preferences["theme"] != "dark" {
+		t.Errorf("Expected theme preference to be 'dark', got %v", profile.Preferences["theme"])
+	}
+
+	if profile.Settings["timeout"] != 300 {
+		t.Errorf("Expected timeout setting to be 300, got %v", profile.Settings["timeout"])
+	}
+
+	if profile.Metadata["role"] != "admin" {
+		t.Errorf("Expected role metadata to be 'admin', got %v", profile.Metadata["role"])
+	}
+
+	if !profile.UpdatedAt.After(originalUpdatedAt) {
+		t.Error("Expected UpdatedAt to be updated")
+	}
+}
+
+func TestProfileJSONMarshaling(t *testing.T) {
+	profile := NewProfile("test-user")
+	profile.Username = "testuser"
+	profile.Email = "test@example.com"
+	profile.DisplayName = "Test User"
+	profile.Preferences["theme"] = "dark"
+	profile.Settings["timeout"] = 300
+	profile.Metadata["role"] = "user"
+
+	now := time.Now()
+	profile.LastLoginAt = &now
+
+	// Marshal to JSON
+	data, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("Failed to marshal profile: %v", err)
+	}
+
+	// Unmarshal back
+	var unmarshaled Profile
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal profile: %v", err)
+	}
+
+	// Verify fields
+	if unmarshaled.UserID != profile.UserID {
+		t.Errorf("UserID mismatch: expected %s, got %s", profile.UserID, unmarshaled.UserID)
+	}
+
+	if unmarshaled.Username != profile.Username {
+		t.Errorf("Username mismatch: expected %s, got %s", profile.Username, unmarshaled.Username)
+	}
+
+	if unmarshaled.Email != profile.Email {
+		t.Errorf("Email mismatch: expected %s, got %s", profile.Email, unmarshaled.Email)
+	}
+
+	if unmarshaled.DisplayName != profile.DisplayName {
+		t.Errorf("DisplayName mismatch: expected %s, got %s", profile.DisplayName, unmarshaled.DisplayName)
+	}
+
+	if unmarshaled.Preferences["theme"] != "dark" {
+		t.Errorf("Theme preference mismatch: expected 'dark', got %v", unmarshaled.Preferences["theme"])
+	}
+
+	if unmarshaled.Settings["timeout"] != float64(300) { // JSON unmarshaling converts numbers to float64
+		t.Errorf("Timeout setting mismatch: expected 300, got %v", unmarshaled.Settings["timeout"])
+	}
+
+	if unmarshaled.Metadata["role"] != "user" {
+		t.Errorf("Role metadata mismatch: expected 'user', got %v", unmarshaled.Metadata["role"])
+	}
+
+	// Check timestamps (allow small difference due to serialization precision)
+	if abs(unmarshaled.CreatedAt.Sub(profile.CreatedAt)) > time.Second {
+		t.Errorf("CreatedAt mismatch: expected %v, got %v", profile.CreatedAt, unmarshaled.CreatedAt)
+	}
+
+	if abs(unmarshaled.UpdatedAt.Sub(profile.UpdatedAt)) > time.Second {
+		t.Errorf("UpdatedAt mismatch: expected %v, got %v", profile.UpdatedAt, unmarshaled.UpdatedAt)
+	}
+
+	if unmarshaled.LastLoginAt == nil || abs(unmarshaled.LastLoginAt.Sub(*profile.LastLoginAt)) > time.Second {
+		t.Errorf("LastLoginAt mismatch: expected %v, got %v", profile.LastLoginAt, unmarshaled.LastLoginAt)
+	}
+}
+
+func TestProfileUpdatePartial(t *testing.T) {
+	profile := NewProfile("test-user")
+	profile.Username = "original"
+	profile.Email = "original@example.com"
+	profile.Preferences["theme"] = "light"
+	profile.Settings["timeout"] = 100
+
+	// Partial update - only update username and add a new preference
+	update := &ProfileUpdate{
+		Username: "updated",
+		Preferences: map[string]interface{}{
+			"lang": "en",
+		},
+	}
+
+	profile.Update(update)
+
+	// Check updated field
+	if profile.Username != "updated" {
+		t.Errorf("Expected Username to be updated to 'updated', got %s", profile.Username)
+	}
+
+	// Check unchanged field
+	if profile.Email != "original@example.com" {
+		t.Errorf("Expected Email to remain 'original@example.com', got %s", profile.Email)
+	}
+
+	// Check that existing preference is preserved
+	if profile.Preferences["theme"] != "light" {
+		t.Errorf("Expected existing theme preference to be preserved as 'light', got %v", profile.Preferences["theme"])
+	}
+
+	// Check that new preference is added
+	if profile.Preferences["lang"] != "en" {
+		t.Errorf("Expected new lang preference to be 'en', got %v", profile.Preferences["lang"])
+	}
+
+	// Check that existing setting is preserved
+	if profile.Settings["timeout"] != 100 {
+		t.Errorf("Expected existing timeout setting to be preserved as 100, got %v", profile.Settings["timeout"])
+	}
+}
+
+// Helper function to calculate absolute duration
+func abs(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}

--- a/pkg/profile/s3.go
+++ b/pkg/profile/s3.go
@@ -1,0 +1,224 @@
+package profile
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// S3Storage implements profile storage using AWS S3
+type S3Storage struct {
+	client *s3.Client
+	bucket string
+	prefix string
+}
+
+// NewS3Storage creates a new S3-based profile storage
+func NewS3Storage(bucket, region, endpoint, prefix string) (*S3Storage, error) {
+	if bucket == "" {
+		return nil, fmt.Errorf("S3 bucket name is required")
+	}
+
+	// Load AWS config
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(region),
+	}
+
+	// Use custom endpoint if provided (for S3-compatible services)
+	if endpoint != "" {
+		opts = append(opts, config.WithBaseEndpoint(endpoint))
+	}
+
+	cfg, err := config.LoadDefaultConfig(context.Background(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if endpoint != "" {
+			o.UsePathStyle = true // Required for MinIO and some S3-compatible services
+		}
+	})
+
+	return &S3Storage{
+		client: client,
+		bucket: bucket,
+		prefix: strings.TrimSuffix(prefix, "/"),
+	}, nil
+}
+
+// getObjectKey returns the S3 object key for a user's profile
+func (s *S3Storage) getObjectKey(userID string) string {
+	// Sanitize userID to prevent path traversal
+	safeUserID := strings.ReplaceAll(userID, "..", "")
+	safeUserID = strings.ReplaceAll(safeUserID, "/", "_")
+	safeUserID = strings.ReplaceAll(safeUserID, "\\", "_")
+
+	if s.prefix != "" {
+		return fmt.Sprintf("%s/%s/profile.json", s.prefix, safeUserID)
+	}
+	return fmt.Sprintf("%s/profile.json", safeUserID)
+}
+
+// Save stores a profile to S3
+func (s *S3Storage) Save(ctx context.Context, profile *Profile) error {
+	if profile == nil || profile.UserID == "" {
+		return ErrInvalidProfile
+	}
+
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal profile: %w", err)
+	}
+
+	key := s.getObjectKey(profile.UserID)
+
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String("application/json"),
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to save profile to S3: %w", err)
+	}
+
+	return nil
+}
+
+// Load retrieves a profile from S3
+func (s *S3Storage) Load(ctx context.Context, userID string) (*Profile, error) {
+	if userID == "" {
+		return nil, ErrInvalidProfile
+	}
+
+	key := s.getObjectKey(userID)
+
+	result, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchKey") || strings.Contains(err.Error(), "NotFound") {
+			return nil, ErrProfileNotFound
+		}
+		return nil, fmt.Errorf("failed to get profile from S3: %w", err)
+	}
+	defer func() { _ = result.Body.Close() }()
+
+	var profile Profile
+	decoder := json.NewDecoder(result.Body)
+	if err := decoder.Decode(&profile); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal profile: %w", err)
+	}
+
+	return &profile, nil
+}
+
+// Update updates an existing profile in S3
+func (s *S3Storage) Update(ctx context.Context, userID string, update *ProfileUpdate) error {
+	if userID == "" || update == nil {
+		return ErrInvalidProfile
+	}
+
+	// Load existing profile
+	profile, err := s.Load(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	// Apply updates
+	profile.Update(update)
+
+	// Save updated profile
+	return s.Save(ctx, profile)
+}
+
+// Delete removes a profile from S3
+func (s *S3Storage) Delete(ctx context.Context, userID string) error {
+	if userID == "" {
+		return ErrInvalidProfile
+	}
+
+	key := s.getObjectKey(userID)
+
+	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to delete profile from S3: %w", err)
+	}
+
+	return nil
+}
+
+// Exists checks if a profile exists in S3
+func (s *S3Storage) Exists(ctx context.Context, userID string) (bool, error) {
+	if userID == "" {
+		return false, ErrInvalidProfile
+	}
+
+	key := s.getObjectKey(userID)
+
+	_, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchKey") || strings.Contains(err.Error(), "NotFound") {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check profile existence: %w", err)
+	}
+
+	return true, nil
+}
+
+// List returns all profile IDs in S3
+func (s *S3Storage) List(ctx context.Context) ([]string, error) {
+	var userIDs []string
+
+	prefix := s.prefix
+	if prefix != "" {
+		prefix += "/"
+	}
+
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if strings.Contains(err.Error(), "NoSuchBucket") {
+				return []string{}, nil
+			}
+			return nil, fmt.Errorf("failed to list profiles: %w", err)
+		}
+
+		for _, obj := range page.Contents {
+			key := aws.ToString(obj.Key)
+			// Extract user ID from key
+			// Format: [prefix/]userID/profile.json
+			parts := strings.Split(key, "/")
+			if len(parts) >= 2 && parts[len(parts)-1] == "profile.json" {
+				userID := parts[len(parts)-2]
+				userIDs = append(userIDs, userID)
+			}
+		}
+	}
+
+	return userIDs, nil
+}

--- a/pkg/profile/service.go
+++ b/pkg/profile/service.go
@@ -1,0 +1,207 @@
+package profile
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Service provides profile management operations
+type Service struct {
+	storage Storage
+}
+
+// NewService creates a new profile service
+func NewService(storage Storage) *Service {
+	return &Service{
+		storage: storage,
+	}
+}
+
+// CreateProfile creates a new profile for a user
+func (s *Service) CreateProfile(ctx context.Context, userID, username, email, displayName string) (*Profile, error) {
+	if userID == "" {
+		return nil, ErrInvalidProfile
+	}
+
+	// Check if profile already exists
+	exists, err := s.storage.Exists(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check profile existence: %w", err)
+	}
+	if exists {
+		return nil, fmt.Errorf("profile already exists for user %s", userID)
+	}
+
+	// Create new profile
+	profile := NewProfile(userID)
+	profile.Username = username
+	profile.Email = email
+	profile.DisplayName = displayName
+
+	// Save profile
+	if err := s.storage.Save(ctx, profile); err != nil {
+		return nil, fmt.Errorf("failed to save profile: %w", err)
+	}
+
+	return profile, nil
+}
+
+// GetProfile retrieves a profile by user ID
+func (s *Service) GetProfile(ctx context.Context, userID string) (*Profile, error) {
+	if userID == "" {
+		return nil, ErrInvalidProfile
+	}
+
+	profile, err := s.storage.Load(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load profile: %w", err)
+	}
+
+	return profile, nil
+}
+
+// UpdateProfile updates a profile
+func (s *Service) UpdateProfile(ctx context.Context, userID string, update *ProfileUpdate) (*Profile, error) {
+	if userID == "" || update == nil {
+		return nil, ErrInvalidProfile
+	}
+
+	// Update the profile
+	if err := s.storage.Update(ctx, userID, update); err != nil {
+		return nil, fmt.Errorf("failed to update profile: %w", err)
+	}
+
+	// Return updated profile
+	return s.storage.Load(ctx, userID)
+}
+
+// DeleteProfile deletes a profile
+func (s *Service) DeleteProfile(ctx context.Context, userID string) error {
+	if userID == "" {
+		return ErrInvalidProfile
+	}
+
+	if err := s.storage.Delete(ctx, userID); err != nil {
+		return fmt.Errorf("failed to delete profile: %w", err)
+	}
+
+	return nil
+}
+
+// ProfileExists checks if a profile exists
+func (s *Service) ProfileExists(ctx context.Context, userID string) (bool, error) {
+	if userID == "" {
+		return false, ErrInvalidProfile
+	}
+
+	return s.storage.Exists(ctx, userID)
+}
+
+// ListProfiles returns all profile IDs
+func (s *Service) ListProfiles(ctx context.Context) ([]string, error) {
+	return s.storage.List(ctx)
+}
+
+// UpdateLastLogin updates the last login timestamp for a user
+func (s *Service) UpdateLastLogin(ctx context.Context, userID string) error {
+	if userID == "" {
+		return ErrInvalidProfile
+	}
+
+	now := time.Now()
+
+	// Load existing profile to update last login timestamp
+	profile, err := s.storage.Load(ctx, userID)
+	if err == ErrProfileNotFound {
+		// Create a new profile if it doesn't exist
+		_, err = s.CreateProfile(ctx, userID, "", "", "")
+		if err != nil {
+			return fmt.Errorf("failed to create profile: %w", err)
+		}
+		profile, err = s.storage.Load(ctx, userID)
+		if err != nil {
+			return fmt.Errorf("failed to load newly created profile: %w", err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to load profile: %w", err)
+	}
+
+	profile.LastLoginAt = &now
+
+	if err := s.storage.Save(ctx, profile); err != nil {
+		return fmt.Errorf("failed to update last login: %w", err)
+	}
+
+	return nil
+}
+
+// SetPreference sets a specific preference for a user
+func (s *Service) SetPreference(ctx context.Context, userID, key string, value interface{}) error {
+	if userID == "" || key == "" {
+		return ErrInvalidProfile
+	}
+
+	update := &ProfileUpdate{
+		Preferences: map[string]interface{}{
+			key: value,
+		},
+	}
+
+	_, err := s.UpdateProfile(ctx, userID, update)
+	return err
+}
+
+// GetPreference gets a specific preference for a user
+func (s *Service) GetPreference(ctx context.Context, userID, key string) (interface{}, error) {
+	if userID == "" || key == "" {
+		return nil, ErrInvalidProfile
+	}
+
+	profile, err := s.GetProfile(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	value, exists := profile.Preferences[key]
+	if !exists {
+		return nil, fmt.Errorf("preference %s not found", key)
+	}
+
+	return value, nil
+}
+
+// SetSetting sets a specific setting for a user
+func (s *Service) SetSetting(ctx context.Context, userID, key string, value interface{}) error {
+	if userID == "" || key == "" {
+		return ErrInvalidProfile
+	}
+
+	update := &ProfileUpdate{
+		Settings: map[string]interface{}{
+			key: value,
+		},
+	}
+
+	_, err := s.UpdateProfile(ctx, userID, update)
+	return err
+}
+
+// GetSetting gets a specific setting for a user
+func (s *Service) GetSetting(ctx context.Context, userID, key string) (interface{}, error) {
+	if userID == "" || key == "" {
+		return nil, ErrInvalidProfile
+	}
+
+	profile, err := s.GetProfile(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	value, exists := profile.Settings[key]
+	if !exists {
+		return nil, fmt.Errorf("setting %s not found", key)
+	}
+
+	return value, nil
+}

--- a/pkg/profile/service_test.go
+++ b/pkg/profile/service_test.go
@@ -1,0 +1,424 @@
+package profile
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServiceBasicOperations(t *testing.T) {
+	// Create temporary directory for filesystem storage
+	tmpDir, err := os.MkdirTemp("", "profile-service-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create filesystem storage
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	// Create service
+	service := NewService(storage)
+
+	ctx := context.Background()
+	userID := "test-user-123"
+
+	// Test ProfileExists - should return false initially
+	exists, err := service.ProfileExists(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to check profile existence: %v", err)
+	}
+	if exists {
+		t.Error("Profile should not exist initially")
+	}
+
+	// Test GetProfile - should return ErrProfileNotFound
+	_, err = service.GetProfile(ctx, userID)
+	if err == nil || !strings.Contains(err.Error(), "profile not found") {
+		t.Errorf("Expected error containing 'profile not found', got %v", err)
+	}
+
+	// Test CreateProfile
+	profile, err := service.CreateProfile(ctx, userID, "testuser", "test@example.com", "Test User")
+	if err != nil {
+		t.Fatalf("Failed to create profile: %v", err)
+	}
+
+	if profile.UserID != userID {
+		t.Errorf("Expected UserID %s, got %s", userID, profile.UserID)
+	}
+
+	if profile.Username != "testuser" {
+		t.Errorf("Expected Username 'testuser', got %s", profile.Username)
+	}
+
+	if profile.Email != "test@example.com" {
+		t.Errorf("Expected Email 'test@example.com', got %s", profile.Email)
+	}
+
+	if profile.DisplayName != "Test User" {
+		t.Errorf("Expected DisplayName 'Test User', got %s", profile.DisplayName)
+	}
+
+	// Test ProfileExists - should return true now
+	exists, err = service.ProfileExists(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to check profile existence: %v", err)
+	}
+	if !exists {
+		t.Error("Profile should exist after creation")
+	}
+
+	// Test GetProfile - should return the profile
+	retrievedProfile, err := service.GetProfile(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to get profile: %v", err)
+	}
+
+	if retrievedProfile.UserID != userID {
+		t.Errorf("Expected UserID %s, got %s", userID, retrievedProfile.UserID)
+	}
+
+	// Test CreateProfile again - should fail with duplicate
+	_, err = service.CreateProfile(ctx, userID, "testuser", "test@example.com", "Test User")
+	if err == nil {
+		t.Error("Expected error when creating duplicate profile")
+	}
+
+	// Test UpdateProfile
+	update := &ProfileUpdate{
+		DisplayName: "Updated Test User",
+		Preferences: map[string]interface{}{
+			"theme": "dark",
+			"lang":  "en",
+		},
+		Settings: map[string]interface{}{
+			"timeout": 300,
+		},
+		Metadata: map[string]string{
+			"role": "admin",
+		},
+	}
+
+	updatedProfile, err := service.UpdateProfile(ctx, userID, update)
+	if err != nil {
+		t.Fatalf("Failed to update profile: %v", err)
+	}
+
+	if updatedProfile.DisplayName != "Updated Test User" {
+		t.Errorf("Expected DisplayName 'Updated Test User', got %s", updatedProfile.DisplayName)
+	}
+
+	if updatedProfile.Preferences["theme"] != "dark" {
+		t.Errorf("Expected theme 'dark', got %v", updatedProfile.Preferences["theme"])
+	}
+
+	// Test ListProfiles
+	profiles, err := service.ListProfiles(ctx)
+	if err != nil {
+		t.Fatalf("Failed to list profiles: %v", err)
+	}
+
+	if len(profiles) != 1 {
+		t.Errorf("Expected 1 profile, got %d", len(profiles))
+	}
+
+	if profiles[0] != userID {
+		t.Errorf("Expected profile %s, got %s", userID, profiles[0])
+	}
+
+	// Test DeleteProfile
+	err = service.DeleteProfile(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to delete profile: %v", err)
+	}
+
+	// Test ProfileExists - should return false after deletion
+	exists, err = service.ProfileExists(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to check profile existence: %v", err)
+	}
+	if exists {
+		t.Error("Profile should not exist after deletion")
+	}
+}
+
+func TestServicePreferenceOperations(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-service-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	service := NewService(storage)
+	ctx := context.Background()
+	userID := "test-user-123"
+
+	// Create profile first
+	_, err = service.CreateProfile(ctx, userID, "testuser", "test@example.com", "Test User")
+	if err != nil {
+		t.Fatalf("Failed to create profile: %v", err)
+	}
+
+	// Test SetPreference
+	err = service.SetPreference(ctx, userID, "theme", "dark")
+	if err != nil {
+		t.Fatalf("Failed to set preference: %v", err)
+	}
+
+	// Test GetPreference
+	value, err := service.GetPreference(ctx, userID, "theme")
+	if err != nil {
+		t.Fatalf("Failed to get preference: %v", err)
+	}
+
+	if value != "dark" {
+		t.Errorf("Expected preference value 'dark', got %v", value)
+	}
+
+	// Test GetPreference for non-existent key
+	_, err = service.GetPreference(ctx, userID, "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent preference")
+	}
+
+	// Test SetPreference with complex value
+	complexValue := map[string]interface{}{
+		"nested": "value",
+		"number": 42,
+	}
+
+	err = service.SetPreference(ctx, userID, "complex", complexValue)
+	if err != nil {
+		t.Fatalf("Failed to set complex preference: %v", err)
+	}
+
+	// Retrieve and verify complex value
+	retrievedValue, err := service.GetPreference(ctx, userID, "complex")
+	if err != nil {
+		t.Fatalf("Failed to get complex preference: %v", err)
+	}
+
+	complexMap, ok := retrievedValue.(map[string]interface{})
+	if !ok {
+		t.Errorf("Expected complex preference to be a map, got %T", retrievedValue)
+	} else {
+		if complexMap["nested"] != "value" {
+			t.Errorf("Expected nested value 'value', got %v", complexMap["nested"])
+		}
+	}
+}
+
+func TestServiceSettingOperations(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-service-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	service := NewService(storage)
+	ctx := context.Background()
+	userID := "test-user-123"
+
+	// Create profile first
+	_, err = service.CreateProfile(ctx, userID, "testuser", "test@example.com", "Test User")
+	if err != nil {
+		t.Fatalf("Failed to create profile: %v", err)
+	}
+
+	// Test SetSetting
+	err = service.SetSetting(ctx, userID, "timeout", 300)
+	if err != nil {
+		t.Fatalf("Failed to set setting: %v", err)
+	}
+
+	// Test GetSetting
+	value, err := service.GetSetting(ctx, userID, "timeout")
+	if err != nil {
+		t.Fatalf("Failed to get setting: %v", err)
+	}
+
+	// Note: JSON unmarshaling converts numbers to float64
+	if value != float64(300) {
+		t.Errorf("Expected setting value 300, got %v", value)
+	}
+
+	// Test GetSetting for non-existent key
+	_, err = service.GetSetting(ctx, userID, "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent setting")
+	}
+}
+
+func TestServiceUpdateLastLogin(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-service-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	service := NewService(storage)
+	ctx := context.Background()
+	userID := "test-user-123"
+
+	// Test UpdateLastLogin for non-existent profile - should create profile
+	err = service.UpdateLastLogin(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to update last login: %v", err)
+	}
+
+	// Verify profile was created
+	profile, err := service.GetProfile(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to get profile after updating last login: %v", err)
+	}
+
+	if profile.LastLoginAt == nil {
+		t.Error("Expected LastLoginAt to be set")
+	}
+
+	// Test UpdateLastLogin for existing profile
+	firstLoginTime := *profile.LastLoginAt
+
+	// Sleep a bit to ensure timestamp difference
+	time.Sleep(100 * time.Millisecond)
+
+	err = service.UpdateLastLogin(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to update last login again: %v", err)
+	}
+
+	// Verify last login was updated
+	updatedProfile, err := service.GetProfile(ctx, userID)
+	if err != nil {
+		t.Fatalf("Failed to get updated profile: %v", err)
+	}
+
+	if updatedProfile.LastLoginAt == nil {
+		t.Error("Expected LastLoginAt to be set after update")
+	} else if updatedProfile.LastLoginAt.Equal(firstLoginTime) || updatedProfile.LastLoginAt.Before(firstLoginTime) {
+		t.Errorf("Expected LastLoginAt to be updated to a later time. First: %v, Updated: %v", firstLoginTime, *updatedProfile.LastLoginAt)
+	}
+}
+
+func TestServiceInvalidInputs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "profile-service-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	storage, err := NewFilesystemStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to create filesystem storage: %v", err)
+	}
+
+	service := NewService(storage)
+	ctx := context.Background()
+
+	// Test CreateProfile with empty UserID
+	_, err = service.CreateProfile(ctx, "", "user", "email", "name")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test GetProfile with empty UserID
+	_, err = service.GetProfile(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test UpdateProfile with empty UserID
+	_, err = service.UpdateProfile(ctx, "", &ProfileUpdate{})
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test UpdateProfile with nil update
+	_, err = service.UpdateProfile(ctx, "user123", nil)
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for nil update, got %v", err)
+	}
+
+	// Test DeleteProfile with empty UserID
+	err = service.DeleteProfile(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test ProfileExists with empty UserID
+	_, err = service.ProfileExists(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	// Test SetPreference with empty UserID or key
+	err = service.SetPreference(ctx, "", "key", "value")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	err = service.SetPreference(ctx, "user123", "", "value")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty key, got %v", err)
+	}
+
+	// Test GetPreference with empty UserID or key
+	_, err = service.GetPreference(ctx, "", "key")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	_, err = service.GetPreference(ctx, "user123", "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty key, got %v", err)
+	}
+
+	// Test SetSetting with empty UserID or key
+	err = service.SetSetting(ctx, "", "key", "value")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	err = service.SetSetting(ctx, "user123", "", "value")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty key, got %v", err)
+	}
+
+	// Test GetSetting with empty UserID or key
+	_, err = service.GetSetting(ctx, "", "key")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+
+	_, err = service.GetSetting(ctx, "user123", "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty key, got %v", err)
+	}
+
+	// Test UpdateLastLogin with empty UserID
+	err = service.UpdateLastLogin(ctx, "")
+	if err != ErrInvalidProfile {
+		t.Errorf("Expected ErrInvalidProfile for empty UserID, got %v", err)
+	}
+}

--- a/pkg/profile/storage.go
+++ b/pkg/profile/storage.go
@@ -1,0 +1,55 @@
+package profile
+
+import (
+	"context"
+	"errors"
+)
+
+// Common errors
+var (
+	ErrProfileNotFound = errors.New("profile not found")
+	ErrInvalidProfile  = errors.New("invalid profile data")
+)
+
+// Storage defines the interface for profile persistence
+type Storage interface {
+	// Save stores a profile
+	Save(ctx context.Context, profile *Profile) error
+
+	// Load retrieves a profile by user ID
+	Load(ctx context.Context, userID string) (*Profile, error)
+
+	// Update updates an existing profile
+	Update(ctx context.Context, userID string, update *ProfileUpdate) error
+
+	// Delete removes a profile
+	Delete(ctx context.Context, userID string) error
+
+	// Exists checks if a profile exists
+	Exists(ctx context.Context, userID string) (bool, error)
+
+	// List returns all profile IDs (optional, may return empty slice if not supported)
+	List(ctx context.Context) ([]string, error)
+}
+
+// StorageType represents the type of storage backend
+type StorageType string
+
+const (
+	StorageTypeFilesystem StorageType = "filesystem"
+	StorageTypeS3         StorageType = "s3"
+)
+
+// Config represents configuration for profile storage
+type Config struct {
+	Type StorageType `yaml:"type" json:"type"`
+
+	// Filesystem-specific config
+	BasePath string `yaml:"base_path,omitempty" json:"base_path,omitempty"`
+
+	// S3-specific config
+	S3Bucket   string `yaml:"s3_bucket,omitempty" json:"s3_bucket,omitempty"`
+	S3Region   string `yaml:"s3_region,omitempty" json:"s3_region,omitempty"`
+	S3Endpoint string `yaml:"s3_endpoint,omitempty" json:"s3_endpoint,omitempty"`
+	S3Prefix   string `yaml:"s3_prefix,omitempty" json:"s3_prefix,omitempty"`
+}

--- a/pkg/proxy/profile_handlers.go
+++ b/pkg/proxy/profile_handlers.go
@@ -1,0 +1,328 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/profile"
+)
+
+// ProfileHandlers handles HTTP requests for profile management
+type ProfileHandlers struct {
+	service *profile.Service
+}
+
+// NewProfileHandlers creates a new profile handlers instance
+func NewProfileHandlers(service *profile.Service) *ProfileHandlers {
+	return &ProfileHandlers{
+		service: service,
+	}
+}
+
+// CreateProfileRequest represents the request body for creating a profile
+type CreateProfileRequest struct {
+	Username    string `json:"username,omitempty"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+// UpdateProfileRequest represents the request body for updating a profile
+type UpdateProfileRequest struct {
+	Username    string                 `json:"username,omitempty"`
+	Email       string                 `json:"email,omitempty"`
+	DisplayName string                 `json:"display_name,omitempty"`
+	Preferences map[string]interface{} `json:"preferences,omitempty"`
+	Settings    map[string]interface{} `json:"settings,omitempty"`
+	Metadata    map[string]string      `json:"metadata,omitempty"`
+}
+
+// SetPreferenceRequest represents the request body for setting a preference
+type SetPreferenceRequest struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+// SetSettingRequest represents the request body for setting a setting
+type SetSettingRequest struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+// GetProfile handles GET /profile - get current user's profile
+func (h *ProfileHandlers) GetProfile(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	userProfile, err := h.service.GetProfile(c.Request().Context(), user.UserID)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get profile")
+	}
+
+	return c.JSON(http.StatusOK, userProfile)
+}
+
+// CreateProfile handles POST /profile - create current user's profile
+func (h *ProfileHandlers) CreateProfile(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var req CreateProfileRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	profile, err := h.service.CreateProfile(c.Request().Context(), user.UserID, req.Username, req.Email, req.DisplayName)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return echo.NewHTTPError(http.StatusConflict, "Profile already exists")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create profile")
+	}
+
+	return c.JSON(http.StatusCreated, profile)
+}
+
+// UpdateProfile handles PUT /profile - update current user's profile
+func (h *ProfileHandlers) UpdateProfile(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var req UpdateProfileRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	update := &profile.ProfileUpdate{
+		Username:    req.Username,
+		Email:       req.Email,
+		DisplayName: req.DisplayName,
+		Preferences: req.Preferences,
+		Settings:    req.Settings,
+		Metadata:    req.Metadata,
+	}
+
+	updatedProfile, err := h.service.UpdateProfile(c.Request().Context(), user.UserID, update)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update profile")
+	}
+
+	return c.JSON(http.StatusOK, updatedProfile)
+}
+
+// DeleteProfile handles DELETE /profile - delete current user's profile
+func (h *ProfileHandlers) DeleteProfile(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	err := h.service.DeleteProfile(c.Request().Context(), user.UserID)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete profile")
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+// SetPreference handles POST /profile/preference - set a preference
+func (h *ProfileHandlers) SetPreference(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var req SetPreferenceRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.Key == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Preference key is required")
+	}
+
+	err := h.service.SetPreference(c.Request().Context(), user.UserID, req.Key, req.Value)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to set preference")
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"message": "Preference set successfully",
+		"key":     req.Key,
+		"value":   req.Value,
+	})
+}
+
+// GetPreference handles GET /profile/preference/:key - get a preference
+func (h *ProfileHandlers) GetPreference(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	key := c.Param("key")
+	if key == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Preference key is required")
+	}
+
+	value, err := h.service.GetPreference(c.Request().Context(), user.UserID, key)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		if strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "Preference not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get preference")
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"key":   key,
+		"value": value,
+	})
+}
+
+// SetSetting handles POST /profile/setting - set a setting
+func (h *ProfileHandlers) SetSetting(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var req SetSettingRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.Key == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Setting key is required")
+	}
+
+	err := h.service.SetSetting(c.Request().Context(), user.UserID, req.Key, req.Value)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to set setting")
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"message": "Setting set successfully",
+		"key":     req.Key,
+		"value":   req.Value,
+	})
+}
+
+// GetSetting handles GET /profile/setting/:key - get a setting
+func (h *ProfileHandlers) GetSetting(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	key := c.Param("key")
+	if key == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Setting key is required")
+	}
+
+	value, err := h.service.GetSetting(c.Request().Context(), user.UserID, key)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		if strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "Setting not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get setting")
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"key":   key,
+		"value": value,
+	})
+}
+
+// Admin endpoints
+
+// ListProfiles handles GET /profiles - list all profiles (admin only)
+func (h *ProfileHandlers) ListProfiles(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	userIDs, err := h.service.ListProfiles(c.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list profiles")
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"profiles": userIDs,
+		"count":    len(userIDs),
+	})
+}
+
+// GetUserProfile handles GET /profiles/:userID - get specific user's profile (admin only)
+func (h *ProfileHandlers) GetUserProfile(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	userID := c.Param("userID")
+	if userID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "User ID is required")
+	}
+
+	userProfile, err := h.service.GetProfile(c.Request().Context(), userID)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get profile")
+	}
+
+	return c.JSON(http.StatusOK, userProfile)
+}
+
+// DeleteUserProfile handles DELETE /profiles/:userID - delete specific user's profile (admin only)
+func (h *ProfileHandlers) DeleteUserProfile(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	userID := c.Param("userID")
+	if userID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "User ID is required")
+	}
+
+	err := h.service.DeleteProfile(c.Request().Context(), userID)
+	if err != nil {
+		if err == profile.ErrProfileNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "Profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete profile")
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}


### PR DESCRIPTION
## Summary
- Add comprehensive profile persistence feature with filesystem and S3 storage backends
- Implement REST API endpoints for profile management with authentication and authorization
- Support user preferences, settings, and metadata with JSON serialization
- Include admin endpoints for profile administration across all users

## Key Features
- **Profile Model**: Complete profile structure with timestamps, preferences, settings, and metadata
- **Filesystem Storage**: JSON files stored in user-specific directories with atomic writes
- **S3 Storage**: Support for AWS S3 and S3-compatible services (MinIO, etc.)
- **REST API**: Full CRUD operations with proper HTTP status codes and error handling
- **Authentication**: Integration with existing auth system and permission-based access control
- **Admin Features**: List, view, and delete profiles across all users (admin permission required)

## API Endpoints
### User Profile Management
- `GET /profile` - Get current user's profile
- `POST /profile` - Create current user's profile  
- `PUT /profile` - Update current user's profile
- `DELETE /profile` - Delete current user's profile

### Preference/Setting Management
- `POST /profile/preference` - Set a preference
- `GET /profile/preference/:key` - Get a preference
- `POST /profile/setting` - Set a setting
- `GET /profile/setting/:key` - Get a setting

### Admin Endpoints (admin permission required)
- `GET /profiles` - List all profiles
- `GET /profiles/:userID` - Get specific user's profile
- `DELETE /profiles/:userID` - Delete specific user's profile

## Configuration
```yaml
profile:
  type: filesystem  # or "s3"
  # Filesystem configuration
  base_path: ~/.agentapi-proxy/profiles
  
  # S3 configuration (when type: s3)
  s3_bucket: my-profiles-bucket
  s3_region: us-east-1
  s3_endpoint: ""  # Optional, for S3-compatible services
  s3_prefix: profiles  # Optional prefix for keys
```

## Test Plan
- [x] Unit tests for profile model and JSON serialization
- [x] Integration tests for filesystem storage operations
- [x] Service layer tests with comprehensive coverage
- [x] Error handling and edge case validation
- [x] Lint and format checks passed
- [x] All existing tests continue to pass

## Files Added
- `pkg/profile/` - Complete profile package implementation
- `pkg/proxy/profile_handlers.go` - HTTP API handlers
- `docs/profile-api.md` - Comprehensive API documentation

## Files Modified  
- `pkg/config/config.go` - Added profile configuration support
- `pkg/proxy/proxy.go` - Integrated profile service and routes

🤖 Generated with [Claude Code](https://claude.ai/code)