### PR TITLE
fix: Add -L flag to find command for notification file copy

### DIFF
--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -510,7 +510,7 @@ fi
 # Use -L to follow symlinks (Secret mounts use symlinks)
 # Use find to avoid glob expansion issues when directory is empty
 if [ -d /notification-subscriptions-source ]; then
-    file_count=$(find /notification-subscriptions-source -maxdepth 1 -type f 2>/dev/null | wc -l)
+    file_count=$(find -L /notification-subscriptions-source -maxdepth 1 -type f 2>/dev/null | wc -l)
     if [ "$file_count" -gt 0 ]; then
         cp -rL /notification-subscriptions-source/* /notifications/
         echo "Notification subscriptions copied"


### PR DESCRIPTION
## Summary

- Fixed notification file copy in the `setup-claude` init container not working because Kubernetes Secrets mount files as symbolic links
- Added `-L` flag to `find` command to follow symlinks when detecting files in the notification-subscriptions-source directory

## Problem

The notification file copy logic in `setupClaudeScript` was using `find -type f` to check if there are files to copy:

```shell
file_count=$(find /notification-subscriptions-source -maxdepth 1 -type f 2>/dev/null | wc -l)
```

However, Kubernetes Secrets mount files as symbolic links (e.g., `key1 -> ..data/key1`). The `-type f` option only matches regular files and ignores symlinks, so `file_count` was always 0 and the copy was never executed.

## Solution

Added the `-L` flag to the `find` command to follow symbolic links:

```shell
file_count=$(find -L /notification-subscriptions-source -maxdepth 1 -type f 2>/dev/null | wc -l)
```

This makes `find` follow symlinks and check if the target is a regular file, correctly detecting files in Kubernetes Secret mounts.

## Test plan

- [x] Unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)