### PR TITLE
feat: update claude-agentapi to latest version before startup

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2853,6 +2853,14 @@ func (m *KubernetesSessionManager) buildClaudeStartCommand() string {
 	baseCmd := `
 # Determine which agent to start based on AGENTAPI_AGENT_TYPE
 if [ "$AGENTAPI_AGENT_TYPE" = "claude-agentapi" ]; then
+    # Update claude-agentapi to the latest version
+    echo "[STARTUP] Updating claude-agentapi to the latest version"
+    if bun install -g github:takutakahashi/claude-agentapi; then
+        echo "[STARTUP] claude-agentapi update successful"
+    else
+        echo "[STARTUP] Warning: Failed to update claude-agentapi, continuing with existing version"
+    fi
+
     # Start claude-agentapi
     echo "[STARTUP] Starting claude-agentapi on $HOST:$PORT"
 


### PR DESCRIPTION
## Summary
- claude-agentapi を起動前に最新バージョンにアップデートする機能を追加
- アップデートが失敗した場合でも既存のバージョンで起動を継続するようにエラーハンドリングを追加

## Changes
- `buildClaudeStartCommand` 関数で claude-agentapi 起動前に `bun install -g github:takutakahashi/claude-agentapi` を実行
- アップデート成功/失敗をログ出力

## Test plan
- [x] make lint 実行済み
- [x] 関連するテスト実行済み (internal/infrastructure/services)
- [ ] CI で全体のテストを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)