### PR TITLE
fix: remove user_email label from otelcol metrics

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2882,6 +2882,8 @@ processors:
           - set(attributes["claude_session_id"], attributes["session_id"]) where attributes["session_id"] != nil
           - delete_key(attributes, "user_id")
           - delete_key(attributes, "session_id")
+          # Remove user_email label to prevent it from being scraped by Prometheus
+          - delete_key(attributes, "user_email")
           # Add agentapi labels
           - set(attributes["agentapi_session_id"], "${env:SESSION_ID}")
           - set(attributes["agentapi_user_id"], "${env:USER_ID}")


### PR DESCRIPTION
## Summary
Claude Code が export するメトリクスに含まれる user_email ラベルを OpenTelemetry Collector のレイヤーで削除するように修正しました。

## Changes
- `kubernetes_session_manager.go` の `ensureOtelcolConfigMap` 関数を修正
- transform processor に `user_email` を削除する処理を追加

## Motivation
Prometheus でスクレイピングされる際に個人情報である user_email ラベルを含めないようにするための対応です。

## Test plan
- [x] `make lint` を実行し、コードスタイルに問題がないことを確認
- [ ] CI でのテスト結果を確認
- [ ] 実際の環境でメトリクスに user_email が含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)