### PR TITLE
Fix: Add mount_payload field to SessionConfig HTTP layer

### DIFF
--- a/internal/interfaces/controllers/webhook_controller.go
+++ b/internal/interfaces/controllers/webhook_controller.go
@@ -105,6 +105,7 @@ type SessionConfigRequest struct {
 	ReuseMessageTemplate   string                `json:"reuse_message_template,omitempty"`
 	Params                 *SessionParamsRequest `json:"params,omitempty"`
 	ReuseSession           bool                  `json:"reuse_session,omitempty"`
+	MountPayload           bool                  `json:"mount_payload,omitempty"`
 }
 
 // SessionParamsRequest represents session params in requests
@@ -200,6 +201,7 @@ type SessionConfigResponse struct {
 	ReuseMessageTemplate   string                 `json:"reuse_message_template,omitempty"`
 	Params                 *SessionParamsResponse `json:"params,omitempty"`
 	ReuseSession           bool                   `json:"reuse_session,omitempty"`
+	MountPayload           bool                   `json:"mount_payload,omitempty"`
 }
 
 // SessionParamsResponse represents session params in responses
@@ -667,6 +669,7 @@ func (c *WebhookController) requestToSessionConfig(req *SessionConfigRequest) *e
 	config.SetInitialMessageTemplate(req.InitialMessageTemplate)
 	config.SetReuseMessageTemplate(req.ReuseMessageTemplate)
 	config.SetReuseSession(req.ReuseSession)
+	config.SetMountPayload(req.MountPayload)
 	if req.Params != nil {
 		params := entities.NewWebhookSessionParams()
 		params.SetGithubToken(req.Params.GithubToken)
@@ -780,6 +783,7 @@ func (c *WebhookController) sessionConfigToResponse(sc *entities.WebhookSessionC
 		InitialMessageTemplate: sc.InitialMessageTemplate(),
 		ReuseMessageTemplate:   sc.ReuseMessageTemplate(),
 		ReuseSession:           sc.ReuseSession(),
+		MountPayload:           sc.MountPayload(),
 	}
 	// GitHubトークンは機密情報なのでレスポンスに含めない
 	// params フィールドは意図的に省略


### PR DESCRIPTION
## 問題

UIで設定した `mount_payload` オプションがAPIによって保存・返却されていませんでした。

## 原因

ドメインエンティティとリポジトリ層では `mount_payload` が既にサポートされていましたが、HTTP API層（コントローラー）で以下が不足していました：

- `SessionConfigRequest` 構造体に `MountPayload` フィールドがない
- `SessionConfigResponse` 構造体に `MountPayload` フィールドがない
- リクエストからエンティティへの変換で `mount_payload` が設定されない
- エンティティからレスポンスへの変換で `mount_payload` が含まれない

## 修正内容

1. `SessionConfigRequest` に `MountPayload` フィールドを追加
2. `SessionConfigResponse` に `MountPayload` フィールドを追加
3. `requestToSessionConfig` 関数で `mount_payload` をリクエストから設定
4. `sessionConfigToResponse` 関数で `mount_payload` をレスポンスに含める

## 影響範囲

- HTTP API のみ（`internal/interfaces/controllers/webhook_controller.go`）
- ドメイン層とリポジトリ層は変更不要（既に実装済み）
- OpenAPI定義も既に正しい（変更不要）

## テスト

UIからmount_payloadオプションを設定して、正しく保存・取得されることを確認してください。