### PR TITLE
Force image tag to use Chart appVersion

### DIFF
--- a/.github/workflows/helm-dev-build.yml
+++ b/.github/workflows/helm-dev-build.yml
@@ -266,7 +266,6 @@ jobs:
           helm install agentapi-proxy-dev \
             oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/${{ env.CHART_NAME }} \
             --version ${{ steps.version.outputs.dev_version }} \
-            --set image.tag=dev-${{ steps.commit.outputs.hash }} \
             --set config.enableMultipleUsers=true
           ```
 

--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -53,8 +53,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                | Description                       | Value                                      |
 | ------------------- | --------------------------------- | ------------------------------------------ |
 | `image.repository`  | AgentAPI Proxy image repository   | `ghcr.io/takutakahashi/agentapi-proxy`     |
-| `image.tag`         | AgentAPI Proxy image tag          | `0.18.0`                                   |
 | `image.pullPolicy`  | AgentAPI Proxy image pull policy  | `IfNotPresent`                             |
+
+**Note:** The image tag is not configurable and always uses the Chart's `appVersion`.
 
 ### Deployment parameters
 
@@ -139,13 +140,11 @@ helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --
 ```bash
 # From local chart
 helm install agentapi-proxy ./helm/agentapi-proxy \
-  --set image.tag=latest \
   --set replicaCount=2
 
 # From OCI registry
 helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy \
   --version 0.1.0 \
-  --set image.tag=latest \
   --set replicaCount=2
 ```
 

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -201,7 +201,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_NAMESPACE
               value: {{ .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE
-              value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion)) | quote }}
+              value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -34,7 +34,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/takutakahashi/agentapi-proxy
   pullPolicy: IfNotPresent
-  tag: ""
+  # Image tag is not configurable and always uses Chart's appVersion
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary

Remove `image.tag` configuration option from Helm chart to ensure the image tag always matches the Chart's `appVersion`. This provides better version consistency and prevents tag mismatches between the chart version and deployed image version.

## Changes

- **values.yaml**: Removed `image.tag` parameter (now uses appVersion only)
- **deployment.yaml**: Updated to use `.Chart.AppVersion` directly instead of `.Values.image.tag | default .Chart.AppVersion`
- **README.md**: 
  - Removed `image.tag` from parameter documentation
  - Added note explaining that image tag always uses Chart's appVersion
  - Removed `--set image.tag=latest` from installation examples
- **helm-dev-build.yml**: Removed `--set image.tag=dev-...` from workflow examples (appVersion is already updated in the workflow)

## Benefits

1. **Version Consistency**: Image tag will always match Chart appVersion
2. **Simplified Configuration**: One less parameter to configure
3. **Prevents Mismatches**: Eliminates possibility of deploying wrong image version
4. **Clear Intent**: Makes it obvious which version is being deployed

## Migration Guide

For users currently using `--set image.tag=...`:
- Remove this parameter from your deployment commands
- Update Chart's `appVersion` in Chart.yaml if you need to use a specific image version
- For development builds, the workflow already handles appVersion updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)