### PR TITLE
security: remove header names from webhook error messages

### DIFF
--- a/internal/interfaces/controllers/webhook_custom_controller.go
+++ b/internal/interfaces/controllers/webhook_custom_controller.go
@@ -89,7 +89,7 @@ func (c *WebhookCustomController) HandleCustomWebhook(ctx echo.Context) error {
 
 		if signatureHeader == "" {
 			log.Printf("[WEBHOOK_CUSTOM] Missing signature header '%s' for webhook %s", headerName, webhookID)
-			return ctx.JSON(http.StatusUnauthorized, map[string]string{"error": fmt.Sprintf("Missing signature header: %s", headerName)})
+			return ctx.JSON(http.StatusUnauthorized, map[string]string{"error": "Missing signature header"})
 		}
 
 		if !c.verifySignature(body, signatureHeader, matchedWebhook.Secret()) {
@@ -106,7 +106,7 @@ func (c *WebhookCustomController) HandleCustomWebhook(ctx echo.Context) error {
 
 		if token == "" {
 			log.Printf("[WEBHOOK_CUSTOM] Missing token header '%s' for webhook %s", headerName, webhookID)
-			return ctx.JSON(http.StatusUnauthorized, map[string]string{"error": fmt.Sprintf("Missing token header: %s", headerName)})
+			return ctx.JSON(http.StatusUnauthorized, map[string]string{"error": "Missing token header"})
 		}
 
 		if token != matchedWebhook.Secret() {
@@ -125,7 +125,7 @@ func (c *WebhookCustomController) HandleCustomWebhook(ctx echo.Context) error {
 
 		if signatureHeader == "" {
 			log.Printf("[WEBHOOK_CUSTOM] Missing signature header '%s' for webhook %s", headerName, webhookID)
-			return ctx.JSON(http.StatusUnauthorized, map[string]string{"error": fmt.Sprintf("Missing signature header: %s", headerName)})
+			return ctx.JSON(http.StatusUnauthorized, map[string]string{"error": "Missing signature header"})
 		}
 
 		if !c.verifySignature(body, signatureHeader, matchedWebhook.Secret()) {

--- a/internal/interfaces/controllers/webhook_github_controller.go
+++ b/internal/interfaces/controllers/webhook_github_controller.go
@@ -162,7 +162,7 @@ func (c *WebhookGitHubController) HandleGitHubWebhook(ctx echo.Context) error {
 
 	if event == "" {
 		log.Printf("[WEBHOOK] Missing X-GitHub-Event header")
-		return ctx.JSON(http.StatusBadRequest, map[string]string{"error": "Missing X-GitHub-Event header"})
+		return ctx.JSON(http.StatusBadRequest, map[string]string{"error": "Missing required header"})
 	}
 
 	log.Printf("[WEBHOOK] Received GitHub webhook: webhook_id=%s, event=%s, delivery=%s", webhookID, event, deliveryID)


### PR DESCRIPTION
## Summary

Remove specific header names from webhook authentication error responses to prevent leaking implementation details to potential attackers.

## Changes

- **Custom webhooks**: Remove header names from signature/token error messages
  - Changed `"Missing signature header: %s"` → `"Missing signature header"`
  - Changed `"Missing token header: %s"` → `"Missing token header"`
- **GitHub webhooks**: Remove specific header name from error message
  - Changed `"Missing X-GitHub-Event header"` → `"Missing required header"`

## Test plan

- [x] Ran `make lint` - passed
- [x] Ran tests - passed
- [ ] Verify error messages no longer expose header names in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)