### PR TITLE
feat: Unify enabled_official_plugins and marketplace.enabled_plugins into enabled_plugins

### DIFF
--- a/internal/domain/entities/marketplace.go
+++ b/internal/domain/entities/marketplace.go
@@ -4,16 +4,14 @@ import "errors"
 
 // Marketplace represents a plugin marketplace
 type Marketplace struct {
-	name           string
-	url            string   // Git repository URL
-	enabledPlugins []string // Plugin names (without marketplace qualifier)
+	name string
+	url  string // Git repository URL
 }
 
 // NewMarketplace creates a new Marketplace
 func NewMarketplace(name string) *Marketplace {
 	return &Marketplace{
-		name:           name,
-		enabledPlugins: []string{},
+		name: name,
 	}
 }
 
@@ -27,32 +25,9 @@ func (m *Marketplace) URL() string {
 	return m.url
 }
 
-// EnabledPlugins returns the list of enabled plugin names
-func (m *Marketplace) EnabledPlugins() []string {
-	return m.enabledPlugins
-}
-
 // SetURL sets the Git repository URL
 func (m *Marketplace) SetURL(url string) {
 	m.url = url
-}
-
-// SetEnabledPlugins sets the list of enabled plugin names
-func (m *Marketplace) SetEnabledPlugins(plugins []string) {
-	if plugins == nil {
-		m.enabledPlugins = []string{}
-	} else {
-		m.enabledPlugins = plugins
-	}
-}
-
-// QualifiedPluginNames returns plugin names in "plugin@marketplace" format
-func (m *Marketplace) QualifiedPluginNames() []string {
-	result := make([]string, len(m.enabledPlugins))
-	for i, plugin := range m.enabledPlugins {
-		result[i] = plugin + "@" + m.name
-	}
-	return result
 }
 
 // Validate validates the Marketplace configuration
@@ -101,16 +76,6 @@ func (s *MarketplacesSettings) RemoveMarketplace(name string) {
 // IsEmpty returns true if there are no marketplaces
 func (s *MarketplacesSettings) IsEmpty() bool {
 	return len(s.marketplaces) == 0
-}
-
-// AllEnabledPlugins returns all enabled plugins from all marketplaces
-// in "plugin@marketplace" format
-func (s *MarketplacesSettings) AllEnabledPlugins() []string {
-	var result []string
-	for _, m := range s.marketplaces {
-		result = append(result, m.QualifiedPluginNames()...)
-	}
-	return result
 }
 
 // Validate validates all marketplaces

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -84,13 +84,13 @@ func (b *BedrockSettings) Validate() error {
 
 // Settings represents user or team settings
 type Settings struct {
-	name                   string
-	bedrock                *BedrockSettings
-	mcpServers             *MCPServersSettings
-	marketplaces           *MarketplacesSettings
-	enabledOfficialPlugins []string
-	createdAt              time.Time
-	updatedAt              time.Time
+	name           string
+	bedrock        *BedrockSettings
+	mcpServers     *MCPServersSettings
+	marketplaces   *MarketplacesSettings
+	enabledPlugins []string // plugin@marketplace format (e.g., "commit@claude-plugins-official")
+	createdAt      time.Time
+	updatedAt      time.Time
 }
 
 // NewSettings creates a new Settings
@@ -151,14 +151,14 @@ func (s *Settings) SetMarketplaces(marketplaces *MarketplacesSettings) {
 	s.updatedAt = time.Now()
 }
 
-// EnabledOfficialPlugins returns the list of enabled official plugins
-func (s *Settings) EnabledOfficialPlugins() []string {
-	return s.enabledOfficialPlugins
+// EnabledPlugins returns the list of enabled plugins in "plugin@marketplace" format
+func (s *Settings) EnabledPlugins() []string {
+	return s.enabledPlugins
 }
 
-// SetEnabledOfficialPlugins sets the list of enabled official plugins
-func (s *Settings) SetEnabledOfficialPlugins(plugins []string) {
-	s.enabledOfficialPlugins = plugins
+// SetEnabledPlugins sets the list of enabled plugins in "plugin@marketplace" format
+func (s *Settings) SetEnabledPlugins(plugins []string) {
+	s.enabledPlugins = plugins
 	s.updatedAt = time.Now()
 }
 

--- a/internal/domain/entities/settings_test.go
+++ b/internal/domain/entities/settings_test.go
@@ -107,12 +107,12 @@ func TestSettings_SetBedrock(t *testing.T) {
 	}
 }
 
-func TestSettings_EnabledOfficialPlugins(t *testing.T) {
+func TestSettings_EnabledPlugins(t *testing.T) {
 	settings := NewSettings("test-user")
 
 	// Initially should be nil/empty
-	if len(settings.EnabledOfficialPlugins()) != 0 {
-		t.Error("Expected EnabledOfficialPlugins to be empty initially")
+	if len(settings.EnabledPlugins()) != 0 {
+		t.Error("Expected EnabledPlugins to be empty initially")
 	}
 
 	originalUpdatedAt := settings.UpdatedAt()
@@ -120,17 +120,17 @@ func TestSettings_EnabledOfficialPlugins(t *testing.T) {
 	// Wait a bit to ensure time difference
 	time.Sleep(time.Millisecond)
 
-	// Set plugins
-	plugins := []string{"context7", "typescript", "python"}
-	settings.SetEnabledOfficialPlugins(plugins)
+	// Set plugins in plugin@marketplace format
+	plugins := []string{"context7@claude-plugins-official", "typescript@claude-plugins-official", "my-plugin@my-marketplace"}
+	settings.SetEnabledPlugins(plugins)
 
 	// Verify plugins are set
-	result := settings.EnabledOfficialPlugins()
+	result := settings.EnabledPlugins()
 	if len(result) != 3 {
 		t.Errorf("Expected 3 plugins, got %d", len(result))
 	}
-	if result[0] != "context7" || result[1] != "typescript" || result[2] != "python" {
-		t.Errorf("Expected plugins [context7, typescript, python], got %v", result)
+	if result[0] != "context7@claude-plugins-official" || result[1] != "typescript@claude-plugins-official" || result[2] != "my-plugin@my-marketplace" {
+		t.Errorf("Expected plugins in plugin@marketplace format, got %v", result)
 	}
 
 	// Verify UpdatedAt is updated

--- a/internal/infrastructure/services/kubernetes_marketplace_secret_syncer.go
+++ b/internal/infrastructure/services/kubernetes_marketplace_secret_syncer.go
@@ -34,8 +34,7 @@ type MarketplaceConfig struct {
 
 // MarketplaceServerConfig represents a single marketplace configuration
 type MarketplaceServerConfig struct {
-	URL            string   `json:"url"`
-	EnabledPlugins []string `json:"enabled_plugins,omitempty"`
+	URL string `json:"url"`
 }
 
 // KubernetesMarketplaceSecretSyncer implements MarketplaceSecretSyncer using Kubernetes Secrets
@@ -174,11 +173,6 @@ func (s *KubernetesMarketplaceSecretSyncer) buildMarketplaceConfig(settings *ent
 		mpConfig := MarketplaceServerConfig{
 			URL: marketplace.URL(),
 		}
-
-		if len(marketplace.EnabledPlugins()) > 0 {
-			mpConfig.EnabledPlugins = marketplace.EnabledPlugins()
-		}
-
 		config.Marketplaces[name] = mpConfig
 	}
 

--- a/pkg/proxy/settings_handlers.go
+++ b/pkg/proxy/settings_handlers.go
@@ -65,16 +65,15 @@ type MCPServerRequest struct {
 
 // MarketplaceRequest is the request body for a single marketplace
 type MarketplaceRequest struct {
-	URL            string   `json:"url"`
-	EnabledPlugins []string `json:"enabled_plugins,omitempty"`
+	URL string `json:"url"`
 }
 
 // UpdateSettingsRequest is the request body for updating settings
 type UpdateSettingsRequest struct {
-	Bedrock                *BedrockSettingsRequest        `json:"bedrock"`
-	MCPServers             map[string]*MCPServerRequest   `json:"mcp_servers,omitempty"`
-	Marketplaces           map[string]*MarketplaceRequest `json:"marketplaces,omitempty"`
-	EnabledOfficialPlugins []string                       `json:"enabled_official_plugins,omitempty"`
+	Bedrock        *BedrockSettingsRequest        `json:"bedrock"`
+	MCPServers     map[string]*MCPServerRequest   `json:"mcp_servers,omitempty"`
+	Marketplaces   map[string]*MarketplaceRequest `json:"marketplaces,omitempty"`
+	EnabledPlugins []string                       `json:"enabled_plugins,omitempty"` // plugin@marketplace format
 }
 
 // BedrockSettingsResponse is the response body for Bedrock settings
@@ -99,19 +98,18 @@ type MCPServerResponse struct {
 
 // MarketplaceResponse is the response body for a single marketplace
 type MarketplaceResponse struct {
-	URL            string   `json:"url"`
-	EnabledPlugins []string `json:"enabled_plugins,omitempty"`
+	URL string `json:"url"`
 }
 
 // SettingsResponse is the response body for settings
 type SettingsResponse struct {
-	Name                   string                          `json:"name"`
-	Bedrock                *BedrockSettingsResponse        `json:"bedrock,omitempty"`
-	MCPServers             map[string]*MCPServerResponse   `json:"mcp_servers,omitempty"`
-	Marketplaces           map[string]*MarketplaceResponse `json:"marketplaces,omitempty"`
-	EnabledOfficialPlugins []string                        `json:"enabled_official_plugins,omitempty"`
-	CreatedAt              string                          `json:"created_at"`
-	UpdatedAt              string                          `json:"updated_at"`
+	Name           string                          `json:"name"`
+	Bedrock        *BedrockSettingsResponse        `json:"bedrock,omitempty"`
+	MCPServers     map[string]*MCPServerResponse   `json:"mcp_servers,omitempty"`
+	Marketplaces   map[string]*MarketplaceResponse `json:"marketplaces,omitempty"`
+	EnabledPlugins []string                        `json:"enabled_plugins,omitempty"` // plugin@marketplace format
+	CreatedAt      string                          `json:"created_at"`
+	UpdatedAt      string                          `json:"updated_at"`
 }
 
 // GetSettings handles GET /settings/:name
@@ -247,15 +245,14 @@ func (h *SettingsHandlers) UpdateSettings(c echo.Context) error {
 		for marketplaceName, marketplaceReq := range req.Marketplaces {
 			marketplace := entities.NewMarketplace(marketplaceName)
 			marketplace.SetURL(marketplaceReq.URL)
-			marketplace.SetEnabledPlugins(marketplaceReq.EnabledPlugins)
 			marketplaces.SetMarketplace(marketplaceName, marketplace)
 		}
 		settings.SetMarketplaces(marketplaces)
 	}
 
-	// Update enabled official plugins
-	if req.EnabledOfficialPlugins != nil {
-		settings.SetEnabledOfficialPlugins(req.EnabledOfficialPlugins)
+	// Update enabled plugins
+	if req.EnabledPlugins != nil {
+		settings.SetEnabledPlugins(req.EnabledPlugins)
 	}
 
 	// Validate
@@ -453,14 +450,13 @@ func (h *SettingsHandlers) toResponse(settings *entities.Settings) *SettingsResp
 		resp.Marketplaces = make(map[string]*MarketplaceResponse)
 		for name, marketplace := range marketplaces.Marketplaces() {
 			resp.Marketplaces[name] = &MarketplaceResponse{
-				URL:            marketplace.URL(),
-				EnabledPlugins: marketplace.EnabledPlugins(),
+				URL: marketplace.URL(),
 			}
 		}
 	}
 
-	if plugins := settings.EnabledOfficialPlugins(); len(plugins) > 0 {
-		resp.EnabledOfficialPlugins = plugins
+	if plugins := settings.EnabledPlugins(); len(plugins) > 0 {
+		resp.EnabledPlugins = plugins
 	}
 
 	return resp

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -660,10 +660,10 @@
                   },
                   "marketplaces": {
                     "my-marketplace": {
-                      "url": "https://github.com/example/my-marketplace.git",
-                      "enabled_plugins": ["plugin1", "plugin2"]
+                      "url": "https://github.com/example/my-marketplace.git"
                     }
                   },
+                  "enabled_plugins": ["commit@claude-plugins-official", "plugin1@my-marketplace"],
                   "created_at": "2025-01-01T00:00:00Z",
                   "updated_at": "2025-01-02T00:00:00Z"
                 }
@@ -759,18 +759,17 @@
                   }
                 },
                 "marketplaces": {
-                  "summary": "Plugin marketplaces",
+                  "summary": "Plugin marketplaces with enabled plugins",
                   "value": {
                     "marketplaces": {
                       "my-marketplace": {
-                        "url": "https://github.com/example/my-marketplace.git",
-                        "enabled_plugins": ["plugin1", "plugin2"]
+                        "url": "https://github.com/example/my-marketplace.git"
                       },
                       "another-marketplace": {
-                        "url": "https://github.com/example/another-marketplace.git",
-                        "enabled_plugins": ["pluginA"]
+                        "url": "https://github.com/example/another-marketplace.git"
                       }
-                    }
+                    },
+                    "enabled_plugins": ["plugin1@my-marketplace", "plugin2@my-marketplace", "pluginA@another-marketplace"]
                   }
                 }
               }
@@ -1251,12 +1250,12 @@
             },
             "description": "Claude Code plugin marketplace configurations keyed by marketplace name"
           },
-          "enabled_official_plugins": {
+          "enabled_plugins": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "List of official plugin names to enable from claude-plugins-official marketplace"
+            "description": "List of enabled plugins in 'plugin@marketplace' format (e.g., 'commit@claude-plugins-official')"
           }
         }
       },
@@ -1336,13 +1335,6 @@
           "url": {
             "type": "string",
             "description": "Git repository URL of the marketplace"
-          },
-          "enabled_plugins": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of plugin names to enable from this marketplace"
           }
         }
       },
@@ -1370,12 +1362,12 @@
             },
             "description": "Claude Code plugin marketplace configurations"
           },
-          "enabled_official_plugins": {
+          "enabled_plugins": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "List of enabled official plugin names from claude-plugins-official marketplace"
+            "description": "List of enabled plugins in 'plugin@marketplace' format"
           },
           "created_at": {
             "type": "string",
@@ -1446,13 +1438,6 @@
           "url": {
             "type": "string",
             "description": "Git repository URL of the marketplace"
-          },
-          "enabled_plugins": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "List of plugin names enabled from this marketplace"
           }
         }
       },


### PR DESCRIPTION
## Summary
- `enabled_official_plugins` (トップレベル) を削除
- `marketplaces[name].enabled_plugins` を削除
- 新しい `enabled_plugins` フィールドを追加 (`plugin@marketplace` 形式)

## 変更内容
オフィシャルプラグインとマーケットプレイスのプラグインが別々の設定になっていた問題を解決し、統一された `enabled_plugins` フィールドに統合しました。

### Before (旧フォーマット)
```json
{
  "enabled_official_plugins": ["commit", "review-pr"],
  "marketplaces": {
    "my-marketplace": {
      "url": "https://...",
      "enabled_plugins": ["plugin1", "plugin2"]
    }
  }
}
```

### After (新フォーマット)
```json
{
  "enabled_plugins": ["commit@claude-plugins-official", "review-pr@claude-plugins-official", "plugin1@my-marketplace"],
  "marketplaces": {
    "my-marketplace": {
      "url": "https://..."
    }
  }
}
```

## 影響範囲
- `internal/domain/entities/settings.go`
- `internal/domain/entities/marketplace.go`
- `pkg/proxy/settings_handlers.go`
- `pkg/startup/sync.go`
- `internal/infrastructure/repositories/kubernetes_settings_repository.go`
- `internal/infrastructure/services/kubernetes_marketplace_secret_syncer.go`
- `spec/openapi.json`

## Breaking Changes
⚠️ **破壊的変更**: API スキーマ変更により後方互換性なし

## Test plan
- [x] `go test ./...` が通ることを確認
- [x] `golangci-lint run` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)