### PR TITLE
feat: Configure tagpr to always bump minor version

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -3,3 +3,5 @@
 
 [tagpr]
 releaseBranch = main
+# Always bump minor version (e.g., v0.1.0 -> v0.2.0)
+command = "git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' | awk -F. '{printf \"v%d.%d.0\", $1, $2+1}' || echo 'v0.1.0'"


### PR DESCRIPTION
## Summary
- tagpr の設定に `command` オプションを追加し、常にマイナーバージョンをインクリメントするように設定
- 例: v0.1.0 → v0.2.0 → v0.3.0

## 変更内容
現在のタグから次のマイナーバージョンを計算するコマンドを設定:
```
git describe --tags --abbrev=0 | sed 's/^v//' | awk -F. '{printf "v%d.%d.0", $1, $2+1}'
```

## Test plan
- [ ] tagpr ワークフローが実行されたときに、マイナーバージョンが正しくインクリメントされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)