### PR TITLE
feat: Add enabled_official_plugins field to Settings API

### DIFF
--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -84,12 +84,13 @@ func (b *BedrockSettings) Validate() error {
 
 // Settings represents user or team settings
 type Settings struct {
-	name         string
-	bedrock      *BedrockSettings
-	mcpServers   *MCPServersSettings
-	marketplaces *MarketplacesSettings
-	createdAt    time.Time
-	updatedAt    time.Time
+	name                   string
+	bedrock                *BedrockSettings
+	mcpServers             *MCPServersSettings
+	marketplaces           *MarketplacesSettings
+	enabledOfficialPlugins []string
+	createdAt              time.Time
+	updatedAt              time.Time
 }
 
 // NewSettings creates a new Settings
@@ -147,6 +148,17 @@ func (s *Settings) Marketplaces() *MarketplacesSettings {
 // SetMarketplaces sets the marketplaces settings
 func (s *Settings) SetMarketplaces(marketplaces *MarketplacesSettings) {
 	s.marketplaces = marketplaces
+	s.updatedAt = time.Now()
+}
+
+// EnabledOfficialPlugins returns the list of enabled official plugins
+func (s *Settings) EnabledOfficialPlugins() []string {
+	return s.enabledOfficialPlugins
+}
+
+// SetEnabledOfficialPlugins sets the list of enabled official plugins
+func (s *Settings) SetEnabledOfficialPlugins(plugins []string) {
+	s.enabledOfficialPlugins = plugins
 	s.updatedAt = time.Now()
 }
 

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -107,6 +107,38 @@ func TestSettings_SetBedrock(t *testing.T) {
 	}
 }
 
+func TestSettings_EnabledOfficialPlugins(t *testing.T) {
+	settings := NewSettings("test-user")
+
+	// Initially should be nil/empty
+	if len(settings.EnabledOfficialPlugins()) != 0 {
+		t.Error("Expected EnabledOfficialPlugins to be empty initially")
+	}
+
+	originalUpdatedAt := settings.UpdatedAt()
+
+	// Wait a bit to ensure time difference
+	time.Sleep(time.Millisecond)
+
+	// Set plugins
+	plugins := []string{"context7", "typescript", "python"}
+	settings.SetEnabledOfficialPlugins(plugins)
+
+	// Verify plugins are set
+	result := settings.EnabledOfficialPlugins()
+	if len(result) != 3 {
+		t.Errorf("Expected 3 plugins, got %d", len(result))
+	}
+	if result[0] != "context7" || result[1] != "typescript" || result[2] != "python" {
+		t.Errorf("Expected plugins [context7, typescript, python], got %v", result)
+	}
+
+	// Verify UpdatedAt is updated
+	if !settings.UpdatedAt().After(originalUpdatedAt) {
+		t.Error("Expected UpdatedAt to be updated")
+	}
+}
+
 func TestSettings_Validate(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -29,12 +29,13 @@ const (
 
 // settingsJSON is the JSON representation of settings stored in Secret
 type settingsJSON struct {
-	Name         string                      `json:"name"`
-	Bedrock      *bedrockJSON                `json:"bedrock,omitempty"`
-	MCPServers   map[string]*mcpServerJSON   `json:"mcp_servers,omitempty"`
-	Marketplaces map[string]*marketplaceJSON `json:"marketplaces,omitempty"`
-	CreatedAt    time.Time                   `json:"created_at"`
-	UpdatedAt    time.Time                   `json:"updated_at"`
+	Name                   string                      `json:"name"`
+	Bedrock                *bedrockJSON                `json:"bedrock,omitempty"`
+	MCPServers             map[string]*mcpServerJSON   `json:"mcp_servers,omitempty"`
+	Marketplaces           map[string]*marketplaceJSON `json:"marketplaces,omitempty"`
+	EnabledOfficialPlugins []string                    `json:"enabled_official_plugins,omitempty"`
+	CreatedAt              time.Time                   `json:"created_at"`
+	UpdatedAt              time.Time                   `json:"updated_at"`
 }
 
 // bedrockJSON is the JSON representation of Bedrock settings
@@ -239,6 +240,10 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 		}
 	}
 
+	if plugins := settings.EnabledOfficialPlugins(); len(plugins) > 0 {
+		sj.EnabledOfficialPlugins = plugins
+	}
+
 	return json.Marshal(sj)
 }
 
@@ -296,6 +301,12 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 		}
 		settings.SetMarketplaces(marketplaces)
 		// Reset updatedAt since SetMarketplaces updates it
+		settings.SetUpdatedAt(sj.UpdatedAt)
+	}
+
+	if len(sj.EnabledOfficialPlugins) > 0 {
+		settings.SetEnabledOfficialPlugins(sj.EnabledOfficialPlugins)
+		// Reset updatedAt since SetEnabledOfficialPlugins updates it
 		settings.SetUpdatedAt(sj.UpdatedAt)
 	}
 

--- a/pkg/proxy/settings_handlers.go
+++ b/pkg/proxy/settings_handlers.go
@@ -71,9 +71,10 @@ type MarketplaceRequest struct {
 
 // UpdateSettingsRequest is the request body for updating settings
 type UpdateSettingsRequest struct {
-	Bedrock      *BedrockSettingsRequest        `json:"bedrock"`
-	MCPServers   map[string]*MCPServerRequest   `json:"mcp_servers,omitempty"`
-	Marketplaces map[string]*MarketplaceRequest `json:"marketplaces,omitempty"`
+	Bedrock                *BedrockSettingsRequest        `json:"bedrock"`
+	MCPServers             map[string]*MCPServerRequest   `json:"mcp_servers,omitempty"`
+	Marketplaces           map[string]*MarketplaceRequest `json:"marketplaces,omitempty"`
+	EnabledOfficialPlugins []string                       `json:"enabled_official_plugins,omitempty"`
 }
 
 // BedrockSettingsResponse is the response body for Bedrock settings
@@ -104,12 +105,13 @@ type MarketplaceResponse struct {
 
 // SettingsResponse is the response body for settings
 type SettingsResponse struct {
-	Name         string                          `json:"name"`
-	Bedrock      *BedrockSettingsResponse        `json:"bedrock,omitempty"`
-	MCPServers   map[string]*MCPServerResponse   `json:"mcp_servers,omitempty"`
-	Marketplaces map[string]*MarketplaceResponse `json:"marketplaces,omitempty"`
-	CreatedAt    string                          `json:"created_at"`
-	UpdatedAt    string                          `json:"updated_at"`
+	Name                   string                          `json:"name"`
+	Bedrock                *BedrockSettingsResponse        `json:"bedrock,omitempty"`
+	MCPServers             map[string]*MCPServerResponse   `json:"mcp_servers,omitempty"`
+	Marketplaces           map[string]*MarketplaceResponse `json:"marketplaces,omitempty"`
+	EnabledOfficialPlugins []string                        `json:"enabled_official_plugins,omitempty"`
+	CreatedAt              string                          `json:"created_at"`
+	UpdatedAt              string                          `json:"updated_at"`
 }
 
 // GetSettings handles GET /settings/:name
@@ -249,6 +251,11 @@ func (h *SettingsHandlers) UpdateSettings(c echo.Context) error {
 			marketplaces.SetMarketplace(marketplaceName, marketplace)
 		}
 		settings.SetMarketplaces(marketplaces)
+	}
+
+	// Update enabled official plugins
+	if req.EnabledOfficialPlugins != nil {
+		settings.SetEnabledOfficialPlugins(req.EnabledOfficialPlugins)
 	}
 
 	// Validate
@@ -450,6 +457,10 @@ func (h *SettingsHandlers) toResponse(settings *entities.Settings) *SettingsResp
 				EnabledPlugins: marketplace.EnabledPlugins(),
 			}
 		}
+	}
+
+	if plugins := settings.EnabledOfficialPlugins(); len(plugins) > 0 {
+		resp.EnabledOfficialPlugins = plugins
 	}
 
 	return resp

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1250,6 +1250,13 @@
               "$ref": "#/components/schemas/MarketplaceRequest"
             },
             "description": "Claude Code plugin marketplace configurations keyed by marketplace name"
+          },
+          "enabled_official_plugins": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of official plugin names to enable from claude-plugins-official marketplace"
           }
         }
       },
@@ -1362,6 +1369,13 @@
               "$ref": "#/components/schemas/MarketplaceResponse"
             },
             "description": "Claude Code plugin marketplace configurations"
+          },
+          "enabled_official_plugins": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of enabled official plugin names from claude-plugins-official marketplace"
           },
           "created_at": {
             "type": "string",


### PR DESCRIPTION
## Summary

- Settings API に `enabled_official_plugins` フィールドを追加し、公式 Claude プラグインマーケットプレイス（claude-plugins-official）のプラグインを有効化できるようにしました
- 公式プラグインは `plugin@claude-plugins-official` 形式で settings.json に追加されます

## Changes

- **エンティティ層**: `Settings` 構造体に `enabledOfficialPlugins` フィールド追加
- **リポジトリ層**: `kubernetes_settings_repository.go` の JSON 構造を更新
- **Sync 処理**: `sync.go` で公式プラグインを `enabledPlugins` に追加
- **API ハンドラー**: リクエスト/レスポンス型に `enabled_official_plugins` 追加
- **OpenAPI 仕様**: スキーマ更新

## API Usage

```json
PUT /settings/:name
{
  "enabled_official_plugins": ["context7", "typescript", "python"],
  "marketplaces": {
    "my-marketplace": {
      "url": "https://github.com/example/my-marketplace.git",
      "enabled_plugins": ["plugin1"]
    }
  }
}
```

## Generated settings.json

```json
{
  "enabledPlugins": {
    "context7@claude-plugins-official": true,
    "typescript@claude-plugins-official": true,
    "python@claude-plugins-official": true,
    "plugin1@my-marketplace": true
  }
}
```

## Test plan

- [x] 単体テストを追加・実行
- [x] lint を通過
- [x] make test を通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)