### PR TITLE
fix: Extract repository info from tags when creating sessions via schedule

### DIFF
--- a/pkg/schedule/handlers.go
+++ b/pkg/schedule/handlers.go
@@ -375,6 +375,9 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 		req.GithubToken = schedule.SessionConfig.Params.GithubToken
 	}
 
+	// Extract repository information from tags
+	req.RepoInfo = proxy.ExtractRepositoryInfo(req.Tags, sessionID)
+
 	session, err := h.sessionManager.CreateSession(c.Request().Context(), sessionID, req)
 	if err != nil {
 		log.Printf("Failed to trigger schedule %s: %v", id, err)

--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -152,7 +152,7 @@ func (w *Worker) executeSchedule(ctx context.Context, schedule *Schedule) {
 
 	// Create session
 	sessionID := uuid.New().String()
-	req := w.buildRunServerRequest(schedule)
+	req := w.buildRunServerRequest(schedule, sessionID)
 
 	session, err := w.sessionManager.CreateSession(ctx, sessionID, req)
 	if err != nil {
@@ -207,7 +207,7 @@ func (w *Worker) executeSchedule(ctx context.Context, schedule *Schedule) {
 }
 
 // buildRunServerRequest builds a RunServerRequest from a schedule
-func (w *Worker) buildRunServerRequest(schedule *Schedule) *proxy.RunServerRequest {
+func (w *Worker) buildRunServerRequest(schedule *Schedule, sessionID string) *proxy.RunServerRequest {
 	req := &proxy.RunServerRequest{
 		UserID:      schedule.UserID,
 		Environment: schedule.SessionConfig.Environment,
@@ -225,6 +225,9 @@ func (w *Worker) buildRunServerRequest(schedule *Schedule) *proxy.RunServerReque
 		req.InitialMessage = schedule.SessionConfig.Params.Message
 		req.GithubToken = schedule.SessionConfig.Params.GithubToken
 	}
+
+	// Extract repository information from tags
+	req.RepoInfo = proxy.ExtractRepositoryInfo(req.Tags, sessionID)
 
 	return req
 }


### PR DESCRIPTION
## Summary

- Schedule worker and handlers were creating `RunServerRequest` without populating `RepoInfo`
- This caused repository cloning to be skipped when sessions were created via schedule (both manual trigger and automatic execution)
- Added `ExtractRepositoryInfo` as a public function in proxy package for reuse
- Updated schedule worker and handlers to properly extract repository info from tags

## Changes

- `pkg/proxy/proxy.go`: Added `ExtractRepositoryInfo` public function and refactored existing `extractRepositoryInfo` method to use it
- `pkg/schedule/worker.go`: Call `proxy.ExtractRepositoryInfo` when building `RunServerRequest`  
- `pkg/schedule/handlers.go`: Call `proxy.ExtractRepositoryInfo` in `TriggerSchedule` handler

## Test plan

- [x] All existing tests pass (`make lint && make test`)
- [ ] Create a schedule with `SessionConfig.Tags["repository"]` set and verify repository is cloned when session starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)