### PR TITLE
fix: Kubernetes Session Pod に CLAUDE.md をコピーする処理を追加

### DIFF
--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -474,6 +474,13 @@ if [ -f /claude-config-base/settings.json ]; then
     cp /claude-config-base/settings.json /claude-config/.claude/settings.json
 fi
 
+# Copy CLAUDE.md from embedded location (from Docker image)
+if [ -f /tmp/config/CLAUDE.md ]; then
+    cp /tmp/config/CLAUDE.md /claude-config/.claude/CLAUDE.md
+    chmod 644 /claude-config/.claude/CLAUDE.md
+    echo "CLAUDE.md copied from Docker image"
+fi
+
 # Copy credentials.json from Secret if exists
 if [ -f /claude-credentials/credentials.json ]; then
     cp /claude-credentials/credentials.json /claude-config/.claude/.credentials.json


### PR DESCRIPTION
## Summary
- Kubernetes セッションモードで Session Pod に CLAUDE.md がコピーされていない問題を修正
- `setupClaudeScript` に CLAUDE.md のコピー処理を追加
- Docker イメージに埋め込まれた `/tmp/config/CLAUDE.md` を利用し、Docker モードと同様に `~/.claude/CLAUDE.md` にファイルを配置

## Test plan
- [x] `make lint` - 0 issues
- [x] `make test` - all tests passed
- [ ] Kubernetes 環境でセッションを作成し、Pod 内に `~/.claude/CLAUDE.md` が存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)