### PR TITLE
security: remove dangerous 'none' signature type from webhooks

### DIFF
--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -263,21 +263,6 @@ webhook作成時に`signature_type`フィールドで署名検証の方式を指
      -d '{"event": "test"}'
    ```
 
-3. **`none`**: 署名検証なし
-   - 開発・テスト環境専用
-   - 本番環境では使用しないでください
-
-   ```json
-   {
-     "name": "Development Webhook",
-     "type": "custom",
-     "signature_type": "none",
-     "triggers": [...]
-   }
-   ```
-
-   ⚠️ **警告**: `signature_type: "none"`は開発・テスト環境でのみ使用してください。本番環境では必ず`hmac`または`static`を使用してください。
-
 ### 初期メッセージテンプレート
 
 Goのtext/templateを使用して、ペイロードデータから動的にメッセージを生成できます。

--- a/internal/domain/entities/webhook.go
+++ b/internal/domain/entities/webhook.go
@@ -32,8 +32,6 @@ const (
 	WebhookSignatureTypeHMAC WebhookSignatureType = "hmac"
 	// WebhookSignatureTypeStatic indicates static token comparison
 	WebhookSignatureTypeStatic WebhookSignatureType = "static"
-	// WebhookSignatureTypeNone indicates no signature verification (for development/testing)
-	WebhookSignatureTypeNone WebhookSignatureType = "none"
 )
 
 // DeliveryStatus defines the status of a webhook delivery

--- a/internal/interfaces/controllers/webhook_custom_controller.go
+++ b/internal/interfaces/controllers/webhook_custom_controller.go
@@ -116,11 +116,6 @@ func (c *WebhookCustomController) HandleCustomWebhook(ctx echo.Context) error {
 
 		log.Printf("[WEBHOOK_CUSTOM] Static token verified for webhook %s (%s)", matchedWebhook.ID(), matchedWebhook.Name())
 
-	case entities.WebhookSignatureTypeNone:
-		// No signature verification (for development/testing only)
-		log.Printf("[WEBHOOK_CUSTOM] WARNING: No signature verification for webhook %s (%s) - signature_type is 'none'",
-			matchedWebhook.ID(), matchedWebhook.Name())
-
 	default:
 		log.Printf("[WEBHOOK_CUSTOM] Unknown signature type '%s' for webhook %s, defaulting to HMAC", sigType, webhookID)
 

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1976,8 +1976,8 @@
       },
       "WebhookSignatureType": {
         "type": "string",
-        "enum": ["hmac", "static", "none"],
-        "description": "Signature verification type: hmac (HMAC-based signature verification, default), static (simple token comparison), none (no verification, for development/testing)"
+        "enum": ["hmac", "static"],
+        "description": "Signature verification type: hmac (HMAC-based signature verification, default), static (simple token comparison)"
       },
       "CreateWebhookRequest": {
         "type": "object",


### PR DESCRIPTION
## 概要

署名検証タイプ `none` を削除しました。この設定は署名検証を完全にバイパスするため、非常に危険でした。

## 問題点

`signature_type: "none"` が設定されたカスタムwebhookは、以下の脆弱性がありました：

- 署名検証が完全にスキップされる
- 誰でも認証なしでwebhookエンドポイントにリクエストを送信可能
- 悪意のあるペイロードを注入される可能性
- セキュリティ監査やコンプライアンス要件に違反

## 変更内容

- ✅ `WebhookSignatureTypeNone` 定数を削除
- ✅ `webhook_custom_controller.go` の none ケースを削除  
- ✅ OpenAPI 仕様から `"none"` を削除
- ✅ README.md から none の説明を削除

## 影響

これにより、すべてのカスタムwebhookは以下のいずれかの署名検証が必須となります：
- `hmac` - HMAC-based signature verification (推奨、デフォルト)
- `static` - Static token comparison

## テスト

- ✅ すべてのユニットテストが成功
- ✅ Lint チェックが成功（0 issues）

## Breaking Change

⚠️ **Breaking Change**: 既存の `signature_type: "none"` を使用しているwebhook設定は動作しなくなります。
該当するwebhookは `hmac` または `static` に変更する必要があります。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)