### PR TITLE
fix: Use ServiceAccount from config for session pods

### DIFF
--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -811,7 +811,7 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "agentapi-proxy",
+					ServiceAccountName: m.k8sConfig.ServiceAccount,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup:    int64Ptr(999),
 						RunAsUser:  int64Ptr(999),

--- a/pkg/proxy/kubernetes_session_manager_test.go
+++ b/pkg/proxy/kubernetes_session_manager_test.go
@@ -838,9 +838,9 @@ func TestKubernetesSessionManager_DeploymentSpec(t *testing.T) {
 
 	// Verify pod spec
 	podSpec := deployment.Spec.Template.Spec
-	// ServiceAccount is always fixed to "agentapi-proxy" regardless of config
-	if podSpec.ServiceAccountName != "agentapi-proxy" {
-		t.Errorf("Expected service account 'agentapi-proxy', got %s", podSpec.ServiceAccountName)
+	// ServiceAccount should come from config
+	if podSpec.ServiceAccountName != "custom-sa" {
+		t.Errorf("Expected service account 'custom-sa', got %s", podSpec.ServiceAccountName)
 	}
 
 	// Verify security context


### PR DESCRIPTION
## Summary

- セッション Pod の ServiceAccount がハードコードされていた問題を修正
- `m.k8sConfig.ServiceAccount` を使用するように変更
- PR #361 で作成された `agentapi-proxy-session` ServiceAccount が実際に使用されるようになった

## 問題

`kubernetes_session_manager.go:814` で ServiceAccount が `"agentapi-proxy"` にハードコードされていたため、Helm で設定した `kubernetesSession.serviceAccount` の値が無視されていました。

## 修正内容

```go
// Before (問題)
ServiceAccountName: "agentapi-proxy",

// After (修正後)
ServiceAccountName: m.k8sConfig.ServiceAccount,
```

## Test plan

- [x] `make lint` - 成功
- [x] `make test` - 成功
- [x] `TestKubernetesSessionManager_DeploymentSpec` のテストを更新し、設定から ServiceAccount が読み込まれることを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)