### PR TITLE
fix: update credentials-sync sidecar to work without secrets:get permission

### DIFF
--- a/helm/agentapi-proxy/templates/session-role.yaml
+++ b/helm/agentapi-proxy/templates/session-role.yaml
@@ -13,4 +13,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list"]
+  # Permissions for credentials-sync sidecar to sync credentials.json to Secret
+  # Note: 'get' is intentionally not included - the sidecar uses patch-first approach
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "patch"]
 {{- end }}


### PR DESCRIPTION
## Summary
- credentials-sync サイドカーのスクリプトを `kubectl get secret` を使わない patch-first アプローチに変更
- session-role.yaml に secrets の `create` と `patch` 権限を追加（`get` は意図的に含めない）
- セキュリティ向上のため secrets:get 権限を不要に

## Changes
1. **credentialsSyncScript の改修** (`pkg/proxy/kubernetes_session_manager.go`)
   - 従来: `kubectl get secret` で存在確認 → 存在すれば `patch`、なければ `create`
   - 改修後: 最初に `kubectl patch` を試行 → NotFound エラーの場合のみ `create`

2. **session-role.yaml の更新** (`helm/agentapi-proxy/templates/session-role.yaml`)
   - secrets に `create` と `patch` 権限を追加
   - `get` 権限は意図的に含めない（コメントで明記）

## Test plan
- [x] `make lint` 成功
- [x] `make test` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)