### PR TITLE
feat: reduce GitHub auth cache TTL from 1 hour to 30 seconds

### DIFF
--- a/pkg/auth/github.go
+++ b/pkg/auth/github.go
@@ -65,7 +65,7 @@ type GitHubAuthProvider struct {
 // NewGitHubAuthProvider creates a new GitHub authentication provider
 func NewGitHubAuthProvider(cfg *config.GitHubAuthConfig) *GitHubAuthProvider {
 	// Use very short cache TTL in tests to reduce race conditions
-	cacheTTL := 1 * time.Hour
+	cacheTTL := 30 * time.Second
 	if isTestEnvironment() {
 		cacheTTL = 1 * time.Millisecond // Very short TTL for tests
 	}


### PR DESCRIPTION
## Summary
- GitHub認証キャッシュのTTLを1時間から30秒に短縮
- ユーザーのパーミッションやチームメンバーシップの変更がより速く反映されるようになります

## 変更箇所
- `pkg/auth/github.go:68` - `cacheTTL` を `1 * time.Hour` から `30 * time.Second` に変更

## Test plan
- [x] `make lint` が成功することを確認
- [x] `make test` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)