### PR TITLE
fix: Webhook API で secret をマスクせずに返すように変更

### DIFF
--- a/internal/interfaces/controllers/webhook_controller.go
+++ b/internal/interfaces/controllers/webhook_controller.go
@@ -594,7 +594,7 @@ func (c *WebhookController) toResponse(ctx echo.Context, w *entities.Webhook) We
 		TeamID:        w.TeamID(),
 		Status:        w.Status(),
 		Type:          w.WebhookType(),
-		Secret:        w.MaskSecret(),
+		Secret:        w.Secret(),
 		WebhookURL:    c.getWebhookURL(ctx, w),
 		CreatedAt:     w.CreatedAt().Format(time.RFC3339),
 		UpdatedAt:     w.UpdatedAt().Format(time.RFC3339),


### PR DESCRIPTION
## Summary
- Webhook API のレスポンスで `secret` フィールドをマスクせずに返すように変更
- UI から secret をコピーできるようになる

## Changes
- `toResponse` 関数で `w.MaskSecret()` → `w.Secret()` に変更

## Test plan
- Webhook 一覧を取得し、secret が完全な形で返されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)