### PR TITLE
feat: Add MCP servers configuration to Settings API

### DIFF
--- a/internal/domain/entities/mcp_server.go
+++ b/internal/domain/entities/mcp_server.go
@@ -1,0 +1,207 @@
+package entities
+
+import (
+	"errors"
+	"sort"
+)
+
+// MCPServer represents a single MCP server configuration
+type MCPServer struct {
+	name    string
+	type_   string            // "stdio", "http", "sse"
+	url     string            // for http/sse
+	command string            // for stdio
+	args    []string          // for stdio
+	env     map[string]string // environment variables (may contain secrets)
+	headers map[string]string // for http/sse (may contain secrets)
+}
+
+// NewMCPServer creates a new MCPServer
+func NewMCPServer(name string, serverType string) *MCPServer {
+	return &MCPServer{
+		name:    name,
+		type_:   serverType,
+		args:    []string{},
+		env:     make(map[string]string),
+		headers: make(map[string]string),
+	}
+}
+
+// Name returns the server name
+func (s *MCPServer) Name() string {
+	return s.name
+}
+
+// Type returns the server type
+func (s *MCPServer) Type() string {
+	return s.type_
+}
+
+// URL returns the URL for http/sse servers
+func (s *MCPServer) URL() string {
+	return s.url
+}
+
+// Command returns the command for stdio servers
+func (s *MCPServer) Command() string {
+	return s.command
+}
+
+// Args returns the arguments for stdio servers
+func (s *MCPServer) Args() []string {
+	return s.args
+}
+
+// Env returns the environment variables
+func (s *MCPServer) Env() map[string]string {
+	return s.env
+}
+
+// Headers returns the headers for http/sse servers
+func (s *MCPServer) Headers() map[string]string {
+	return s.headers
+}
+
+// SetURL sets the URL
+func (s *MCPServer) SetURL(url string) {
+	s.url = url
+}
+
+// SetCommand sets the command
+func (s *MCPServer) SetCommand(command string) {
+	s.command = command
+}
+
+// SetArgs sets the arguments
+func (s *MCPServer) SetArgs(args []string) {
+	if args == nil {
+		s.args = []string{}
+	} else {
+		s.args = args
+	}
+}
+
+// SetEnv sets the environment variables
+func (s *MCPServer) SetEnv(env map[string]string) {
+	if env == nil {
+		s.env = make(map[string]string)
+	} else {
+		s.env = env
+	}
+}
+
+// SetHeaders sets the headers
+func (s *MCPServer) SetHeaders(headers map[string]string) {
+	if headers == nil {
+		s.headers = make(map[string]string)
+	} else {
+		s.headers = headers
+	}
+}
+
+// Validate validates the MCPServer configuration
+func (s *MCPServer) Validate() error {
+	if s.name == "" {
+		return errors.New("server name is required")
+	}
+
+	switch s.type_ {
+	case "stdio":
+		if s.command == "" {
+			return errors.New("command is required for stdio server")
+		}
+	case "http", "sse":
+		if s.url == "" {
+			return errors.New("url is required for http/sse server")
+		}
+	case "":
+		return errors.New("server type is required")
+	default:
+		return errors.New("invalid server type: must be stdio, http, or sse")
+	}
+
+	return nil
+}
+
+// EnvKeys returns sorted list of environment variable keys
+func (s *MCPServer) EnvKeys() []string {
+	if len(s.env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(s.env))
+	for k := range s.env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// HeaderKeys returns sorted list of header keys
+func (s *MCPServer) HeaderKeys() []string {
+	if len(s.headers) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(s.headers))
+	for k := range s.headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// MCPServersSettings represents MCP servers configuration
+type MCPServersSettings struct {
+	servers map[string]*MCPServer
+}
+
+// NewMCPServersSettings creates a new MCPServersSettings
+func NewMCPServersSettings() *MCPServersSettings {
+	return &MCPServersSettings{
+		servers: make(map[string]*MCPServer),
+	}
+}
+
+// Servers returns all servers
+func (m *MCPServersSettings) Servers() map[string]*MCPServer {
+	return m.servers
+}
+
+// GetServer returns a server by name
+func (m *MCPServersSettings) GetServer(name string) *MCPServer {
+	return m.servers[name]
+}
+
+// SetServer sets a server
+func (m *MCPServersSettings) SetServer(name string, server *MCPServer) {
+	m.servers[name] = server
+}
+
+// RemoveServer removes a server
+func (m *MCPServersSettings) RemoveServer(name string) {
+	delete(m.servers, name)
+}
+
+// ServerNames returns sorted list of server names
+func (m *MCPServersSettings) ServerNames() []string {
+	names := make([]string, 0, len(m.servers))
+	for name := range m.servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsEmpty returns true if there are no servers
+func (m *MCPServersSettings) IsEmpty() bool {
+	return len(m.servers) == 0
+}
+
+// Validate validates all servers
+func (m *MCPServersSettings) Validate() error {
+	for _, server := range m.servers {
+		if err := server.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -84,10 +84,11 @@ func (b *BedrockSettings) Validate() error {
 
 // Settings represents user or team settings
 type Settings struct {
-	name      string
-	bedrock   *BedrockSettings
-	createdAt time.Time
-	updatedAt time.Time
+	name       string
+	bedrock    *BedrockSettings
+	mcpServers *MCPServersSettings
+	createdAt  time.Time
+	updatedAt  time.Time
 }
 
 // NewSettings creates a new Settings
@@ -126,6 +127,17 @@ func (s *Settings) SetBedrock(bedrock *BedrockSettings) {
 	s.updatedAt = time.Now()
 }
 
+// MCPServers returns the MCP servers settings
+func (s *Settings) MCPServers() *MCPServersSettings {
+	return s.mcpServers
+}
+
+// SetMCPServers sets the MCP servers settings
+func (s *Settings) SetMCPServers(mcpServers *MCPServersSettings) {
+	s.mcpServers = mcpServers
+	s.updatedAt = time.Now()
+}
+
 // SetCreatedAt sets the creation time (for loading from storage)
 func (s *Settings) SetCreatedAt(t time.Time) {
 	s.createdAt = t
@@ -144,6 +156,12 @@ func (s *Settings) Validate() error {
 
 	if s.bedrock != nil {
 		if err := s.bedrock.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if s.mcpServers != nil {
+		if err := s.mcpServers.Validate(); err != nil {
 			return err
 		}
 	}

--- a/internal/infrastructure/services/kubernetes_mcp_secret_syncer.go
+++ b/internal/infrastructure/services/kubernetes_mcp_secret_syncer.go
@@ -1,0 +1,239 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+const (
+	// MCPSecretPrefix is the prefix for MCP servers Secret names
+	// This matches the existing mcp_servers_team_secret_prefix and mcp_servers_user_secret_prefix
+	MCPSecretPrefix = "mcp-servers-"
+	// MCPSecretDataKey is the key in the Secret data for MCP servers configuration
+	MCPSecretDataKey = "mcp-servers.json"
+	// LabelMCPServers is the label key for MCP servers resources
+	LabelMCPServers = "agentapi.proxy/mcp-servers"
+	// LabelMCPServersName is the label key for MCP servers name
+	LabelMCPServersName = "agentapi.proxy/mcp-servers-name"
+)
+
+// MCPConfig represents the structure of MCP configuration (matches pkg/mcp/merge.go)
+type MCPConfig struct {
+	MCPServers map[string]MCPServerConfig `json:"mcpServers"`
+}
+
+// MCPServerConfig represents a single MCP server configuration
+type MCPServerConfig struct {
+	Type    string            `json:"type,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// KubernetesMCPSecretSyncer implements MCPSecretSyncer using Kubernetes Secrets
+type KubernetesMCPSecretSyncer struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewKubernetesMCPSecretSyncer creates a new KubernetesMCPSecretSyncer
+func NewKubernetesMCPSecretSyncer(client kubernetes.Interface, namespace string) *KubernetesMCPSecretSyncer {
+	return &KubernetesMCPSecretSyncer{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// Sync creates or updates the MCP servers secret based on settings
+func (s *KubernetesMCPSecretSyncer) Sync(ctx context.Context, settings *entities.Settings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+
+	// If no MCP servers, delete the secret
+	if settings.MCPServers() == nil || settings.MCPServers().IsEmpty() {
+		return s.Delete(ctx, settings.Name())
+	}
+
+	secretName := s.secretName(settings.Name())
+	labelValue := sanitizeMCPLabelValue(settings.Name())
+
+	// Build MCP config from settings
+	mcpConfig := s.buildMCPConfig(settings)
+	data, err := json.MarshalIndent(mcpConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal MCP config: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: s.namespace,
+			Labels: map[string]string{
+				LabelMCPServers:     "true",
+				LabelMCPServersName: labelValue,
+				LabelManagedBy:      "settings",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			MCPSecretDataKey: data,
+		},
+	}
+
+	// Try to get existing secret
+	existing, err := s.client.CoreV1().Secrets(s.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create new secret
+			_, err = s.client.CoreV1().Secrets(s.namespace).Create(ctx, secret, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create MCP servers secret: %w", err)
+			}
+			log.Printf("[MCP_SYNCER] Created MCP servers secret %s", secretName)
+			return nil
+		}
+		return fmt.Errorf("failed to get MCP servers secret: %w", err)
+	}
+
+	// Check if secret is managed by settings
+	if existing.Labels[LabelManagedBy] != "settings" {
+		// Secret exists but is not managed by settings, skip update
+		log.Printf("[MCP_SYNCER] Skipping update for secret %s: not managed by settings", secretName)
+		return nil
+	}
+
+	// Update existing secret
+	secret.ResourceVersion = existing.ResourceVersion
+	_, err = s.client.CoreV1().Secrets(s.namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update MCP servers secret: %w", err)
+	}
+	log.Printf("[MCP_SYNCER] Updated MCP servers secret %s", secretName)
+
+	return nil
+}
+
+// Delete removes the MCP servers secret for the given name
+func (s *KubernetesMCPSecretSyncer) Delete(ctx context.Context, name string) error {
+	secretName := s.secretName(name)
+
+	// Check if secret exists and is managed by settings
+	existing, err := s.client.CoreV1().Secrets(s.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Secret doesn't exist, nothing to delete
+			return nil
+		}
+		return fmt.Errorf("failed to get MCP servers secret: %w", err)
+	}
+
+	// Only delete if managed by settings
+	if existing.Labels[LabelManagedBy] != "settings" {
+		log.Printf("[MCP_SYNCER] Skipping delete for secret %s: not managed by settings", secretName)
+		return nil
+	}
+
+	err = s.client.CoreV1().Secrets(s.namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete MCP servers secret: %w", err)
+	}
+	log.Printf("[MCP_SYNCER] Deleted MCP servers secret %s", secretName)
+
+	return nil
+}
+
+// secretName returns the Secret name for the given settings name
+func (s *KubernetesMCPSecretSyncer) secretName(name string) string {
+	return MCPSecretPrefix + sanitizeMCPSecretName(name)
+}
+
+// buildMCPConfig builds the MCP config from settings
+func (s *KubernetesMCPSecretSyncer) buildMCPConfig(settings *entities.Settings) *MCPConfig {
+	config := &MCPConfig{
+		MCPServers: make(map[string]MCPServerConfig),
+	}
+
+	mcpServers := settings.MCPServers()
+	if mcpServers == nil {
+		return config
+	}
+
+	for name, server := range mcpServers.Servers() {
+		serverConfig := MCPServerConfig{
+			Type:    server.Type(),
+			URL:     server.URL(),
+			Command: server.Command(),
+		}
+
+		if len(server.Args()) > 0 {
+			serverConfig.Args = server.Args()
+		}
+
+		if len(server.Env()) > 0 {
+			serverConfig.Env = server.Env()
+		}
+
+		if len(server.Headers()) > 0 {
+			serverConfig.Headers = server.Headers()
+		}
+
+		config.MCPServers[name] = serverConfig
+	}
+
+	return config
+}
+
+// sanitizeMCPSecretName sanitizes a string to be used as a Kubernetes Secret name
+func sanitizeMCPSecretName(s string) string {
+	// Convert to lowercase
+	sanitized := strings.ToLower(s)
+	// Replace non-alphanumeric characters (except dash) with dash
+	re := regexp.MustCompile(`[^a-z0-9-]`)
+	sanitized = re.ReplaceAllString(sanitized, "-")
+	// Remove leading/trailing dashes
+	sanitized = strings.Trim(sanitized, "-")
+	// Collapse multiple dashes
+	re = regexp.MustCompile(`-+`)
+	sanitized = re.ReplaceAllString(sanitized, "-")
+	// Truncate to 253 characters (max Secret name length is 253)
+	maxLen := 253 - len(MCPSecretPrefix)
+	if len(sanitized) > maxLen {
+		sanitized = sanitized[:maxLen]
+	}
+	return sanitized
+}
+
+// sanitizeMCPLabelValue sanitizes a string to be used as a Kubernetes label value
+func sanitizeMCPLabelValue(s string) string {
+	// Label values must be 63 characters or less
+	// Must start and end with alphanumeric character (or be empty)
+	// Can contain dashes, underscores, dots, and alphanumerics
+	re := regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
+	sanitized := re.ReplaceAllString(s, "-")
+	// Remove leading/trailing invalid chars
+	sanitized = strings.Trim(sanitized, "-_.")
+	// Truncate to 63 characters
+	if len(sanitized) > 63 {
+		sanitized = sanitized[:63]
+	}
+	// Ensure it ends with alphanumeric
+	sanitized = strings.TrimRight(sanitized, "-_.")
+	return sanitized
+}

--- a/internal/usecases/ports/services/mcp_secret_syncer.go
+++ b/internal/usecases/ports/services/mcp_secret_syncer.go
@@ -1,0 +1,17 @@
+package services
+
+import (
+	"context"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+// MCPSecretSyncer syncs MCP server settings to Kubernetes Secrets
+type MCPSecretSyncer interface {
+	// Sync creates or updates the MCP servers secret based on settings
+	// If settings has no MCP servers, the secret will be deleted
+	Sync(ctx context.Context, settings *entities.Settings) error
+
+	// Delete removes the MCP servers secret for the given name
+	Delete(ctx context.Context, name string) error
+}

--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -37,14 +37,23 @@ type CustomHandler interface {
 func NewRouter(e *echo.Echo, proxy *Proxy) *Router {
 	settingsHandlers := NewSettingsHandlers(proxy.settingsRepo)
 
-	// Set credentials secret syncer if Kubernetes mode is enabled
+	// Set credentials secret syncer and MCP secret syncer if Kubernetes mode is enabled
 	if k8sManager, ok := proxy.sessionManager.(*KubernetesSessionManager); ok {
-		syncer := services.NewKubernetesCredentialsSecretSyncer(
+		// Set credentials secret syncer
+		credSyncer := services.NewKubernetesCredentialsSecretSyncer(
 			k8sManager.GetClient(),
 			k8sManager.GetNamespace(),
 		)
-		settingsHandlers.SetCredentialsSecretSyncer(syncer)
+		settingsHandlers.SetCredentialsSecretSyncer(credSyncer)
 		log.Printf("[ROUTER] Credentials secret syncer configured for settings handlers")
+
+		// Set MCP secret syncer
+		mcpSyncer := services.NewKubernetesMCPSecretSyncer(
+			k8sManager.GetClient(),
+			k8sManager.GetNamespace(),
+		)
+		settingsHandlers.SetMCPSecretSyncer(mcpSyncer)
+		log.Printf("[ROUTER] MCP secret syncer configured for settings handlers")
 	}
 
 	return &Router{


### PR DESCRIPTION
## Summary

- Settings APIを拡張し、MCPサーバー設定を登録・管理できるようになりました
- 登録されたMCPサーバー設定はKubernetes Secretに保存され、Session Podから利用可能になります
- 既存のMCP merge infrastructure（`mcp-servers-{name}`）と完全に互換性があります

## Changes

### ドメイン層
- `MCPServer` / `MCPServersSettings` エンティティを追加
- `Settings` エンティティに `mcpServers` フィールドを追加

### インフラ層
- `MCPSecretSyncer` インターフェースと `KubernetesMCPSecretSyncer` 実装を追加
- `SettingsRepository` を拡張してMCPサーバー設定のシリアライズ/デシリアライズをサポート

### API層
- `PUT /settings/:name` が `mcp_servers` フィールドを受け付けるようになりました
- `GET /settings/:name` が `mcp_servers` を返すようになりました（`env_keys`/`header_keys`のみ、値はセキュリティのため返しません）
- `DELETE /settings/:name` で関連するMCPサーバーSecretも削除されます

## API Example

### リクエスト (PUT /settings/myorg-backend)
```json
{
  "mcp_servers": {
    "github": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-github"],
      "env": {
        "GITHUB_TOKEN": "ghp_xxxx"
      }
    }
  }
}
```

### レスポンス (GET /settings/myorg-backend)
```json
{
  "name": "myorg-backend",
  "mcp_servers": {
    "github": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-github"],
      "env_keys": ["GITHUB_TOKEN"]
    }
  },
  "created_at": "...",
  "updated_at": "..."
}
```

## Test plan

- [x] `make lint` が通ること
- [x] `go test ./...` が通ること
- [ ] Settings APIでMCPサーバーを登録できること
- [ ] 登録したMCPサーバーがKubernetes Secretとして保存されること
- [ ] Session PodがMCPサーバー設定を使用できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)