### PR TITLE
fix: exclude Bedrock env vars when using OAuth token authentication

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -416,4 +416,13 @@ func runCredentialsSecretMigration(configData *config.Config) {
 	}
 
 	log.Printf("[ENV_MIGRATION] Credentials secret migration completed successfully")
+
+	// Resync OAuth mode secrets to add Bedrock override values
+	if err := syncer.ResyncSecretsForOAuthMode(context.Background()); err != nil {
+		log.Printf("[ENV_RESYNC] Resync failed: %v", err)
+		// Continue even if resync fails - we don't want to prevent server startup
+		return
+	}
+
+	log.Printf("[ENV_RESYNC] OAuth mode secrets resync completed successfully")
 }


### PR DESCRIPTION
## Summary

OAuth token認証時に、Bedrock関連の環境変数（`ANTHROPIC_MODEL`, `AWS_ACCESS_KEY_ID`など）をPodにマウントしないように修正しました。

以前は、OAuthトークンとBedrock認証情報の両方が設定されている場合、両方の環境変数がPodに追加されていました。この変更により、アクティブな認証モードの認証情報のみがマウントされるようになります。

## Changes

- `buildSecretData`メソッドを修正し、アクティブな認証モードの認証情報のみを追加するようにしました
- フォールバックロジックを更新し、有効なBedrock設定のみを考慮するようにしました
- OAuth modeでBedrock認証情報が設定されている場合のテストケースを追加しました

## Test Plan

- [x] 既存のテストがすべて成功することを確認
- [x] 新しいテストケース`TestKubernetesCredentialsSecretSyncer_Sync_OAuthModeWithBedrock`を追加し、OAuth mode時にBedrock環境変数が追加されないことを確認
- [x] `make lint`を実行してlintエラーがないことを確認
- [x] `make test`（race detectorなし）を実行してすべてのテストが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)