### PR TITLE
Support global values from parent charts

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -64,9 +64,43 @@ spec:
             - name: AGENTAPI_AUTH_GITHUB_TOKEN_HEADER
               value: {{ .Values.config.auth.github.tokenHeader | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID
-              value: {{ ((.Values.global).config.auth.github.oauth.clientId | default .Values.config.auth.github.oauth.clientId) | quote }}
+              {{- $clientId := .Values.config.auth.github.oauth.clientId }}
+              {{- if .Values.global }}
+                {{- if .Values.global.github }}
+                  {{- if .Values.global.github.oauth }}
+                    {{- $clientId = .Values.global.github.oauth.clientId | default $clientId }}
+                  {{- end }}
+                {{- end }}
+                {{- if .Values.global.config }}
+                  {{- if .Values.global.config.auth }}
+                    {{- if .Values.global.config.auth.github }}
+                      {{- if .Values.global.config.auth.github.oauth }}
+                        {{- $clientId = .Values.global.config.auth.github.oauth.clientId | default $clientId }}
+                      {{- end }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+              value: {{ $clientId | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET
-              value: {{ ((.Values.global).config.auth.github.oauth.clientSecret | default .Values.config.auth.github.oauth.clientSecret) | quote }}
+              {{- $clientSecret := .Values.config.auth.github.oauth.clientSecret }}
+              {{- if .Values.global }}
+                {{- if .Values.global.github }}
+                  {{- if .Values.global.github.oauth }}
+                    {{- $clientSecret = .Values.global.github.oauth.clientSecret | default $clientSecret }}
+                  {{- end }}
+                {{- end }}
+                {{- if .Values.global.config }}
+                  {{- if .Values.global.config.auth }}
+                    {{- if .Values.global.config.auth.github }}
+                      {{- if .Values.global.config.auth.github.oauth }}
+                        {{- $clientSecret = .Values.global.config.auth.github.oauth.clientSecret | default $clientSecret }}
+                      {{- end }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+              value: {{ $clientSecret | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_SCOPE
               value: {{ .Values.config.auth.github.oauth.scope | quote }}
             - name: AGENTAPI_AUTH_GITHUB_OAUTH_BASE_URL
@@ -82,28 +116,34 @@ spec:
               value: {{ .Values.config.roleEnvFiles.path | quote }}
             - name: AGENTAPI_ROLE_ENV_FILES_LOAD_DEFAULT
               value: {{ .Values.config.roleEnvFiles.loadDefault | quote }}
-            {{- $githubEnterpriseEnabled := false }}
+            {{- $githubEnterpriseEnabled := .Values.github.enterprise.enabled }}
             {{- if .Values.global }}
-              {{- $githubEnterpriseEnabled = .Values.global.github.enterprise.enabled | default .Values.github.enterprise.enabled }}
-            {{- else }}
-              {{- $githubEnterpriseEnabled = .Values.github.enterprise.enabled }}
+              {{- if .Values.global.github }}
+                {{- if .Values.global.github.enterprise }}
+                  {{- $githubEnterpriseEnabled = .Values.global.github.enterprise.enabled | default $githubEnterpriseEnabled }}
+                {{- end }}
+              {{- end }}
             {{- end }}
             {{- if $githubEnterpriseEnabled }}
-            {{- $githubEnterpriseBaseUrl := "" }}
+            {{- $githubEnterpriseBaseUrl := .Values.github.enterprise.baseUrl }}
             {{- if .Values.global }}
-              {{- $githubEnterpriseBaseUrl = .Values.global.github.enterprise.baseUrl | default .Values.github.enterprise.baseUrl }}
-            {{- else }}
-              {{- $githubEnterpriseBaseUrl = .Values.github.enterprise.baseUrl }}
+              {{- if .Values.global.github }}
+                {{- if .Values.global.github.enterprise }}
+                  {{- $githubEnterpriseBaseUrl = .Values.global.github.enterprise.baseUrl | default $githubEnterpriseBaseUrl }}
+                {{- end }}
+              {{- end }}
             {{- end }}
             {{- if $githubEnterpriseBaseUrl }}
             - name: GITHUB_URL
               value: {{ $githubEnterpriseBaseUrl | quote }}
             {{- end }}
-            {{- $githubEnterpriseApiUrl := "" }}
+            {{- $githubEnterpriseApiUrl := .Values.github.enterprise.apiUrl }}
             {{- if .Values.global }}
-              {{- $githubEnterpriseApiUrl = .Values.global.github.enterprise.apiUrl | default .Values.github.enterprise.apiUrl }}
-            {{- else }}
-              {{- $githubEnterpriseApiUrl = .Values.github.enterprise.apiUrl }}
+              {{- if .Values.global.github }}
+                {{- if .Values.global.github.enterprise }}
+                  {{- $githubEnterpriseApiUrl = .Values.global.github.enterprise.apiUrl | default $githubEnterpriseApiUrl }}
+                {{- end }}
+              {{- end }}
             {{- end }}
             {{- if $githubEnterpriseApiUrl }}
             - name: GITHUB_API

--- a/helm/agentapi-proxy/templates/github-session-secret.yaml
+++ b/helm/agentapi-proxy/templates/github-session-secret.yaml
@@ -57,17 +57,21 @@ stringData:
   Kept separate from authentication credentials so that params.github_token
   can override GITHUB_TOKEN without losing GITHUB_API and GITHUB_URL settings.
 */}}
-{{- $githubEnterpriseApiUrl := "" }}
+{{- $githubEnterpriseApiUrl := .Values.github.enterprise.apiUrl }}
 {{- if .Values.global }}
-  {{- $githubEnterpriseApiUrl = .Values.global.github.enterprise.apiUrl | default .Values.github.enterprise.apiUrl }}
-{{- else }}
-  {{- $githubEnterpriseApiUrl = .Values.github.enterprise.apiUrl }}
+  {{- if .Values.global.github }}
+    {{- if .Values.global.github.enterprise }}
+      {{- $githubEnterpriseApiUrl = .Values.global.github.enterprise.apiUrl | default $githubEnterpriseApiUrl }}
+    {{- end }}
+  {{- end }}
 {{- end }}
-{{- $githubEnterpriseBaseUrl := "" }}
+{{- $githubEnterpriseBaseUrl := .Values.github.enterprise.baseUrl }}
 {{- if .Values.global }}
-  {{- $githubEnterpriseBaseUrl = .Values.global.github.enterprise.baseUrl | default .Values.github.enterprise.baseUrl }}
-{{- else }}
-  {{- $githubEnterpriseBaseUrl = .Values.github.enterprise.baseUrl }}
+  {{- if .Values.global.github }}
+    {{- if .Values.global.github.enterprise }}
+      {{- $githubEnterpriseBaseUrl = .Values.global.github.enterprise.baseUrl | default $githubEnterpriseBaseUrl }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if and .Values.kubernetesSession.enabled (or $githubEnterpriseApiUrl $githubEnterpriseBaseUrl) }}
 apiVersion: v1

--- a/helm/agentapi-proxy/templates/ingress.yaml
+++ b/helm/agentapi-proxy/templates/ingress.yaml
@@ -1,4 +1,26 @@
 {{- if .Values.ingress.enabled -}}
+{{- $ingressClassName := .Values.ingress.className }}
+{{- if .Values.global }}
+  {{- if .Values.global.ingress }}
+    {{- $ingressClassName = .Values.global.ingress.className | default $ingressClassName }}
+  {{- end }}
+{{- end }}
+{{- $tlsEnabled := false }}
+{{- if .Values.ingress.tls }}
+  {{- $tlsEnabled = true }}
+{{- else if .Values.global }}
+  {{- if .Values.global.ingress }}
+    {{- if .Values.global.ingress.tls }}
+      {{- $tlsEnabled = .Values.global.ingress.tls.enabled | default false }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $apiHostname := "" }}
+{{- if .Values.global }}
+  {{- $apiHostname = .Values.global.apiHostname | default .Values.config.hostname }}
+{{- else }}
+  {{- $apiHostname = .Values.config.hostname }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,8 +32,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and $ingressClassName (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $ingressClassName }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
@@ -22,8 +44,14 @@ spec:
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
+  {{- else if and $tlsEnabled $apiHostname }}
+  tls:
+    - hosts:
+        - {{ $apiHostname | quote }}
+      secretName: {{ include "agentapi-proxy.fullname" . }}-tls
   {{- end }}
   rules:
+    {{- if .Values.ingress.hosts }}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -44,5 +72,24 @@ spec:
               servicePort: {{ $.Values.service.port }}
               {{- end }}
           {{- end }}
+    {{- end }}
+    {{- else if $apiHostname }}
+    - host: {{ $apiHostname | quote }}
+      http:
+        paths:
+          - path: /
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.fullname" . }}
+              servicePort: {{ .Values.service.port }}
+              {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -3,6 +3,32 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# =============================================================================
+# グローバル設定 (オプション)
+# =============================================================================
+# 親チャート（ccplant等）から渡されるグローバル設定を受け取ります。
+# これらの設定は後方互換性のためオプションです。
+# global設定が存在しない場合、各設定のローカル値がフォールバックとして使用されます。
+#
+# global:
+#   # UIホスト名 (agentapi-ui用)
+#   hostname: ""
+#   # APIホスト名 (agentapi-proxy用)
+#   apiHostname: ""
+#
+#   github:
+#     enterprise:
+#       enabled: false
+#       baseUrl: ""
+#     oauth:
+#       clientId: ""
+#       clientSecret: ""
+#
+#   ingress:
+#     className: nginx
+#     tls:
+#       enabled: true
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
## Summary

ccplantなどの親チャートからのグローバル設定をサポートし、後方互換性を保ちながらHelm Chartの統合を改善しました。

### 変更内容

- **values.yaml**: グローバル設定セクションを追加
  - `global.apiHostname`: Ingress設定用のAPIホスト名
  - `global.github.oauth`: OAuthクライアントID/シークレット
  - `global.github.enterprise`: GitHub Enterprise設定
  - `global.ingress.className`: Ingressクラス名
  - `global.ingress.tls.enabled`: TLS有効化フラグ

- **templates/deployment.yaml**: 
  - global.github.oauthのサポートを追加（ccplant構造に合わせて）
  - global.github.enterpriseのnil pointerエラーを修正

- **templates/ingress.yaml**:
  - global.apiHostnameのサポートを追加
  - global.ingress.classNameとglobal.ingress.tls.enabledのサポートを追加

- **templates/github-session-secret.yaml**:
  - global.github.enterpriseのnil pointerエラーを修正

### 後方互換性

- すべてのグローバル設定はオプションです
- グローバル設定が存在しない場合、ローカル値がフォールバックとして使用されます
- 既存のデプロイメントに影響はありません

### テスト

```bash
# グローバル値なしでのテスト（後方互換性確認）
helm template test ./helm/agentapi-proxy --set ingress.enabled=true --set config.hostname=test.example.com

# グローバル値ありでのテスト
helm template test ./helm/agentapi-proxy --set ingress.enabled=true \
  --set global.apiHostname=api.ccplant.example.com \
  --set global.ingress.className=nginx \
  --set global.ingress.tls.enabled=true \
  --set ingress.hosts=null
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)