### PR TITLE
revert: user_controller.go を PR #673 以前の状態に戻す

### DIFF
--- a/internal/interfaces/controllers/user_controller.go
+++ b/internal/interfaces/controllers/user_controller.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 )
 
@@ -14,13 +13,9 @@ type UserController struct{}
 
 // UserInfoResponse represents the response for /user/info endpoint
 type UserInfoResponse struct {
-	UserID      string   `json:"user_id"`
-	Username    string   `json:"username"`
-	UserType    string   `json:"user_type"`
-	Teams       []string `json:"teams"`
-	TeamID      string   `json:"team_id,omitempty"`
-	IsAdmin     bool     `json:"is_admin"`
-	Permissions []string `json:"permissions"`
+	Username string   `json:"username"`
+	Teams    []string `json:"teams"`
+	IsAdmin  bool     `json:"is_admin"`
 }
 
 // NewUserController creates a new UserController instance
@@ -40,35 +35,20 @@ func (c *UserController) GetUserInfo(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	permissions := make([]string, len(user.Permissions()))
-	for i, p := range user.Permissions() {
-		permissions[i] = string(p)
-	}
-
 	response := UserInfoResponse{
-		UserID:      string(user.ID()),
-		Username:    user.Username(),
-		UserType:    string(user.UserType()),
-		Teams:       []string{},
-		IsAdmin:     user.IsAdmin(),
-		Permissions: permissions,
+		Teams:   []string{},
+		IsAdmin: user.IsAdmin(),
 	}
 
-	switch user.UserType() {
-	case entities.UserTypeGitHub:
-		if githubInfo := user.GitHubInfo(); githubInfo != nil {
-			response.Username = githubInfo.Login()
-			for _, team := range githubInfo.Teams() {
-				teamSlug := fmt.Sprintf("%s/%s", team.Organization, team.TeamSlug)
-				response.Teams = append(response.Teams, teamSlug)
-			}
+	if githubInfo := user.GitHubInfo(); githubInfo != nil {
+		response.Username = githubInfo.Login()
+		for _, team := range githubInfo.Teams() {
+			teamSlug := fmt.Sprintf("%s/%s", team.Organization, team.TeamSlug)
+			response.Teams = append(response.Teams, teamSlug)
 		}
-	case entities.UserTypeServiceAccount:
-		// Service accounts are tied to a specific team
-		response.TeamID = user.TeamID()
-		if user.TeamID() != "" {
-			response.Teams = []string{user.TeamID()}
-		}
+	} else {
+		// Fallback for non-GitHub users (e.g., personal API key users)
+		response.Username = user.Username()
 	}
 
 	return ctx.JSON(http.StatusOK, response)


### PR DESCRIPTION
## 概要

PR #673 で変更した `/user/info` レスポンス形式を元に戻す。

`user_type`、`user_id`、`permissions` フィールドを削除し、`username` / `teams` / `is_admin` のみのシンプルな形式に戻す。

## 関連

- Reverts changes from #673 (user_controller.go のみ)
- Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)