### PR TITLE
fix: Add configmap update/patch/delete permissions for session shares

### DIFF
--- a/helm/agentapi-proxy/templates/role.yaml
+++ b/helm/agentapi-proxy/templates/role.yaml
@@ -29,7 +29,7 @@ rules:
     verbs: ["get", "list", "create", "update", "delete", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
   {{- if $scheduleWorkerEnabled }}
   # Leader election for schedule worker (enabled by default)
   - apiGroups: ["coordination.k8s.io"]


### PR DESCRIPTION
## Summary
- セッション共有リンクを保存する ConfigMap (`agentapi-session-shares`) の更新・削除に必要な権限を追加

## Changes
- `helm/agentapi-proxy/templates/role.yaml`: ConfigMapの権限に `update`, `patch`, `delete` を追加

## Background
PR #406 でセッション削除時に共有リンクも削除する機能を追加しましたが、サービスアカウントに ConfigMap の更新権限がなかったため 500 エラーが発生していました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)