### PR TITLE
feat: 同一セッションへの通知を3分間に1回に制限

### DIFF
--- a/pkg/notification/json_storage.go
+++ b/pkg/notification/json_storage.go
@@ -181,7 +181,7 @@ func (s *JSONStorage) GetSubscriptions(userID string) ([]Subscription, error) {
 	s.mu.RLock()
 	subscriptions, err := s.loadSubscriptions(userID)
 	s.mu.RUnlock()
-	
+
 	if err != nil {
 		return nil, err
 	}
@@ -209,21 +209,21 @@ func (s *JSONStorage) GetSubscriptions(userID string) ([]Subscription, error) {
 	go func() {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		
+
 		// Re-load subscriptions to avoid stale data
 		currentSubs, err := s.loadSubscriptions(userID)
 		if err != nil {
 			fmt.Printf("Warning: failed to load subscriptions for update: %v\n", err)
 			return
 		}
-		
+
 		// Update last used timestamps
 		for i := range currentSubs {
 			if currentSubs[i].Active && seenEndpoints[currentSubs[i].Endpoint] {
 				currentSubs[i].LastUsed = now
 			}
 		}
-		
+
 		if err := s.saveSubscriptions(userID, currentSubs); err != nil {
 			fmt.Printf("Warning: failed to update last used timestamps: %v\n", err)
 		}


### PR DESCRIPTION
## Summary
- send-notificationコマンドに同一セッションへの通知を3分間に1回に制限する機能を追加
- 作業ディレクトリから自動的にセッションIDを抽出し、重複通知を防止
- Claude.mdの通知ガイドラインに従い、ユーザー体験を向上

## Changes
1. **セッションID自動抽出**: `cmd/helpers.go`で作業ディレクトリからUUID形式のセッションIDを自動抽出
2. **レート制限機能**: `pkg/notification/cli_utils.go`に以下を追加:
   - `hasRecentNotificationForSession()`: 直近3分間の通知履歴をチェック
   - `SendNotifications()`でレート制限チェックを実行
   - 通知履歴にセッションIDを保存
3. **エラーハンドリング**: golintの指摘に従い、ファイルクローズのエラーチェックを追加

## Test plan
- [x] 通知履歴が存在しない場合、通知が送信されることを確認
- [x] 3分以内に同じセッションへ通知を送信しようとした場合、ブロックされることを確認
- [x] 3分経過後は通知が送信できることを確認
- [x] セッションIDが指定されていない場合は、レート制限が適用されないことを確認
- [x] make lintが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)