### PR TITLE
feat: separate session ServiceAccount and Role for security

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT
-              value: {{ .Values.kubernetesSession.serviceAccount | quote }}
+              value: {{ .Values.kubernetesSession.serviceAccount | default (printf "%s-session" (include "agentapi-proxy.fullname" .)) | quote }}
             - name: AGENTAPI_K8S_SESSION_BASE_PORT
               value: {{ .Values.kubernetesSession.basePort | quote }}
             - name: AGENTAPI_K8S_SESSION_CPU_REQUEST

--- a/helm/agentapi-proxy/templates/session-role.yaml
+++ b/helm/agentapi-proxy/templates/session-role.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.kubernetesSession .Values.kubernetesSession.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-session
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+rules:
+  # Minimal permissions for session pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/helm/agentapi-proxy/templates/session-rolebinding.yaml
+++ b/helm/agentapi-proxy/templates/session-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.kubernetesSession .Values.kubernetesSession.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-session
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentapi-proxy.fullname" . }}-session
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "agentapi-proxy.fullname" . }}-session
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/agentapi-proxy/templates/session-serviceaccount.yaml
+++ b/helm/agentapi-proxy/templates/session-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.kubernetesSession .Values.kubernetesSession.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-session
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+automountServiceAccountToken: true
+{{- end }}

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -133,7 +133,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT
-              value: {{ .Values.kubernetesSession.serviceAccount | quote }}
+              value: {{ .Values.kubernetesSession.serviceAccount | default (printf "%s-session" (include "agentapi-proxy.fullname" .)) | quote }}
             - name: AGENTAPI_K8S_SESSION_BASE_PORT
               value: {{ .Values.kubernetesSession.basePort | quote }}
             - name: AGENTAPI_K8S_SESSION_CPU_REQUEST

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -302,7 +302,9 @@ kubernetesSession:
   imagePullPolicy: "IfNotPresent"
 
   # Service account for session pods
-  serviceAccount: "default"
+  # When empty, uses the auto-created session service account (agentapi-proxy-session)
+  # This SA has minimal permissions (pods, configmaps read-only) and cannot access secrets
+  serviceAccount: ""
 
   # Base port that agentapi listens on in session pods
   basePort: 9000


### PR DESCRIPTION
## Summary
- セッションPod用に専用のServiceAccount (`agentapi-proxy-session`) を作成
- 最小限の権限を持つRole (pods, configmaps の read-only) を作成
- セッションからSecretsにアクセスできなくなり、セキュリティが向上
- deployment.yaml と statefulset.yaml を更新してセッションSAをデフォルトで使用
- `kubernetesSession.serviceAccount` のデフォルト値を空に変更 (自動作成されるSAを使用)

## Changes
- NEW: `helm/agentapi-proxy/templates/session-serviceaccount.yaml`
- NEW: `helm/agentapi-proxy/templates/session-role.yaml`
- NEW: `helm/agentapi-proxy/templates/session-rolebinding.yaml`
- MODIFIED: `helm/agentapi-proxy/values.yaml`
- MODIFIED: `helm/agentapi-proxy/templates/deployment.yaml`
- MODIFIED: `helm/agentapi-proxy/templates/statefulset.yaml`

## Test plan
- [x] `make lint` passed
- [x] `make test` passed
- [ ] Deploy to staging and verify session pods use the new ServiceAccount
- [ ] Verify session pods cannot access Secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)