### PR TITLE
feat: support params.github_token for direct GitHub token authentication

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
             - name: AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME
               value: {{ printf "%s-github-session" (include "agentapi-proxy.fullname" .) | quote }}
             {{- end }}
+            {{- if or .Values.github.enterprise.apiUrl .Values.github.enterprise.baseUrl }}
+            - name: AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME
+              value: {{ printf "%s-github-config" (include "agentapi-proxy.fullname" .) | quote }}
+            {{- end }}
             {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations }}
             - name: AGENTAPI_K8S_SESSION_CONFIG_FILE
               value: "/etc/k8s-session-config/k8s-session-config.yaml"

--- a/helm/agentapi-proxy/templates/github-session-secret.yaml
+++ b/helm/agentapi-proxy/templates/github-session-secret.yaml
@@ -2,7 +2,7 @@
 {{- $hasApp := and .Values.github.app.id .Values.github.app.privateKey.secretName }}
 {{- if and .Values.kubernetesSession.enabled (or $hasToken $hasApp) }}
 {{- /*
-  GitHub Session Secret
+  GitHub Session Secret (Authentication)
   This Secret contains GitHub authentication credentials for the clone-repo init container
   in session pods. Uses existing github settings from values.yaml.
 
@@ -12,6 +12,9 @@
 
   The PEM content is read from the existing Secret specified in github.app.privateKey.secretName
   using Helm's lookup function. This requires the PEM Secret to exist before running helm install/upgrade.
+
+  Note: GITHUB_API and GITHUB_URL are in a separate Secret (github-config) so that
+  params.github_token can override authentication without losing Enterprise Server settings.
 */}}
 {{- $pemSecret := "" }}
 {{- $pemKey := .Values.github.app.privateKey.key | default "private-key" }}
@@ -46,8 +49,28 @@ stringData:
   {{- if .Values.github.app.installationId }}
   GITHUB_INSTALLATION_ID: {{ .Values.github.app.installationId | quote }}
   {{- end }}
-  {{- /* GitHub Enterprise API URL from github.enterprise settings */}}
+{{- end }}
+---
+{{- /*
+  GitHub Config Secret (Enterprise Server Settings)
+  This Secret contains GitHub Enterprise Server URL settings.
+  Kept separate from authentication credentials so that params.github_token
+  can override GITHUB_TOKEN without losing GITHUB_API and GITHUB_URL settings.
+*/}}
+{{- if and .Values.kubernetesSession.enabled (or .Values.github.enterprise.apiUrl .Values.github.enterprise.baseUrl) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-github-config
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: github-config
+type: Opaque
+stringData:
   {{- if .Values.github.enterprise.apiUrl }}
   GITHUB_API: {{ .Values.github.enterprise.apiUrl | quote }}
+  {{- end }}
+  {{- if .Values.github.enterprise.baseUrl }}
+  GITHUB_URL: {{ .Values.github.enterprise.baseUrl | quote }}
   {{- end }}
 {{- end }}

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -158,6 +158,10 @@ spec:
             - name: AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME
               value: {{ printf "%s-github-session" (include "agentapi-proxy.fullname" .) | quote }}
             {{- end }}
+            {{- if or .Values.github.enterprise.apiUrl .Values.github.enterprise.baseUrl }}
+            - name: AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME
+              value: {{ printf "%s-github-config" (include "agentapi-proxy.fullname" .) | quote }}
+            {{- end }}
             {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations }}
             - name: AGENTAPI_K8S_SESSION_CONFIG_FILE
               value: "/etc/k8s-session-config/k8s-session-config.yaml"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -165,8 +165,13 @@ type KubernetesSessionConfig struct {
 	InitContainerImage string `json:"init_container_image" mapstructure:"init_container_image"`
 	// GitHubSecretName is the name of the Kubernetes Secret containing GitHub authentication credentials
 	// This Secret is used by the clone-repo init container for repository cloning
-	// Expected keys: GITHUB_TOKEN, GITHUB_APP_ID, GITHUB_APP_PEM, GITHUB_INSTALLATION_ID, GITHUB_API
+	// Expected keys: GITHUB_TOKEN, GITHUB_APP_ID, GITHUB_APP_PEM, GITHUB_INSTALLATION_ID
 	GitHubSecretName string `json:"github_secret_name" mapstructure:"github_secret_name"`
+	// GitHubConfigSecretName is the name of the Kubernetes Secret containing GitHub configuration (non-auth)
+	// This Secret contains GITHUB_API and GITHUB_URL for GitHub Enterprise Server support
+	// It is kept separate from GitHubSecretName so that params.github_token can override authentication
+	// without losing Enterprise Server URL settings
+	GitHubConfigSecretName string `json:"github_config_secret_name" mapstructure:"github_config_secret_name"`
 	// ConfigFile is the path to an external configuration file for kubernetes session settings
 	// This file can contain node_selector and tolerations settings
 	ConfigFile string `json:"config_file,omitempty" mapstructure:"config_file"`
@@ -416,6 +421,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.claude_config_user_configmap_prefix", "AGENTAPI_K8S_SESSION_CLAUDE_CONFIG_USER_CONFIGMAP_PREFIX")
 	_ = v.BindEnv("kubernetes_session.init_container_image", "AGENTAPI_K8S_SESSION_INIT_CONTAINER_IMAGE")
 	_ = v.BindEnv("kubernetes_session.github_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME")
+	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")
 
 	// MCP servers configuration

--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -615,10 +615,32 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 		workingDir = "/home/agentapi/workdir/repo"
 	}
 
-	// Build envFrom for GitHub secret (used for GitHub authentication in session)
+	// Build envFrom for GitHub secrets
+	// Two secrets are used:
+	// - GitHubSecretName: Contains GITHUB_TOKEN, GITHUB_APP_PEM, GITHUB_APP_ID, GITHUB_INSTALLATION_ID (authentication)
+	// - GitHubConfigSecretName: Contains GITHUB_API, GITHUB_URL (configuration for Enterprise Server)
 	var envFrom []corev1.EnvFromSource
+
 	if req.GithubToken != "" {
-		// Use session-specific GitHub token Secret when params.github_token is provided
+		// When params.github_token is provided:
+		// - Do NOT mount GitHubSecretName (to avoid exposing GITHUB_APP_PEM and other auth credentials)
+		// - Mount GitHubConfigSecretName for GITHUB_API/GITHUB_URL settings
+		// - Mount session-specific Secret for GITHUB_TOKEN
+
+		// Mount GitHub config Secret (GITHUB_API, GITHUB_URL) if available
+		if m.k8sConfig.GitHubConfigSecretName != "" {
+			envFrom = append(envFrom, corev1.EnvFromSource{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: m.k8sConfig.GitHubConfigSecretName,
+					},
+					Optional: boolPtr(true),
+				},
+			})
+			log.Printf("[K8S_SESSION] Mounting GitHub config Secret %s for session %s", m.k8sConfig.GitHubConfigSecretName, session.id)
+		}
+
+		// Mount session-specific Secret for GITHUB_TOKEN
 		githubTokenSecretName := fmt.Sprintf("%s-github-token", session.serviceName)
 		envFrom = append(envFrom, corev1.EnvFromSource{
 			SecretRef: &corev1.SecretEnvSource{
@@ -630,7 +652,9 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 		})
 		log.Printf("[K8S_SESSION] Using session-specific GitHub token Secret %s for session %s", githubTokenSecretName, session.id)
 	} else if m.k8sConfig.GitHubSecretName != "" {
-		// Fall back to GitHub App Secret when params.github_token is not provided
+		// When params.github_token is NOT provided:
+		// - Mount GitHubSecretName for full GitHub App authentication
+		// - Also mount GitHubConfigSecretName (config values will override auth secret if same keys exist)
 		envFrom = append(envFrom, corev1.EnvFromSource{
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -639,6 +663,18 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 				Optional: boolPtr(true),
 			},
 		})
+
+		// Mount GitHub config Secret if available (for any additional config)
+		if m.k8sConfig.GitHubConfigSecretName != "" {
+			envFrom = append(envFrom, corev1.EnvFromSource{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: m.k8sConfig.GitHubConfigSecretName,
+					},
+					Optional: boolPtr(true),
+				},
+			})
+		}
 	}
 
 	// Add team-based credentials Secrets (agent-credentials-{org}-{team})
@@ -1224,26 +1260,16 @@ func (m *KubernetesSessionManager) deleteInitialMessageSecret(ctx context.Contex
 	return nil
 }
 
-// createGithubTokenSecret creates a Secret containing GitHub credentials
-// This is used when params.github_token is provided instead of GitHub App authentication
-// It also includes GITHUB_API and GITHUB_URL if provided for Enterprise Server support
+// createGithubTokenSecret creates a Secret containing the GitHub token
+// This is used when params.github_token is provided to override GITHUB_TOKEN
+// from GitHubSecretName. Other GitHub settings (GITHUB_API, GITHUB_URL) are
+// still read from GitHubSecretName.
 func (m *KubernetesSessionManager) createGithubTokenSecret(
 	ctx context.Context,
 	session *kubernetesSession,
 	token string,
 ) error {
 	secretName := fmt.Sprintf("%s-github-token", session.serviceName)
-
-	// Build secret data with GitHub token and optional API/URL settings
-	secretData := map[string]string{
-		"GITHUB_TOKEN": token,
-	}
-	if session.request.GithubApi != "" {
-		secretData["GITHUB_API"] = session.request.GithubApi
-	}
-	if session.request.GithubUrl != "" {
-		secretData["GITHUB_URL"] = session.request.GithubUrl
-	}
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1255,8 +1281,10 @@ func (m *KubernetesSessionManager) createGithubTokenSecret(
 				"agentapi.proxy/resource":   "github-token",
 			},
 		},
-		Type:       corev1.SecretTypeOpaque,
-		StringData: secretData,
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"GITHUB_TOKEN": token,
+		},
 	}
 
 	_, err := m.client.CoreV1().Secrets(m.namespace).Create(ctx, secret, metav1.CreateOptions{})

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -324,12 +324,10 @@ func (p *Proxy) CreateSession(sessionID string, startReq StartRequest, userID, u
 		initialMessage = startReq.Params.Message
 	}
 
-	// Determine GitHub settings from Params
-	var githubToken, githubApi, githubUrl string
-	if startReq.Params != nil {
+	// Determine GitHub token from Params.GithubToken
+	var githubToken string
+	if startReq.Params != nil && startReq.Params.GithubToken != "" {
 		githubToken = startReq.Params.GithubToken
-		githubApi = startReq.Params.GithubApi
-		githubUrl = startReq.Params.GithubUrl
 	}
 
 	// Build run server request
@@ -341,8 +339,6 @@ func (p *Proxy) CreateSession(sessionID string, startReq StartRequest, userID, u
 		InitialMessage: initialMessage,
 		Teams:          teams,
 		GithubToken:    githubToken,
-		GithubApi:      githubApi,
-		GithubUrl:      githubUrl,
 	}
 
 	// Delegate to session manager

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -6,10 +6,6 @@ type SessionParams struct {
 	Message string `json:"message,omitempty"`
 	// GithubToken is a GitHub token to use for authentication instead of GitHub App
 	GithubToken string `json:"github_token,omitempty"`
-	// GithubApi is the GitHub API URL for Enterprise Server (e.g., https://github.enterprise.com/api/v3)
-	GithubApi string `json:"github_api,omitempty"`
-	// GithubUrl is the GitHub URL for Enterprise Server (e.g., https://github.enterprise.com)
-	GithubUrl string `json:"github_url,omitempty"`
 }
 
 // StartRequest represents the request body for starting a new agentapi server
@@ -36,6 +32,4 @@ type RunServerRequest struct {
 	InitialMessage string
 	Teams          []string // GitHub team slugs (e.g., ["org/team-a", "org/team-b"])
 	GithubToken    string   // GitHub token passed via params.github_token
-	GithubApi      string   // GitHub API URL passed via params.github_api
-	GithubUrl      string   // GitHub URL passed via params.github_url
 }


### PR DESCRIPTION
## Summary

- `params.github_token` が指定された場合、GitHub App 認証をスキップして直接 GitHub Token を使用
- セッション専用の Kubernetes Secret を作成し、`GITHUB_TOKEN` 環境変数としてマウント
- GitHub App が設定されていない環境や、ユーザー独自のトークンを使用したい場合に対応

## Changes

- `pkg/proxy/types.go`: `SessionParams.GithubToken` と `RunServerRequest.GithubToken` を追加
- `pkg/proxy/proxy.go`: `CreateSession` で `params.github_token` を `RunServerRequest` に渡す
- `pkg/proxy/kubernetes_session_manager.go`:
  - `createGithubTokenSecret()` メソッドを追加
  - `buildDeployment` で `params.github_token` が設定されている場合、専用 Secret を使用するよう条件分岐

## Test plan

- [ ] `make lint` 通過
- [ ] `make test` 通過
- [ ] `params.github_token` を指定してセッション開始し、`GITHUB_TOKEN` が設定されることを確認
- [ ] `params.github_token` を指定しない場合、従来の GitHub App 認証が使用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)