### PR TITLE
Support global values from parent chart

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -64,9 +64,9 @@ spec:
             - name: AGENTAPI_AUTH_GITHUB_TOKEN_HEADER
               value: {{ .Values.config.auth.github.tokenHeader | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID
-              value: {{ (.Values.global.config.auth.github.oauth.clientId | default .Values.config.auth.github.oauth.clientId) | quote }}
+              value: {{ ((.Values.global).config.auth.github.oauth.clientId | default .Values.config.auth.github.oauth.clientId) | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET
-              value: {{ (.Values.global.config.auth.github.oauth.clientSecret | default .Values.config.auth.github.oauth.clientSecret) | quote }}
+              value: {{ ((.Values.global).config.auth.github.oauth.clientSecret | default .Values.config.auth.github.oauth.clientSecret) | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_SCOPE
               value: {{ .Values.config.auth.github.oauth.scope | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_BASE_URL
@@ -82,14 +82,29 @@ spec:
               value: {{ .Values.config.roleEnvFiles.path | quote }}
             - name: AGENTAPI_ROLE_ENV_FILES_LOAD_DEFAULT
               value: {{ .Values.config.roleEnvFiles.loadDefault | quote }}
-            {{- $githubEnterpriseEnabled := .Values.global.github.enterprise.enabled | default .Values.github.enterprise.enabled }}
+            {{- $githubEnterpriseEnabled := false }}
+            {{- if .Values.global }}
+              {{- $githubEnterpriseEnabled = .Values.global.github.enterprise.enabled | default .Values.github.enterprise.enabled }}
+            {{- else }}
+              {{- $githubEnterpriseEnabled = .Values.github.enterprise.enabled }}
+            {{- end }}
             {{- if $githubEnterpriseEnabled }}
-            {{- $githubEnterpriseBaseUrl := .Values.global.github.enterprise.baseUrl | default .Values.github.enterprise.baseUrl }}
+            {{- $githubEnterpriseBaseUrl := "" }}
+            {{- if .Values.global }}
+              {{- $githubEnterpriseBaseUrl = .Values.global.github.enterprise.baseUrl | default .Values.github.enterprise.baseUrl }}
+            {{- else }}
+              {{- $githubEnterpriseBaseUrl = .Values.github.enterprise.baseUrl }}
+            {{- end }}
             {{- if $githubEnterpriseBaseUrl }}
             - name: GITHUB_URL
               value: {{ $githubEnterpriseBaseUrl | quote }}
             {{- end }}
-            {{- $githubEnterpriseApiUrl := .Values.global.github.enterprise.apiUrl | default .Values.github.enterprise.apiUrl }}
+            {{- $githubEnterpriseApiUrl := "" }}
+            {{- if .Values.global }}
+              {{- $githubEnterpriseApiUrl = .Values.global.github.enterprise.apiUrl | default .Values.github.enterprise.apiUrl }}
+            {{- else }}
+              {{- $githubEnterpriseApiUrl = .Values.github.enterprise.apiUrl }}
+            {{- end }}
             {{- if $githubEnterpriseApiUrl }}
             - name: GITHUB_API
               value: {{ $githubEnterpriseApiUrl | quote }}
@@ -112,7 +127,12 @@ spec:
             - name: GITHUB_APP_PEM_PATH
               value: "/etc/github-app/{{ .Values.github.app.privateKey.key }}"
             {{- end }}
-            {{- $hostname := .Values.global.hostname | default .Values.config.hostname }}
+            {{- $hostname := "" }}
+            {{- if .Values.global }}
+              {{- $hostname = .Values.global.hostname | default .Values.config.hostname }}
+            {{- else }}
+              {{- $hostname = .Values.config.hostname }}
+            {{- end }}
             {{- if .Values.config.notification.baseUrl }}
             - name: NOTIFICATION_BASE_URL
               value: {{ .Values.config.notification.baseUrl | quote }}

--- a/helm/agentapi-proxy/templates/github-session-secret.yaml
+++ b/helm/agentapi-proxy/templates/github-session-secret.yaml
@@ -57,8 +57,18 @@ stringData:
   Kept separate from authentication credentials so that params.github_token
   can override GITHUB_TOKEN without losing GITHUB_API and GITHUB_URL settings.
 */}}
-{{- $githubEnterpriseApiUrl := .Values.global.github.enterprise.apiUrl | default .Values.github.enterprise.apiUrl }}
-{{- $githubEnterpriseBaseUrl := .Values.global.github.enterprise.baseUrl | default .Values.github.enterprise.baseUrl }}
+{{- $githubEnterpriseApiUrl := "" }}
+{{- if .Values.global }}
+  {{- $githubEnterpriseApiUrl = .Values.global.github.enterprise.apiUrl | default .Values.github.enterprise.apiUrl }}
+{{- else }}
+  {{- $githubEnterpriseApiUrl = .Values.github.enterprise.apiUrl }}
+{{- end }}
+{{- $githubEnterpriseBaseUrl := "" }}
+{{- if .Values.global }}
+  {{- $githubEnterpriseBaseUrl = .Values.global.github.enterprise.baseUrl | default .Values.github.enterprise.baseUrl }}
+{{- else }}
+  {{- $githubEnterpriseBaseUrl = .Values.github.enterprise.baseUrl }}
+{{- end }}
 {{- if and .Values.kubernetesSession.enabled (or $githubEnterpriseApiUrl $githubEnterpriseBaseUrl) }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## Summary
- Add support for global values from parent charts like ccplant
- Enable the chart to be used as a Helm dependency with global configuration

## Changes
- Support `global.hostname` for hostname configuration
- Support `global.github.enterprise.enabled`, `global.github.enterprise.baseUrl`, and `global.github.enterprise.apiUrl` for GitHub Enterprise settings
- Support `global.config.auth.github.oauth.clientId` and `global.config.auth.github.oauth.clientSecret` for OAuth configuration
- Fall back to local values when global values are not provided
- Update deployment.yaml to use global values
- Update github-session-secret.yaml to use global values

## Benefits
- Allows parent charts to configure multiple child charts with shared global settings
- Maintains backward compatibility with existing deployments
- Reduces duplication of configuration values

## Related PRs
- ccplant: Remove submodules and use Helm chart dependencies
- agentapi-ui: Support global values from parent chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)