### PR TITLE
feat: add symlink for claude command to ~/.local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,12 +87,15 @@ RUN curl https://mise.run | sh && \
 # Install claude code and move to /opt/claude for persistence across volume mounts
 # The installer creates a symlink at ~/.local/bin/claude -> ~/.local/share/claude/versions/X.X.X
 # We copy with -L to follow the symlink and get the actual binary, then clean up
+# Then create a symlink at ~/.local/bin/claude -> /opt/claude/bin/claude for volume mount compatibility
 RUN curl -fsSL https://claude.ai/install.sh | bash && \
     sudo mkdir -p /opt/claude/bin && \
     sudo cp -L /home/agentapi/.local/bin/claude /opt/claude/bin/claude && \
     sudo chown agentapi:agentapi /opt/claude/bin/claude && \
     sudo chmod +x /opt/claude/bin/claude && \
-    rm -rf /home/agentapi/.local/share/claude/versions /home/agentapi/.local/bin/claude 2>/dev/null || true
+    rm -rf /home/agentapi/.local/share/claude/versions /home/agentapi/.local/bin/claude 2>/dev/null || true && \
+    mkdir -p /home/agentapi/.local/bin && \
+    ln -sf /opt/claude/bin/claude /home/agentapi/.local/bin/claude
 
 # Install uv for Python package management (enables uvx) and clean cache
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \


### PR DESCRIPTION
## Summary
- `/opt/claude/bin/claude` から `/home/agentapi/.local/bin/claude` へのシンボリックリンクを作成
- `~/.local` ディレクトリがボリュームマウントされた場合でも claude コマンドにアクセス可能に

## Test plan
- [ ] Docker イメージのビルドが成功することを確認
- [ ] コンテナ内で `/home/agentapi/.local/bin/claude` からコマンドが実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)