### PR TITLE
security: remove /auth/types endpoint

### DIFF
--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -61,7 +61,6 @@ type OAuthSession struct {
 func (s *Server) setupAuthRoutes() {
 	// Add authentication info routes
 	authInfoController := controllers.NewAuthInfoController(s.config)
-	s.echo.GET("/auth/types", authInfoController.GetAuthTypes)
 	s.echo.GET("/auth/status", authInfoController.GetAuthStatus)
 
 	// Add OAuth routes if OAuth is configured

--- a/internal/interfaces/controllers/auth_info_controller.go
+++ b/internal/interfaces/controllers/auth_info_controller.go
@@ -9,19 +9,6 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 )
 
-// AuthTypesResponse represents the response for available auth types
-type AuthTypesResponse struct {
-	Enabled bool       `json:"enabled"`
-	Types   []AuthType `json:"types"`
-}
-
-// AuthType represents a single authentication type
-type AuthType struct {
-	Type      string `json:"type"`
-	Name      string `json:"name"`
-	Available bool   `json:"available"`
-}
-
 // AuthStatusResponse represents the response for auth status
 type AuthStatusResponse struct {
 	Authenticated bool                 `json:"authenticated"`
@@ -40,45 +27,6 @@ type AuthInfoController struct {
 // NewAuthInfoController creates a new AuthInfoController
 func NewAuthInfoController(cfg *config.Config) *AuthInfoController {
 	return &AuthInfoController{cfg: cfg}
-}
-
-// GetAuthTypes returns available authentication types
-func (c *AuthInfoController) GetAuthTypes(ctx echo.Context) error {
-	response := AuthTypesResponse{
-		Enabled: c.cfg.Auth.Enabled,
-		Types:   []AuthType{},
-	}
-
-	if !c.cfg.Auth.Enabled {
-		return ctx.JSON(http.StatusOK, response)
-	}
-
-	if c.cfg.Auth.Static != nil && c.cfg.Auth.Static.Enabled {
-		response.Types = append(response.Types, AuthType{
-			Type:      "api_key",
-			Name:      "API Key",
-			Available: true,
-		})
-	}
-
-	if c.cfg.Auth.GitHub != nil && c.cfg.Auth.GitHub.Enabled {
-		githubAuth := AuthType{
-			Type:      "github",
-			Name:      "GitHub",
-			Available: true,
-		}
-
-		if c.cfg.Auth.GitHub.OAuth != nil &&
-			c.cfg.Auth.GitHub.OAuth.ClientID != "" &&
-			c.cfg.Auth.GitHub.OAuth.ClientSecret != "" {
-			githubAuth.Type = "github_oauth"
-			githubAuth.Name = "GitHub OAuth"
-		}
-
-		response.Types = append(response.Types, githubAuth)
-	}
-
-	return ctx.JSON(http.StatusOK, response)
 }
 
 // GetAuthStatus returns current authentication status


### PR DESCRIPTION
## Summary

セキュリティリスクのある `/auth/types` エンドポイントを削除しました。

このエンドポイントは認証なしでアクセス可能で、以下の情報を公開していました:
- 認証が有効かどうか
- 利用可能な認証タイプ (API Key, GitHub OAuth など)
- システムの認証設定の詳細

攻撃者がこの情報を利用してシステムの偵察を行える可能性があったため、削除しました。

## Changes

- `GET /auth/types` ルート登録を削除
- `GetAuthTypes` コントローラーメソッドを削除
- `AuthTypesResponse` および `AuthType` 構造体を削除

## Test Plan

- [x] `make lint` を実行して問題ないことを確認
- [x] `go test ./...` を実行して全てのテストが成功することを確認
- [x] 削除されたエンドポイントが使用されていないことを確認

## Security Impact

このエンドポイントは公開されているシステムで特に危険でした:
- 認証設定の情報漏洩
- システムの攻撃対象領域の削減

🤖 Generated with Claude Code