### PR TITLE
Add metadata.description to session list response

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3340,3 +3340,8 @@ func (m *KubernetesSessionManager) UpdateServiceAnnotation(ctx context.Context, 
 
 	return nil
 }
+
+// GetInitialMessage retrieves the initial message from Secret for a given session
+func (m *KubernetesSessionManager) GetInitialMessage(ctx context.Context, session *KubernetesSession) string {
+	return m.getInitialMessageFromSecret(ctx, session.ServiceName())
+}

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -239,17 +239,27 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 
 	filteredSessions := make([]map[string]interface{}, 0, len(matchingSessions))
 	for _, session := range matchingSessions {
+		// Get initial message from Secret if available
+		var initialMessage string
+		if ksManager, ok := c.getSessionManager().(*services.KubernetesSessionManager); ok {
+			if ks, ok := session.(*services.KubernetesSession); ok {
+				initialMessage = ksManager.GetInitialMessage(context.Background(), ks)
+			}
+		}
+
 		sessionData := map[string]interface{}{
-			"session_id":  session.ID(),
-			"user_id":     session.UserID(),
-			"scope":       session.Scope(),
-			"team_id":     session.TeamID(),
-			"status":      session.Status(),
-			"started_at":  session.StartedAt(),
-			"updated_at":  session.UpdatedAt(),
-			"addr":        session.Addr(),
-			"tags":        session.Tags(),
-			"description": session.Description(),
+			"session_id": session.ID(),
+			"user_id":    session.UserID(),
+			"scope":      session.Scope(),
+			"team_id":    session.TeamID(),
+			"status":     session.Status(),
+			"started_at": session.StartedAt(),
+			"updated_at": session.UpdatedAt(),
+			"addr":       session.Addr(),
+			"tags":       session.Tags(),
+			"metadata": map[string]interface{}{
+				"description": initialMessage,
+			},
 		}
 		filteredSessions = append(filteredSessions, sessionData)
 	}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1926,9 +1926,15 @@
             },
             "description": "Session tags"
           },
-          "description": {
-            "type": "string",
-            "description": "Session description (initial message or tags.description)"
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "description": "Initial message sent to the agent"
+              }
+            },
+            "description": "Session metadata"
           }
         }
       },


### PR DESCRIPTION
## Summary
- listSession API のレスポンスに metadata.description を追加
- Secret から initial message を取得して表示

## Changes
- SessionResponse から description フィールドを削除し、metadata オブジェクトに移動
- KubernetesSessionManager に GetInitialMessage() メソッドを追加
- SearchSessions で各セッションの initial message を Secret から取得
- OpenAPI 仕様を更新して metadata 構造を反映

## Technical Details
- `metadata.description` には Kubernetes Secret に保存された initial message を使用
- 既存の `getInitialMessageFromSecret()` を活用し、公開メソッド `GetInitialMessage()` でラップ
- レスポンス構造をより拡張可能な形に改善

## Test Plan
- [x] make lint 実行済み
- [x] make test 実行済み
- [x] コード品質チェック完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)