### PR TITLE
fix: Use explicit conditional for session ServiceAccount in Helm template

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT
-              value: {{ .Values.kubernetesSession.serviceAccount | default (printf "%s-session" (include "agentapi-proxy.fullname" .)) | quote }}
+              value: {{ if .Values.kubernetesSession.serviceAccount }}{{ .Values.kubernetesSession.serviceAccount | quote }}{{ else }}{{ printf "%s-session" (include "agentapi-proxy.fullname" .) | quote }}{{ end }}
             - name: AGENTAPI_K8S_SESSION_BASE_PORT
               value: {{ .Values.kubernetesSession.basePort | quote }}
             - name: AGENTAPI_K8S_SESSION_CPU_REQUEST


### PR DESCRIPTION
## Summary
- Fixed Helm template to properly handle empty string for `kubernetesSession.serviceAccount`
- The Helm `default` function treats empty string `""` as a valid value, so session pods were incorrectly using the `default` ServiceAccount instead of the dedicated `{fullname}-session` ServiceAccount
- Changed from `default` function to explicit `if` conditional to properly fall back when the value is empty

## Test plan
- [ ] Deploy with `kubernetesSession.serviceAccount: ""` (default) and verify session pods use `{release-name}-session` ServiceAccount
- [ ] Deploy with `kubernetesSession.serviceAccount: "custom-sa"` and verify session pods use `custom-sa` ServiceAccount

🤖 Generated with [Claude Code](https://claude.com/claude-code)