### PR TITLE
feat: Delete session share when session is deleted

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -319,6 +319,16 @@ func (p *Proxy) SetSessionManager(manager SessionManager) {
 	p.sessionManager = manager
 }
 
+// GetShareRepository returns the share repository
+func (p *Proxy) GetShareRepository() ShareRepository {
+	return p.shareRepo
+}
+
+// SetShareRepository allows configuration of a custom share repository (for testing)
+func (p *Proxy) SetShareRepository(repo ShareRepository) {
+	p.shareRepo = repo
+}
+
 // GetContainer returns the DI container
 func (p *Proxy) GetContainer() *di.Container {
 	return p.container
@@ -380,6 +390,11 @@ func (p *Proxy) CreateSession(sessionID string, startReq StartRequest, userID, u
 
 // DeleteSessionByID deletes a session by ID
 func (p *Proxy) DeleteSessionByID(sessionID string) error {
+	// Delete associated share link if exists (ignore errors as share may not exist)
+	if p.shareRepo != nil {
+		_ = p.shareRepo.Delete(sessionID)
+	}
+
 	return p.sessionManager.DeleteSession(sessionID)
 }
 


### PR DESCRIPTION
## Summary
- セッション削除時に、関連する共有リンクも自動的に削除されるようになりました
- 孤立した共有リンクが残ることを防ぎます
- 共有リンクが存在しない場合でもエラーにならないため、後方互換性が保たれています

## Changes
- `Proxy.DeleteSessionByID`: セッション削除前に関連する共有リンクを削除
- `Proxy.GetShareRepository` / `SetShareRepository`: テスト用のメソッドを追加

## Test plan
- [x] `TestDeleteSessionByID_DeletesShareLink`: 共有リンクがセッション削除と同時に削除されることを確認
- [x] `TestDeleteSessionByID_NoShareExists`: 共有リンクがない場合もセッション削除が成功することを確認
- [x] `make lint` が成功
- [x] `make test` が成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)