### PR TITLE
fix: Add GitHub auth setup to sync and mount marketplaces volume in main container

### DIFF
--- a/pkg/proxy/kubernetes_session_manager.go
+++ b/pkg/proxy/kubernetes_session_manager.go
@@ -2215,6 +2215,12 @@ func (m *KubernetesSessionManager) buildMainContainerVolumeMounts() []corev1.Vol
 			MountPath: "/github-app",
 			ReadOnly:  true,
 		},
+		// Mount marketplaces directory (cloned by sync init container)
+		{
+			Name:      "marketplaces",
+			MountPath: "/marketplaces",
+			ReadOnly:  true,
+		},
 	}
 
 	// Add MCP config volume mount if enabled

--- a/pkg/proxy/kubernetes_session_manager_test.go
+++ b/pkg/proxy/kubernetes_session_manager_test.go
@@ -887,9 +887,9 @@ func TestKubernetesSessionManager_DeploymentSpec(t *testing.T) {
 		t.Errorf("Expected CUSTOM_VAR 'custom-value', got %s", envMap["CUSTOM_VAR"])
 	}
 
-	// Verify volume mounts (workdir + claude-config for .claude.json and .claude + notification-subscriptions + github-app)
-	if len(container.VolumeMounts) != 5 {
-		t.Errorf("Expected 5 volume mounts, got %d", len(container.VolumeMounts))
+	// Verify volume mounts (workdir + claude-config for .claude.json and .claude + notification-subscriptions + github-app + marketplaces)
+	if len(container.VolumeMounts) != 6 {
+		t.Errorf("Expected 6 volume mounts, got %d", len(container.VolumeMounts))
 	}
 	volumeMountNames := make(map[string]bool)
 	for _, vm := range container.VolumeMounts {
@@ -906,6 +906,9 @@ func TestKubernetesSessionManager_DeploymentSpec(t *testing.T) {
 	}
 	if !volumeMountNames["github-app"] {
 		t.Error("Expected github-app volume mount")
+	}
+	if !volumeMountNames["marketplaces"] {
+		t.Error("Expected marketplaces volume mount")
 	}
 
 	// Verify probes

--- a/pkg/startup/sync.go
+++ b/pkg/startup/sync.go
@@ -73,6 +73,13 @@ func Sync(opts SyncOptions) error {
 	log.Printf("[SYNC] Starting sync with settings file: %s, output dir: %s, marketplaces dir: %s",
 		opts.SettingsFile, opts.OutputDir, opts.MarketplacesDir)
 
+	// Setup GitHub authentication first (for marketplace cloning)
+	log.Printf("[SYNC] Setting up GitHub authentication")
+	if err := SetupGitHubAuth(""); err != nil {
+		// Warning only - continue even if auth setup fails (public repos may work)
+		log.Printf("[SYNC] Warning: GitHub auth setup failed: %v", err)
+	}
+
 	// Load settings from file (optional - file may not exist)
 	settings, err := loadSettingsFile(opts.SettingsFile)
 	if err != nil {


### PR DESCRIPTION
## Summary

- init container の sync コマンドで marketplace リポジトリをクローンする前に GitHub 認証を設定するように `SetupGitHubAuth` の呼び出しを追加
- init container でクローンした marketplaces EmptyDir ボリュームをメインコンテナにマウントするように修正
- テストを更新してボリュームマウント数を 5 から 6 に変更

## Test plan

- [x] `make lint` を実行して lint エラーがないことを確認
- [x] `make test` を実行してすべてのテストがパスすることを確認
- [ ] Kubernetes 環境でデプロイして marketplace リポジトリが正しくクローンされ、メインコンテナからアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)