### PR TITLE
fix: Add nil checks for scheduleWorker and kubernetesSession in templates

### DIFF
--- a/helm/agentapi-proxy/templates/role.yaml
+++ b/helm/agentapi-proxy/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.kubernetesSession.enabled .Values.scheduleWorker.enabled }}
+{{- if or (and .Values.kubernetesSession .Values.kubernetesSession.enabled) (and .Values.scheduleWorker .Values.scheduleWorker.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "agentapi-proxy.labels" . | nindent 4 }}
 rules:
-  {{- if .Values.kubernetesSession.enabled }}
+  {{- if and .Values.kubernetesSession .Values.kubernetesSession.enabled }}
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch", "create", "delete"]
@@ -26,7 +26,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create"]
-  {{- if .Values.scheduleWorker.enabled }}
+  {{- if and .Values.scheduleWorker .Values.scheduleWorker.enabled }}
   # Leader election for schedule worker
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/helm/agentapi-proxy/templates/rolebinding.yaml
+++ b/helm/agentapi-proxy/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.kubernetesSession.enabled .Values.scheduleWorker.enabled }}
+{{- if or (and .Values.kubernetesSession .Values.kubernetesSession.enabled) (and .Values.scheduleWorker .Values.scheduleWorker.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
## Summary
- `scheduleWorker` や `kubernetesSession` が values.yaml で定義されていない場合に発生する nil ポインタエラーを修正
- `.enabled` プロパティにアクセスする前に nil チェックを追加

## 修正内容
- `role.yaml`: 1行目、9行目、29行目の条件式に nil チェックを追加
- `rolebinding.yaml`: 1行目の条件式に nil チェックを追加

## エラー例
```
template: agentapi-proxy/templates/role.yaml:29:16: executing "agentapi-proxy/templates/role.yaml" at <.Values.scheduleWorker.enabled>: nil pointer evaluating interface {}.enabled
```

## Test plan
- [ ] `scheduleWorker` を values.yaml で定義せずに helm template を実行してエラーが発生しないことを確認
- [ ] `kubernetesSession` を values.yaml で定義せずに helm template を実行してエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)