### PR TITLE
feat: Hardcode MCP secret naming convention

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -170,10 +170,6 @@ spec:
               value: "true"
             - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_BASE_SECRET
               value: {{ .Values.kubernetesSession.mcpServers.baseSecret | quote }}
-            - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_TEAM_SECRET_PREFIX
-              value: {{ .Values.kubernetesSession.mcpServers.teamSecretPrefix | quote }}
-            - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_USER_SECRET_PREFIX
-              value: {{ .Values.kubernetesSession.mcpServers.userSecretPrefix | quote }}
             {{- end }}
             # Schedule Worker configuration (enabled by default)
             - name: AGENTAPI_SCHEDULE_WORKER_ENABLED

--- a/helm/agentapi-proxy/templates/statefulset.yaml
+++ b/helm/agentapi-proxy/templates/statefulset.yaml
@@ -172,10 +172,6 @@ spec:
               value: "true"
             - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_BASE_SECRET
               value: {{ .Values.kubernetesSession.mcpServers.baseSecret | quote }}
-            - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_TEAM_SECRET_PREFIX
-              value: {{ .Values.kubernetesSession.mcpServers.teamSecretPrefix | quote }}
-            - name: AGENTAPI_K8S_SESSION_MCP_SERVERS_USER_SECRET_PREFIX
-              value: {{ .Values.kubernetesSession.mcpServers.userSecretPrefix | quote }}
             {{- end }}
             {{- end }}
             {{- range .Values.env }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -360,6 +360,11 @@ kubernetesSession:
   # Allows loading MCP servers from Kubernetes Secrets with 3-tier hierarchy:
   # base (organization-wide) -> team (team-specific) -> user (user-specific)
   # Later tiers override earlier ones for servers with the same name
+  #
+  # Secret naming convention:
+  # - Base: mcp-servers-base (configurable via baseSecret)
+  # - Team: mcp-servers-{team-name} (e.g., mcp-servers-myorg-backend-team)
+  # - User: mcp-servers-{user-id} (e.g., mcp-servers-johndoe)
   mcpServers:
     # Enable MCP server loading from Secrets
     enabled: true
@@ -368,16 +373,6 @@ kubernetesSession:
     # The Secret should contain a key 'mcp-servers.json' with the MCP server configuration
     # Format: {"mcpServers": {"server-name": {"type": "http|stdio|sse", ...}}}
     baseSecret: "mcp-servers-base"
-
-    # Prefix for team-specific MCP config Secrets
-    # Team secrets will be named: {prefix}-{team-name}
-    # e.g., mcp-servers-team-myorg-backend-team
-    teamSecretPrefix: "mcp-servers"
-
-    # Prefix for user-specific MCP config Secrets
-    # User secrets will be named: {prefix}-{user-id}
-    # e.g., mcp-servers-johndoe
-    userSecretPrefix: "mcp-servers"
 
     # Example Secret structure:
     # apiVersion: v1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -207,12 +207,6 @@ type KubernetesSessionConfig struct {
 	// This Secret is applied to all sessions. Each key should be a JSON file name (e.g., "github.json")
 	// containing mcpServers configuration
 	MCPServersBaseSecret string `json:"mcp_servers_base_secret" mapstructure:"mcp_servers_base_secret"`
-	// MCPServersTeamSecretPrefix is the prefix for team-specific MCP server Secret names
-	// Full name will be: {prefix}-{org}-{team} (e.g., mcp-servers-myorg-backend)
-	MCPServersTeamSecretPrefix string `json:"mcp_servers_team_secret_prefix" mapstructure:"mcp_servers_team_secret_prefix"`
-	// MCPServersUserSecretPrefix is the prefix for user-specific MCP server Secret names
-	// Full name will be: {prefix}-{userID} (e.g., mcp-servers-johndoe)
-	MCPServersUserSecretPrefix string `json:"mcp_servers_user_secret_prefix" mapstructure:"mcp_servers_user_secret_prefix"`
 }
 
 // Config represents the proxy configuration

--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -1586,9 +1586,9 @@ func (m *KubernetesSessionManager) buildMCPVolumes(session *kubernetesSession) [
 	}
 
 	// Add team MCP config Secrets
-	if m.k8sConfig.MCPServersTeamSecretPrefix != "" && session.request != nil {
+	if m.k8sConfig.MCPServersEnabled && session.request != nil {
 		for i, team := range session.request.Teams {
-			secretName := fmt.Sprintf("%s-%s", m.k8sConfig.MCPServersTeamSecretPrefix, sanitizeSecretName(team))
+			secretName := fmt.Sprintf("mcp-servers-%s", sanitizeSecretName(team))
 			projectedSources = append(projectedSources, corev1.VolumeProjection{
 				Secret: &corev1.SecretProjection{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -1607,8 +1607,8 @@ func (m *KubernetesSessionManager) buildMCPVolumes(session *kubernetesSession) [
 	}
 
 	// Add user MCP config Secret
-	if m.k8sConfig.MCPServersUserSecretPrefix != "" && session.request != nil && session.request.UserID != "" {
-		userSecretName := fmt.Sprintf("%s-%s", m.k8sConfig.MCPServersUserSecretPrefix, sanitizeSecretName(session.request.UserID))
+	if m.k8sConfig.MCPServersEnabled && session.request != nil && session.request.UserID != "" {
+		userSecretName := fmt.Sprintf("mcp-servers-%s", sanitizeSecretName(session.request.UserID))
 		projectedSources = append(projectedSources, corev1.VolumeProjection{
 			Secret: &corev1.SecretProjection{
 				LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
## Summary
- Remove configurable team and user secret prefixes for MCP servers
- Hardcode the naming convention to:
  - Base: `mcp-servers-base` (configurable via baseSecret)
  - Team: `mcp-servers-{team-name}`
  - User: `mcp-servers-{user-id}`
- This simplifies configuration and prevents configuration drift

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [ ] Deploy and verify MCP secrets are correctly mounted with hardcoded naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)