### PR TITLE
feat: add Cache-Control header with 30s TTL to /user/info endpoint

### DIFF
--- a/pkg/proxy/user_handlers.go
+++ b/pkg/proxy/user_handlers.go
@@ -45,5 +45,6 @@ func (h *UserHandlers) GetUserInfo(c echo.Context) error {
 		}
 	}
 
+	c.Response().Header().Set("Cache-Control", "max-age=30")
 	return c.JSON(http.StatusOK, response)
 }

--- a/pkg/proxy/user_handlers_test.go
+++ b/pkg/proxy/user_handlers_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+func TestGetUserInfo_CacheControlHeader(t *testing.T) {
+	e := echo.New()
+
+	h := &UserHandlers{}
+
+	// Create user with GitHub info
+	user := entities.NewUser(
+		entities.UserID("test-user"),
+		entities.UserTypeGitHub,
+		"test-user",
+	)
+	info := entities.NewGitHubUserInfo(123, "testuser", "Test User", "test@example.com", "", "", "")
+	user.SetGitHubInfo(info, []entities.GitHubTeamMembership{
+		{Organization: "org1", TeamSlug: "team1"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/user/info", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("internal_user", user)
+
+	err := h.GetUserInfo(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "max-age=30", rec.Header().Get("Cache-Control"))
+}
+
+func TestGetUserInfo_Unauthorized(t *testing.T) {
+	e := echo.New()
+
+	h := &UserHandlers{}
+
+	req := httptest.NewRequest(http.MethodGet, "/user/info", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// No user set in context
+
+	err := h.GetUserInfo(c)
+	assert.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
+}


### PR DESCRIPTION
## Summary
- `/user/info` エンドポイントに `Cache-Control: max-age=30` ヘッダーを追加
- クライアントがユーザー情報を30秒間キャッシュできるようになります
- ユーザーハンドラーのテストを追加

## Test plan
- [x] `make lint` が成功することを確認
- [x] `make test` が成功することを確認
- [x] 新しいテスト `TestGetUserInfo_CacheControlHeader` でヘッダーが正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)