### PR TITLE
fix: Extract session ID from URL for notification throttling

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -475,6 +475,14 @@ func runSendNotification(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Also try to extract session ID from URL if still not set
+	if notifySessionID == "" && notifyURL != "" {
+		uuidRegex := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
+		if match := uuidRegex.FindString(notifyURL); match != "" {
+			notifySessionID = match
+		}
+	}
+
 	// Validate VAPID configuration
 	vapidPublicKey := os.Getenv("VAPID_PUBLIC_KEY")
 	vapidPrivateKey := os.Getenv("VAPID_PRIVATE_KEY")


### PR DESCRIPTION
## Summary
- 通知のスロットリング（3分間の重複通知防止）機能が動いていなかった問題を修正
- `--session-id` フラグが未指定で、かつカレントディレクトリにUUIDが含まれない場合、`--url` パラメータからセッションIDを抽出するようにした

## Problem
CLAUDE.md で示されている以下のようなコマンドパターンでは、セッションIDがスロットリングに使用されていませんでした：
```
agentapi-proxy helpers send-notification \
  --title "作業が完了しました" \
  --body "作業内容を確認してください" \
  --url "$NOTIFICATION_BASE_URL/agentapi?session={{ session ID }}"
```

これにより、3分以内に同じセッションに対して複数の通知が送信されていました。

## Solution
URLからもセッションID（UUID形式）を抽出するロジックを追加しました。これにより、既存のコマンド呼び出しがそのまま機能します。

## Test plan
- [x] `make lint` パス
- [x] `make test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)