### PR TITLE
chore: bump agentapi version from v0.11.2 to v0.11.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM golang:1.25-alpine AS agentapi-builder
 RUN apk add --no-cache git
 
 # Set the agentapi version
-ARG AGENTAPI_VERSION=v0.11.2
+ARG AGENTAPI_VERSION=v0.11.6
 
 # Clone and build agentapi from source
 WORKDIR /agentapi-src


### PR DESCRIPTION
## Summary
- agentapi のバージョンを v0.11.2 から v0.11.6 にアップデート

## Changes
- `Dockerfile` の `AGENTAPI_VERSION` 引数を更新

## Test plan
- [x] `make lint` が通ることを確認
- [x] `make test` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)