### PR TITLE
fix: Add scope filtering to ListSessions (#417)

### DIFF
--- a/pkg/proxy/local_session_manager.go
+++ b/pkg/proxy/local_session_manager.go
@@ -210,6 +210,30 @@ func (m *LocalSessionManager) ListSessions(filter SessionFilter) []Session {
 			continue
 		}
 
+		// Scope filter
+		if filter.Scope != "" && session.request.Scope != filter.Scope {
+			continue
+		}
+
+		// TeamID filter
+		if filter.TeamID != "" && session.request.TeamID != filter.TeamID {
+			continue
+		}
+
+		// TeamIDs filter (for team-scoped sessions, check if session's team is in user's teams)
+		if len(filter.TeamIDs) > 0 && session.request.Scope == ScopeTeam {
+			teamMatch := false
+			for _, teamID := range filter.TeamIDs {
+				if session.request.TeamID == teamID {
+					teamMatch = true
+					break
+				}
+			}
+			if !teamMatch {
+				continue
+			}
+		}
+
 		// Tag filters
 		if len(filter.Tags) > 0 {
 			matchAllTags := true


### PR DESCRIPTION
## Summary

This PR fixes the issue where `ListSessions` was not filtering by scope, causing users to see all sessions (both user-scoped and team-scoped) regardless of scope selection.

### Changes

- **buildLabels**: Add `agentapi.proxy/scope` and `agentapi.proxy/team-id` labels to Kubernetes resources
- **restoreSessionFromService**: Restore `Scope` and `TeamID` from Kubernetes labels
- **restoreSessionFromServiceWithDeployment**: Same restoration logic for pre-fetched deployment case
- **KubernetesSessionManager.ListSessions**: Apply `Scope`, `TeamID`, and `TeamIDs` filters
- **LocalSessionManager.ListSessions**: Apply same filters for local session management

### Backward Compatibility

Existing sessions without scope labels will default to `ScopeUser` for backward compatibility.

## Test plan

- [x] Added `TestKubernetesSessionManager_ListSessions_ScopeFilter` (envtest-based)
- [x] Added `TestLocalSessionManager_ListSessions_ScopeFilter` (unit test)
- [x] `make lint` passes
- [x] `go test -race ./...` passes

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)