### PR TITLE
feat: Kubernetes Session Pod の PVC 作成を選択可能に

### DIFF
--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -143,6 +143,8 @@ spec:
               value: {{ .Values.kubernetesSession.resources.requests.memory | quote }}
             - name: AGENTAPI_K8S_SESSION_MEMORY_LIMIT
               value: {{ .Values.kubernetesSession.resources.limits.memory | quote }}
+            - name: AGENTAPI_K8S_SESSION_PVC_ENABLED
+              value: {{ .Values.kubernetesSession.pvc.enabled | quote }}
             - name: AGENTAPI_K8S_SESSION_PVC_STORAGE_CLASS
               value: {{ .Values.kubernetesSession.pvc.storageClass | quote }}
             - name: AGENTAPI_K8S_SESSION_PVC_STORAGE_SIZE

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -315,6 +315,9 @@ kubernetesSession:
 
   # PVC configuration for session workdir
   pvc:
+    # Enable PersistentVolumeClaim for session pods workdir
+    # When disabled, EmptyDir is used instead (data is not persisted across pod restarts)
+    enabled: true
     # Storage class for session PVCs (empty for default)
     storageClass: ""
     # Storage size for session PVCs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,6 +143,9 @@ type KubernetesSessionConfig struct {
 	MemoryRequest string `json:"memory_request" mapstructure:"memory_request"`
 	// MemoryLimit is the memory limit for session pods
 	MemoryLimit string `json:"memory_limit" mapstructure:"memory_limit"`
+	// PVCEnabled enables PersistentVolumeClaim for session pods workdir
+	// When disabled, EmptyDir is used instead (data is not persisted across pod restarts)
+	PVCEnabled *bool `json:"pvc_enabled,omitempty" mapstructure:"pvc_enabled"`
 	// PVCStorageClass is the storage class for session PVCs
 	PVCStorageClass string `json:"pvc_storage_class" mapstructure:"pvc_storage_class"`
 	// PVCStorageSize is the storage size for session PVCs
@@ -390,6 +393,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.cpu_limit", "AGENTAPI_K8S_SESSION_CPU_LIMIT")
 	_ = v.BindEnv("kubernetes_session.memory_request", "AGENTAPI_K8S_SESSION_MEMORY_REQUEST")
 	_ = v.BindEnv("kubernetes_session.memory_limit", "AGENTAPI_K8S_SESSION_MEMORY_LIMIT")
+	_ = v.BindEnv("kubernetes_session.pvc_enabled", "AGENTAPI_K8S_SESSION_PVC_ENABLED")
 	_ = v.BindEnv("kubernetes_session.pvc_storage_class", "AGENTAPI_K8S_SESSION_PVC_STORAGE_CLASS")
 	_ = v.BindEnv("kubernetes_session.pvc_storage_size", "AGENTAPI_K8S_SESSION_PVC_STORAGE_SIZE")
 	_ = v.BindEnv("kubernetes_session.pod_start_timeout", "AGENTAPI_K8S_SESSION_POD_START_TIMEOUT")
@@ -436,6 +440,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.cpu_limit", "2")
 	v.SetDefault("kubernetes_session.memory_request", "512Mi")
 	v.SetDefault("kubernetes_session.memory_limit", "4Gi")
+	v.SetDefault("kubernetes_session.pvc_enabled", true)
 	v.SetDefault("kubernetes_session.pvc_storage_class", "")
 	v.SetDefault("kubernetes_session.pvc_storage_size", "10Gi")
 	v.SetDefault("kubernetes_session.pod_start_timeout", 120)


### PR DESCRIPTION
## Summary
- Kubernetes セッションモードで、ワークディレクトリ用の PVC を作成するかどうかを選択可能に
- PVC を無効化すると EmptyDir を使用（Pod 再起動時にデータは失われる）
- デフォルトは有効（従来の動作を維持）

## 変更内容
- `KubernetesSessionConfig` に `PVCEnabled` フィールドを追加
- Helm values に `kubernetesSession.pvc.enabled` オプションを追加
- 環境変数 `AGENTAPI_K8S_SESSION_PVC_ENABLED` で設定可能

## 使用例

```yaml
kubernetesSession:
  enabled: true
  pvc:
    enabled: false  # PVC を無効化し EmptyDir を使用
    storageClass: ""
    storageSize: "10Gi"
```

## Test plan
- [ ] `pvc.enabled: true`（デフォルト）の場合、従来通り PVC が作成されることを確認
- [ ] `pvc.enabled: false` の場合、PVC が作成されず EmptyDir が使用されることを確認
- [ ] セッション削除時に PVC 削除がスキップされることを確認（`pvc.enabled: false` の場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)