### PR TITLE
refactor: Remove get permission for secrets in credentials sync

### DIFF
--- a/helm/agentapi-proxy/templates/role.yaml
+++ b/helm/agentapi-proxy/templates/role.yaml
@@ -26,7 +26,7 @@ rules:
   {{- end }}
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create", "update", "delete", "patch"]
+    verbs: ["list", "create", "update", "delete", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create"]


### PR DESCRIPTION
## Summary
- Sync メソッドを create-then-patch パターンに変更（get-then-create/update から）
- Delete メソッドから事前の存在確認を削除し、直接削除するように変更
- LabelManagedBy チェックを削除（get なしでは確認不可能）
- Helm Role から secrets の `get` verb を削除

## 変更内容

### credentials syncer の変更
- `Sync`: 最初に Create を試み、`AlreadyExists` エラーの場合は Patch で更新
- `Delete`: 直接 Delete を実行し、`NotFound` エラーは無視

### RBAC の変更
- secrets の権限から `get` を削除: `["list", "create", "update", "delete", "patch"]`

## 注意点
⚠️ LabelManagedBy チェックがなくなるため、同名の Secret が他のシステムで管理されている場合は上書き/削除されます。

## Test plan
- [x] `make lint` を実行して成功
- [x] `make test` を実行して成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)