### PR TITLE
feat: add unique URL per webhook for GitHub webhook receiver

### DIFF
--- a/internal/interfaces/controllers/webhook_controller.go
+++ b/internal/interfaces/controllers/webhook_controller.go
@@ -700,7 +700,7 @@ func (c *WebhookController) getWebhookURL(ctx echo.Context, w *entities.Webhook)
 
 	switch w.WebhookType() {
 	case entities.WebhookTypeGitHub:
-		return fmt.Sprintf("%s/hooks/github", baseURL)
+		return fmt.Sprintf("%s/hooks/github/%s", baseURL, w.ID())
 	default:
 		return fmt.Sprintf("%s/hooks/custom/%s", baseURL, w.ID())
 	}

--- a/pkg/webhook/handlers.go
+++ b/pkg/webhook/handlers.go
@@ -46,7 +46,7 @@ func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *app.Server) error {
 
 	// Receiver endpoints
 	hooks := e.Group("/hooks")
-	hooks.POST("/github", h.githubController.HandleGitHubWebhook)
+	hooks.POST("/github/:id", h.githubController.HandleGitHubWebhook)
 
 	log.Printf("Registered webhook management routes")
 	return nil

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1186,13 +1186,24 @@
         }
       }
     },
-    "/hooks/github": {
+    "/hooks/github/{id}": {
       "post": {
         "summary": "Receive GitHub webhook",
-        "description": "Receives webhook payloads from GitHub/GHES. Matches the payload against configured webhooks by repository and verifies the signature.",
+        "description": "Receives webhook payloads from GitHub/GHES. Uses the webhook ID from the URL to identify the webhook and verifies the signature using the webhook's secret.",
         "operationId": "handleGitHubWebhook",
         "tags": ["Webhooks"],
         "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Webhook ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1235,6 +1246,9 @@
           },
           "401": {
             "description": "Signature verification failed"
+          },
+          "404": {
+            "description": "Webhook not found"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Changed webhook receiver endpoint from `/hooks/github` to `/hooks/github/{id}`
- Each webhook now has its own unique URL that GitHub can send events to
- Solves signature verification issues when multiple webhooks are configured for the same repository

## Background
Previously, all GitHub webhooks shared a single endpoint `/hooks/github`. When a webhook event was received, the system had to search for candidate webhooks by repository and try each one's secret until signature verification succeeded. This caused issues when multiple webhooks existed for the same repository with different secrets.

## Changes
- `webhook_github_controller.go`: Updated `HandleGitHubWebhook` to get webhook ID from URL path parameter and verify signature using that specific webhook's secret
- `handlers.go`: Updated route from `/github` to `/github/:id`
- `webhook_controller.go`: Updated `webhook_url` generation to include webhook ID
- `spec/openapi.json`: Updated API specification with new path parameter

## Test plan
- [ ] Create multiple webhooks for the same repository
- [ ] Verify each webhook has a unique `webhook_url` containing its ID
- [ ] Configure GitHub webhooks using each unique URL and corresponding secret
- [ ] Verify signature verification works correctly for each webhook independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)