### PR TITLE
fix: add OAuth token support to session pods and init container

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -47,12 +47,24 @@ func SetupClaudeCode(homeDir string) error {
 		},
 	}
 
+	// Build env map for tokens
+	envMap := make(map[string]string)
+
 	// Try to get GitHub token and add to env if available
 	if githubToken, err := GetGitHubToken(""); err == nil && githubToken != "" {
-		settings["env"] = map[string]string{
-			"GITHUB_TOKEN": githubToken,
-		}
+		envMap["GITHUB_TOKEN"] = githubToken
 		log.Printf("Added GITHUB_TOKEN to Claude Code settings")
+	}
+
+	// Add Claude Code OAuth token if available in environment
+	if oauthToken := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN"); oauthToken != "" {
+		envMap["CLAUDE_CODE_OAUTH_TOKEN"] = oauthToken
+		log.Printf("Added CLAUDE_CODE_OAUTH_TOKEN to Claude Code settings")
+	}
+
+	// Add env to settings if any tokens are available
+	if len(envMap) > 0 {
+		settings["env"] = envMap
 	}
 
 	// Marshal settings to JSON


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_OAUTH_TOKEN` support to `startup.go` `SetupClaudeCode` function to include OAuth token in `~/.claude/settings.json` env field alongside `GITHUB_TOKEN`
- Fix init container (`buildMCPSetupInitContainer`) to properly handle Team-scoped credentials mounting, matching the logic in main container
  - Team-scoped: mount specific team's credentials secret
  - User-scoped: mount all team secrets and user-specific secret

## Background
This PR addresses the issue where Claude Code OAuth tokens from Settings API were not being properly passed through to session pods. The fix ensures:

1. **startup.go**: OAuth token from `CLAUDE_CODE_OAUTH_TOKEN` environment variable is now included in the Claude Code settings JSON
2. **kubernetes_session_manager.go**: Init container now correctly mounts credentials secrets based on scope, matching the main container behavior

## Test plan
- [x] Run `make test` - all tests pass
- [x] Run `make lint` - no issues
- [ ] Deploy new version and verify OAuth token is properly set in session pods
- [ ] Verify Claude Code can authenticate using OAuth token in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)