### PR TITLE
chore: tagpr のラベルを tagpr:minor に設定

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -5,3 +5,4 @@
 releaseBranch = main
 	vPrefix = true
 	versionFile = -
+	label = tagpr:minor


### PR DESCRIPTION
## Summary
- tagpr が作成するリリース PR に `tagpr:minor` ラベルを付けるように設定

## Test plan
- [x] `make lint` 成功
- [x] `make test` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)