### PR TITLE
feat: purge stale stock sessions when image changes (periodic check)

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -400,6 +400,71 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 	return nil
 }
 
+// PurgeStaleStockSessions deletes stock sessions whose agentapi.proxy/stock-image
+// annotation does not match the current configured image (m.k8sConfig.Image).
+// This is called on each periodic check so that pre-warmed sessions built from an
+// outdated image are replaced without requiring a full proxy restart.
+func (m *KubernetesSessionManager) PurgeStaleStockSessions(ctx context.Context) error {
+	svcs, err := m.client.CoreV1().Services(m.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "agentapi.proxy/stock=true,app.kubernetes.io/managed-by=agentapi-proxy",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list stock services for stale check: %w", err)
+	}
+
+	currentImage := m.k8sConfig.Image
+	deletePolicy := metav1.DeletePropagationForeground
+	deleteOptions := metav1.DeleteOptions{PropagationPolicy: &deletePolicy}
+
+	var purgeErrs []string
+	stalePurged := 0
+	for i := range svcs.Items {
+		svc := &svcs.Items[i]
+		if svc.DeletionTimestamp != nil {
+			continue
+		}
+		stockImage := svc.Annotations["agentapi.proxy/stock-image"]
+		// If the annotation is missing or mismatches the current image, purge.
+		if stockImage == currentImage {
+			continue
+		}
+		sessionID := svc.Labels["agentapi.proxy/session-id"]
+		log.Printf("[STOCK_INVENTORY] Purging stale stock session %s (image: %q, current: %q)",
+			sessionID, stockImage, currentImage)
+
+		if err := m.client.CoreV1().Services(m.namespace).Delete(ctx, svc.Name, deleteOptions); err != nil && !errors.IsNotFound(err) {
+			purgeErrs = append(purgeErrs, fmt.Sprintf("service %s: %v", svc.Name, err))
+			continue
+		}
+
+		if sessionID == "" {
+			stalePurged++
+			continue
+		}
+
+		depName := fmt.Sprintf("agentapi-session-%s", sessionID)
+		if err := m.client.AppsV1().Deployments(m.namespace).Delete(ctx, depName, deleteOptions); err != nil && !errors.IsNotFound(err) {
+			purgeErrs = append(purgeErrs, fmt.Sprintf("deployment %s: %v", depName, err))
+		}
+
+		if m.isPVCEnabled() {
+			pvcName := fmt.Sprintf("agentapi-session-%s-pvc", sessionID)
+			if err := m.client.CoreV1().PersistentVolumeClaims(m.namespace).Delete(ctx, pvcName, deleteOptions); err != nil && !errors.IsNotFound(err) {
+				purgeErrs = append(purgeErrs, fmt.Sprintf("pvc %s: %v", pvcName, err))
+			}
+		}
+		stalePurged++
+	}
+
+	if len(purgeErrs) > 0 {
+		return fmt.Errorf("stale purge errors: %s", strings.Join(purgeErrs, "; "))
+	}
+	if stalePurged > 0 {
+		log.Printf("[STOCK_INVENTORY] Purged %d stale stock session(s) (outdated image)", stalePurged)
+	}
+	return nil
+}
+
 // findStockSession lists Services labeled agentapi.proxy/stock=true and returns the
 // oldest available one (by CreationTimestamp, ascending). Oldest sessions have been
 // warmed up the longest and are the most ready to serve.
@@ -1825,6 +1890,11 @@ func (m *KubernetesSessionManager) createService(ctx context.Context, session *K
 	// Record the initial message time as the last message time for all sessions.
 	// This annotation is updated by SendMessage when follow-up messages arrive.
 	annotations["agentapi.proxy/last-message-at"] = session.startedAt.UTC().Format(time.RFC3339)
+	// For stock sessions, record the image used so that stale sessions built from
+	// an outdated image can be detected and replaced during periodic checks.
+	if session.isStock {
+		annotations["agentapi.proxy/stock-image"] = m.k8sConfig.Image
+	}
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/stock_inventory/worker.go
+++ b/pkg/stock_inventory/worker.go
@@ -18,6 +18,11 @@ type StockRepository interface {
 	// worker startup so that stale sessions (e.g. built from an old image)
 	// are replaced with fresh ones.
 	PurgeStockSessions(ctx context.Context) error
+	// PurgeStaleStockSessions deletes stock sessions whose image annotation
+	// does not match the current configured image. Called on each periodic
+	// check so that sessions built from an outdated image are replaced
+	// without requiring a full proxy restart.
+	PurgeStaleStockSessions(ctx context.Context) error
 }
 
 // WorkerConfig contains configuration for the stock inventory worker.
@@ -125,7 +130,14 @@ func (w *Worker) run(ctx context.Context) {
 }
 
 // replenishStock checks the current stock count and creates sessions to reach TargetCount.
+// It first purges any stale sessions whose image does not match the current configured
+// image, so that outdated pre-warmed pods are replaced even without a proxy restart.
 func (w *Worker) replenishStock(ctx context.Context) {
+	// Purge sessions built from an outdated image before counting.
+	if err := w.repo.PurgeStaleStockSessions(ctx); err != nil {
+		log.Printf("[STOCK_INVENTORY] Warning: failed to purge stale stock sessions: %v", err)
+	}
+
 	count, err := w.repo.CountStockSessions(ctx)
 	if err != nil {
 		log.Printf("[STOCK_INVENTORY] Failed to count stock sessions: %v", err)


### PR DESCRIPTION
## Summary

- エージェント在庫セッション作成時に `agentapi.proxy/stock-image` アノテーションへ使用イメージを記録するようにした
- 定期チェック（`replenishStock()`）の冒頭で `PurgeStaleStockSessions()` を呼び、アノテーションのイメージが現在の設定と異なるセッションを自動削除・再作成するようにした
- `StockRepository` インターフェースに `PurgeStaleStockSessions()` メソッドを追加した

## 背景

これまでは、イメージ更新時に古い在庫セッションを削除する仕組みが「proxy Pod 起動時の全削除 (`PurgeStockSessions`)」のみだった。proxy の再起動なしにイメージだけを変更したケースや、リーダー選出のタイムラグにより削除が遅れるケースがあった。

今回の変更により、**proxy の再起動を必要とせず**定期チェックのタイミングで古いイメージのセッションが確実に入れ替わる。

## Test plan

- [ ] `go build ./...` が通ること（確認済み）
- [ ] `go test ./internal/... ./pkg/stock_inventory/...` が全て通ること（確認済み）
- [ ] `golangci-lint run` が 0 issues（確認済み）
- [ ] 在庫セッション作成後に Service の `agentapi.proxy/stock-image` アノテーションに正しいイメージが記録されること
- [ ] イメージを変更した後の次回定期チェックで古いセッションが削除・再作成されること

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)