### PR TITLE
chore: remove unused config settings

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -213,10 +213,6 @@ spec:
             - name: AGENTAPI_SCHEDULE_WORKER_NAMESPACE
               value: {{ .Values.scheduleWorker.namespace | quote }}
             {{- end }}
-            {{- if (.Values.scheduleWorker).defaultTimezone }}
-            - name: AGENTAPI_SCHEDULE_WORKER_DEFAULT_TIMEZONE
-              value: {{ .Values.scheduleWorker.defaultTimezone | quote }}
-            {{- end }}
             {{- if (.Values.scheduleWorker).leaseDuration }}
             - name: AGENTAPI_SCHEDULE_WORKER_LEASE_DURATION
               value: {{ .Values.scheduleWorker.leaseDuration | quote }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -452,9 +452,6 @@ scheduleWorker:
   # How often to check for due schedules
   checkInterval: "30s"
 
-  # Default timezone for schedules (used when not specified in request)
-  defaultTimezone: "Asia/Tokyo"
-
   # Leader election configuration (for multi-replica deployments)
   leaderElection:
     # Lease duration (how long leader holds the lock)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,8 +151,6 @@ type ScheduleWorkerConfig struct {
 	CheckInterval string `json:"check_interval" mapstructure:"check_interval"`
 	// Namespace is the Kubernetes namespace for schedule resources
 	Namespace string `json:"namespace" mapstructure:"namespace"`
-	// DefaultTimezone is the default timezone for schedules (e.g., "Asia/Tokyo")
-	DefaultTimezone string `json:"default_timezone" mapstructure:"default_timezone"`
 	// LeaseDuration is the duration that non-leader candidates will wait to force acquire leadership
 	LeaseDuration string `json:"lease_duration" mapstructure:"lease_duration"`
 	// RenewDeadline is the duration that the acting master will retry refreshing leadership before giving up
@@ -524,8 +522,6 @@ func bindEnvVars(v *viper.Viper) {
 	// MCP servers configuration
 	_ = v.BindEnv("kubernetes_session.mcp_servers_enabled", "AGENTAPI_K8S_SESSION_MCP_SERVERS_ENABLED")
 	_ = v.BindEnv("kubernetes_session.mcp_servers_base_secret", "AGENTAPI_K8S_SESSION_MCP_SERVERS_BASE_SECRET")
-	_ = v.BindEnv("kubernetes_session.mcp_servers_team_secret_prefix", "AGENTAPI_K8S_SESSION_MCP_SERVERS_TEAM_SECRET_PREFIX")
-	_ = v.BindEnv("kubernetes_session.mcp_servers_user_secret_prefix", "AGENTAPI_K8S_SESSION_MCP_SERVERS_USER_SECRET_PREFIX")
 
 	// OpenTelemetry Collector configuration
 	_ = v.BindEnv("kubernetes_session.otel_collector_enabled", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_ENABLED")
@@ -542,7 +538,6 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("schedule_worker.enabled", "AGENTAPI_SCHEDULE_WORKER_ENABLED")
 	_ = v.BindEnv("schedule_worker.check_interval", "AGENTAPI_SCHEDULE_WORKER_CHECK_INTERVAL")
 	_ = v.BindEnv("schedule_worker.namespace", "AGENTAPI_SCHEDULE_WORKER_NAMESPACE")
-	_ = v.BindEnv("schedule_worker.default_timezone", "AGENTAPI_SCHEDULE_WORKER_DEFAULT_TIMEZONE")
 	_ = v.BindEnv("schedule_worker.lease_duration", "AGENTAPI_SCHEDULE_WORKER_LEASE_DURATION")
 	_ = v.BindEnv("schedule_worker.renew_deadline", "AGENTAPI_SCHEDULE_WORKER_RENEW_DEADLINE")
 	_ = v.BindEnv("schedule_worker.retry_period", "AGENTAPI_SCHEDULE_WORKER_RETRY_PERIOD")
@@ -601,14 +596,11 @@ func setDefaults(v *viper.Viper) {
 	// MCP servers defaults
 	v.SetDefault("kubernetes_session.mcp_servers_enabled", true)
 	v.SetDefault("kubernetes_session.mcp_servers_base_secret", "mcp-servers-base")
-	v.SetDefault("kubernetes_session.mcp_servers_team_secret_prefix", "mcp-servers")
-	v.SetDefault("kubernetes_session.mcp_servers_user_secret_prefix", "mcp-servers")
 
 	// Schedule worker defaults
 	v.SetDefault("schedule_worker.enabled", true)
 	v.SetDefault("schedule_worker.check_interval", "30s")
 	v.SetDefault("schedule_worker.namespace", "")
-	v.SetDefault("schedule_worker.default_timezone", "Asia/Tokyo")
 	v.SetDefault("schedule_worker.lease_duration", "15s")
 	v.SetDefault("schedule_worker.renew_deadline", "10s")
 	v.SetDefault("schedule_worker.retry_period", "2s")


### PR DESCRIPTION
## Summary

This PR removes unused configuration settings that are defined but never actually used in the application logic.

### Changes

1. **MCP Secret Prefix settings** (already hardcoded in implementation)
   - Removed `AGENTAPI_K8S_SESSION_MCP_SERVERS_TEAM_SECRET_PREFIX` environment variable binding
   - Removed `AGENTAPI_K8S_SESSION_MCP_SERVERS_USER_SECRET_PREFIX` environment variable binding
   - These settings were replaced by hardcoded constants in commit `4449798`

2. **Schedule Worker DefaultTimezone setting** (not used in code)
   - Removed `DefaultTimezone` field from `ScheduleWorkerConfig` struct
   - Removed environment variable binding `AGENTAPI_SCHEDULE_WORKER_DEFAULT_TIMEZONE`
   - Removed default value from config
   - Removed from Helm `values.yaml`
   - Removed from `deployment.yaml`

### Testing

- ✅ `make lint` passed
- ✅ `go test -v ./...` passed

### Impact

- No functional changes - these configurations were defined but unused
- Simplifies configuration by removing dead code
- No breaking changes for existing deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)