### PR TITLE
Add git repository and storage path fields to settings

### DIFF
--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -101,6 +101,8 @@ type Settings struct {
 	claudeCodeOAuthToken string   // Claude Code OAuth token
 	authMode             AuthMode // Authentication mode (oauth or bedrock)
 	enabledPlugins       []string // plugin@marketplace format (e.g., "commit@claude-plugins-official")
+	gitRepository        string   // Git repository URL for settings sync
+	storagePath          string   // Storage path for settings sync
 	createdAt            time.Time
 	updatedAt            time.Time
 }
@@ -208,6 +210,28 @@ func (s *Settings) AuthMode() AuthMode {
 // SetAuthMode sets the authentication mode
 func (s *Settings) SetAuthMode(mode AuthMode) {
 	s.authMode = mode
+	s.updatedAt = time.Now()
+}
+
+// GitRepository returns the git repository URL
+func (s *Settings) GitRepository() string {
+	return s.gitRepository
+}
+
+// SetGitRepository sets the git repository URL
+func (s *Settings) SetGitRepository(repo string) {
+	s.gitRepository = repo
+	s.updatedAt = time.Now()
+}
+
+// StoragePath returns the storage path
+func (s *Settings) StoragePath() string {
+	return s.storagePath
+}
+
+// SetStoragePath sets the storage path
+func (s *Settings) SetStoragePath(path string) {
+	s.storagePath = path
 	s.updatedAt = time.Now()
 }
 

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -36,6 +36,8 @@ type settingsJSON struct {
 	ClaudeCodeOAuthToken string                      `json:"claude_code_oauth_token,omitempty"`
 	AuthMode             string                      `json:"auth_mode,omitempty"`
 	EnabledPlugins       []string                    `json:"enabled_plugins,omitempty"` // plugin@marketplace format
+	GitRepository        string                      `json:"git_repository,omitempty"`  // Git repository URL for settings sync
+	StoragePath          string                      `json:"storage_path,omitempty"`    // Storage path for settings sync
 	CreatedAt            time.Time                   `json:"created_at"`
 	UpdatedAt            time.Time                   `json:"updated_at"`
 }
@@ -204,6 +206,8 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 		Name:                 settings.Name(),
 		ClaudeCodeOAuthToken: settings.ClaudeCodeOAuthToken(),
 		AuthMode:             string(settings.AuthMode()),
+		GitRepository:        settings.GitRepository(),
+		StoragePath:          settings.StoragePath(),
 		CreatedAt:            settings.CreatedAt(),
 		UpdatedAt:            settings.UpdatedAt(),
 	}
@@ -321,6 +325,18 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 	if sj.AuthMode != "" {
 		settings.SetAuthMode(entities.AuthMode(sj.AuthMode))
 		// Reset updatedAt since SetAuthMode updates it
+		settings.SetUpdatedAt(sj.UpdatedAt)
+	}
+
+	if sj.GitRepository != "" {
+		settings.SetGitRepository(sj.GitRepository)
+		// Reset updatedAt since SetGitRepository updates it
+		settings.SetUpdatedAt(sj.UpdatedAt)
+	}
+
+	if sj.StoragePath != "" {
+		settings.SetStoragePath(sj.StoragePath)
+		// Reset updatedAt since SetStoragePath updates it
 		settings.SetUpdatedAt(sj.UpdatedAt)
 	}
 

--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -81,6 +81,8 @@ type UpdateSettingsRequest struct {
 	ClaudeCodeOAuthToken *string                        `json:"claude_code_oauth_token,omitempty"`
 	AuthMode             *string                        `json:"auth_mode,omitempty"`       // "oauth" or "bedrock"
 	EnabledPlugins       []string                       `json:"enabled_plugins,omitempty"` // plugin@marketplace format
+	GitRepository        *string                        `json:"git_repository,omitempty"`  // Git repository URL for settings sync
+	StoragePath          *string                        `json:"storage_path,omitempty"`    // Storage path for settings sync
 }
 
 // BedrockSettingsResponse is the response body for Bedrock settings
@@ -117,6 +119,8 @@ type SettingsResponse struct {
 	HasClaudeCodeOAuthToken bool                            `json:"has_claude_code_oauth_token"`
 	AuthMode                string                          `json:"auth_mode,omitempty"`
 	EnabledPlugins          []string                        `json:"enabled_plugins,omitempty"` // plugin@marketplace format
+	GitRepository           string                          `json:"git_repository,omitempty"`  // Git repository URL for settings sync
+	StoragePath             string                          `json:"storage_path,omitempty"`    // Storage path for settings sync
 	CreatedAt               string                          `json:"created_at"`
 	UpdatedAt               string                          `json:"updated_at"`
 }
@@ -267,6 +271,16 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 	// Update Claude Code OAuth Token
 	if req.ClaudeCodeOAuthToken != nil {
 		settings.SetClaudeCodeOAuthToken(*req.ClaudeCodeOAuthToken)
+	}
+
+	// Update Git Repository
+	if req.GitRepository != nil {
+		settings.SetGitRepository(*req.GitRepository)
+	}
+
+	// Update Storage Path
+	if req.StoragePath != nil {
+		settings.SetStoragePath(*req.StoragePath)
 	}
 
 	// Determine and set auth_mode
@@ -501,6 +515,8 @@ func (c *SettingsController) toResponse(settings *entities.Settings) *SettingsRe
 		Name:                    settings.Name(),
 		HasClaudeCodeOAuthToken: settings.HasClaudeCodeOAuthToken(),
 		AuthMode:                string(settings.AuthMode()),
+		GitRepository:           settings.GitRepository(),
+		StoragePath:             settings.StoragePath(),
 		CreatedAt:               settings.CreatedAt().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:               settings.UpdatedAt().Format("2006-01-02T15:04:05Z07:00"),
 	}


### PR DESCRIPTION
## Summary
- 設定に Git repository URL と storage path フィールドを追加しました
- これにより、設定を Git リポジトリと同期する機能の基盤を提供します

## Changes
- `Settings` エンティティに `git_repository` と `storage_path` フィールドを追加
- コントローラで新しいフィールドをリクエスト/レスポンスで処理
- リポジトリレイヤーで新しいフィールドを永続化

## Test plan
- [x] lint 実行済み (0 issues)
- [ ] 手動テスト: 設定の保存と読み取りで新しいフィールドが正しく扱われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)