### PR TITLE
fix: add procps package to Docker image for defunct process cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN set -ex && \
 # Runtime stage
 FROM debian:bookworm-slim
 
-# Install essential packages: ca-certificates, curl, bash, git, make, sudo, jq, and GitHub CLI
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq && \
+# Install essential packages: ca-certificates, curl, bash, git, make, sudo, jq, procps, and GitHub CLI
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \


### PR DESCRIPTION
## Summary

This PR adds the `procps` package to the Docker image to fix the defunct process cleanup functionality.

## Problem

The `cleanupDefunctProcesses()` function in `internal/app/server.go:519` uses the `ps aux` command to monitor and clean up defunct (zombie) processes. However, the Docker image was missing the `procps` package which provides the `ps` command, causing the cleanup functionality to fail silently with:

```
Failed to get process list for defunct cleanup: exec: "ps": executable file not found in $PATH
```

## Solution

Added `procps` to the runtime dependencies in the Dockerfile (line 45) to ensure the process cleanup feature works correctly in containerized environments.

## Changes

- Modified `Dockerfile` line 45: Added `procps` to the list of installed packages

## Testing

- ✅ `mise exec -- make lint` - passed with 0 issues
- ✅ `mise exec -- go test ./...` - all tests passed

## Impact

- The defunct process cleanup goroutine will now function correctly in Docker containers
- Prevents accumulation of zombie processes over time
- No breaking changes or API modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)