### PR TITLE
feat: add updated_at field to session list response

### DIFF
--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -80,6 +80,9 @@ type Session interface {
 	// StartedAt returns when the session was started
 	StartedAt() time.Time
 
+	// UpdatedAt returns when the session was last updated
+	UpdatedAt() time.Time
+
 	// Description returns the session description
 	// Returns tags["description"] if exists, otherwise returns InitialMessage
 	Description() string

--- a/pkg/schedule/worker_test.go
+++ b/pkg/schedule/worker_test.go
@@ -21,6 +21,7 @@ type mockProxySession struct {
 	addr      string
 	tags      map[string]string
 	startedAt time.Time
+	updatedAt time.Time
 }
 
 func (s *mockProxySession) ID() string                    { return s.id }
@@ -29,6 +30,7 @@ func (s *mockProxySession) UserID() string                { return s.userID }
 func (s *mockProxySession) Tags() map[string]string       { return s.tags }
 func (s *mockProxySession) Status() string                { return s.status }
 func (s *mockProxySession) StartedAt() time.Time          { return s.startedAt }
+func (s *mockProxySession) UpdatedAt() time.Time          { return s.updatedAt }
 func (s *mockProxySession) Description() string           { return "" }
 func (s *mockProxySession) Scope() entities.ResourceScope { return entities.ScopeUser }
 func (s *mockProxySession) TeamID() string                { return "" }
@@ -39,13 +41,15 @@ func newMockProxySessionManager() *mockProxySessionManager {
 }
 
 func (m *mockProxySessionManager) CreateSession(ctx context.Context, id string, req *entities.RunServerRequest) (entities.Session, error) {
+	now := time.Now()
 	session := &mockProxySession{
 		id:        id,
 		userID:    req.UserID,
 		status:    "active",
 		addr:      "localhost:9000",
 		tags:      req.Tags,
-		startedAt: time.Now(),
+		startedAt: now,
+		updatedAt: now,
 	}
 	m.sessions[id] = session
 	return session, nil

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1797,6 +1797,11 @@
             "format": "date-time",
             "description": "When the session was started"
           },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the session was last updated (e.g., last message received)"
+          },
           "addr": {
             "type": "string",
             "description": "Address of the agentapi server (host:port)"


### PR DESCRIPTION
## Summary

- `updated_at` フィールドを `GET /search` (listSession) のレスポンスに追加
- メッセージ受信時 (`POST /:sessionId/message`) に `updated_at` を更新
- Kubernetes Service の annotations に `updated_at` を保存することで、k8s API コール回数を削減

## 変更内容

### エンティティ層
- `Session` interface に `UpdatedAt()` メソッドを追加

### インフラストラクチャ層
- `KubernetesSession` に `updatedAt` フィールドと関連メソッドを追加
  - `UpdatedAt()`: 最終更新日時を取得
  - `SetUpdatedAt()`: 復元時に更新日時を設定
  - `TouchUpdatedAt()`: 現在時刻で更新日時を更新
- Service の annotations に `agentapi.proxy/updated-at` を追加
  - 作成時: `started_at` と同じ値で初期化
  - 復元時: annotations から読み取り
- `UpdateServiceAnnotation()` メソッドを追加してメッセージ受信時に更新

### コントローラー層
- `POST /:sessionId/message` 時に `updated_at` を更新
  - インメモリのタイムスタンプを即座に更新
  - Service annotations を非同期で更新（リクエストをブロックしない）
- `GET /search` レスポンスに `updated_at` を追加

### OpenAPI 仕様
- `SessionResponse` スキーマに `updated_at` フィールドを追加

### テスト
- `mockProxySession` に `UpdatedAt()` を実装

## 設計上の利点

1. **k8s API コール削減**: Service annotations に保存することで、ListSessions 時に追加の API コールが不要
2. **非同期更新**: メッセージ受信時の annotations 更新を非同期化し、レスポンスタイムに影響を与えない
3. **後方互換性**: `updated_at` が存在しない場合は `created_at` をデフォルト値として使用

## Test plan

- [x] `make lint` 成功
- [x] `make test` (without -race) 成功
- [ ] 新規セッション作成時に `updated_at` が `started_at` と同じ値で初期化されることを確認
- [ ] メッセージ送信時に `updated_at` が更新されることを確認
- [ ] `GET /search` レスポンスに `updated_at` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)