### PR TITLE
fix: handle empty notification-subscriptions-source directory gracefully

### DIFF
--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -496,9 +496,13 @@ fi
 
 # Copy notification subscriptions from Secret to writable EmptyDir
 # Use -L to follow symlinks (Secret mounts use symlinks)
-if [ -d /notification-subscriptions-source ] && [ "$(ls -A /notification-subscriptions-source 2>/dev/null)" ]; then
-    cp -rL /notification-subscriptions-source/* /notifications/
-    echo "Notification subscriptions copied"
+# Use find to avoid glob expansion issues when directory is empty
+if [ -d /notification-subscriptions-source ]; then
+    file_count=$(find /notification-subscriptions-source -maxdepth 1 -type f 2>/dev/null | wc -l)
+    if [ "$file_count" -gt 0 ]; then
+        cp -rL /notification-subscriptions-source/* /notifications/
+        echo "Notification subscriptions copied"
+    fi
 fi
 
 # Set permissions (running as user 999)


### PR DESCRIPTION
## Summary
- notification-subscriptions Secret がオプションで存在しない場合、ディレクトリが空になることがあります
- 以前のグロブパターン `*` は、ファイルがない場合に `cannot stat` エラーで失敗していました
- `find` コマンドを使用してファイル数を確認し、ディレクトリが空の場合のシェルグロブ展開の問題を回避しました

## Changes
- `setupClaudeScript` の通知サブスクリプションコピー処理を修正
- `ls -A` から `find -maxdepth 1 -type f | wc -l` に変更し、ファイルが存在する場合のみコピーを実行

## Test plan
- [x] `make lint` 通過
- [x] `make test` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)