### PR TITLE
feat: disable encryption for settings API

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -169,7 +169,6 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 	settingsRepo = repositories.NewKubernetesSettingsRepository(
 		k8sSessionManager.GetClient(),
 		k8sSessionManager.GetNamespace(),
-		encryptionRegistry,
 	)
 	// Set settings repository in session manager for Bedrock integration
 	k8sSessionManager.SetSettingsRepository(settingsRepo)

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	"github.com/takutakahashi/agentapi-proxy/internal/domain/services"
-	infraservices "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 )
 
 const (
@@ -69,18 +67,15 @@ type marketplaceJSON struct {
 
 // KubernetesSettingsRepository implements SettingsRepository using Kubernetes Secrets
 type KubernetesSettingsRepository struct {
-	client             kubernetes.Interface
-	namespace          string
-	encryptionRegistry *infraservices.EncryptionServiceRegistry
+	client    kubernetes.Interface
+	namespace string
 }
 
 // NewKubernetesSettingsRepository creates a new KubernetesSettingsRepository
-// encryptionRegistry manages encryption/decryption services
-func NewKubernetesSettingsRepository(client kubernetes.Interface, namespace string, encryptionRegistry *infraservices.EncryptionServiceRegistry) *KubernetesSettingsRepository {
+func NewKubernetesSettingsRepository(client kubernetes.Interface, namespace string) *KubernetesSettingsRepository {
 	return &KubernetesSettingsRepository{
-		client:             client,
-		namespace:          namespace,
-		encryptionRegistry: encryptionRegistry,
+		client:    client,
+		namespace: namespace,
 	}
 }
 
@@ -93,43 +88,7 @@ func (r *KubernetesSettingsRepository) Save(ctx context.Context, settings *entit
 	secretName := r.secretName(settings.Name())
 	labelValue := sanitizeLabelValue(settings.Name())
 
-	// Create plaintext backup first
-	plaintextData, err := r.toJSONPlaintext(settings)
-	if err != nil {
-		return fmt.Errorf("failed to marshal plaintext settings: %w", err)
-	}
-
-	backupSecretName := secretName + "-plaintext-backup"
-	backupSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      backupSecretName,
-			Namespace: r.namespace,
-			Labels: map[string]string{
-				"agentapi.proxy/settings-backup": "true",
-				LabelSettingsName:                 labelValue,
-				"backup":                          "plaintext",
-			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			SecretKeySettings: plaintextData,
-		},
-	}
-
-	// Save plaintext backup (create or update)
-	_, err = r.client.CoreV1().Secrets(r.namespace).Create(ctx, backupSecret, metav1.CreateOptions{})
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			_, err = r.client.CoreV1().Secrets(r.namespace).Update(ctx, backupSecret, metav1.UpdateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to update plaintext backup secret: %w", err)
-			}
-		} else {
-			return fmt.Errorf("failed to create plaintext backup secret: %w", err)
-		}
-	}
-
-	// Convert to JSON (with encryption)
+	// Convert to JSON (without encryption)
 	data, err := r.toJSON(settings)
 	if err != nil {
 		return fmt.Errorf("failed to marshal settings: %w", err)
@@ -239,143 +198,8 @@ func (r *KubernetesSettingsRepository) secretName(name string) string {
 	return SettingsSecretPrefix + sanitizeSecretName(name)
 }
 
-// encryptValue encrypts a plaintext value and returns a JSON-encoded EncryptedData
-func (r *KubernetesSettingsRepository) encryptValue(ctx context.Context, plaintext string) (string, error) {
-	if plaintext == "" {
-		return "", nil
-	}
-
-	// Use primary encryption service from registry
-	service := r.encryptionRegistry.GetForEncryption()
-	encrypted, err := service.Encrypt(ctx, plaintext)
-	if err != nil {
-		return "", fmt.Errorf("failed to encrypt value: %w", err)
-	}
-
-	// JSON encode the EncryptedData
-	data, err := json.Marshal(encrypted)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal encrypted data: %w", err)
-	}
-
-	return string(data), nil
-}
-
-// decryptValue attempts to decrypt a value if it's encrypted, otherwise returns it as-is
-func (r *KubernetesSettingsRepository) decryptValue(ctx context.Context, value string) (string, error) {
-	if value == "" {
-		return "", nil
-	}
-
-	// Try to unmarshal as EncryptedData
-	var encrypted services.EncryptedData
-	if err := json.Unmarshal([]byte(value), &encrypted); err != nil {
-		// Not encrypted, return as-is (plaintext for backward compatibility)
-		return value, nil
-	}
-
-	// Get appropriate decryption service based on metadata
-	service := r.encryptionRegistry.GetForDecryption(encrypted.Metadata)
-	plaintext, err := service.Decrypt(ctx, &encrypted)
-	if err != nil {
-		return "", fmt.Errorf("failed to decrypt value: %w", err)
-	}
-
-	return plaintext, nil
-}
-
-// toJSON converts Settings entity to JSON bytes
+// toJSON converts Settings entity to JSON bytes without encryption
 func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]byte, error) {
-	ctx := context.Background()
-
-	// Encrypt OAuth token if present
-	oauthToken, err := r.encryptValue(ctx, settings.ClaudeCodeOAuthToken())
-	if err != nil {
-		return nil, fmt.Errorf("failed to encrypt oauth token: %w", err)
-	}
-
-	sj := &settingsJSON{
-		Name:                 settings.Name(),
-		ClaudeCodeOAuthToken: oauthToken,
-		AuthMode:             string(settings.AuthMode()),
-		CreatedAt:            settings.CreatedAt(),
-		UpdatedAt:            settings.UpdatedAt(),
-	}
-
-	if bedrock := settings.Bedrock(); bedrock != nil {
-		// Encrypt sensitive Bedrock fields
-		accessKeyID, err := r.encryptValue(ctx, bedrock.AccessKeyID())
-		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt access key id: %w", err)
-		}
-		secretAccessKey, err := r.encryptValue(ctx, bedrock.SecretAccessKey())
-		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt secret access key: %w", err)
-		}
-
-		sj.Bedrock = &bedrockJSON{
-			Enabled:         bedrock.Enabled(),
-			Model:           bedrock.Model(),
-			AccessKeyID:     accessKeyID,
-			SecretAccessKey: secretAccessKey,
-			RoleARN:         bedrock.RoleARN(),
-			Profile:         bedrock.Profile(),
-		}
-	}
-
-	if mcpServers := settings.MCPServers(); mcpServers != nil && !mcpServers.IsEmpty() {
-		sj.MCPServers = make(map[string]*mcpServerJSON)
-		for name, server := range mcpServers.Servers() {
-			// Encrypt env values
-			encryptedEnv := make(map[string]string)
-			for k, v := range server.Env() {
-				encrypted, err := r.encryptValue(ctx, v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to encrypt env %s: %w", k, err)
-				}
-				encryptedEnv[k] = encrypted
-			}
-
-			// Encrypt header values
-			encryptedHeaders := make(map[string]string)
-			for k, v := range server.Headers() {
-				encrypted, err := r.encryptValue(ctx, v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to encrypt header %s: %w", k, err)
-				}
-				encryptedHeaders[k] = encrypted
-			}
-
-			sj.MCPServers[name] = &mcpServerJSON{
-				Type:    server.Type(),
-				URL:     server.URL(),
-				Command: server.Command(),
-				Args:    server.Args(),
-				Env:     encryptedEnv,
-				Headers: encryptedHeaders,
-			}
-		}
-	}
-
-	if marketplaces := settings.Marketplaces(); marketplaces != nil && !marketplaces.IsEmpty() {
-		sj.Marketplaces = make(map[string]*marketplaceJSON)
-		for name, marketplace := range marketplaces.Marketplaces() {
-			sj.Marketplaces[name] = &marketplaceJSON{
-				URL: marketplace.URL(),
-			}
-		}
-	}
-
-	if plugins := settings.EnabledPlugins(); len(plugins) > 0 {
-		sj.EnabledPlugins = plugins
-	}
-
-	return json.Marshal(sj)
-}
-
-// toJSONPlaintext converts Settings entity to JSON bytes without encryption
-// This is used for creating plaintext backup secrets
-func (r *KubernetesSettingsRepository) toJSONPlaintext(settings *entities.Settings) ([]byte, error) {
 	sj := &settingsJSON{
 		Name:                 settings.Name(),
 		ClaudeCodeOAuthToken: settings.ClaudeCodeOAuthToken(),
@@ -427,8 +251,6 @@ func (r *KubernetesSettingsRepository) toJSONPlaintext(settings *entities.Settin
 
 // fromSecret converts a Kubernetes Secret to Settings entity
 func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entities.Settings, error) {
-	ctx := context.Background()
-
 	data, ok := secret.Data[SecretKeySettings]
 	if !ok {
 		return nil, fmt.Errorf("secret missing settings data")
@@ -446,19 +268,8 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 	if sj.Bedrock != nil {
 		bedrock := entities.NewBedrockSettings(sj.Bedrock.Enabled)
 		bedrock.SetModel(sj.Bedrock.Model)
-
-		// Decrypt sensitive Bedrock fields
-		accessKeyID, err := r.decryptValue(ctx, sj.Bedrock.AccessKeyID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt access key id: %w", err)
-		}
-		secretAccessKey, err := r.decryptValue(ctx, sj.Bedrock.SecretAccessKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt secret access key: %w", err)
-		}
-
-		bedrock.SetAccessKeyID(accessKeyID)
-		bedrock.SetSecretAccessKey(secretAccessKey)
+		bedrock.SetAccessKeyID(sj.Bedrock.AccessKeyID)
+		bedrock.SetSecretAccessKey(sj.Bedrock.SecretAccessKey)
 		bedrock.SetRoleARN(sj.Bedrock.RoleARN)
 		bedrock.SetProfile(sj.Bedrock.Profile)
 		settings.SetBedrock(bedrock)
@@ -473,28 +284,8 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 			server.SetURL(serverJSON.URL)
 			server.SetCommand(serverJSON.Command)
 			server.SetArgs(serverJSON.Args)
-
-			// Decrypt env values
-			decryptedEnv := make(map[string]string)
-			for k, v := range serverJSON.Env {
-				decrypted, err := r.decryptValue(ctx, v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decrypt env %s: %w", k, err)
-				}
-				decryptedEnv[k] = decrypted
-			}
-			server.SetEnv(decryptedEnv)
-
-			// Decrypt header values
-			decryptedHeaders := make(map[string]string)
-			for k, v := range serverJSON.Headers {
-				decrypted, err := r.decryptValue(ctx, v)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decrypt header %s: %w", k, err)
-				}
-				decryptedHeaders[k] = decrypted
-			}
-			server.SetHeaders(decryptedHeaders)
+			server.SetEnv(serverJSON.Env)
+			server.SetHeaders(serverJSON.Headers)
 
 			mcpServers.SetServer(name, server)
 		}
@@ -522,12 +313,7 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 	}
 
 	if sj.ClaudeCodeOAuthToken != "" {
-		// Decrypt OAuth token
-		oauthToken, err := r.decryptValue(ctx, sj.ClaudeCodeOAuthToken)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt oauth token: %w", err)
-		}
-		settings.SetClaudeCodeOAuthToken(oauthToken)
+		settings.SetClaudeCodeOAuthToken(sj.ClaudeCodeOAuthToken)
 		// Reset updatedAt since SetClaudeCodeOAuthToken updates it
 		settings.SetUpdatedAt(sj.UpdatedAt)
 	}

--- a/internal/infrastructure/repositories/kubernetes_settings_repository_encryption_test.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository_encryption_test.go
@@ -9,12 +9,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 )
 
 func TestKubernetesSettingsRepository_EncryptDecrypt_Bedrock(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create settings with Bedrock credentials
@@ -44,7 +43,7 @@ func TestKubernetesSettingsRepository_EncryptDecrypt_Bedrock(t *testing.T) {
 
 func TestKubernetesSettingsRepository_EncryptDecrypt_OAuthToken(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create settings with OAuth token
@@ -65,7 +64,7 @@ func TestKubernetesSettingsRepository_EncryptDecrypt_OAuthToken(t *testing.T) {
 
 func TestKubernetesSettingsRepository_EncryptDecrypt_MCPServers(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create settings with MCP servers
@@ -109,7 +108,7 @@ func TestKubernetesSettingsRepository_EncryptDecrypt_MCPServers(t *testing.T) {
 
 func TestKubernetesSettingsRepository_EncryptDecrypt_AllFields(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create settings with all sensitive fields
@@ -153,7 +152,7 @@ func TestKubernetesSettingsRepository_EncryptDecrypt_AllFields(t *testing.T) {
 
 func TestKubernetesSettingsRepository_EmptyValues(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create settings with empty values

--- a/internal/infrastructure/repositories/kubernetes_settings_repository_test.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository_test.go
@@ -5,19 +5,16 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 )
 
 func TestKubernetesSettingsRepository_Save(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 
 	settings := entities.NewSettings("test-user")
 	bedrock := entities.NewBedrockSettings(true)
@@ -47,7 +44,7 @@ func TestKubernetesSettingsRepository_Save(t *testing.T) {
 
 func TestKubernetesSettingsRepository_Save_VerifySecretContent(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 
 	settings := entities.NewSettings("verify-content")
 	bedrock := entities.NewBedrockSettings(true)
@@ -113,24 +110,12 @@ func TestKubernetesSettingsRepository_Save_VerifySecretContent(t *testing.T) {
 	if bedrockData["model"] != "anthropic.claude-sonnet-4-20250514-v1:0" {
 		t.Errorf("Expected model='anthropic.claude-sonnet-4-20250514-v1:0', got '%v'", bedrockData["model"])
 	}
-	// Sensitive fields should be encrypted (contain EncryptedData JSON)
-	accessKeyIDStr, ok := bedrockData["access_key_id"].(string)
-	if !ok {
-		t.Errorf("Expected access_key_id to be a string, got %T", bedrockData["access_key_id"])
-	} else {
-		var encData map[string]interface{}
-		if err := json.Unmarshal([]byte(accessKeyIDStr), &encData); err != nil {
-			t.Errorf("Expected access_key_id to be encrypted JSON, got parse error: %v", err)
-		}
+	// Verify sensitive fields are stored as plaintext
+	if bedrockData["access_key_id"] != "AKIAIOSFODNN7EXAMPLE" {
+		t.Errorf("Expected access_key_id='AKIAIOSFODNN7EXAMPLE', got '%v'", bedrockData["access_key_id"])
 	}
-	secretAccessKeyStr, ok := bedrockData["secret_access_key"].(string)
-	if !ok {
-		t.Errorf("Expected secret_access_key to be a string, got %T", bedrockData["secret_access_key"])
-	} else {
-		var encData map[string]interface{}
-		if err := json.Unmarshal([]byte(secretAccessKeyStr), &encData); err != nil {
-			t.Errorf("Expected secret_access_key to be encrypted JSON, got parse error: %v", err)
-		}
+	if bedrockData["secret_access_key"] != "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" {
+		t.Errorf("Expected secret_access_key='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', got '%v'", bedrockData["secret_access_key"])
 	}
 	if bedrockData["role_arn"] != "arn:aws:iam::123456789012:role/ExampleRole" {
 		t.Errorf("Expected role_arn to be preserved, got '%v'", bedrockData["role_arn"])
@@ -150,7 +135,7 @@ func TestKubernetesSettingsRepository_Save_VerifySecretContent(t *testing.T) {
 
 func TestKubernetesSettingsRepository_SaveUpdate(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create initial settings
@@ -184,7 +169,7 @@ func TestKubernetesSettingsRepository_SaveUpdate(t *testing.T) {
 
 func TestKubernetesSettingsRepository_SaveUpdate_AllFields(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create initial settings with all fields
@@ -251,24 +236,12 @@ func TestKubernetesSettingsRepository_SaveUpdate_AllFields(t *testing.T) {
 	if bedrockData["model"] != "anthropic.claude-opus-4-20250514-v1:0" {
 		t.Errorf("Expected updated model 'anthropic.claude-opus-4-20250514-v1:0', got '%v'", bedrockData["model"])
 	}
-	// Sensitive fields should be encrypted (contain EncryptedData JSON)
-	accessKeyIDStr, ok := bedrockData["access_key_id"].(string)
-	if !ok {
-		t.Errorf("Expected access_key_id to be a string, got %T", bedrockData["access_key_id"])
-	} else {
-		var encData map[string]interface{}
-		if err := json.Unmarshal([]byte(accessKeyIDStr), &encData); err != nil {
-			t.Errorf("Expected access_key_id to be encrypted JSON, got parse error: %v", err)
-		}
+	// Verify sensitive fields are stored as plaintext
+	if bedrockData["access_key_id"] != "AKIAIOSFODNN7UPDATED" {
+		t.Errorf("Expected access_key_id='AKIAIOSFODNN7UPDATED', got '%v'", bedrockData["access_key_id"])
 	}
-	secretAccessKeyStr, ok := bedrockData["secret_access_key"].(string)
-	if !ok {
-		t.Errorf("Expected secret_access_key to be a string, got %T", bedrockData["secret_access_key"])
-	} else {
-		var encData map[string]interface{}
-		if err := json.Unmarshal([]byte(secretAccessKeyStr), &encData); err != nil {
-			t.Errorf("Expected secret_access_key to be encrypted JSON, got parse error: %v", err)
-		}
+	if bedrockData["secret_access_key"] != "updated-secret-key" {
+		t.Errorf("Expected secret_access_key='updated-secret-key', got '%v'", bedrockData["secret_access_key"])
 	}
 	if bedrockData["role_arn"] != "arn:aws:iam::222222222222:role/UpdatedRole" {
 		t.Errorf("Expected updated role_arn, got '%v'", bedrockData["role_arn"])
@@ -302,7 +275,7 @@ func TestKubernetesSettingsRepository_SaveUpdate_AllFields(t *testing.T) {
 
 func TestKubernetesSettingsRepository_SaveUpdate_VerifySecretOverwritten(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create initial settings
@@ -374,7 +347,7 @@ func TestKubernetesSettingsRepository_SaveUpdate_VerifySecretOverwritten(t *test
 
 func TestKubernetesSettingsRepository_FindByName(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Save settings
@@ -406,7 +379,7 @@ func TestKubernetesSettingsRepository_FindByName(t *testing.T) {
 
 func TestKubernetesSettingsRepository_FindByName_NotFound(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	_, err := repo.FindByName(ctx, "nonexistent")
@@ -417,7 +390,7 @@ func TestKubernetesSettingsRepository_FindByName_NotFound(t *testing.T) {
 
 func TestKubernetesSettingsRepository_Delete(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Save settings
@@ -455,7 +428,7 @@ func TestKubernetesSettingsRepository_Delete(t *testing.T) {
 
 func TestKubernetesSettingsRepository_Delete_NotFound(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	err := repo.Delete(ctx, "nonexistent")
@@ -466,7 +439,7 @@ func TestKubernetesSettingsRepository_Delete_NotFound(t *testing.T) {
 
 func TestKubernetesSettingsRepository_List(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Save multiple settings
@@ -492,7 +465,7 @@ func TestKubernetesSettingsRepository_List(t *testing.T) {
 
 func TestKubernetesSettingsRepository_List_SkipsInvalid(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
+	repo := NewKubernetesSettingsRepository(client, "default")
 	ctx := context.Background()
 
 	// Create a valid settings secret
@@ -577,65 +550,3 @@ func TestSanitizeLabelValue(t *testing.T) {
 	}
 }
 
-func TestKubernetesSettingsRepository_Save_CreatesPlaintextBackup(t *testing.T) {
-	client := fake.NewSimpleClientset()
-	repo := NewKubernetesSettingsRepository(client, "default", services.NewEncryptionServiceRegistry(services.NewNoopEncryptionService()))
-	ctx := context.Background()
-
-	// Create settings with sensitive data
-	settings := entities.NewSettings("test-backup")
-	settings.SetClaudeCodeOAuthToken("secret-oauth-token-12345")
-
-	bedrock := entities.NewBedrockSettings(true)
-	bedrock.SetModel("claude-sonnet-4")
-	bedrock.SetAccessKeyID("AKIAIOSFODNN7EXAMPLE")
-	bedrock.SetSecretAccessKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
-	settings.SetBedrock(bedrock)
-
-	mcpServers := entities.NewMCPServersSettings()
-	server := entities.NewMCPServer("github", "stdio")
-	server.SetCommand("mcp-server-github")
-	server.SetEnv(map[string]string{"GITHUB_TOKEN": "ghp_secrettoken123"})
-	server.SetHeaders(map[string]string{"Authorization": "Bearer secret-bearer-token"})
-	mcpServers.SetServer("github", server)
-	settings.SetMCPServers(mcpServers)
-
-	// Save
-	err := repo.Save(ctx, settings)
-	require.NoError(t, err)
-
-	// Check that both main secret and backup secret were created
-	mainSecret, err := client.CoreV1().Secrets("default").Get(ctx, "agentapi-settings-test-backup", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.NotNil(t, mainSecret)
-
-	backupSecret, err := client.CoreV1().Secrets("default").Get(ctx, "agentapi-settings-test-backup-plaintext-backup", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.NotNil(t, backupSecret)
-
-	// Verify backup secret has correct labels
-	assert.Equal(t, "true", backupSecret.Labels["agentapi.proxy/settings-backup"])
-	assert.Equal(t, "plaintext", backupSecret.Labels["backup"])
-
-	// Verify backup contains plaintext data
-	var backupData map[string]interface{}
-	err = json.Unmarshal(backupSecret.Data["settings.json"], &backupData)
-	require.NoError(t, err)
-
-	// Check that oauth token is plaintext (not encrypted JSON)
-	oauthToken := backupData["claude_code_oauth_token"].(string)
-	assert.Equal(t, "secret-oauth-token-12345", oauthToken)
-
-	// Check that bedrock credentials are plaintext
-	bedrockData := backupData["bedrock"].(map[string]interface{})
-	assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", bedrockData["access_key_id"].(string))
-	assert.Equal(t, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", bedrockData["secret_access_key"].(string))
-
-	// Check that MCP server env and headers are plaintext
-	mcpData := backupData["mcp_servers"].(map[string]interface{})
-	githubServer := mcpData["github"].(map[string]interface{})
-	envData := githubServer["env"].(map[string]interface{})
-	assert.Equal(t, "ghp_secrettoken123", envData["GITHUB_TOKEN"].(string))
-	headersData := githubServer["headers"].(map[string]interface{})
-	assert.Equal(t, "Bearer secret-bearer-token", headersData["Authorization"].(string))
-}


### PR DESCRIPTION
## Summary
- Settings API の暗号化機能を無効化し、全てのデータを平文で Kubernetes Secrets に保存するように変更
- `KubernetesSettingsRepository` から暗号化/復号化ロジックを削除
- plaintext backup 機能を削除
- `encryptionRegistry` 依存を削除

## 主な変更
- `internal/infrastructure/repositories/kubernetes_settings_repository.go`: 暗号化/復号化処理を削除、`toJSON`/`fromSecret` メソッドを平文処理に変更
- `internal/app/server.go`: `NewKubernetesSettingsRepository` 呼び出しから `encryptionRegistry` 引数を削除
- テストファイル: 暗号化検証ロジックを削除し、平文保存を検証するように更新

## Test plan
- [x] `make lint` が成功することを確認
- [x] `go test ./internal/infrastructure/repositories/...` が全て成功することを確認 (25 tests passed)
- [x] Settings の保存・取得が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)