### PR TITLE
refactor: Use create-first then replace approach for credentials-sync

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 golang        latest
 golangci-lint latest
 helm          latest
+kubectl       latest

--- a/helm/agentapi-proxy/templates/session-role.yaml
+++ b/helm/agentapi-proxy/templates/session-role.yaml
@@ -17,7 +17,8 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list"]
   # Permissions for credentials-sync sidecar to sync credentials.json to Secret
+  # Note: 'get' is not needed - uses create-first then replace approach
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["create", "update"]
 {{- end }}


### PR DESCRIPTION
## Summary
- credentials-sync サイドカーで `kubectl patch` の代わりに `kubectl create/replace` を使用するよう変更
- これにより `secrets:get` 権限が不要になる

## 変更内容
- Secret の完全なマニフェストを生成
- まず `kubectl create` を試行
- `AlreadyExists` の場合は `kubectl replace` で更新

## RBAC の変更
```yaml
# Before
verbs: ["get", "create", "patch"]

# After  
verbs: ["create", "update"]
```

## Test plan
- [ ] Helm chart をデプロイして session pod を起動
- [ ] credentials-sync のログで正常に Secret が作成/更新されることを確認
- [ ] `secrets:get` 権限なしで動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)