### PR TITLE
feat: Delete previous session when schedule starts

### DIFF
--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -146,6 +146,8 @@ func (w *Worker) executeSchedule(ctx context.Context, schedule *Schedule) {
 			w.updateNextExecution(ctx, schedule)
 			return
 		}
+		// Delete previous session if it's no longer active
+		w.deletePreviousSession(schedule.LastExecution.SessionID)
 	}
 
 	// Create session
@@ -235,6 +237,15 @@ func (w *Worker) isSessionActive(sessionID string) bool {
 	}
 	status := session.Status()
 	return status == "active" || status == "starting" || status == "creating"
+}
+
+// deletePreviousSession deletes the previous session if it exists
+func (w *Worker) deletePreviousSession(sessionID string) {
+	if err := w.sessionManager.DeleteSession(sessionID); err != nil {
+		log.Printf("[SCHEDULE_WORKER] Failed to delete previous session %s: %v", sessionID, err)
+	} else {
+		log.Printf("[SCHEDULE_WORKER] Deleted previous session %s", sessionID)
+	}
 }
 
 // recordExecution records an execution attempt


### PR DESCRIPTION
## Summary
- スケジュール実行時に、前回のセッションがアクティブでない場合は自動的に削除するようにしました
- 前回セッションがアクティブな場合は既存の「スキップ」動作を維持します
- 古いセッションリソースの蓄積を防ぎます

## Test plan
- [x] `make lint` が成功することを確認
- [x] `make test` が成功することを確認
- [x] 新規テスト `TestWorker_DeletePreviousInactiveSession` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)