### PR TITLE
chore: update agentapi version to v0.11.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM golang:1.25-alpine AS agentapi-builder
 RUN apk add --no-cache git
 
 # Set the agentapi version
-ARG AGENTAPI_VERSION=v0.11.6
+ARG AGENTAPI_VERSION=v0.11.8
 
 # Clone and build agentapi from source
 WORKDIR /agentapi-src


### PR DESCRIPTION
## Summary
- Dockerfile の agentapi バージョンを v0.11.6 から v0.11.8 に更新

## Changes
- `Dockerfile`: `AGENTAPI_VERSION` を `v0.11.8` に更新

## Test plan
- [x] make lint 実行 (成功)
- [x] make test 実行
- [x] make devbuild 実行
- [x] dev 環境へのデプロイ確認
- [x] セッション作成・動作確認

## Deployment
- Dev環境にデプロイ済み: `0.3.0-dev.20260115062856.f008a60`
- Revision: 150

🤖 Generated with [Claude Code](https://claude.com/claude-code)