### PR TITLE
feat: Add name field to marketplace config for custom clone directory

### DIFF
--- a/pkg/startup/sync.go
+++ b/pkg/startup/sync.go
@@ -53,6 +53,7 @@ type mcpServerJSON struct {
 // marketplaceJSON represents a marketplace configuration
 type marketplaceJSON struct {
 	URL            string   `json:"url"`
+	Name           string   `json:"name,omitempty"` // Directory name for cloning (defaults to map key if not specified)
 	EnabledPlugins []string `json:"enabled_plugins,omitempty"`
 }
 
@@ -212,10 +213,16 @@ func syncMarketplaces(opts SyncOptions, settings *settingsJSON) error {
 		extraKnownMarketplaces := make(map[string]extraKnownMarketplace)
 		enabledPlugins := make(map[string]struct{})
 
-		for name, marketplace := range settings.Marketplaces {
+		for key, marketplace := range settings.Marketplaces {
 			if marketplace.URL == "" {
-				log.Printf("[SYNC] Skipping marketplace %s: no URL configured", name)
+				log.Printf("[SYNC] Skipping marketplace %s: no URL configured", key)
 				continue
+			}
+
+			// Use marketplace.Name if specified, otherwise fall back to map key
+			name := marketplace.Name
+			if name == "" {
+				name = key
 			}
 
 			targetDir := filepath.Join(opts.MarketplacesDir, name)


### PR DESCRIPTION
## Summary

- marketplace 設定に `name` フィールドを追加
- `name` を指定すると、その名前でディレクトリを作成してリポジトリをクローン
- `name` を省略した場合は従来通り map のキーをディレクトリ名として使用

## 使用例

```json
{
  "marketplaces": {
    "my-marketplace-key": {
      "url": "https://github.com/org/repo.git",
      "name": "custom-directory-name",
      "enabled_plugins": ["plugin1", "plugin2"]
    }
  }
}
```

上記の場合、`/marketplaces/custom-directory-name` にクローンされます。

## Test plan

- [x] `make lint` を実行して lint エラーがないことを確認
- [x] `make test` を実行してすべてのテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)