### PR TITLE
perf: Optimize Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Git
+.git
+.gitignore
+
+# Build artifacts
+bin/
+
+# Documentation (not needed for build)
+docs/
+*.md
+!config/*.md
+
+# Examples and test files
+examples/
+test/
+*_test.go
+integration_test.go
+
+# GitHub and CI configurations
+.github/
+
+# Helm charts (not needed for container build)
+helm/
+
+# Misc files
+misc/
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Example configuration files
+*.example.*
+config.*.example.*
+
+# Netlify
+netlify/
+netlify.toml
+
+# Serena
+.serena/
+
+# Goreleaser
+.goreleaser.yml
+
+# Tagpr
+.tagpr
+
+# Tool versions
+.tool-versions


### PR DESCRIPTION
## Summary

- Remove unnecessary packages (gcc, python3, procps, tmux) to reduce image size
- Remove Node.js and Playwright MCP as they are no longer needed
- Add Go build optimization flags (`-ldflags="-s -w"`) for smaller binary
- Use `--no-install-recommends` for apt packages
- Add cache cleanup for uv and claude code installations
- Add `.dockerignore` to reduce build context size

### Expected size reduction
| Component | Estimated Reduction |
|-----------|---------------------|
| Node.js | ~200-300MB |
| gcc | ~100-200MB |
| python3 | ~50-100MB |
| procps, tmux | ~10MB |
| Playwright MCP | ~50MB |
| Go binary optimization | ~10-20MB |

## Test plan
- [ ] Build the Docker image and verify it works
- [ ] Verify all required tools (git, gh, mise, uv, claude) are available
- [ ] Compare image size before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)