### PR TITLE
feat: Kubernetes セッションモード時に myclaudesPersistence を自動無効化

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -165,7 +165,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            {{- if .Values.myclaudesPersistence.enabled }}
+            {{- if and .Values.myclaudesPersistence.enabled (not .Values.kubernetesSession.enabled) }}
             - name: myclaudes-data
               mountPath: /home/agentapi/.agentapi-proxy/myclaudes
             {{- end }}
@@ -238,7 +238,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.myclaudesPersistence.enabled }}
+  {{- if and .Values.myclaudesPersistence.enabled (not .Values.kubernetesSession.enabled) }}
   volumeClaimTemplates:
     - metadata:
         name: myclaudes-data

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -69,6 +69,8 @@ resources:
     cpu: 8
 
 # Persistent Volume for myclaudes directory
+# Note: Automatically disabled when kubernetesSession.enabled is true,
+# as credentials are stored in Kubernetes Secrets instead.
 myclaudesPersistence:
   enabled: true
   storageClassName: ""


### PR DESCRIPTION
## Summary

- `kubernetesSession.enabled` が `true` の場合、`myclaudesPersistence` のボリュームマウントと `volumeClaimTemplates` を自動的にスキップ
- Kubernetes セッションモードでは認証情報が Kubernetes Secret に保存されるため、プロキシ Pod の myclaudes ディレクトリを永続化する必要がない
- `values.yaml` にこの動作についてのコメントを追加

## Test plan

- [ ] `kubernetesSession.enabled: false` の場合に `myclaudesPersistence` が有効に動作することを確認
- [ ] `kubernetesSession.enabled: true` の場合に `myclaudesPersistence` が無効化されることを確認
- [ ] Helm テンプレートの出力を `helm template` コマンドで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)