### PR TITLE
fix: Get session ID from AGENTAPI_SESSION_ID environment variable

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -463,7 +463,12 @@ var (
 )
 
 func runSendNotification(cmd *cobra.Command, args []string) error {
-	// Extract session ID from working directory if not provided
+	// Get session ID from environment variable if not provided via flag
+	if notifySessionID == "" {
+		notifySessionID = os.Getenv("AGENTAPI_SESSION_ID")
+	}
+
+	// Fallback: extract session ID from working directory if still not set
 	if notifySessionID == "" {
 		cwd, err := os.Getwd()
 		if err == nil {
@@ -475,7 +480,7 @@ func runSendNotification(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Also try to extract session ID from URL if still not set
+	// Fallback: try to extract session ID from URL if still not set
 	if notifySessionID == "" && notifyURL != "" {
 		uuidRegex := regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)
 		if match := uuidRegex.FindString(notifyURL); match != "" {


### PR DESCRIPTION
## Summary
- 通知スロットリングでセッションIDを `AGENTAPI_SESSION_ID` 環境変数から取得するように変更
- session pod では既に `kubernetes_session_manager.go` で `AGENTAPI_SESSION_ID` が設定されている

## セッションID取得の優先順位
1. `--session-id` フラグ
2. `AGENTAPI_SESSION_ID` 環境変数 (**新規追加**)
3. カレントディレクトリからUUID抽出
4. `--url` パラメータからUUID抽出

## これにより
session pod内から `agentapi-proxy helpers send-notification` を実行すると、環境変数から自動的にセッションIDが取得され、スロットリングが正しく機能します。

## Test plan
- [x] `make lint` パス
- [x] `make test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)