### PR TITLE
feat: Add team-scoped sessions and schedules support

### DIFF
--- a/pkg/proxy/e2e_test.go
+++ b/pkg/proxy/e2e_test.go
@@ -132,6 +132,8 @@ func (s *e2eSession) Tags() map[string]string { return s.tags }
 func (s *e2eSession) Status() string          { return s.status }
 func (s *e2eSession) StartedAt() time.Time    { return s.startedAt }
 func (s *e2eSession) Description() string     { return "" }
+func (s *e2eSession) Scope() ResourceScope    { return ScopeUser }
+func (s *e2eSession) TeamID() string          { return "" }
 func (s *e2eSession) Cancel() {
 	if s.cancel != nil {
 		s.cancel()

--- a/pkg/proxy/kubernetes_session.go
+++ b/pkg/proxy/kubernetes_session.go
@@ -38,6 +38,19 @@ func (s *kubernetesSession) UserID() string {
 	return s.request.UserID
 }
 
+// Scope returns the resource scope ("user" or "team")
+func (s *kubernetesSession) Scope() ResourceScope {
+	if s.request.Scope == "" {
+		return ScopeUser
+	}
+	return s.request.Scope
+}
+
+// TeamID returns the team ID when Scope is "team"
+func (s *kubernetesSession) TeamID() string {
+	return s.request.TeamID
+}
+
 // Tags returns the session tags
 func (s *kubernetesSession) Tags() map[string]string {
 	return s.request.Tags

--- a/pkg/proxy/local_session_manager.go
+++ b/pkg/proxy/local_session_manager.go
@@ -45,6 +45,19 @@ func (s *localSession) UserID() string {
 	return s.request.UserID
 }
 
+// Scope returns the resource scope ("user" or "team")
+func (s *localSession) Scope() ResourceScope {
+	if s.request.Scope == "" {
+		return ScopeUser
+	}
+	return s.request.Scope
+}
+
+// TeamID returns the team ID when Scope is "team"
+func (s *localSession) TeamID() string {
+	return s.request.TeamID
+}
+
 // Tags returns the session tags
 func (s *localSession) Tags() map[string]string {
 	return s.request.Tags

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -382,6 +382,8 @@ func (p *Proxy) CreateSession(sessionID string, startReq StartRequest, userID, u
 		InitialMessage: initialMessage,
 		Teams:          teams,
 		GithubToken:    githubToken,
+		Scope:          startReq.Scope,
+		TeamID:         startReq.TeamID,
 	}
 
 	// Delegate to session manager

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -136,6 +136,8 @@ func (s *mockSession) Tags() map[string]string { return s.tags }
 func (s *mockSession) Status() string          { return s.status }
 func (s *mockSession) StartedAt() time.Time    { return s.startedAt }
 func (s *mockSession) Description() string     { return "" }
+func (s *mockSession) Scope() ResourceScope    { return ScopeUser }
+func (s *mockSession) TeamID() string          { return "" }
 func (s *mockSession) Cancel()                 { s.cancelled = true }
 
 func newMockSessionManager() *mockSessionManager {

--- a/pkg/proxy/session.go
+++ b/pkg/proxy/session.go
@@ -18,6 +18,12 @@ type Session interface {
 	// UserID returns the user ID that owns this session
 	UserID() string
 
+	// Scope returns the resource scope ("user" or "team")
+	Scope() ResourceScope
+
+	// TeamID returns the team ID when Scope is "team"
+	TeamID() string
+
 	// Tags returns the session tags
 	Tags() map[string]string
 
@@ -37,9 +43,12 @@ type Session interface {
 
 // SessionFilter defines filter criteria for listing sessions
 type SessionFilter struct {
-	UserID string
-	Status string
-	Tags   map[string]string
+	UserID  string
+	Status  string
+	Tags    map[string]string
+	Scope   ResourceScope // Filter by scope ("user" or "team")
+	TeamID  string        // Filter by specific team ID
+	TeamIDs []string      // Filter by multiple team IDs (user's teams)
 }
 
 // SessionManager manages the lifecycle of sessions

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -1,5 +1,15 @@
 package proxy
 
+// ResourceScope defines the scope of a resource (session, schedule, etc.)
+type ResourceScope string
+
+const (
+	// ScopeUser indicates the resource is owned by a specific user
+	ScopeUser ResourceScope = "user"
+	// ScopeTeam indicates the resource is owned by a team
+	ScopeTeam ResourceScope = "team"
+)
+
 // SessionParams represents session parameters for agentapi server
 type SessionParams struct {
 	// Message is the initial message to send to the agent after session starts
@@ -14,6 +24,10 @@ type StartRequest struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 	// Params contains session parameters
 	Params *SessionParams `json:"params,omitempty"`
+	// Scope defines the ownership scope ("user" or "team"). Defaults to "user".
+	Scope ResourceScope `json:"scope,omitempty"`
+	// TeamID is the team identifier (e.g., "org/team-slug") when Scope is "team"
+	TeamID string `json:"team_id,omitempty"`
 }
 
 // RepositoryInfo contains repository information extracted from tags
@@ -30,6 +44,8 @@ type RunServerRequest struct {
 	Tags           map[string]string
 	RepoInfo       *RepositoryInfo
 	InitialMessage string
-	Teams          []string // GitHub team slugs (e.g., ["org/team-a", "org/team-b"])
-	GithubToken    string   // GitHub token passed via params.github_token
+	Teams          []string      // GitHub team slugs (e.g., ["org/team-a", "org/team-b"])
+	GithubToken    string        // GitHub token passed via params.github_token
+	Scope          ResourceScope // Resource scope ("user" or "team")
+	TeamID         string        // Team identifier when Scope is "team"
 }

--- a/pkg/schedule/manager.go
+++ b/pkg/schedule/manager.go
@@ -3,6 +3,8 @@ package schedule
 import (
 	"context"
 	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/proxy"
 )
 
 // ScheduleFilter defines filter criteria for listing schedules
@@ -11,6 +13,12 @@ type ScheduleFilter struct {
 	UserID string
 	// Status filters by schedule status
 	Status ScheduleStatus
+	// Scope filters by resource scope
+	Scope proxy.ResourceScope
+	// TeamID filters by team ID (for team-scoped schedules)
+	TeamID string
+	// TeamIDs filters by multiple team IDs (returns schedules for any of these teams)
+	TeamIDs []string
 }
 
 // Manager defines the interface for schedule management

--- a/pkg/schedule/types.go
+++ b/pkg/schedule/types.go
@@ -26,6 +26,10 @@ type Schedule struct {
 	Name string `json:"name"`
 	// UserID is the ID of the user who created the schedule
 	UserID string `json:"user_id"`
+	// Scope defines the ownership scope ("user" or "team"). Defaults to "user".
+	Scope proxy.ResourceScope `json:"scope,omitempty"`
+	// TeamID is the team identifier (e.g., "org/team-slug") when Scope is "team"
+	TeamID string `json:"team_id,omitempty"`
 	// Status is the current status of the schedule
 	Status ScheduleStatus `json:"status"`
 

--- a/pkg/schedule/worker_test.go
+++ b/pkg/schedule/worker_test.go
@@ -23,14 +23,16 @@ type mockProxySession struct {
 	startedAt time.Time
 }
 
-func (s *mockProxySession) ID() string              { return s.id }
-func (s *mockProxySession) Addr() string            { return s.addr }
-func (s *mockProxySession) UserID() string          { return s.userID }
-func (s *mockProxySession) Tags() map[string]string { return s.tags }
-func (s *mockProxySession) Status() string          { return s.status }
-func (s *mockProxySession) StartedAt() time.Time    { return s.startedAt }
-func (s *mockProxySession) Description() string     { return "" }
-func (s *mockProxySession) Cancel()                 {}
+func (s *mockProxySession) ID() string                 { return s.id }
+func (s *mockProxySession) Addr() string               { return s.addr }
+func (s *mockProxySession) UserID() string             { return s.userID }
+func (s *mockProxySession) Tags() map[string]string    { return s.tags }
+func (s *mockProxySession) Status() string             { return s.status }
+func (s *mockProxySession) StartedAt() time.Time       { return s.startedAt }
+func (s *mockProxySession) Description() string        { return "" }
+func (s *mockProxySession) Scope() proxy.ResourceScope { return proxy.ScopeUser }
+func (s *mockProxySession) TeamID() string             { return "" }
+func (s *mockProxySession) Cancel()                    {}
 
 func newMockProxySessionManager() *mockProxySessionManager {
 	return &mockProxySessionManager{sessions: make(map[string]*mockProxySession)}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -131,7 +131,7 @@
     "/search": {
       "get": {
         "summary": "Search sessions",
-        "description": "Returns a list of sessions. Non-admin users can only see their own sessions. Supports filtering by status and tags.",
+        "description": "Returns a list of sessions. Non-admin users can see their own sessions and team-scoped sessions they have access to. Supports filtering by status, scope, team, and tags.",
         "operationId": "searchSessions",
         "tags": ["Sessions"],
         "parameters": [
@@ -141,6 +141,22 @@
             "description": "Filter by session status",
             "schema": {
               "$ref": "#/components/schemas/SessionStatus"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "description": "Filter by resource scope",
+            "schema": {
+              "$ref": "#/components/schemas/ResourceScope"
+            }
+          },
+          {
+            "name": "team_id",
+            "in": "query",
+            "description": "Filter by team ID (e.g., 'org/team-slug')",
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -628,7 +644,7 @@
       },
       "get": {
         "summary": "List schedules",
-        "description": "Returns a list of schedules. Non-admin users can only see their own schedules.",
+        "description": "Returns a list of schedules. Non-admin users can see their own schedules and team-scoped schedules they have access to.",
         "operationId": "listSchedules",
         "tags": ["Schedules"],
         "parameters": [
@@ -638,6 +654,22 @@
             "description": "Filter by schedule status",
             "schema": {
               "$ref": "#/components/schemas/ScheduleStatus"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "description": "Filter by resource scope",
+            "schema": {
+              "$ref": "#/components/schemas/ResourceScope"
+            }
+          },
+          {
+            "name": "team_id",
+            "in": "query",
+            "description": "Filter by team ID (e.g., 'org/team-slug')",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -1239,6 +1271,14 @@
           },
           "params": {
             "$ref": "#/components/schemas/SessionParams"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/ResourceScope",
+            "description": "Ownership scope of the session (default: user)"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Team identifier (e.g., 'org/team-slug') when scope is 'team'"
           }
         }
       },
@@ -1265,6 +1305,14 @@
           "user_id": {
             "type": "string",
             "description": "Owner user ID"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/ResourceScope",
+            "description": "Ownership scope of the session"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Team identifier when scope is 'team'"
           },
           "status": {
             "$ref": "#/components/schemas/SessionStatus"
@@ -1303,6 +1351,14 @@
           "name": {
             "type": "string",
             "description": "Name of the schedule"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/ResourceScope",
+            "description": "Ownership scope of the schedule (default: user)"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Team identifier (e.g., 'org/team-slug') when scope is 'team'"
           },
           "scheduled_at": {
             "type": "string",
@@ -1366,6 +1422,14 @@
           "user_id": {
             "type": "string",
             "description": "Owner user ID"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/ResourceScope",
+            "description": "Ownership scope of the schedule"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Team identifier when scope is 'team'"
           },
           "status": {
             "$ref": "#/components/schemas/ScheduleStatus"
@@ -1456,6 +1520,12 @@
         "type": "string",
         "enum": ["active", "paused", "completed"],
         "description": "Schedule status"
+      },
+      "ResourceScope": {
+        "type": "string",
+        "enum": ["user", "team"],
+        "default": "user",
+        "description": "Ownership scope. 'user' for personal resources, 'team' for team-shared resources"
       },
       "UpdateSettingsRequest": {
         "type": "object",


### PR DESCRIPTION
## Summary
- Add support for team-scoped sessions and schedules where all team members can view, update, and delete the resources
- Enable collaboration within teams by allowing shared access to resources
- Team membership is validated via GitHub team info from OAuth

## Changes

### Data Model
- Add `ResourceScope` type (`"user"` or `"team"`) to sessions and schedules
- Add `TeamID` field to identify the owning team (format: `"org/team-slug"`)
- Extend `SessionFilter` and `ScheduleFilter` with scope and team filtering

### Access Control
- Add `IsMemberOfTeam(teamID string)` method to User entity
- Add `CanAccessResource(ownerUserID, scope, teamID)` method for unified access checks
- All team members can view, update, delete, and trigger team-scoped resources

### API Changes
- `/start` endpoint: Add `scope` and `team_id` request fields
- `/search` endpoint: Add `scope` and `team_id` query parameters
- `/schedules` endpoints: Add `scope` and `team_id` to request/response
- Session and schedule responses include `scope` and `team_id` fields

### OpenAPI Specification
- Add `ResourceScope` enum schema
- Update `StartRequest`, `SessionResponse`, `CreateScheduleRequest`, `ScheduleResponse` schemas
- Update `/search` and `/schedules` endpoints with new query parameters

## Test plan
- [x] All existing tests pass
- [x] Lint passes
- [ ] Manual test: Create team-scoped session
- [ ] Manual test: List sessions shows team-scoped sessions for team members
- [ ] Manual test: Team members can delete team-scoped sessions
- [ ] Manual test: Create team-scoped schedule
- [ ] Manual test: Trigger team-scoped schedule creates team-scoped session

🤖 Generated with [Claude Code](https://claude.com/claude-code)