### PR TITLE
fix: remove AWS credentials from GET settings API response

### DIFF
--- a/pkg/proxy/settings_handlers.go
+++ b/pkg/proxy/settings_handlers.go
@@ -247,23 +247,14 @@ func (h *SettingsHandlers) toResponse(settings *entities.Settings) *SettingsResp
 
 	if bedrock := settings.Bedrock(); bedrock != nil {
 		resp.Bedrock = &BedrockSettingsResponse{
-			Enabled:         bedrock.Enabled(),
-			Region:          bedrock.Region(),
-			Model:           bedrock.Model(),
-			AccessKeyID:     bedrock.AccessKeyID(),
-			SecretAccessKey: maskSecret(bedrock.SecretAccessKey()),
-			RoleARN:         bedrock.RoleARN(),
-			Profile:         bedrock.Profile(),
+			Enabled: bedrock.Enabled(),
+			Region:  bedrock.Region(),
+			Model:   bedrock.Model(),
+			// AccessKeyID and SecretAccessKey are not returned for security reasons
+			RoleARN: bedrock.RoleARN(),
+			Profile: bedrock.Profile(),
 		}
 	}
 
 	return resp
-}
-
-// maskSecret masks a secret value for response
-func maskSecret(secret string) string {
-	if secret == "" {
-		return ""
-	}
-	return "***"
 }


### PR DESCRIPTION
## Summary

- Remove `access_key_id` and `secret_access_key` fields from GET `/settings/:name` API response for security reasons
- Delete unused `maskSecret` helper function
- Credentials can still be stored and updated via PUT requests, but are no longer exposed in GET responses

## Test plan

- [x] Run `make lint` - passed
- [x] Run `make test` - all tests pass
- [ ] Manually verify GET settings API no longer returns AWS credentials
- [ ] Verify PUT settings API still accepts and stores credentials correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)