### PR TITLE
feat: 大規模リファクタリング - cmd と pkg の重複コードを排除

### DIFF
--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/takutakahashi/agentapi-proxy/pkg/client"
 )
 
 func TestClientCmd(t *testing.T) {
@@ -77,7 +78,7 @@ func TestEventsCmd(t *testing.T) {
 }
 
 func TestMessageStruct(t *testing.T) {
-	msg := Message{
+	msg := client.Message{
 		Content: "test message",
 		Type:    "text",
 	}
@@ -85,7 +86,7 @@ func TestMessageStruct(t *testing.T) {
 	data, err := json.Marshal(msg)
 	assert.NoError(t, err)
 
-	var unmarshaled Message
+	var unmarshaled client.Message
 	err = json.Unmarshal(data, &unmarshaled)
 	assert.NoError(t, err)
 
@@ -95,17 +96,19 @@ func TestMessageStruct(t *testing.T) {
 
 func TestMessageResponseStruct(t *testing.T) {
 	now := time.Now()
-	resp := MessageResponse{
-		ID:        "test-id",
-		Role:      "assistant",
-		Content:   "test response",
-		Timestamp: now,
+	resp := client.MessageResponse{
+		Message: client.Message{
+			ID:        "test-id",
+			Role:      "assistant",
+			Content:   "test response",
+			Timestamp: now,
+		},
 	}
 
 	data, err := json.Marshal(resp)
 	assert.NoError(t, err)
 
-	var unmarshaled MessageResponse
+	var unmarshaled client.MessageResponse
 	err = json.Unmarshal(data, &unmarshaled)
 	assert.NoError(t, err)
 
@@ -117,14 +120,14 @@ func TestMessageResponseStruct(t *testing.T) {
 }
 
 func TestStatusResponseStruct(t *testing.T) {
-	status := StatusResponse{
+	status := client.StatusResponse{
 		Status: "active",
 	}
 
 	data, err := json.Marshal(status)
 	assert.NoError(t, err)
 
-	var unmarshaled StatusResponse
+	var unmarshaled client.StatusResponse
 	err = json.Unmarshal(data, &unmarshaled)
 	assert.NoError(t, err)
 
@@ -144,7 +147,7 @@ func TestRunSendWithArgument(t *testing.T) {
 			return
 		}
 
-		var msg Message
+		var msg client.Message
 		err := json.NewDecoder(r.Body).Decode(&msg)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -152,11 +155,13 @@ func TestRunSendWithArgument(t *testing.T) {
 		}
 
 		// Return a mock response
-		response := MessageResponse{
-			ID:        "test-id",
-			Role:      "assistant",
-			Content:   fmt.Sprintf("Response to: %s", msg.Content),
-			Timestamp: time.Now(),
+		response := client.MessageResponse{
+			Message: client.Message{
+				ID:        "test-id",
+				Role:      "assistant",
+				Content:   fmt.Sprintf("Response to: %s", msg.Content),
+				Timestamp: time.Now(),
+			},
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -201,7 +206,7 @@ func TestRunHistoryWithMockServer(t *testing.T) {
 			return
 		}
 
-		messages := []MessageResponse{
+		messages := []client.Message{
 			{
 				ID:        "msg-1",
 				Role:      "user",
@@ -261,7 +266,7 @@ func TestRunStatusWithMockServer(t *testing.T) {
 			return
 		}
 
-		status := StatusResponse{
+		status := client.StatusResponse{
 			Status: "active",
 		}
 
@@ -412,11 +417,13 @@ func TestClientCommandsWithEmptySessionID(t *testing.T) {
 func TestRunSendInteractiveMode(t *testing.T) {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := MessageResponse{
-			ID:        "test-id",
-			Role:      "assistant",
-			Content:   "Interactive response",
-			Timestamp: time.Now(),
+		response := client.MessageResponse{
+			Message: client.Message{
+				ID:        "test-id",
+				Role:      "assistant",
+				Content:   "Interactive response",
+				Timestamp: time.Now(),
+			},
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(response)

--- a/cmd/init_github_repo_test.go
+++ b/cmd/init_github_repo_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v57/github"
+	github_pkg "github.com/takutakahashi/agentapi-proxy/pkg/github"
 )
 
 func TestGenerateInstallationToken(t *testing.T) {
@@ -197,7 +198,7 @@ func TestCreateAuthenticatedURL(t *testing.T) {
 				_ = os.Unsetenv("GITHUB_URL")
 			}
 
-			result, err := createAuthenticatedURL(tt.repoURL, tt.token)
+			result, err := github_pkg.CreateAuthenticatedURL(tt.repoURL, tt.token)
 
 			if tt.expectError {
 				if err == nil {

--- a/pkg/github/utils.go
+++ b/pkg/github/utils.go
@@ -1,0 +1,156 @@
+package github
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ParseRepositoryURL extracts owner/repo from various Git URL formats
+func ParseRepositoryURL(url string) string {
+	// Handle SSH URLs: git@hostname:owner/repo.git
+	if strings.Contains(url, "@") && strings.Contains(url, ":") && !strings.Contains(url, "://") {
+		// SSH format: git@hostname:owner/repo.git
+		parts := strings.Split(url, ":")
+		if len(parts) >= 2 {
+			path := strings.Join(parts[1:], ":")
+			path = strings.TrimSuffix(path, ".git")
+			return path
+		}
+	}
+
+	// Handle HTTPS URLs: https://hostname/owner/repo.git
+	if strings.HasPrefix(url, "https://") {
+		// Remove https:// prefix
+		withoutProtocol := strings.TrimPrefix(url, "https://")
+
+		// Handle URLs with authentication token: token@hostname/owner/repo.git
+		if strings.Contains(withoutProtocol, "@") {
+			parts := strings.Split(withoutProtocol, "@")
+			if len(parts) >= 2 {
+				withoutProtocol = strings.Join(parts[1:], "@")
+			}
+		}
+
+		// Extract path after hostname: hostname/owner/repo.git -> owner/repo.git
+		pathParts := strings.Split(withoutProtocol, "/")
+		if len(pathParts) >= 3 {
+			// Join owner/repo parts
+			path := strings.Join(pathParts[1:], "/")
+			path = strings.TrimSuffix(path, ".git")
+			return path
+		}
+	}
+
+	// Handle HTTP URLs: http://hostname/owner/repo.git
+	if strings.HasPrefix(url, "http://") {
+		// Remove http:// prefix
+		withoutProtocol := strings.TrimPrefix(url, "http://")
+
+		// Handle URLs with authentication token: token@hostname/owner/repo.git
+		if strings.Contains(withoutProtocol, "@") {
+			parts := strings.Split(withoutProtocol, "@")
+			if len(parts) >= 2 {
+				withoutProtocol = strings.Join(parts[1:], "@")
+			}
+		}
+
+		// Extract path after hostname: hostname/owner/repo.git -> owner/repo.git
+		pathParts := strings.Split(withoutProtocol, "/")
+		if len(pathParts) >= 3 {
+			// Join owner/repo parts
+			path := strings.Join(pathParts[1:], "/")
+			path = strings.TrimSuffix(path, ".git")
+			return path
+		}
+	}
+
+	// Handle git protocol URLs: git://hostname/owner/repo.git
+	if strings.HasPrefix(url, "git://") {
+		// Remove git:// prefix
+		withoutProtocol := strings.TrimPrefix(url, "git://")
+
+		// Extract path after hostname: hostname/owner/repo.git -> owner/repo.git
+		pathParts := strings.Split(withoutProtocol, "/")
+		if len(pathParts) >= 3 {
+			// Join owner/repo parts
+			path := strings.Join(pathParts[1:], "/")
+			path = strings.TrimSuffix(path, ".git")
+			return path
+		}
+	}
+
+	return ""
+}
+
+// GetRepositoryFromGitRemote extracts repository full name from git remote
+func GetRepositoryFromGitRemote() string {
+	// Try to get the current working directory first
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	// Use git to get the remote origin URL
+	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	cmd.Dir = cwd
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	remoteURL := strings.TrimSpace(string(output))
+	return ParseRepositoryURL(remoteURL)
+}
+
+// GetAPIBase returns the GitHub API base URL (supports enterprise)
+func GetAPIBase() string {
+	apiBase := os.Getenv("GITHUB_API")
+	if apiBase == "" {
+		apiBase = "https://api.github.com"
+	}
+	return apiBase
+}
+
+// GetGitHubURL returns the GitHub URL (supports enterprise)
+func GetGitHubURL() string {
+	githubURL := os.Getenv("GITHUB_URL")
+	if githubURL == "" {
+		githubURL = "https://github.com"
+	}
+	return githubURL
+}
+
+// ExtractHostname extracts hostname from GitHub URL
+func ExtractHostname(githubURL string) string {
+	// Remove protocol prefix
+	hostname := strings.TrimPrefix(githubURL, "https://")
+	hostname = strings.TrimPrefix(hostname, "http://")
+
+	// Remove any path components
+	if idx := strings.Index(hostname, "/"); idx != -1 {
+		hostname = hostname[:idx]
+	}
+
+	return hostname
+}
+
+// CreateAuthenticatedURL creates an authenticated GitHub URL with token
+func CreateAuthenticatedURL(repoURL, token string) (string, error) {
+	githubURL := GetGitHubURL()
+	githubHost := strings.TrimPrefix(githubURL, "https://")
+	githubHost = strings.TrimPrefix(githubHost, "http://")
+
+	// Parse the repository URL and insert the token
+	if strings.HasPrefix(repoURL, githubURL+"/") {
+		parts := strings.TrimPrefix(repoURL, githubURL+"/")
+		return fmt.Sprintf("https://%s@%s/%s", token, githubHost, parts), nil
+	} else if strings.HasPrefix(repoURL, "git@"+githubHost+":") {
+		parts := strings.TrimPrefix(repoURL, "git@"+githubHost+":")
+		parts = strings.TrimSuffix(parts, ".git")
+		return fmt.Sprintf("https://%s@%s/%s.git", token, githubHost, parts), nil
+	}
+
+	return "", fmt.Errorf("unsupported repository URL format: %s", repoURL)
+}

--- a/pkg/github/utils_test.go
+++ b/pkg/github/utils_test.go
@@ -1,0 +1,282 @@
+package github
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseRepositoryURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "SSH format with github.com",
+			url:      "git@github.com:owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "SSH format without .git",
+			url:      "git@github.com:owner/repo",
+			expected: "owner/repo",
+		},
+		{
+			name:     "HTTPS format with github.com",
+			url:      "https://github.com/owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "HTTPS format without .git",
+			url:      "https://github.com/owner/repo",
+			expected: "owner/repo",
+		},
+		{
+			name:     "HTTPS format with token",
+			url:      "https://token@github.com/owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "HTTP format",
+			url:      "http://github.com/owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "Git protocol format",
+			url:      "git://github.com/owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "Enterprise SSH format",
+			url:      "git@github.enterprise.com:owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "Enterprise HTTPS format",
+			url:      "https://github.enterprise.com/owner/repo.git",
+			expected: "owner/repo",
+		},
+		{
+			name:     "Invalid format",
+			url:      "invalid-url",
+			expected: "",
+		},
+		{
+			name:     "Empty URL",
+			url:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRepositoryURL(tt.url)
+			if result != tt.expected {
+				t.Errorf("ParseRepositoryURL(%q) = %q, expected %q", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAPIBase(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "Default GitHub API",
+			envValue: "",
+			expected: "https://api.github.com",
+		},
+		{
+			name:     "Custom GitHub Enterprise API",
+			envValue: "https://github.enterprise.com/api/v3",
+			expected: "https://github.enterprise.com/api/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original env value
+			originalValue := os.Getenv("GITHUB_API")
+			defer func() {
+				if originalValue != "" {
+					_ = os.Setenv("GITHUB_API", originalValue)
+				} else {
+					_ = os.Unsetenv("GITHUB_API")
+				}
+			}()
+
+			// Set test env value
+			if tt.envValue != "" {
+				_ = os.Setenv("GITHUB_API", tt.envValue)
+			} else {
+				_ = os.Unsetenv("GITHUB_API")
+			}
+
+			result := GetAPIBase()
+			if result != tt.expected {
+				t.Errorf("GetAPIBase() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetGitHubURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "Default GitHub URL",
+			envValue: "",
+			expected: "https://github.com",
+		},
+		{
+			name:     "Custom GitHub Enterprise URL",
+			envValue: "https://github.enterprise.com",
+			expected: "https://github.enterprise.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original env value
+			originalValue := os.Getenv("GITHUB_URL")
+			defer func() {
+				if originalValue != "" {
+					_ = os.Setenv("GITHUB_URL", originalValue)
+				} else {
+					_ = os.Unsetenv("GITHUB_URL")
+				}
+			}()
+
+			// Set test env value
+			if tt.envValue != "" {
+				_ = os.Setenv("GITHUB_URL", tt.envValue)
+			} else {
+				_ = os.Unsetenv("GITHUB_URL")
+			}
+
+			result := GetGitHubURL()
+			if result != tt.expected {
+				t.Errorf("GetGitHubURL() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "HTTPS URL",
+			url:      "https://github.com",
+			expected: "github.com",
+		},
+		{
+			name:     "HTTPS URL with path",
+			url:      "https://github.com/path/to/something",
+			expected: "github.com",
+		},
+		{
+			name:     "HTTP URL",
+			url:      "http://github.enterprise.com",
+			expected: "github.enterprise.com",
+		},
+		{
+			name:     "URL without protocol",
+			url:      "github.com",
+			expected: "github.com",
+		},
+		{
+			name:     "Enterprise URL",
+			url:      "https://github.enterprise.com/api/v3",
+			expected: "github.enterprise.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractHostname(tt.url)
+			if result != tt.expected {
+				t.Errorf("ExtractHostname(%q) = %q, expected %q", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCreateAuthenticatedURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoURL   string
+		token     string
+		githubURL string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:      "HTTPS repo URL",
+			repoURL:   "https://github.com/owner/repo",
+			token:     "token123",
+			githubURL: "https://github.com",
+			expected:  "https://token123@github.com/owner/repo",
+			expectErr: false,
+		},
+		{
+			name:      "SSH repo URL",
+			repoURL:   "git@github.com:owner/repo.git",
+			token:     "token123",
+			githubURL: "https://github.com",
+			expected:  "https://token123@github.com/owner/repo.git",
+			expectErr: false,
+		},
+		{
+			name:      "Unsupported format",
+			repoURL:   "ftp://example.com/repo",
+			token:     "token123",
+			githubURL: "https://github.com",
+			expected:  "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set GitHub URL environment variable
+			originalValue := os.Getenv("GITHUB_URL")
+			defer func() {
+				if originalValue != "" {
+					_ = os.Setenv("GITHUB_URL", originalValue)
+				} else {
+					_ = os.Unsetenv("GITHUB_URL")
+				}
+			}()
+
+			if tt.githubURL != "" {
+				_ = os.Setenv("GITHUB_URL", tt.githubURL)
+			} else {
+				_ = os.Unsetenv("GITHUB_URL")
+			}
+
+			result, err := CreateAuthenticatedURL(tt.repoURL, tt.token)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("CreateAuthenticatedURL(%q, %q) expected error, got nil", tt.repoURL, tt.token)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("CreateAuthenticatedURL(%q, %q) unexpected error: %v", tt.repoURL, tt.token, err)
+				}
+				if result != tt.expected {
+					t.Errorf("CreateAuthenticatedURL(%q, %q) = %q, expected %q", tt.repoURL, tt.token, result, tt.expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/notification/cli_utils.go
+++ b/pkg/notification/cli_utils.go
@@ -1,0 +1,309 @@
+package notification
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/SherClockHolmes/webpush-go"
+)
+
+// CLIUtils provides utilities for command-line notification operations
+type CLIUtils struct{}
+
+// NewCLIUtils creates a new CLI utilities instance
+func NewCLIUtils() *CLIUtils {
+	return &CLIUtils{}
+}
+
+// GetMatchingSubscriptions retrieves subscriptions matching filter criteria
+func (u *CLIUtils) GetMatchingSubscriptions(userID, userType, username, sessionID string, verbose bool) ([]Subscription, error) {
+	var allSubscriptions []Subscription
+
+	// Get base directory for user data
+	baseDir := os.Getenv("USERHOME_BASEDIR")
+	if baseDir == "" {
+		homeDir := os.Getenv("HOME")
+		if homeDir == "" {
+			homeDir = "/home/agentapi"
+		}
+		baseDir = filepath.Join(homeDir, ".agentapi-proxy")
+	}
+	baseDir = filepath.Join(baseDir, "myclaudes")
+
+	// Check if base directory exists
+	if _, err := os.Stat(baseDir); os.IsNotExist(err) {
+		return allSubscriptions, nil
+	}
+
+	// Read all user directories
+	userDirs, err := os.ReadDir(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read user directories: %w", err)
+	}
+
+	for _, userDir := range userDirs {
+		if !userDir.IsDir() {
+			continue
+		}
+
+		userDirID := userDir.Name()
+		subscriptions, err := u.getSubscriptionsForUser(userDirID)
+		if err != nil {
+			if verbose {
+				fmt.Printf("Warning: failed to read subscriptions for user %s: %v\n", userDirID, err)
+			}
+			continue
+		}
+
+		// Filter subscriptions based on criteria
+		for _, sub := range subscriptions {
+			if u.matchesFilter(sub, userID, userType, username, sessionID) {
+				allSubscriptions = append(allSubscriptions, sub)
+			}
+		}
+	}
+
+	return allSubscriptions, nil
+}
+
+// getSubscriptionsForUser retrieves subscriptions for a specific user
+func (u *CLIUtils) getSubscriptionsForUser(userID string) ([]Subscription, error) {
+	// Get base directory for user data
+	baseDir := os.Getenv("USERHOME_BASEDIR")
+	if baseDir == "" {
+		homeDir := os.Getenv("HOME")
+		if homeDir == "" {
+			homeDir = "/home/agentapi"
+		}
+		baseDir = filepath.Join(homeDir, ".agentapi-proxy")
+	}
+
+	subscriptionsFile := filepath.Join(baseDir, "myclaudes", userID, "notifications", "subscriptions.json")
+
+	if _, err := os.Stat(subscriptionsFile); os.IsNotExist(err) {
+		return []Subscription{}, nil
+	}
+
+	file, err := os.Open(subscriptionsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open subscriptions file: %w", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Printf("Warning: failed to close file: %v\n", err)
+		}
+	}()
+
+	var allSubscriptions []Subscription
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&allSubscriptions); err != nil {
+		// If decode fails, return empty slice
+		return []Subscription{}, nil
+	}
+
+	// Filter active subscriptions
+	var subscriptions []Subscription
+	for _, sub := range allSubscriptions {
+		if sub.Active {
+			subscriptions = append(subscriptions, sub)
+		}
+	}
+
+	return subscriptions, nil
+}
+
+// matchesFilter checks if a subscription matches the filter criteria
+func (u *CLIUtils) matchesFilter(sub Subscription, userID, userType, username, sessionID string) bool {
+	// If user-id is specified, it must match
+	if userID != "" && sub.UserID != userID {
+		return false
+	}
+
+	// If user-type is specified, it must match
+	if userType != "" && sub.UserType != userType {
+		return false
+	}
+
+	// If username is specified, it must match
+	if username != "" && sub.Username != username {
+		return false
+	}
+
+	// If session-id is specified, user must be subscribed to that session
+	if sessionID != "" {
+		// Empty session_ids means subscribed to all sessions
+		if len(sub.SessionIDs) == 0 {
+			return true
+		}
+		// Check if the specified session is in the user's session list
+		for _, sessID := range sub.SessionIDs {
+			if sessID == sessionID {
+				return true
+			}
+		}
+		return false
+	}
+
+	return true
+}
+
+// SendNotifications sends notifications to multiple subscriptions
+func (u *CLIUtils) SendNotifications(subscriptions []Subscription, title, body, url, icon, badge string, ttl int, urgency string, vapidPublicKey, vapidPrivateKey, vapidContactEmail string) ([]NotificationResult, error) {
+	var results []NotificationResult
+
+	for _, sub := range subscriptions {
+		result := NotificationResult{Subscription: sub}
+
+		// Create notification payload
+		payload := map[string]interface{}{
+			"title": title,
+			"body":  body,
+			"icon":  icon,
+			"data": map[string]interface{}{
+				"url": url,
+			},
+		}
+
+		if badge != "" {
+			payload["badge"] = badge
+		}
+
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			result.Error = fmt.Errorf("failed to marshal payload: %w", err)
+			results = append(results, result)
+			continue
+		}
+
+		// Create webpush subscription
+		webpushSub := &webpush.Subscription{
+			Endpoint: sub.Endpoint,
+			Keys: webpush.Keys{
+				P256dh: sub.Keys["p256dh"],
+				Auth:   sub.Keys["auth"],
+			},
+		}
+
+		// Create webpush options
+		options := &webpush.Options{
+			Subscriber:      vapidContactEmail,
+			VAPIDPublicKey:  vapidPublicKey,
+			VAPIDPrivateKey: vapidPrivateKey,
+			TTL:             ttl,
+		}
+
+		switch urgency {
+		case "low":
+			options.Urgency = webpush.UrgencyLow
+		case "high":
+			options.Urgency = webpush.UrgencyHigh
+		default:
+			options.Urgency = webpush.UrgencyNormal
+		}
+
+		// Send notification
+		resp, err := webpush.SendNotification(payloadBytes, webpushSub, options)
+		if err != nil {
+			result.Error = fmt.Errorf("failed to send notification: %w", err)
+		} else if resp.StatusCode >= 400 {
+			result.Error = fmt.Errorf("notification rejected with status %d", resp.StatusCode)
+		}
+
+		if resp != nil {
+			if err := resp.Body.Close(); err != nil {
+				fmt.Printf("Warning: failed to close response body: %v\n", err)
+			}
+		}
+
+		results = append(results, result)
+
+		// Save to history
+		if err := u.saveNotificationHistory(sub, title, body, url, icon, badge, ttl, urgency, result.Error == nil, result.Error); err != nil {
+			fmt.Printf("Warning: failed to save notification history: %v\n", err)
+		}
+	}
+
+	return results, nil
+}
+
+// saveNotificationHistory saves notification history to file
+func (u *CLIUtils) saveNotificationHistory(sub Subscription, title, body, url, icon, badge string, ttl int, urgency string, delivered bool, sendError error) error {
+	// Get base directory for user data
+	baseDir := os.Getenv("USERHOME_BASEDIR")
+	if baseDir == "" {
+		homeDir := os.Getenv("HOME")
+		if homeDir == "" {
+			homeDir = "/home/agentapi"
+		}
+		baseDir = filepath.Join(homeDir, ".agentapi-proxy")
+	}
+
+	historyFile := filepath.Join(baseDir, "myclaudes", sub.UserID, "notifications", "history.jsonl")
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(historyFile), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	history := NotificationHistory{
+		ID:             u.generateNotificationID(),
+		UserID:         sub.UserID,
+		SubscriptionID: sub.ID,
+		Title:          title,
+		Body:           body,
+		Type:           "manual", // Sent via command line
+		Data: map[string]interface{}{
+			"url":     url,
+			"icon":    icon,
+			"badge":   badge,
+			"ttl":     ttl,
+			"urgency": urgency,
+		},
+		SentAt:    time.Now(),
+		Delivered: delivered,
+		Clicked:   false, // Will be updated when clicked
+	}
+
+	if sendError != nil {
+		errorMsg := sendError.Error()
+		history.ErrorMessage = &errorMsg
+	}
+
+	// Append to history file
+	file, err := os.OpenFile(historyFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			fmt.Printf("Warning: failed to close history file: %v\n", err)
+		}
+	}()
+
+	encoder := json.NewEncoder(file)
+	return encoder.Encode(history)
+}
+
+// generateNotificationID generates a unique notification ID
+func (u *CLIUtils) generateNotificationID() string {
+	// Generate 4 random bytes for uniqueness
+	randomBytes := make([]byte, 4)
+	if _, err := rand.Read(randomBytes); err != nil {
+		// Fallback to current time nanoseconds if random fails
+		return fmt.Sprintf("notif_%d_%d", time.Now().Unix(), time.Now().Nanosecond())
+	}
+
+	// Convert to hex and combine with timestamp
+	randomHex := fmt.Sprintf("%x", randomBytes)
+	return fmt.Sprintf("notif_%d_%s", time.Now().Unix(), randomHex)
+}
+
+// NotificationResult represents the result of sending a notification
+type NotificationResult struct {
+	Subscription Subscription
+	Error        error
+}

--- a/pkg/notification/cli_utils_test.go
+++ b/pkg/notification/cli_utils_test.go
@@ -1,0 +1,232 @@
+package notification
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewCLIUtils(t *testing.T) {
+	utils := NewCLIUtils()
+	if utils == nil {
+		t.Error("NewCLIUtils() returned nil")
+	}
+}
+
+func TestCLIUtils_matchesFilter(t *testing.T) {
+	utils := NewCLIUtils()
+
+	sub := Subscription{
+		ID:         "sub1",
+		UserID:     "user123",
+		UserType:   "github",
+		Username:   "testuser",
+		SessionIDs: []string{"session1", "session2"},
+		Active:     true,
+	}
+
+	tests := []struct {
+		name      string
+		userID    string
+		userType  string
+		username  string
+		sessionID string
+		expected  bool
+	}{
+		{
+			name:     "Match all criteria",
+			userID:   "user123",
+			userType: "github",
+			username: "testuser",
+			expected: true,
+		},
+		{
+			name:     "Match userID only",
+			userID:   "user123",
+			expected: true,
+		},
+		{
+			name:     "Match userType only",
+			userType: "github",
+			expected: true,
+		},
+		{
+			name:     "Match username only",
+			username: "testuser",
+			expected: true,
+		},
+		{
+			name:      "Match sessionID in list",
+			sessionID: "session1",
+			expected:  true,
+		},
+		{
+			name:      "Match sessionID not in list",
+			sessionID: "session3",
+			expected:  false,
+		},
+		{
+			name:     "No match userID",
+			userID:   "user456",
+			expected: false,
+		},
+		{
+			name:     "No match userType",
+			userType: "api_key",
+			expected: false,
+		},
+		{
+			name:     "No match username",
+			username: "otheruser",
+			expected: false,
+		},
+		{
+			name:     "No criteria (match all)",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.matchesFilter(sub, tt.userID, tt.userType, tt.username, tt.sessionID)
+			if result != tt.expected {
+				t.Errorf("matchesFilter() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCLIUtils_matchesFilter_EmptySessionIDs(t *testing.T) {
+	utils := NewCLIUtils()
+
+	// Subscription with empty SessionIDs (subscribed to all sessions)
+	sub := Subscription{
+		ID:         "sub1",
+		UserID:     "user123",
+		UserType:   "github",
+		Username:   "testuser",
+		SessionIDs: []string{}, // Empty means subscribed to all sessions
+		Active:     true,
+	}
+
+	result := utils.matchesFilter(sub, "", "", "", "any_session")
+	if !result {
+		t.Error("matchesFilter() should return true for empty SessionIDs (subscribed to all)")
+	}
+}
+
+func TestCLIUtils_generateNotificationID(t *testing.T) {
+	utils := NewCLIUtils()
+
+	id1 := utils.generateNotificationID()
+	if id1 == "" {
+		t.Error("generateNotificationID() returned empty string")
+	}
+
+	// Add small delay to ensure different timestamps
+	time.Sleep(1 * time.Millisecond)
+	id2 := utils.generateNotificationID()
+
+	if id1 == id2 {
+		t.Errorf("generateNotificationID() should generate unique IDs, got: %s == %s", id1, id2)
+	}
+
+	// Check format (should start with "notif_")
+	if len(id1) < 6 || id1[:6] != "notif_" {
+		t.Errorf("generateNotificationID() = %q, expected format 'notif_*'", id1)
+	}
+}
+
+func TestSubscription(t *testing.T) {
+	// Test Subscription struct creation
+	now := time.Now()
+	sub := Subscription{
+		ID:                "test-id",
+		UserID:            "user123",
+		UserType:          "github",
+		Username:          "testuser",
+		Endpoint:          "https://fcm.googleapis.com/endpoint",
+		Keys:              map[string]string{"p256dh": "key1", "auth": "key2"},
+		SessionIDs:        []string{"session1", "session2"},
+		NotificationTypes: []string{"message", "status"},
+		CreatedAt:         now,
+		Active:            true,
+	}
+
+	if sub.ID != "test-id" {
+		t.Errorf("Expected ID to be 'test-id', got %q", sub.ID)
+	}
+
+	if sub.UserID != "user123" {
+		t.Errorf("Expected UserID to be 'user123', got %q", sub.UserID)
+	}
+
+	if !sub.Active {
+		t.Error("Expected Active to be true")
+	}
+
+	if len(sub.SessionIDs) != 2 {
+		t.Errorf("Expected 2 SessionIDs, got %d", len(sub.SessionIDs))
+	}
+}
+
+func TestNotificationHistory(t *testing.T) {
+	// Test NotificationHistory struct creation
+	now := time.Now()
+	errorMsg := "test error"
+
+	history := NotificationHistory{
+		ID:             "hist-id",
+		UserID:         "user123",
+		SubscriptionID: "sub-id",
+		Title:          "Test Title",
+		Body:           "Test Body",
+		Type:           "manual",
+		SessionID:      "session1",
+		Data:           map[string]interface{}{"url": "https://example.com"},
+		SentAt:         now,
+		Delivered:      true,
+		Clicked:        false,
+		ErrorMessage:   &errorMsg,
+	}
+
+	if history.ID != "hist-id" {
+		t.Errorf("Expected ID to be 'hist-id', got %q", history.ID)
+	}
+
+	if history.Title != "Test Title" {
+		t.Errorf("Expected Title to be 'Test Title', got %q", history.Title)
+	}
+
+	if !history.Delivered {
+		t.Error("Expected Delivered to be true")
+	}
+
+	if history.ErrorMessage == nil || *history.ErrorMessage != "test error" {
+		t.Error("Expected ErrorMessage to be set correctly")
+	}
+
+	if url, ok := history.Data["url"].(string); !ok || url != "https://example.com" {
+		t.Error("Expected Data to contain correct URL")
+	}
+}
+
+func TestNotificationResult(t *testing.T) {
+	// Test NotificationResult struct creation
+	sub := Subscription{
+		ID:     "sub-id",
+		UserID: "user123",
+	}
+
+	result := NotificationResult{
+		Subscription: sub,
+		Error:        nil,
+	}
+
+	if result.Subscription.ID != "sub-id" {
+		t.Error("Expected Subscription to be set correctly")
+	}
+
+	if result.Error != nil {
+		t.Error("Expected Error to be nil")
+	}
+}


### PR DESCRIPTION
## Summary
- cmd と pkg ディレクトリ間の重複コードを特定し、pkg に統合するリファクタリングを実施
- 全ての変更箇所にテストを追加し、lint エラーもゼロ件に修正
- コードの保守性と再利用性を大幅に向上

## 主な変更内容

### 🔧 GitHub 処理の統合 (pkg/github/utils.go)
- `ParseRepositoryURL`: 各種Git URL形式のパース処理を統合
- `CreateAuthenticatedURL`: 認証付きURL生成処理を統合
- `GetAPIBase`, `GetGitHubURL`: GitHub API/URL取得処理を統合
- `ExtractHostname`: ホスト名抽出処理を統合

### 📢 通知処理の統合 (pkg/notification/cli_utils.go)  
- `GetMatchingSubscriptions`: 購読情報フィルタリング処理を統合
- `SendNotifications`: 通知送信処理を統合
- `generateNotificationID`: ID生成の一意性を改善（crypto/rand使用）
- 通知履歴保存処理を統合

### 🌐 HTTPクライアント処理の統合 (pkg/client)
- 重複する型定義を pkg/client に統合
- Message, MessageResponse, StatusResponse 等の構造体重複を解消

### 🧹 重複コード削除
- cmd/helpers.go から GitHub URL パース処理を削除
- cmd/client.go から重複型定義を削除  
- cmd/init_github_repo.go を pkg 使用に更新

## Test coverage
- ✅ pkg/github/utils_test.go - GitHub処理の包括的テスト
- ✅ pkg/notification/cli_utils_test.go - 通知処理の包括的テスト
- ✅ 既存テストの pkg 使用への更新

## Quality checks
- ✅ `make lint`: 0 issues
- ✅ `make test`: 全パッケージテスト通過
- ✅ golangci-lint エラー全て修正

🤖 Generated with [Claude Code](https://claude.ai/code)