### PR TITLE
fix: add GoTemplate field support to webhook API

### DIFF
--- a/internal/interfaces/controllers/webhook_controller.go
+++ b/internal/interfaces/controllers/webhook_controller.go
@@ -69,8 +69,9 @@ type TriggerRequest struct {
 
 // TriggerConditionsRequest represents trigger conditions in requests
 type TriggerConditionsRequest struct {
-	GitHub   *GitHubConditionsRequest   `json:"github,omitempty"`
-	JSONPath []JSONPathConditionRequest `json:"jsonpath,omitempty"`
+	GitHub     *GitHubConditionsRequest   `json:"github,omitempty"`
+	JSONPath   []JSONPathConditionRequest `json:"jsonpath,omitempty"`
+	GoTemplate string                     `json:"go_template,omitempty"`
 }
 
 // JSONPathConditionRequest represents a JSONPath condition in requests
@@ -159,8 +160,9 @@ type TriggerResponse struct {
 
 // TriggerConditionsResponse represents trigger conditions in responses
 type TriggerConditionsResponse struct {
-	GitHub   *GitHubConditionsResponse   `json:"github,omitempty"`
-	JSONPath []JSONPathConditionResponse `json:"jsonpath,omitempty"`
+	GitHub     *GitHubConditionsResponse   `json:"github,omitempty"`
+	JSONPath   []JSONPathConditionResponse `json:"jsonpath,omitempty"`
+	GoTemplate string                      `json:"go_template,omitempty"`
 }
 
 // JSONPathConditionResponse represents a JSONPath condition in responses
@@ -309,6 +311,9 @@ func (c *WebhookController) CreateWebhook(ctx echo.Context) error {
 				))
 			}
 			conditions.SetJSONPath(jsonPathConditions)
+		}
+		if t.Conditions.GoTemplate != "" {
+			conditions.SetGoTemplate(t.Conditions.GoTemplate)
 		}
 		trigger.SetConditions(conditions)
 
@@ -530,6 +535,9 @@ func (c *WebhookController) UpdateWebhook(ctx echo.Context) error {
 				}
 				conditions.SetJSONPath(jsonPathConditions)
 			}
+			if t.Conditions.GoTemplate != "" {
+				conditions.SetGoTemplate(t.Conditions.GoTemplate)
+			}
 			trigger.SetConditions(conditions)
 
 			if t.SessionConfig != nil {
@@ -704,6 +712,9 @@ func (c *WebhookController) toResponse(ctx echo.Context, w *entities.Webhook) We
 					Value:    jp.Value(),
 				})
 			}
+		}
+		if goTemplate := cond.GoTemplate(); goTemplate != "" {
+			tr.Conditions.GoTemplate = goTemplate
 		}
 
 		// Session config


### PR DESCRIPTION
## Summary

カスタムwebhookのtemplate matcherがAPIのリクエスト/レスポンスで処理されていなかった問題を修正しました。

## Changes

- `TriggerConditionsRequest` に `go_template` フィールドを追加
- `TriggerConditionsResponse` に `go_template` フィールドを追加  
- `CreateWebhook` で GoTemplate を entity に設定する処理を追加
- `UpdateWebhook` で GoTemplate を entity に設定する処理を追加
- `toResponse` で GoTemplate をレスポンスに含める処理を追加

## Background

最近のコミット #453 でGoテンプレートによるマッチング機能が追加されましたが、APIレイヤーでの処理が抜けていたため、webhookを作成・更新する際に `go_template` フィールドが保存されない問題がありました。

リポジトリ層やエンティティ層では既に実装されていましたが、APIコントローラー層で：
1. リクエストから `go_template` を読み取る処理
2. レスポンスに `go_template` を含める処理

が欠けていました。

## Test plan

- [x] `make lint` が成功することを確認
- [x] `make test` が成功することを確認（全てのテストがPASS）
- [x] OpenAPI仕様に `go_template` フィールドが定義されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)