### PR TITLE
feat: sync settings to credentials secret for secure env injection

### DIFF
--- a/internal/infrastructure/services/kubernetes_credentials_secret_syncer.go
+++ b/internal/infrastructure/services/kubernetes_credentials_secret_syncer.go
@@ -1,0 +1,207 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+const (
+	// CredentialsSecretPrefix is the prefix for credentials Secret names
+	CredentialsSecretPrefix = "agent-credentials-"
+	// LabelCredentials is the label key for credentials resources
+	LabelCredentials = "agentapi.proxy/credentials"
+	// LabelCredentialsName is the label key for credentials name
+	LabelCredentialsName = "agentapi.proxy/credentials-name"
+	// LabelManagedBy is the label key for managed-by
+	LabelManagedBy = "agentapi.proxy/managed-by"
+)
+
+// KubernetesCredentialsSecretSyncer implements CredentialsSecretSyncer using Kubernetes Secrets
+type KubernetesCredentialsSecretSyncer struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewKubernetesCredentialsSecretSyncer creates a new KubernetesCredentialsSecretSyncer
+func NewKubernetesCredentialsSecretSyncer(client kubernetes.Interface, namespace string) *KubernetesCredentialsSecretSyncer {
+	return &KubernetesCredentialsSecretSyncer{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// Sync creates or updates the credentials secret based on settings
+func (s *KubernetesCredentialsSecretSyncer) Sync(ctx context.Context, settings *entities.Settings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+
+	secretName := s.secretName(settings.Name())
+	labelValue := sanitizeLabelValue(settings.Name())
+
+	// Build secret data from settings
+	data := s.buildSecretData(settings)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: s.namespace,
+			Labels: map[string]string{
+				LabelCredentials:     "true",
+				LabelCredentialsName: labelValue,
+				LabelManagedBy:       "settings",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+
+	// Try to get existing secret
+	existing, err := s.client.CoreV1().Secrets(s.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create new secret
+			_, err = s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create credentials secret: %w", err)
+			}
+			log.Printf("[CREDENTIALS_SYNCER] Created credentials secret %s", secretName)
+			return nil
+		}
+		return fmt.Errorf("failed to get credentials secret: %w", err)
+	}
+
+	// Check if secret is managed by settings
+	if existing.Labels[LabelManagedBy] != "settings" {
+		// Secret exists but is not managed by settings, skip update
+		log.Printf("[CREDENTIALS_SYNCER] Skipping update for secret %s: not managed by settings", secretName)
+		return nil
+	}
+
+	// Update existing secret
+	secret.ResourceVersion = existing.ResourceVersion
+	_, err = s.client.CoreV1().Secrets(s.namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update credentials secret: %w", err)
+	}
+	log.Printf("[CREDENTIALS_SYNCER] Updated credentials secret %s", secretName)
+
+	return nil
+}
+
+// Delete removes the credentials secret for the given name
+func (s *KubernetesCredentialsSecretSyncer) Delete(ctx context.Context, name string) error {
+	secretName := s.secretName(name)
+
+	// Check if secret exists and is managed by settings
+	existing, err := s.client.CoreV1().Secrets(s.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Secret doesn't exist, nothing to delete
+			return nil
+		}
+		return fmt.Errorf("failed to get credentials secret: %w", err)
+	}
+
+	// Only delete if managed by settings
+	if existing.Labels[LabelManagedBy] != "settings" {
+		log.Printf("[CREDENTIALS_SYNCER] Skipping delete for secret %s: not managed by settings", secretName)
+		return nil
+	}
+
+	err = s.client.CoreV1().Secrets(s.namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete credentials secret: %w", err)
+	}
+	log.Printf("[CREDENTIALS_SYNCER] Deleted credentials secret %s", secretName)
+
+	return nil
+}
+
+// secretName returns the Secret name for the given settings name
+func (s *KubernetesCredentialsSecretSyncer) secretName(name string) string {
+	return CredentialsSecretPrefix + sanitizeSecretName(name)
+}
+
+// buildSecretData builds the secret data from settings
+func (s *KubernetesCredentialsSecretSyncer) buildSecretData(settings *entities.Settings) map[string][]byte {
+	data := make(map[string][]byte)
+
+	bedrock := settings.Bedrock()
+	if bedrock != nil && bedrock.Enabled() {
+		data["ANTHROPIC_BEDROCK"] = []byte("true")
+
+		if bedrock.Region() != "" {
+			data["AWS_REGION"] = []byte(bedrock.Region())
+		}
+		if bedrock.Model() != "" {
+			data["ANTHROPIC_MODEL"] = []byte(bedrock.Model())
+		}
+		if bedrock.AccessKeyID() != "" {
+			data["AWS_ACCESS_KEY_ID"] = []byte(bedrock.AccessKeyID())
+		}
+		if bedrock.SecretAccessKey() != "" {
+			data["AWS_SECRET_ACCESS_KEY"] = []byte(bedrock.SecretAccessKey())
+		}
+		if bedrock.RoleARN() != "" {
+			data["AWS_ROLE_ARN"] = []byte(bedrock.RoleARN())
+		}
+		if bedrock.Profile() != "" {
+			data["AWS_PROFILE"] = []byte(bedrock.Profile())
+		}
+	}
+
+	return data
+}
+
+// sanitizeSecretName sanitizes a string to be used as a Kubernetes Secret name
+// Secret names must be lowercase, alphanumeric, and may contain dashes
+func sanitizeSecretName(s string) string {
+	// Convert to lowercase
+	sanitized := strings.ToLower(s)
+	// Replace non-alphanumeric characters (except dash) with dash
+	re := regexp.MustCompile(`[^a-z0-9-]`)
+	sanitized = re.ReplaceAllString(sanitized, "-")
+	// Remove leading/trailing dashes
+	sanitized = strings.Trim(sanitized, "-")
+	// Collapse multiple dashes
+	re = regexp.MustCompile(`-+`)
+	sanitized = re.ReplaceAllString(sanitized, "-")
+	// Truncate to 253 characters (max Secret name length is 253)
+	maxLen := 253 - len(CredentialsSecretPrefix)
+	if len(sanitized) > maxLen {
+		sanitized = sanitized[:maxLen]
+	}
+	return sanitized
+}
+
+// sanitizeLabelValue sanitizes a string to be used as a Kubernetes label value
+func sanitizeLabelValue(s string) string {
+	// Label values must be 63 characters or less
+	// Must start and end with alphanumeric character (or be empty)
+	// Can contain dashes, underscores, dots, and alphanumerics
+	re := regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
+	sanitized := re.ReplaceAllString(s, "-")
+	// Remove leading/trailing invalid chars
+	sanitized = strings.Trim(sanitized, "-_.")
+	// Truncate to 63 characters
+	if len(sanitized) > 63 {
+		sanitized = sanitized[:63]
+	}
+	// Ensure it ends with alphanumeric
+	sanitized = strings.TrimRight(sanitized, "-_.")
+	return sanitized
+}

--- a/internal/infrastructure/services/kubernetes_credentials_secret_syncer_test.go
+++ b/internal/infrastructure/services/kubernetes_credentials_secret_syncer_test.go
@@ -1,0 +1,358 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+func TestKubernetesCredentialsSecretSyncer_Sync(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Create settings with Bedrock config
+	settings := entities.NewSettings("test-user")
+	bedrock := entities.NewBedrockSettings(true, "us-east-1")
+	bedrock.SetModel("anthropic.claude-sonnet-4-20250514-v1:0")
+	bedrock.SetAccessKeyID("AKIAIOSFODNN7EXAMPLE")
+	bedrock.SetSecretAccessKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	settings.SetBedrock(bedrock)
+
+	err := syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	// Verify Secret was created
+	secret, err := client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-test-user", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+
+	// Verify labels
+	if secret.Labels[LabelCredentials] != "true" {
+		t.Errorf("Expected label %s to be 'true'", LabelCredentials)
+	}
+	if secret.Labels[LabelManagedBy] != "settings" {
+		t.Errorf("Expected label %s to be 'settings'", LabelManagedBy)
+	}
+
+	// Verify data
+	if string(secret.Data["ANTHROPIC_BEDROCK"]) != "true" {
+		t.Error("Expected ANTHROPIC_BEDROCK to be 'true'")
+	}
+	if string(secret.Data["AWS_REGION"]) != "us-east-1" {
+		t.Errorf("Expected AWS_REGION to be 'us-east-1', got '%s'", string(secret.Data["AWS_REGION"]))
+	}
+	if string(secret.Data["ANTHROPIC_MODEL"]) != "anthropic.claude-sonnet-4-20250514-v1:0" {
+		t.Error("Expected ANTHROPIC_MODEL to match")
+	}
+	if string(secret.Data["AWS_ACCESS_KEY_ID"]) != "AKIAIOSFODNN7EXAMPLE" {
+		t.Error("Expected AWS_ACCESS_KEY_ID to match")
+	}
+	if string(secret.Data["AWS_SECRET_ACCESS_KEY"]) != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Error("Expected AWS_SECRET_ACCESS_KEY to match")
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Sync_Update(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Create initial settings
+	settings := entities.NewSettings("update-user")
+	bedrock := entities.NewBedrockSettings(true, "us-east-1")
+	bedrock.SetAccessKeyID("INITIAL_KEY")
+	settings.SetBedrock(bedrock)
+
+	err := syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Failed to sync initial: %v", err)
+	}
+
+	// Update settings
+	newBedrock := entities.NewBedrockSettings(true, "ap-northeast-1")
+	newBedrock.SetAccessKeyID("UPDATED_KEY")
+	settings.SetBedrock(newBedrock)
+
+	err = syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Failed to sync update: %v", err)
+	}
+
+	// Verify Secret was updated
+	secret, err := client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-update-user", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+
+	if string(secret.Data["AWS_REGION"]) != "ap-northeast-1" {
+		t.Errorf("Expected AWS_REGION to be 'ap-northeast-1', got '%s'", string(secret.Data["AWS_REGION"]))
+	}
+	if string(secret.Data["AWS_ACCESS_KEY_ID"]) != "UPDATED_KEY" {
+		t.Errorf("Expected AWS_ACCESS_KEY_ID to be 'UPDATED_KEY', got '%s'", string(secret.Data["AWS_ACCESS_KEY_ID"]))
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Sync_AllFields(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	settings := entities.NewSettings("all-fields")
+	bedrock := entities.NewBedrockSettings(true, "eu-west-1")
+	bedrock.SetModel("anthropic.claude-opus-4-20250514-v1:0")
+	bedrock.SetAccessKeyID("AKIAIOSFODNN7EXAMPLE")
+	bedrock.SetSecretAccessKey("secret-key")
+	bedrock.SetRoleARN("arn:aws:iam::123456789012:role/ExampleRole")
+	bedrock.SetProfile("production")
+	settings.SetBedrock(bedrock)
+
+	err := syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	secret, err := client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-all-fields", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+
+	expectedData := map[string]string{
+		"ANTHROPIC_BEDROCK":     "true",
+		"AWS_REGION":            "eu-west-1",
+		"ANTHROPIC_MODEL":       "anthropic.claude-opus-4-20250514-v1:0",
+		"AWS_ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "secret-key",
+		"AWS_ROLE_ARN":          "arn:aws:iam::123456789012:role/ExampleRole",
+		"AWS_PROFILE":           "production",
+	}
+
+	for key, expected := range expectedData {
+		if string(secret.Data[key]) != expected {
+			t.Errorf("Expected %s to be '%s', got '%s'", key, expected, string(secret.Data[key]))
+		}
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Sync_DisabledBedrock(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Create settings with disabled Bedrock
+	settings := entities.NewSettings("disabled-bedrock")
+	bedrock := entities.NewBedrockSettings(false, "us-east-1")
+	settings.SetBedrock(bedrock)
+
+	err := syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	// Secret should be created but with no Bedrock data
+	secret, err := client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-disabled-bedrock", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+
+	// Should not have ANTHROPIC_BEDROCK key
+	if _, ok := secret.Data["ANTHROPIC_BEDROCK"]; ok {
+		t.Error("Expected no ANTHROPIC_BEDROCK key for disabled bedrock")
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Sync_NilSettings(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	err := syncer.Sync(ctx, nil)
+	if err == nil {
+		t.Error("Expected error for nil settings")
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Sync_SkipsExternalSecret(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Create an external secret (not managed by settings)
+	externalSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-credentials-external-user",
+			Namespace: "default",
+			Labels: map[string]string{
+				LabelCredentials: "true",
+				// No LabelManagedBy label
+			},
+		},
+		Data: map[string][]byte{
+			"CUSTOM_KEY": []byte("custom-value"),
+		},
+	}
+	_, err := client.CoreV1().Secrets("default").Create(ctx, externalSecret, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create external secret: %v", err)
+	}
+
+	// Try to sync settings for the same user
+	settings := entities.NewSettings("external-user")
+	bedrock := entities.NewBedrockSettings(true, "us-east-1")
+	settings.SetBedrock(bedrock)
+
+	err = syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Sync should not fail for external secret: %v", err)
+	}
+
+	// Verify external secret was not modified
+	secret, err := client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-external-user", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get secret: %v", err)
+	}
+
+	// External secret should still have original data
+	if string(secret.Data["CUSTOM_KEY"]) != "custom-value" {
+		t.Error("External secret should not be modified")
+	}
+	if _, ok := secret.Data["ANTHROPIC_BEDROCK"]; ok {
+		t.Error("External secret should not have Bedrock data")
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Delete(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Create settings
+	settings := entities.NewSettings("delete-user")
+	bedrock := entities.NewBedrockSettings(true, "us-east-1")
+	settings.SetBedrock(bedrock)
+
+	err := syncer.Sync(ctx, settings)
+	if err != nil {
+		t.Fatalf("Failed to sync: %v", err)
+	}
+
+	// Verify Secret exists
+	_, err = client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-delete-user", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Secret should exist: %v", err)
+	}
+
+	// Delete
+	err = syncer.Delete(ctx, "delete-user")
+	if err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+
+	// Verify Secret was deleted
+	_, err = client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-delete-user", metav1.GetOptions{})
+	if err == nil {
+		t.Error("Secret should be deleted")
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Delete_NotFound(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Delete non-existent secret should not fail
+	err := syncer.Delete(ctx, "nonexistent")
+	if err != nil {
+		t.Errorf("Delete should not fail for non-existent secret: %v", err)
+	}
+}
+
+func TestKubernetesCredentialsSecretSyncer_Delete_SkipsExternalSecret(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	syncer := NewKubernetesCredentialsSecretSyncer(client, "default")
+	ctx := context.Background()
+
+	// Create an external secret
+	externalSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-credentials-external-delete",
+			Namespace: "default",
+			Labels: map[string]string{
+				LabelCredentials: "true",
+				// No LabelManagedBy = "settings"
+			},
+		},
+		Data: map[string][]byte{
+			"CUSTOM_KEY": []byte("custom-value"),
+		},
+	}
+	_, err := client.CoreV1().Secrets("default").Create(ctx, externalSecret, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create external secret: %v", err)
+	}
+
+	// Try to delete
+	err = syncer.Delete(ctx, "external-delete")
+	if err != nil {
+		t.Fatalf("Delete should not fail: %v", err)
+	}
+
+	// Verify external secret still exists
+	_, err = client.CoreV1().Secrets("default").Get(ctx, "agent-credentials-external-delete", metav1.GetOptions{})
+	if err != nil {
+		t.Error("External secret should not be deleted")
+	}
+}
+
+func TestSanitizeSecretName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"UPPERCASE", "uppercase"},
+		{"with spaces", "with-spaces"},
+		{"org/team-slug", "org-team-slug"},
+		{"user@example.com", "user-example-com"},
+		{"--leading-trailing--", "leading-trailing"},
+		{"multiple---dashes", "multiple-dashes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := sanitizeSecretName(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeSecretName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeLabelValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", "simple"},
+		{"with spaces", "with-spaces"},
+		{"org/team-slug", "org-team-slug"},
+		{"--leading-trailing--", "leading-trailing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := sanitizeLabelValue(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeLabelValue(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/usecases/ports/services/credentials_secret_syncer.go
+++ b/internal/usecases/ports/services/credentials_secret_syncer.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+	"context"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+// CredentialsSecretSyncer defines the interface for syncing settings to credentials secrets
+type CredentialsSecretSyncer interface {
+	// Sync creates or updates the credentials secret based on settings
+	// The credentials secret contains environment variables derived from settings (e.g., Bedrock configuration)
+	Sync(ctx context.Context, settings *entities.Settings) error
+
+	// Delete removes the credentials secret for the given name
+	Delete(ctx context.Context, name string) error
+}


### PR DESCRIPTION
## Summary

- Settings API で設定を更新すると、対応する `agent-credentials-{name}` Secret が自動的に同期されるようになりました
- Bedrock 認証情報（AWS_SECRET_ACCESS_KEY など）が Pod spec に直接露出しなくなり、セキュリティが向上しました
- 外部で管理されている Secret（`agentapi.proxy/managed-by` ラベルがないもの）は上書きされません

## Changes

1. **CredentialsSecretSyncer インターフェースと Kubernetes 実装を追加**
   - `internal/usecases/ports/services/credentials_secret_syncer.go`
   - `internal/infrastructure/services/kubernetes_credentials_secret_syncer.go`

2. **Settings ハンドラに Syncer を統合**
   - `PUT /settings/:name` で設定を保存後、credentials Secret を同期
   - `DELETE /settings/:name` で設定を削除後、credentials Secret を削除

3. **セッション作成時の直接環境変数注入を削除**
   - `addBedrockEnvVars` / `appendBedrockEnvVars` を削除
   - envFrom で `agent-credentials-{name}` Secret からロード

## Architecture

```
Settings API (PUT /settings/:name)
    ↓
SettingsRepository.Save() -- agentapi-settings-{name} Secret 保存
    ↓
CredentialsSecretSyncer.Sync() -- agent-credentials-{name} Secret 更新
    ↓
新規セッション作成時
    ↓
envFrom で agent-credentials-{name} をマウント
    ↓
環境変数として Pod に注入
```

## Test plan

- [x] `make lint` パス
- [x] `make test` パス
- [ ] Kubernetes 環境で Settings API を使用して Bedrock 設定を保存し、credentials Secret が作成されることを確認
- [ ] 新規セッション作成時に envFrom から Bedrock 環境変数が注入されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)