### PR TITLE
fix: do not use creator's github_token for team-scoped webhooks and schedules

### DIFF
--- a/internal/interfaces/controllers/webhook_custom_controller.go
+++ b/internal/interfaces/controllers/webhook_custom_controller.go
@@ -438,8 +438,11 @@ func (c *WebhookCustomController) createSessionFromWebhook(
 	}
 
 	// Handle GitHub token if provided
-	if sessionConfig != nil && sessionConfig.Params() != nil && sessionConfig.Params().GithubToken() != "" {
-		req.GithubToken = sessionConfig.Params().GithubToken()
+	// For team-scoped webhooks, do not use the creator's github_token
+	if webhook.Scope() != entities.ScopeTeam {
+		if sessionConfig != nil && sessionConfig.Params() != nil && sessionConfig.Params().GithubToken() != "" {
+			req.GithubToken = sessionConfig.Params().GithubToken()
+		}
 	}
 
 	// Check session limit per webhook
@@ -589,8 +592,11 @@ Please ensure the webhook payload is valid JSON.
 	}
 
 	// Handle GitHub token if provided
-	if sessionConfig != nil && sessionConfig.Params() != nil && sessionConfig.Params().GithubToken() != "" {
-		req.GithubToken = sessionConfig.Params().GithubToken()
+	// For team-scoped webhooks, do not use the creator's github_token
+	if webhook.Scope() != entities.ScopeTeam {
+		if sessionConfig != nil && sessionConfig.Params() != nil && sessionConfig.Params().GithubToken() != "" {
+			req.GithubToken = sessionConfig.Params().GithubToken()
+		}
 	}
 
 	// Check session limit per webhook

--- a/internal/interfaces/controllers/webhook_github_controller.go
+++ b/internal/interfaces/controllers/webhook_github_controller.go
@@ -579,8 +579,11 @@ func (c *WebhookGitHubController) createSessionFromWebhook(ctx echo.Context, web
 	}
 
 	// Handle GitHub token
-	if sessionConfig != nil && sessionConfig.Params() != nil && sessionConfig.Params().GithubToken() != "" {
-		req.GithubToken = sessionConfig.Params().GithubToken()
+	// For team-scoped webhooks, do not use the creator's github_token
+	if webhook.Scope() != entities.ScopeTeam {
+		if sessionConfig != nil && sessionConfig.Params() != nil && sessionConfig.Params().GithubToken() != "" {
+			req.GithubToken = sessionConfig.Params().GithubToken()
+		}
 	}
 
 	// Set repository info from tags

--- a/pkg/schedule/handlers.go
+++ b/pkg/schedule/handlers.go
@@ -454,16 +454,20 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 
 	// Create session with schedule's scope
 	sessionID := uuid.New().String()
+	scheduleScope := schedule.GetScope() // Use GetScope() to handle default value
 	req := &entities.RunServerRequest{
 		UserID:      schedule.UserID,
 		Environment: schedule.SessionConfig.Environment,
 		Tags:        schedule.SessionConfig.Tags,
-		Scope:       schedule.GetScope(), // Use GetScope() to handle default value
+		Scope:       scheduleScope,
 		TeamID:      schedule.TeamID,
 	}
 	if schedule.SessionConfig.Params != nil {
 		req.InitialMessage = schedule.SessionConfig.Params.Message
-		req.GithubToken = schedule.SessionConfig.Params.GithubToken
+		// For team-scoped schedules, do not use the creator's github_token
+		if scheduleScope != entities.ScopeTeam {
+			req.GithubToken = schedule.SessionConfig.Params.GithubToken
+		}
 	}
 
 	// Extract repository information from tags


### PR DESCRIPTION
## Summary
- team-scoped の webhook と schedule の場合、creator の github_token を使用しないように修正
- personal (user-scoped) の場合のみ github_token を使用するように統一

## Changes
- `webhook_github_controller.go`: team-scoped webhook の場合は github_token をスキップ
- `webhook_custom_controller.go`: team-scoped webhook の場合は github_token をスキップ (createSessionFromWebhook と createSessionForParseError の両方)
- `pkg/schedule/handlers.go`: team-scoped schedule の TriggerSchedule で github_token をスキップ (worker.go との一貫性を確保)

## Test plan
- [x] lint 実行済み (0 issues)
- [x] テスト実行済み (webhook controllers と schedule handlers のテストが全て成功)

## Context
schedule の worker.go では既に team-scoped の場合に github_token を使用しない実装になっていましたが、webhook と schedule の TriggerSchedule では統一されていませんでした。この PR でその一貫性を確保しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)