### PR TITLE
fix: /user/info で GitHub OAuth ユーザーの全チームを返すよう修正

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/personal_api_key"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/spec"
 )
 
@@ -116,7 +117,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 			healthController:         controllers.NewHealthController(),
 			sessionController:        sessionController,
 			settingsController:       settingsController,
-			userController:           controllers.NewUserController(),
+			userController:           controllers.NewUserController(githubBaseURLFromConfig(server.config)),
 			shareController:          shareController,
 			personalAPIKeyController: personalAPIKeyController,
 			memoryController:         memoryController,
@@ -321,4 +322,13 @@ func (r *Router) registerCustomHandlers() error {
 	}
 
 	return nil
+}
+
+// githubBaseURLFromConfig extracts the GitHub API base URL from config safely.
+// Falls back to "https://api.github.com" if GitHub auth is not configured.
+func githubBaseURLFromConfig(cfg *config.Config) string {
+	if cfg != nil && cfg.Auth.GitHub != nil && cfg.Auth.GitHub.BaseURL != "" {
+		return cfg.Auth.GitHub.BaseURL
+	}
+	return "https://api.github.com"
 }

--- a/internal/interfaces/controllers/user_controller.go
+++ b/internal/interfaces/controllers/user_controller.go
@@ -1,8 +1,12 @@
 package controllers
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
@@ -10,7 +14,9 @@ import (
 )
 
 // UserController handles user-related endpoints
-type UserController struct{}
+type UserController struct {
+	githubBaseURL string
+}
 
 // UserInfoResponse represents the response for /user/info endpoint
 type UserInfoResponse struct {
@@ -24,13 +30,65 @@ type UserInfoResponse struct {
 }
 
 // NewUserController creates a new UserController instance
-func NewUserController() *UserController {
-	return &UserController{}
+func NewUserController(githubBaseURL string) *UserController {
+	if githubBaseURL == "" {
+		githubBaseURL = "https://api.github.com"
+	}
+	return &UserController{githubBaseURL: githubBaseURL}
 }
 
 // GetName returns the name of this controller for logging
 func (c *UserController) GetName() string {
 	return "UserController"
+}
+
+// fetchAllGitHubTeams calls the GitHub /user/teams API and returns all teams as "org/slug" strings.
+// It handles pagination automatically (up to 1000 teams / 10 pages).
+func (c *UserController) fetchAllGitHubTeams(ctx context.Context, token string) ([]string, error) {
+	var result []string
+	perPage := 100
+	baseURL := strings.TrimSuffix(c.githubBaseURL, "/")
+
+	for page := 1; page <= 10; page++ {
+		url := fmt.Sprintf("%s/user/teams?per_page=%d&page=%d", baseURL, perPage, page)
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("GitHub API request failed: %w", err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+		}
+
+		var teams []struct {
+			Slug         string `json:"slug"`
+			Organization struct {
+				Login string `json:"login"`
+			} `json:"organization"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&teams); err != nil {
+			return nil, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		for _, t := range teams {
+			result = append(result, fmt.Sprintf("%s/%s", t.Organization.Login, t.Slug))
+		}
+
+		if len(teams) < perPage {
+			break
+		}
+	}
+
+	return result, nil
 }
 
 // GetUserInfo handles GET /user/info requests
@@ -58,9 +116,31 @@ func (c *UserController) GetUserInfo(ctx echo.Context) error {
 	case entities.UserTypeGitHub:
 		if githubInfo := user.GitHubInfo(); githubInfo != nil {
 			response.Username = githubInfo.Login()
+			// Add teams already fetched during authentication (TeamRoleMapping-filtered)
 			for _, team := range githubInfo.Teams() {
 				teamSlug := fmt.Sprintf("%s/%s", team.Organization, team.TeamSlug)
 				response.Teams = append(response.Teams, teamSlug)
+			}
+		}
+		// Additionally call GitHub API to return ALL teams, regardless of TeamRoleMapping config.
+		// This allows the UI to show all teams for scoping/filtering purposes.
+		token := extractBearerToken(ctx.Request().Header.Get("Authorization"))
+		if token != "" {
+			allTeams, err := c.fetchAllGitHubTeams(ctx.Request().Context(), token)
+			if err != nil {
+				log.Printf("[USER_INFO] Warning: failed to fetch all GitHub teams: %v", err)
+			} else {
+				// Merge without duplicates
+				teamSet := make(map[string]bool)
+				for _, t := range response.Teams {
+					teamSet[t] = true
+				}
+				for _, t := range allTeams {
+					if !teamSet[t] {
+						response.Teams = append(response.Teams, t)
+						teamSet[t] = true
+					}
+				}
 			}
 		}
 	case entities.UserTypeServiceAccount:
@@ -72,4 +152,16 @@ func (c *UserController) GetUserInfo(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, response)
+}
+
+// extractBearerToken extracts the token value from an Authorization header.
+// Supports "Bearer <token>" and "token <token>" formats.
+func extractBearerToken(authHeader string) string {
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		return strings.TrimPrefix(authHeader, "Bearer ")
+	}
+	if strings.HasPrefix(authHeader, "token ") {
+		return strings.TrimPrefix(authHeader, "token ")
+	}
+	return ""
 }


### PR DESCRIPTION
## 問題

`/user/info` エンドポイントが `TeamRoleMapping` に設定されているチームしか返さないため、
設定されていないチームに所属しているユーザーは `teams: []` が返り、UI のチーム選択ドロップダウンが表示されない。

## 原因

`GetUserInfo` は auth コンテキストの `githubInfo.Teams()` を使用していたが、
これは `getUserTeamsOptimized()` で取得した「TeamRoleMapping に設定されたチームのみ」を返す。

例: dev 環境では `takutaka-lab/admin` のみ設定 → それ以外のチームはすべて空

## 修正内容

`GetUserInfo` で GitHub OAuth ユーザーの場合、リクエストの Bearer トークンを使って
GitHub API の `/user/teams` を直接呼び出し、全チームを返すよう変更。

- `UserController` に `githubBaseURL` を DI
- `fetchAllGitHubTeams()` ヘルパーを追加（ページネーション対応、最大1000件）
- `GetUserInfo` で auth コンテキストのチームと API 取得の全チームをマージ（重複除外）
- `router.go` で config の GitHub base URL を安全に取得して注入

## 影響範囲

- **認証・認可への影響なし**: teams の取得は `/user/info` のレスポンス用のみ。`TeamRoleMapping` によるロール/パーミッション付与のロジックは変更なし
- **パフォーマンス**: `/user/info` 呼び出し時に GitHub API を追加で呼び出す（キャッシュなし、毎回）

🤖 Generated with [Claude Code](https://claude.com/claude-code)