### PR TITLE
feat: refactor Helm values - move env variables to dedicated config fields

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -233,6 +233,39 @@ spec:
             - name: AGENTAPI_ENCRYPTION_KEY
               value: {{ .Values.config.encryption.key | quote }}
             {{- end }}
+            # GitHub Token configuration (for backward compatibility)
+            {{- if .Values.github.token }}
+            - name: GITHUB_TOKEN
+              value: {{ .Values.github.token | quote }}
+            {{- end }}
+            # Claude Code configuration
+            {{- if .Values.config.claude.args }}
+            - name: CLAUDE_ARGS
+              value: {{ .Values.config.claude.args | quote }}
+            {{- end }}
+            # OAuth configuration
+            {{- if .Values.config.auth.github.oauth.allowedRedirectUris }}
+            - name: OAUTH_ALLOWED_REDIRECT_URIS
+              value: {{ .Values.config.auth.github.oauth.allowedRedirectUris | quote }}
+            {{- end }}
+            # Userhome configuration
+            {{- if .Values.config.userhome.basedir }}
+            - name: USERHOME_BASEDIR
+              value: {{ .Values.config.userhome.basedir | quote }}
+            {{- end }}
+            # VAPID configuration
+            {{- if .Values.config.vapid.publicKey }}
+            - name: VAPID_PUBLIC_KEY
+              value: {{ .Values.config.vapid.publicKey | quote }}
+            {{- end }}
+            {{- if .Values.config.vapid.privateKey }}
+            - name: VAPID_PRIVATE_KEY
+              value: {{ .Values.config.vapid.privateKey | quote }}
+            {{- end }}
+            {{- if .Values.config.vapid.contactEmail }}
+            - name: VAPID_CONTACT_EMAIL
+              value: {{ .Values.config.vapid.contactEmail | quote }}
+            {{- end }}
             {{- range .Values.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -118,6 +118,28 @@ config:
         clientSecret: ""
         scope: "read:user read:org repo workflow"
         baseUrl: ""
+        # 許可するリダイレクトURI (カンマ区切りで複数指定可能)
+        allowedRedirectUris: ""
+
+  # Claude Code 設定
+  claude:
+    # Claude Code の起動引数 (例: "--dangerously-skip-permissions")
+    args: ""
+
+  # ユーザーホームディレクトリ設定
+  userhome:
+    # ユーザーホームディレクトリのベースパス
+    # 設定しない場合は /home/agentapi/.agentapi-proxy がデフォルト
+    basedir: ""
+
+  # VAPID (Web Push 通知) 設定
+  vapid:
+    # VAPID 公開鍵 (Web Push 通知用)
+    publicKey: ""
+    # VAPID 秘密鍵 (Web Push 通知用)
+    privateKey: ""
+    # VAPID 連絡先メールアドレス
+    contactEmail: ""
 
   # ロールベース環境変数ファイル設定
   roleEnvFiles:


### PR DESCRIPTION
## Summary
環境変数を `env` フィールドから `values.yaml` の専用フィールドに移行しました。
これにより、設定がより明確になり、管理しやすくなります。

## 変更内容
### values.yaml に新しい設定項目を追加
- `config.claude.args`: Claude Code の起動引数
- `config.auth.github.oauth.allowedRedirectUris`: 許可するリダイレクトURI
- `config.userhome.basedir`: ユーザーホームディレクトリのベースパス
- `config.vapid.publicKey/privateKey/contactEmail`: VAPID (Web Push 通知) 設定

### deployment.yaml テンプレートを更新
- 新しい設定項目から環境変数を設定
- `github.token` フィールドから `GITHUB_TOKEN` 環境変数を設定
- 既存の `env` フィールドは後方互換性のため維持

## Test plan
- [x] Helm template のレンダリングテスト
- [x] 新しい values フィールドが正しく環境変数に変換されることを確認
- [x] `make lint` の実行
- [x] `go test` の実行

## 移行方法
現在 `env` フィールドで設定している環境変数を、新しい `values.yaml` のフィールドに移行してください。

例:
```yaml
# 移行前
env:
  - name: CLAUDE_ARGS
    value: "--dangerously-skip-permissions"
  - name: OAUTH_ALLOWED_REDIRECT_URIS
    value: "https://example.com"
  - name: GITHUB_TOKEN
    value: "github_pat_..."
  - name: VAPID_PUBLIC_KEY
    value: "..."

# 移行後
github:
  token: "github_pat_..."

config:
  claude:
    args: "--dangerously-skip-permissions"
  auth:
    github:
      oauth:
        allowedRedirectUris: "https://example.com"
  vapid:
    publicKey: "..."
    privateKey: "..."
    contactEmail: "your-email@example.com"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)