### PR TITLE
fix: Register schedule handlers in router to fix 404 error

### DIFF
--- a/pkg/schedule/handlers.go
+++ b/pkg/schedule/handlers.go
@@ -42,7 +42,8 @@ func (h *Handlers) GetName() string {
 }
 
 // RegisterRoutes registers schedule management routes
-func (h *Handlers) RegisterRoutes(e *echo.Echo) error {
+// Implements the proxy.CustomHandler interface
+func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *proxy.Proxy) error {
 	g := e.Group("/schedules")
 
 	g.POST("", h.CreateSchedule)


### PR DESCRIPTION
## Summary
- Schedule handlers were implemented in #357 but not registered with the router, causing 404 errors when accessing `/schedules` endpoints
- Updated `schedule.Handlers.RegisterRoutes` to implement the `CustomHandler` interface
- Added `AddCustomHandler` method to `Proxy` for post-initialization handler registration
- Register schedule handlers in `server.go` when Kubernetes mode is enabled

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [ ] Verify `/schedules` endpoints are accessible in Kubernetes environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)