### PR TITLE
fix: 設定画面での環境変数削除が機能しない問題を修正

### DIFF
--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -737,14 +737,14 @@ func (c *SettingsController) toResponse(settings *entities.Settings) *SettingsRe
 
 // mergeSecrets merges existing and new secret maps.
 // Keys in new with non-empty values are added or updated.
-// Keys in new with empty string values are ignored (existing values are preserved).
+// Keys in new with empty string values are deleted from the result.
 // Keys in existing that are not present in new are preserved.
 func (c *SettingsController) mergeSecrets(existing, new map[string]string) map[string]string {
 	if new == nil {
 		return existing
 	}
 	if existing == nil {
-		// Filter out empty strings
+		// Filter out empty strings (nothing to delete when existing is nil)
 		result := make(map[string]string)
 		for k, v := range new {
 			if v != "" {
@@ -760,13 +760,15 @@ func (c *SettingsController) mergeSecrets(existing, new map[string]string) map[s
 		result[k] = v
 	}
 
-	// Apply changes from new (empty strings are ignored)
+	// Apply changes from new (empty strings delete the key)
 	for k, v := range new {
 		if v != "" {
 			// Non-empty value adds or updates the key
 			result[k] = v
+		} else {
+			// Empty string deletes the key
+			delete(result, k)
 		}
-		// Empty string is ignored - existing values are preserved
 	}
 	return result
 }

--- a/internal/interfaces/controllers/settings_controller_test.go
+++ b/internal/interfaces/controllers/settings_controller_test.go
@@ -274,11 +274,11 @@ func TestMergeSecrets(t *testing.T) {
 		assert.Equal(t, map[string]string{"A": "updated", "B": "2", "C": "3"}, result)
 	})
 
-	t.Run("empty string in new is ignored, preserving existing value", func(t *testing.T) {
+	t.Run("empty string in new deletes the existing key", func(t *testing.T) {
 		existing := map[string]string{"A": "1", "B": "2"}
 		newMap := map[string]string{"A": ""}
 		result := ctrl.mergeSecrets(existing, newMap)
-		assert.Equal(t, map[string]string{"A": "1", "B": "2"}, result)
+		assert.Equal(t, map[string]string{"B": "2"}, result)
 	})
 
 	t.Run("add new key while preserving existing keys", func(t *testing.T) {
@@ -288,11 +288,18 @@ func TestMergeSecrets(t *testing.T) {
 		assert.Equal(t, map[string]string{"A": "1", "B": "2", "C": "3"}, result)
 	})
 
-	t.Run("update key while empty string for another is ignored", func(t *testing.T) {
+	t.Run("update key while empty string for another deletes it", func(t *testing.T) {
 		existing := map[string]string{"A": "1", "B": "2", "C": "3"}
 		newMap := map[string]string{"A": "updated", "B": ""}
 		result := ctrl.mergeSecrets(existing, newMap)
-		assert.Equal(t, map[string]string{"A": "updated", "B": "2", "C": "3"}, result)
+		assert.Equal(t, map[string]string{"A": "updated", "C": "3"}, result)
+	})
+
+	t.Run("delete all keys by sending all as empty strings", func(t *testing.T) {
+		existing := map[string]string{"A": "1", "B": "2"}
+		newMap := map[string]string{"A": "", "B": ""}
+		result := ctrl.mergeSecrets(existing, newMap)
+		assert.Equal(t, map[string]string{}, result)
 	})
 
 	t.Run("both nil returns nil", func(t *testing.T) {


### PR DESCRIPTION
## 概要

設定画面から環境変数を削除できない問題を修正しました。

## 原因

フロントエンド（agentapi-ui）は環境変数を削除する際に、対象のキーに空文字列（`""`）を設定してバックエンドに送信する設計になっています。しかし、バックエンドの `mergeSecrets()` 関数は空文字列を「無視（既存値を保持）」として扱っていたため、削除が機能していませんでした。

### フロントエンドの削除フロー（agentapi-ui）
1. `EnvVarsSettings.tsx` の `handleDelete` が `{ "KEY": "" }` を送信
2. `settings.ts` の `prepareSettingsForSave` がそのまま API に送信
3. バックエンドが受け取るが `mergeSecrets()` が空文字列を無視 → **削除されない**

## 修正内容

`mergeSecrets()` 関数の挙動を変更：
- **変更前**: 空文字列は無視（既存値を保持）
- **変更後**: 空文字列はそのキーを削除するシグナルとして扱い、マップから削除

## テスト

既存のテストケースを更新し、削除動作を検証する新しいテストケースを追加しました。

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)