### PR TITLE
refactor: simplify initial message to use only params.message

### DIFF
--- a/pkg/proxy/e2e_test.go
+++ b/pkg/proxy/e2e_test.go
@@ -284,7 +284,9 @@ func TestE2ESessionLifecycle(t *testing.T) {
 		Environment: map[string]string{
 			"TEST_ENV": "e2e_test",
 		},
-		Message: "Hello from e2e test",
+		Params: &SessionParams{
+			Message: "Hello from e2e test",
+		},
 	}
 
 	body, _ := json.Marshal(startReq)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -318,17 +318,10 @@ func (p *Proxy) CreateSession(sessionID string, startReq StartRequest, userID, u
 	// Extract repository information from tags
 	repoInfo := p.extractRepositoryInfo(sessionID, startReq.Tags)
 
-	// Determine initial message - priority: Params.Message > tags.message > Message (backward compat)
+	// Determine initial message from Params.Message
 	var initialMessage string
 	if startReq.Params != nil && startReq.Params.Message != "" {
 		initialMessage = startReq.Params.Message
-	} else if startReq.Tags != nil {
-		if msg, exists := startReq.Tags["message"]; exists && msg != "" {
-			initialMessage = msg
-		}
-	}
-	if initialMessage == "" && startReq.Message != "" {
-		initialMessage = startReq.Message
 	}
 
 	// Build run server request

--- a/pkg/proxy/session_handlers.go
+++ b/pkg/proxy/session_handlers.go
@@ -91,7 +91,7 @@ func (h *SessionHandlers) StartSession(c echo.Context) error {
 	session, err := h.proxy.CreateSession(sessionID, StartRequest{
 		Environment: startReq.Environment,
 		Tags:        startReq.Tags,
-		Message:     startReq.Message,
+		Params:      startReq.Params,
 	}, userID, userRole, teams)
 	if err != nil {
 		log.Printf("Failed to create session: %v", err)

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -12,9 +12,6 @@ type StartRequest struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 	// Params contains session parameters
 	Params *SessionParams `json:"params,omitempty"`
-	// Message is the initial message (deprecated: use Params.Message instead)
-	// Kept for backward compatibility
-	Message string `json:"message,omitempty"`
 }
 
 // RepositoryInfo contains repository information extracted from tags


### PR DESCRIPTION
## Summary
- Remove `StartRequest.Message` field (deprecated backward compatibility field)
- Remove `Tags["message"]` fallback for initial message specification
- Simplify initial message logic to only use `params.message`

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- All existing tests updated to use `params.message` instead of deprecated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)