### PR TITLE
feat: detect CrashLoopBackOff and report session creation failure

### DIFF
--- a/pkg/proxy/e2e_test.go
+++ b/pkg/proxy/e2e_test.go
@@ -130,6 +130,7 @@ func (s *e2eSession) Addr() string            { return fmt.Sprintf("localhost:%d
 func (s *e2eSession) UserID() string          { return s.userID }
 func (s *e2eSession) Tags() map[string]string { return s.tags }
 func (s *e2eSession) Status() string          { return s.status }
+func (s *e2eSession) ErrorMessage() string    { return "" }
 func (s *e2eSession) StartedAt() time.Time    { return s.startedAt }
 func (s *e2eSession) Cancel() {
 	if s.cancel != nil {

--- a/pkg/proxy/kubernetes_session.go
+++ b/pkg/proxy/kubernetes_session.go
@@ -18,6 +18,7 @@ type kubernetesSession struct {
 	namespace      string
 	startedAt      time.Time
 	status         string
+	errorMessage   string
 	cancelFunc     context.CancelFunc
 	mutex          sync.RWMutex
 }
@@ -50,6 +51,13 @@ func (s *kubernetesSession) Status() string {
 	return s.status
 }
 
+// ErrorMessage returns the error message if the session failed
+func (s *kubernetesSession) ErrorMessage() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.errorMessage
+}
+
 // StartedAt returns when the session was started
 func (s *kubernetesSession) StartedAt() time.Time {
 	return s.startedAt
@@ -67,6 +75,14 @@ func (s *kubernetesSession) setStatus(status string) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.status = status
+}
+
+// setError updates the session status to failed and sets the error message
+func (s *kubernetesSession) setError(errorMessage string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.status = "failed"
+	s.errorMessage = errorMessage
 }
 
 // ServiceDNS returns the Kubernetes Service DNS name for this session

--- a/pkg/proxy/kubernetes_session_test.go
+++ b/pkg/proxy/kubernetes_session_test.go
@@ -1,8 +1,17 @@
 package proxy
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
 )
 
 func TestSanitizeLabelFunctions(t *testing.T) {
@@ -113,5 +122,368 @@ func TestKubernetesSession_Methods(t *testing.T) {
 	expectedDNS := "test-svc.test-ns.svc.cluster.local"
 	if session.ServiceDNS() != expectedDNS {
 		t.Errorf("Expected ServiceDNS %s, got %s", expectedDNS, session.ServiceDNS())
+	}
+
+	// Test ErrorMessage (initially empty)
+	if session.ErrorMessage() != "" {
+		t.Errorf("Expected empty error message, got %s", session.ErrorMessage())
+	}
+
+	// Test setError
+	session.setError("Container 'test' failed: CrashLoopBackOff")
+	if session.Status() != "failed" {
+		t.Errorf("Expected status 'failed' after setError, got %s", session.Status())
+	}
+	if session.ErrorMessage() != "Container 'test' failed: CrashLoopBackOff" {
+		t.Errorf("Expected error message 'Container 'test' failed: CrashLoopBackOff', got %s", session.ErrorMessage())
+	}
+}
+
+func TestKubernetesSession_ErrorMessageThreadSafety(t *testing.T) {
+	session := &kubernetesSession{
+		id:     "test-session",
+		status: "creating",
+		request: &RunServerRequest{
+			UserID: "test-user",
+		},
+	}
+
+	// Test concurrent access to ErrorMessage and setError
+	done := make(chan bool)
+
+	// Writer goroutine
+	go func() {
+		for i := 0; i < 100; i++ {
+			session.setError("error message")
+			session.setStatus("active")
+		}
+		done <- true
+	}()
+
+	// Reader goroutine
+	go func() {
+		for i := 0; i < 100; i++ {
+			_ = session.ErrorMessage()
+			_ = session.Status()
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+}
+
+func TestCheckPodErrorStatus(t *testing.T) {
+	tests := []struct {
+		name             string
+		pods             []corev1.Pod
+		expectedHasError bool
+		expectedContains string
+	}{
+		{
+			name:             "no pods",
+			pods:             []corev1.Pod{},
+			expectedHasError: false,
+			expectedContains: "",
+		},
+		{
+			name: "pod running successfully",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Running: &corev1.ContainerStateRunning{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: false,
+			expectedContains: "",
+		},
+		{
+			name: "container in CrashLoopBackOff",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "CrashLoopBackOff",
+										Message: "back-off 5m0s restarting failed container",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "CrashLoopBackOff",
+		},
+		{
+			name: "container in ImagePullBackOff",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "ImagePullBackOff",
+										Message: "Back-off pulling image",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "ImagePullBackOff",
+		},
+		{
+			name: "init container in CrashLoopBackOff",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						InitContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "clone-repo",
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "CrashLoopBackOff",
+										Message: "back-off",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "Init container 'clone-repo' failed: CrashLoopBackOff",
+		},
+		{
+			name: "init container terminated with error",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						InitContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "setup-claude",
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 1,
+										Reason:   "Error",
+										Message:  "configuration failed",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "Init container 'setup-claude' failed with exit code 1",
+		},
+		{
+			name: "container terminated with error",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 127,
+										Reason:   "ContainerCannotRun",
+										Message:  "command not found",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "terminated with exit code 127",
+		},
+		{
+			name: "container in ErrImagePull",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "ErrImagePull",
+										Message: "rpc error: code = NotFound",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "ErrImagePull",
+		},
+		{
+			name: "container in CreateContainerConfigError",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "CreateContainerConfigError",
+										Message: "secret not found",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: true,
+			expectedContains: "CreateContainerConfigError",
+		},
+		{
+			name: "container waiting for PodInitializing (not an error)",
+			pods: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"agentapi.proxy/session-id": "test-session",
+						},
+					},
+					Status: corev1.PodStatus{
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: "agentapi",
+								State: corev1.ContainerState{
+									Waiting: &corev1.ContainerStateWaiting{
+										Reason:  "PodInitializing",
+										Message: "waiting for init containers",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedHasError: false,
+			expectedContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client with pods
+			fakeClient := fake.NewSimpleClientset()
+			for i := range tt.pods {
+				_, err := fakeClient.CoreV1().Pods("test-ns").Create(
+					context.Background(), &tt.pods[i], metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create pod: %v", err)
+				}
+			}
+
+			// Create manager with fake client
+			cfg := &config.Config{
+				KubernetesSession: config.KubernetesSessionConfig{
+					Enabled:   true,
+					Namespace: "test-ns",
+				},
+			}
+			lgr := logger.NewLogger()
+			manager, err := NewKubernetesSessionManagerWithClient(cfg, false, lgr, fakeClient)
+			if err != nil {
+				t.Fatalf("Failed to create manager: %v", err)
+			}
+
+			// Call checkPodErrorStatus
+			hasError, errorMsg := manager.checkPodErrorStatus("test-session")
+
+			// Verify results
+			if hasError != tt.expectedHasError {
+				t.Errorf("Expected hasError=%v, got %v", tt.expectedHasError, hasError)
+			}
+
+			if tt.expectedContains != "" && !strings.Contains(errorMsg, tt.expectedContains) {
+				t.Errorf("Expected error message to contain '%s', got '%s'", tt.expectedContains, errorMsg)
+			}
+		})
 	}
 }

--- a/pkg/proxy/local_session_manager.go
+++ b/pkg/proxy/local_session_manager.go
@@ -55,6 +55,12 @@ func (s *localSession) Status() string {
 	return s.status
 }
 
+// ErrorMessage returns the error message if the session failed
+// Local sessions don't track error messages, so this always returns empty string
+func (s *localSession) ErrorMessage() string {
+	return ""
+}
+
 // StartedAt returns when the session was started
 func (s *localSession) StartedAt() time.Time {
 	return s.startedAt

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -134,6 +134,7 @@ func (s *mockSession) Addr() string            { return fmt.Sprintf("localhost:%
 func (s *mockSession) UserID() string          { return s.userID }
 func (s *mockSession) Tags() map[string]string { return s.tags }
 func (s *mockSession) Status() string          { return s.status }
+func (s *mockSession) ErrorMessage() string    { return "" }
 func (s *mockSession) StartedAt() time.Time    { return s.startedAt }
 func (s *mockSession) Cancel()                 { s.cancelled = true }
 

--- a/pkg/proxy/session.go
+++ b/pkg/proxy/session.go
@@ -24,6 +24,10 @@ type Session interface {
 	// Status returns the current status of the session
 	Status() string
 
+	// ErrorMessage returns the error message if the session failed
+	// Returns an empty string if there is no error
+	ErrorMessage() string
+
 	// StartedAt returns when the session was started
 	StartedAt() time.Time
 

--- a/pkg/proxy/session_handlers.go
+++ b/pkg/proxy/session_handlers.go
@@ -159,6 +159,10 @@ func (h *SessionHandlers) SearchSessions(c echo.Context) error {
 			"addr":       session.Addr(),
 			"tags":       session.Tags(),
 		}
+		// Include error_message if the session has failed
+		if errorMsg := session.ErrorMessage(); errorMsg != "" {
+			sessionData["error_message"] = errorMsg
+		}
 		filteredSessions = append(filteredSessions, sessionData)
 	}
 


### PR DESCRIPTION
## Summary

- Add functionality to detect Pod container errors (CrashLoopBackOff, ImagePullBackOff, ErrImagePull, CreateContainerConfigError) in Kubernetes sessions
- Report error messages to users via the SearchSessions API response when session fails to start
- Include error detection in both initial session startup and continuous status monitoring

## Changes

- Add `ErrorMessage()` method to `Session` interface
- Add `errorMessage` field and `setError()` method to `kubernetesSession`
- Add `checkPodErrorStatus()` function to check Pod ContainerStatuses for error states
- Integrate Pod error detection in `watchSession()` and `watchDeploymentStatus()`
- Include `error_message` field in SearchSessions API response when session has failed
- Update `getSessionStatusFromDeployment()` to return error messages
- Update `restoreSessionFromService()` to restore error state from Pod status

## Test plan

- [x] Run `make lint` - passes
- [x] Run `make test` - passes
- [ ] Manually test with a session that triggers CrashLoopBackOff (e.g., invalid image or command)
- [ ] Verify error_message is returned in SearchSessions API response for failed sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)