### PR TITLE
fix: remove GitHub token from webhook API responses

### DIFF
--- a/internal/interfaces/controllers/webhook_controller.go
+++ b/internal/interfaces/controllers/webhook_controller.go
@@ -672,11 +672,8 @@ func (c *WebhookController) sessionConfigToResponse(sc *entities.WebhookSessionC
 		Tags:                   sc.Tags(),
 		InitialMessageTemplate: sc.InitialMessageTemplate(),
 	}
-	if params := sc.Params(); params != nil {
-		resp.Params = &SessionParamsResponse{
-			GithubToken: params.GithubToken(),
-		}
-	}
+	// GitHubトークンは機密情報なのでレスポンスに含めない
+	// params フィールドは意図的に省略
 	return resp
 }
 

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -2007,7 +2007,7 @@
             }
           },
           "session_config": {
-            "$ref": "#/components/schemas/WebhookSessionConfig"
+            "$ref": "#/components/schemas/WebhookSessionConfigResponse"
           },
           "created_at": {
             "type": "string",
@@ -2201,11 +2201,33 @@
             "properties": {
               "github_token": {
                 "type": "string",
-                "description": "GitHub token for the session"
+                "description": "GitHub token for the session (used in requests only)"
               }
             }
           }
         }
+      },
+      "WebhookSessionConfigResponse": {
+        "type": "object",
+        "properties": {
+          "environment": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "initial_message_template": {
+            "type": "string",
+            "description": "Go template for initial message (e.g., 'Review PR #{{.pull_request.Number}}')"
+          }
+        },
+        "description": "Session configuration in responses (sensitive params like github_token are excluded)"
       },
       "WebhookDeliveryRecord": {
         "type": "object",


### PR DESCRIPTION
## Summary

This PR removes sensitive GitHub tokens from webhook API responses to prevent accidental exposure.

## Changes

- Modified `sessionConfigToResponse()` in `webhook_controller.go` to omit the `params` field containing GitHub tokens
- Added `WebhookSessionConfigResponse` schema to OpenAPI spec (excludes `params` field)
- Updated `WebhookResponse` to use `WebhookSessionConfigResponse` instead of `WebhookSessionConfig`
- Updated `github_token` field description in `WebhookSessionConfig` to clarify it's request-only

## Security Impact

**Before**: GitHub tokens stored in webhook configurations were exposed in API responses (GET /webhooks/:id)

**After**: GitHub tokens are properly excluded from all webhook GET responses while still being accepted in POST/PUT requests

## Testing

- ✅ All tests passing
- ✅ Lint checks passing
- ✅ Verified response structure excludes sensitive params

## Related Issue

Fixes security vulnerability where GitHub tokens were exposed in webhook API responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)