### PR TITLE
fix: Add team settings name format validation

### DIFF
--- a/internal/interfaces/controllers/settings_controller_test.go
+++ b/internal/interfaces/controllers/settings_controller_test.go
@@ -77,6 +77,194 @@ func createTestUser(userID string, isAdmin bool) *entities.User {
 	return user
 }
 
+// createTestGitHubUser creates a GitHub user with team memberships for testing
+func createTestGitHubUser(userID string, teams []entities.GitHubTeamMembership) *entities.User {
+	githubInfo := entities.NewGitHubUserInfo(
+		12345,
+		userID,
+		"Test User",
+		"test@example.com",
+		"https://example.com/avatar.png",
+		"Test Corp",
+		"Tokyo",
+	)
+	user := entities.NewGitHubUser(
+		entities.UserID(userID),
+		userID,
+		"test@example.com",
+		githubInfo,
+	)
+	user.SetGitHubInfo(githubInfo, teams)
+	return user
+}
+
+func TestValidateTeamSettingsName(t *testing.T) {
+	tests := []struct {
+		name        string
+		user        *entities.User
+		settingName string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "non-GitHub user bypasses validation",
+			user:        createTestUser("test-user", false),
+			settingName: "my-team",
+			wantErr:     false,
+		},
+		{
+			name:        "GitHub user without teams bypasses validation",
+			user:        createTestGitHubUser("test-user", []entities.GitHubTeamMembership{}),
+			settingName: "my-team",
+			wantErr:     false,
+		},
+		{
+			name: "correct format org/team passes validation",
+			user: createTestGitHubUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "myorg", TeamSlug: "myteam", Role: "maintainer"},
+			}),
+			settingName: "myorg/myteam",
+			wantErr:     false,
+		},
+		{
+			name: "incorrect format team-only returns error",
+			user: createTestGitHubUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "myorg", TeamSlug: "myteam", Role: "maintainer"},
+			}),
+			settingName: "myteam",
+			wantErr:     true,
+			errContains: "myorg/myteam",
+		},
+		{
+			name: "unrelated name passes validation",
+			user: createTestGitHubUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "myorg", TeamSlug: "myteam", Role: "maintainer"},
+			}),
+			settingName: "unrelated-name",
+			wantErr:     false,
+		},
+		{
+			name: "case-insensitive matching for team slug",
+			user: createTestGitHubUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "MyOrg", TeamSlug: "MyTeam", Role: "maintainer"},
+			}),
+			settingName: "myteam",
+			wantErr:     true,
+			errContains: "MyOrg/MyTeam",
+		},
+		{
+			name: "multiple teams - matches first team slug",
+			user: createTestGitHubUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "org1", TeamSlug: "team1", Role: "maintainer"},
+				{Organization: "org2", TeamSlug: "team2", Role: "member"},
+			}),
+			settingName: "team1",
+			wantErr:     true,
+			errContains: "org1/team1",
+		},
+		{
+			name: "multiple teams - matches second team slug",
+			user: createTestGitHubUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "org1", TeamSlug: "team1", Role: "maintainer"},
+				{Organization: "org2", TeamSlug: "team2", Role: "member"},
+			}),
+			settingName: "team2",
+			wantErr:     true,
+			errContains: "org2/team2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockSettingsRepository()
+			h := NewSettingsController(repo)
+
+			err := h.validateTeamSettingsName(tt.user, tt.settingName)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// createTestGitHubAdminUser creates a GitHub user with admin role and team memberships for testing
+func createTestGitHubAdminUser(userID string, teams []entities.GitHubTeamMembership) *entities.User {
+	user := createTestGitHubUser(userID, teams)
+	_ = user.SetRoles([]entities.Role{entities.RoleAdmin})
+	return user
+}
+
+func TestUpdateSettings_TeamNameValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           *entities.User
+		settingName    string
+		expectedStatus int
+		errContains    string
+	}{
+		{
+			name: "team slug only format rejected",
+			user: createTestGitHubAdminUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "myorg", TeamSlug: "myteam", Role: "maintainer"},
+			}),
+			settingName:    "myteam",
+			expectedStatus: http.StatusBadRequest,
+			errContains:    "myorg/myteam",
+		},
+		{
+			name: "org/team format accepted",
+			user: createTestGitHubAdminUser("test-user", []entities.GitHubTeamMembership{
+				{Organization: "myorg", TeamSlug: "myteam", Role: "maintainer"},
+			}),
+			settingName:    "myorg/myteam",
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newMockSettingsRepository()
+			h := NewSettingsController(repo)
+
+			requestBody := UpdateSettingsRequest{
+				Bedrock: &BedrockSettingsRequest{
+					Enabled: true,
+				},
+			}
+			body, err := json.Marshal(requestBody)
+			require.NoError(t, err)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPut, "/settings/"+tt.settingName, bytes.NewReader(body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("name")
+			c.SetParamValues(tt.settingName)
+			c.Set("internal_user", tt.user)
+
+			err = h.UpdateSettings(c)
+
+			if tt.expectedStatus == http.StatusOK {
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, rec.Code)
+			} else {
+				require.Error(t, err)
+				httpErr, ok := err.(*echo.HTTPError)
+				require.True(t, ok)
+				assert.Equal(t, tt.expectedStatus, httpErr.Code)
+				if tt.errContains != "" {
+					assert.Contains(t, httpErr.Message, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
 func TestUpdateSettings_PreserveExistingCredentials(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -888,7 +888,7 @@
             "name": "name",
             "in": "path",
             "required": true,
-            "description": "Settings name (user ID or team name like 'org-team')",
+            "description": "Settings name. For personal settings, use your user ID. For team settings, use '{org}/{team-slug}' format (e.g., 'myorg/backend-team').",
             "schema": {
               "type": "string"
             }
@@ -950,7 +950,7 @@
             "name": "name",
             "in": "path",
             "required": true,
-            "description": "Settings name (user ID or team name like 'org-team')",
+            "description": "Settings name. For personal settings, use your user ID. For team settings, use '{org}/{team-slug}' format (e.g., 'myorg/backend-team').",
             "schema": {
               "type": "string"
             }
@@ -1074,7 +1074,7 @@
             "name": "name",
             "in": "path",
             "required": true,
-            "description": "Settings name (user ID or team name like 'org-team')",
+            "description": "Settings name. For personal settings, use your user ID. For team settings, use '{org}/{team-slug}' format (e.g., 'myorg/backend-team').",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
## Summary

- Settings API で team 設定を作成する際に、正しい `{org}/{team-slug}` 形式を使用するよう検証を追加
- 不正な形式（team-slug のみ）を使用した場合、正しい形式を提案するエラーメッセージを表示
- OpenAPI 仕様を更新して正しい形式を文書化

## Problem

セッション作成時は team 名を `{org}/{team-slug}` 形式（例: `myorg/backend-team`）で扱い、Secret 名を `agent-credentials-myorg-backend-team` として生成します。しかし Settings API では任意の名前が許可されていたため、ユーザーが `backend-team` のみで設定を作成すると、Secret 名が `agent-credentials-backend-team` となり、セッション作成時に参照される Secret と一致しませんでした。

## Solution

`UpdateSettings` で team 設定名の形式を検証し、team-slug のみの名前が使用された場合は正しい形式を提案するエラーメッセージを返すようにしました。

## Test plan

- [x] `validateTeamSettingsName` の単体テスト追加
- [x] `UpdateSettings` の統合テスト追加
- [x] `make lint` 通過
- [x] `make test` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)