### PR TITLE
fix: claude-acp session HTTP stub handlers and AgentType restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,18 @@ RUN ARCH=$(dpkg --print-architecture) && \
       -o /usr/local/bin/claude-posts && \
     chmod +x /usr/local/bin/claude-posts
 
+# Download acp-ws-server binary for ACP WebSocket transport (used by claude-acp agent type)
+ARG ACP_WS_SERVER_VERSION=server/v0.1.0
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "$ARCH" in \
+      amd64) ACP_WS_ARCH="linux-amd64" ;; \
+      arm64) ACP_WS_ARCH="linux-arm64" ;; \
+      *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/takutakahashi/acp-transport-ws/releases/download/${ACP_WS_SERVER_VERSION}/acp-ws-server-${ACP_WS_ARCH}" \
+      -o /usr/local/bin/acp-ws-server && \
+    chmod +x /usr/local/bin/acp-ws-server
+
 # Download otelcol-contrib binary for in-process OpenTelemetry Collector support.
 # Used when OtelCollectorInProcess=true (e.g. when stock inventory is enabled) so
 # that otelcol starts after user context is known instead of at Pod creation time.
@@ -158,6 +170,9 @@ RUN bun install -g @takutakahashi/claude-agentapi
 
 # Install codex CLI
 RUN bun install -g @openai/codex
+
+# Install claude-agent-acp for ACP protocol support (used by claude-acp agent type)
+RUN bun install -g @agentclientprotocol/claude-agent-acp
 
 # Set default CLAUDE_MD_PATH for Docker environment
 ENV CLAUDE_MD_PATH=/tmp/config/CLAUDE.md

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/google/go-github/v62 v62.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/jsonschema-go v0.3.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2367,6 +2367,9 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 		servicePort = int(svc.Spec.Ports[0].Port)
 	}
 
+	// Restore agent type from annotation (set at session creation time)
+	agentType := svc.Annotations["agentapi.proxy/agent-type"]
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Create session using constructor
@@ -2380,6 +2383,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 			InitialMessage: initialMessage,
 			MemoryKey:      memoryKey,
 			Teams:          teams,
+			AgentType:      agentType,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,
@@ -2404,7 +2408,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 	// Start watching deployment status
 	go m.watchDeploymentStatus(ctx, session)
 
-	log.Printf("[K8S_SESSION] Restored session %s from Service", sessionID)
+	log.Printf("[K8S_SESSION] Restored session %s from Service (agent_type=%q)", sessionID, agentType)
 
 	return session
 }
@@ -2484,6 +2488,9 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 		servicePort = int(svc.Spec.Ports[0].Port)
 	}
 
+	// Restore agent type from annotation (set at session creation time)
+	agentType := svc.Annotations["agentapi.proxy/agent-type"]
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Create session using constructor
@@ -2497,6 +2504,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 			InitialMessage: initialMessage,
 			MemoryKey:      memoryKey,
 			Teams:          teams,
+			AgentType:      agentType,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,
@@ -2521,7 +2529,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 	// Start watching deployment status
 	go m.watchDeploymentStatus(ctx, session)
 
-	log.Printf("[K8S_SESSION] Restored session %s from Service (with pre-fetched deployment)", sessionID)
+	log.Printf("[K8S_SESSION] Restored session %s from Service with pre-fetched deployment (agent_type=%q)", sessionID, agentType)
 
 	return session
 }

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1105,6 +1105,14 @@ func (m *KubernetesSessionManager) GetMessages(ctx context.Context, id string) (
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
 
+	// ACP WebSocket sessions (claude-acp) do not expose an HTTP /messages endpoint.
+	// Messages are streamed via the ACP WebSocket protocol instead.
+	// Return an empty list so the UI can still initialize and use ACP WS for messaging.
+	if ks, ok := session.(*KubernetesSession); ok && ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
+		log.Printf("[K8S_SESSION] Skipping GetMessages for claude-acp session %s (ACP WS only)", id)
+		return []portrepos.Message{}, nil
+	}
+
 	// Build service name and endpoint URL
 	serviceName := fmt.Sprintf("agentapi-session-%s-svc", id)
 	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/messages",

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2047,8 +2047,10 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 	if req.AgentType != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_AGENT_TYPE", Value: req.AgentType})
 
-		// Add claude-agentapi / codex-agentapi specific environment variables
-		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" {
+		// Add HOST/PORT env vars so the agent binary knows where to bind.
+		// Required by: claude-agentapi, codex-agentapi, and claude-acp
+		// (acp-ws-server uses the same HOST/PORT convention).
+		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" || req.AgentType == "claude-acp" {
 			envVars = append(envVars, corev1.EnvVar{Name: "HOST", Value: "0.0.0.0"})
 			envVars = append(envVars, corev1.EnvVar{Name: "PORT", Value: fmt.Sprintf("%d", m.k8sConfig.BasePort)})
 		}
@@ -2776,8 +2778,9 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	if req.AgentType != "" {
 		env["AGENTAPI_AGENT_TYPE"] = req.AgentType
 
-		// Add claude-agentapi / codex-agentapi specific environment variables
-		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" {
+		// Add HOST/PORT env vars so the agent binary knows where to bind.
+		// Required by: claude-agentapi, codex-agentapi, and claude-acp.
+		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" || req.AgentType == "claude-acp" {
 			env["HOST"] = "0.0.0.0"
 			env["PORT"] = fmt.Sprintf("%d", m.k8sConfig.BasePort)
 		}
@@ -3021,11 +3024,18 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	}
 
 	// Startup command (simplified version for now - full command logic in pod)
-	if req.AgentType == "claude-agentapi" {
+	switch req.AgentType {
+	case "claude-agentapi":
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"claude-agentapi"},
 		}
-	} else {
+	case "claude-acp":
+		// acp-ws-server is the entry point; it spawns claude-agentapi per WS connection.
+		settings.Startup = sessionsettings.StartupConfig{
+			Command: []string{"acp-ws-server"},
+			Args:    []string{"--", "claude-agentapi", "--output-file", "/opt/claude-agentapi/history.jsonl"},
+		}
+	default:
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"agentapi", "server"},
 			Args:    []string{"--allowed-hosts", "*", "--allowed-origins", "*", "--port", fmt.Sprintf("%d", m.k8sConfig.BasePort)},

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3030,10 +3030,11 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			Command: []string{"claude-agentapi"},
 		}
 	case "claude-acp":
-		// acp-ws-server is the entry point; it spawns claude-agentapi per WS connection.
+		// acp-ws-server is the entry point; it spawns claude-agent-acp
+		// (@agentclientprotocol/claude-agent-acp) per WS connection.
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"acp-ws-server"},
-			Args:    []string{"--", "claude-agentapi", "--output-file", "/opt/claude-agentapi/history.jsonl"},
+			Args:    []string{"--", "claude-agent-acp"},
 		}
 	default:
 		settings.Startup = sessionsettings.StartupConfig{

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -446,6 +446,39 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 		return c.handleWebSocketProxy(ctx, session)
 	}
 
+	// For claude-acp sessions (WebSocket-only), handle HTTP paths that have no
+	// equivalent on acp-ws-server to avoid 400/error responses that break the UI.
+	if ks, ok := session.(*services.KubernetesSession); ok && ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
+		requestPath := ctx.Request().URL.Path
+		// Strip the leading /{sessionId} prefix from the path
+		pathParts := strings.SplitN(requestPath, "/", 3)
+		subPath := ""
+		if len(pathParts) >= 3 {
+			subPath = "/" + pathParts[2]
+		}
+		switch {
+		case strings.HasPrefix(subPath, "/messages"):
+			// Return empty messages list; messages are streamed via ACP WebSocket
+			return ctx.JSON(http.StatusOK, map[string]interface{}{
+				"messages": []interface{}{},
+				"total":    0,
+				"hasMore":  false,
+			})
+		case strings.HasPrefix(subPath, "/status"):
+			// Return a minimal status so the UI knows the session is up
+			return ctx.JSON(http.StatusOK, map[string]interface{}{
+				"status":  session.Status(),
+				"message": "",
+			})
+		case strings.HasPrefix(subPath, "/message") && ctx.Request().Method == http.MethodPost:
+			// Sending messages to ACP sessions via HTTP is not supported;
+			// messages must be sent over the ACP WebSocket protocol.
+			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
+				"message": "claude-acp sessions require ACP WebSocket for messaging",
+			})
+		}
+	}
+
 	// Determine target URL using session address
 	targetURL := fmt.Sprintf("http://%s", session.Addr())
 	target, err := url.Parse(targetURL)

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -441,6 +441,11 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 		}
 	}
 
+	// If this is a WebSocket upgrade request, hand off to the WS proxy handler.
+	if isWebSocketUpgrade(ctx.Request()) {
+		return c.handleWebSocketProxy(ctx, session)
+	}
+
 	// Determine target URL using session address
 	targetURL := fmt.Sprintf("http://%s", session.Addr())
 	target, err := url.Parse(targetURL)

--- a/internal/interfaces/controllers/ws_proxy.go
+++ b/internal/interfaces/controllers/ws_proxy.go
@@ -1,0 +1,109 @@
+package controllers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+var wsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	// Allow all origins — CORS is handled by the proxy middleware.
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// isWebSocketUpgrade reports whether r is an HTTP → WebSocket upgrade request.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
+// handleWebSocketProxy upgrades the incoming HTTP connection to WebSocket and
+// bidirectionally proxies all frames to the downstream session's WebSocket
+// endpoint at ws://{session.Addr()}{subPath}.
+//
+// If the downstream is unreachable the client receives a Close frame and the
+// handler returns nil (so Echo does not write a second error response).
+func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entities.Session) error {
+	sessionID := session.ID()
+
+	// Strip the leading /:sessionId segment to derive the downstream sub-path.
+	//   /abc123/ws  → /ws
+	//   /abc123     → /
+	originalPath := ctx.Request().URL.Path
+	pathParts := strings.SplitN(originalPath, "/", 3)
+	var subPath string
+	if len(pathParts) >= 3 {
+		subPath = "/" + pathParts[2]
+	} else {
+		subPath = "/"
+	}
+
+	targetURL := fmt.Sprintf("ws://%s%s", session.Addr(), subPath)
+	log.Printf("[WS] Proxying WebSocket for session %s → %s", sessionID, targetURL)
+
+	// 1. Upgrade the incoming HTTP connection to WebSocket.
+	clientConn, err := wsUpgrader.Upgrade(ctx.Response().Writer, ctx.Request(), nil)
+	if err != nil {
+		// Upgrader writes its own 400/500 response; just log and return nil.
+		log.Printf("[WS] Failed to upgrade client connection for session %s: %v", sessionID, err)
+		return nil
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	// 2. Dial the downstream WebSocket endpoint.
+	serverConn, _, err := websocket.DefaultDialer.Dial(targetURL, nil)
+	if err != nil {
+		log.Printf("[WS] Failed to dial downstream for session %s at %s: %v", sessionID, targetURL, err)
+		_ = clientConn.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "backend unavailable"),
+		)
+		return nil
+	}
+	defer func() { _ = serverConn.Close() }()
+
+	// 3. Bidirectional bridge — two goroutines, one error channel.
+	errChan := make(chan error, 2)
+
+	// client → downstream
+	go func() {
+		for {
+			msgType, payload, err := clientConn.ReadMessage()
+			if err != nil {
+				errChan <- fmt.Errorf("client read: %w", err)
+				return
+			}
+			if err := serverConn.WriteMessage(msgType, payload); err != nil {
+				errChan <- fmt.Errorf("downstream write: %w", err)
+				return
+			}
+		}
+	}()
+
+	// downstream → client
+	go func() {
+		for {
+			msgType, payload, err := serverConn.ReadMessage()
+			if err != nil {
+				errChan <- fmt.Errorf("downstream read: %w", err)
+				return
+			}
+			if err := clientConn.WriteMessage(msgType, payload); err != nil {
+				errChan <- fmt.Errorf("client write: %w", err)
+				return
+			}
+		}
+	}()
+
+	if err := <-errChan; err != nil {
+		log.Printf("[WS] WebSocket proxy closed for session %s: %v", sessionID, err)
+	}
+	return nil
+}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -578,6 +578,18 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	case "codex-agentapi":
 		return "bunx", []string{"@takutakahashi/codex-agentapi"}
 
+	case "claude-acp":
+		// acp-ws-server bridges WebSocket ↔ stdio of the ACP agent.
+		// It listens on HOST:PORT (injected as env vars) and spawns
+		// claude-agentapi as a subprocess per WebSocket connection.
+		claudeAcpArgs := []string{"--output-file", "/opt/claude-agentapi/history.jsonl"}
+		if claudeArgs := os.Getenv("CLAUDE_ARGS"); claudeArgs != "" {
+			claudeAcpArgs = append(claudeAcpArgs, strings.Fields(claudeArgs)...)
+		}
+		args := []string{"--", "claude-agentapi"}
+		args = append(args, claudeAcpArgs...)
+		return "acp-ws-server", args
+
 	default:
 		// Default: agentapi server wrapping claude
 		claudeCmd := "claude"

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -581,14 +581,10 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	case "claude-acp":
 		// acp-ws-server bridges WebSocket ↔ stdio of the ACP agent.
 		// It listens on HOST:PORT (injected as env vars) and spawns
-		// claude-agentapi as a subprocess per WebSocket connection.
-		claudeAcpArgs := []string{"--output-file", "/opt/claude-agentapi/history.jsonl"}
-		if claudeArgs := os.Getenv("CLAUDE_ARGS"); claudeArgs != "" {
-			claudeAcpArgs = append(claudeAcpArgs, strings.Fields(claudeArgs)...)
-		}
-		args := []string{"--", "claude-agentapi"}
-		args = append(args, claudeAcpArgs...)
-		return "acp-ws-server", args
+		// claude-agent-acp (@agentclientprotocol/claude-agent-acp) as a
+		// subprocess per WebSocket connection.
+		// claude-agent-acp speaks the ACP protocol over stdio (ndjson).
+		return "acp-ws-server", []string{"--", "claude-agent-acp"}
 
 	default:
 		// Default: agentapi server wrapping claude

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -182,7 +182,9 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}
 
 	// ── Step 9: send initial message ─────────────────────────────────────────
-	if settings.InitialMessage != "" {
+	// claude-acp sessions use ACP WebSocket protocol and do not expose an HTTP
+	// message endpoint, so initial messages cannot be sent via HTTP.
+	if settings.InitialMessage != "" && settings.Session.AgentType != "claude-acp" {
 		log.Printf("[PROVISIONER] Sending initial message")
 		agentType := settings.Session.AgentType
 		waitSec := 2
@@ -192,6 +194,8 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 			}
 		}
 		sendInitialMessage(ctx, agentapiURL, settings.InitialMessage, agentType, waitSec)
+	} else if settings.InitialMessage != "" && settings.Session.AgentType == "claude-acp" {
+		log.Printf("[PROVISIONER] Skipping initial message for claude-acp session (ACP WS only)")
 	}
 
 	// ── Step 10: mark ready and supervise ────────────────────────────────────

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -159,13 +160,26 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}
 	agentapiURL := fmt.Sprintf("http://localhost:%s", agentapiPort)
 
-	log.Printf("[PROVISIONER] Waiting for agentapi to be ready at %s", agentapiURL)
-	if err := waitForAgentAPI(ctx, agentapiURL, 120); err != nil {
-		s.setStatus(StatusError, fmt.Sprintf("agentapi not ready: %v", err))
-		_ = cmd.Process.Kill()
-		return
+	if settings.Session.AgentType == "claude-acp" {
+		// acp-ws-server is a WebSocket-only server; it does not serve the
+		// agentapi HTTP /status endpoint.  Use a plain TCP connect check
+		// to confirm the server is accepting connections.
+		log.Printf("[PROVISIONER] Waiting for acp-ws-server to be ready on port %s", agentapiPort)
+		if err := waitForTCPConnect(ctx, "localhost", agentapiPort, 120); err != nil {
+			s.setStatus(StatusError, fmt.Sprintf("acp-ws-server not ready: %v", err))
+			_ = cmd.Process.Kill()
+			return
+		}
+		log.Printf("[PROVISIONER] acp-ws-server is ready")
+	} else {
+		log.Printf("[PROVISIONER] Waiting for agentapi to be ready at %s", agentapiURL)
+		if err := waitForAgentAPI(ctx, agentapiURL, 120); err != nil {
+			s.setStatus(StatusError, fmt.Sprintf("agentapi not ready: %v", err))
+			_ = cmd.Process.Kill()
+			return
+		}
+		log.Printf("[PROVISIONER] agentapi is ready")
 	}
-	log.Printf("[PROVISIONER] agentapi is ready")
 
 	// ── Step 9: send initial message ─────────────────────────────────────────
 	if settings.InitialMessage != "" {
@@ -584,7 +598,9 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 		// claude-agent-acp (@agentclientprotocol/claude-agent-acp) as a
 		// subprocess per WebSocket connection.
 		// claude-agent-acp speaks the ACP protocol over stdio (ndjson).
-		return "acp-ws-server", []string{"--", "claude-agent-acp"}
+		// acp-ws-server uses --host/--port flags (not env vars), so we
+		// pass them explicitly using the same port as the agentapi proxy expects.
+		return "acp-ws-server", []string{"--host", "0.0.0.0", "--port", agentapiPort, "--", "claude-agent-acp"}
 
 	default:
 		// Default: agentapi server wrapping claude
@@ -627,6 +643,29 @@ func waitForAgentAPI(ctx context.Context, agentapiURL string, maxRetries int) er
 		time.Sleep(500 * time.Millisecond)
 	}
 	return fmt.Errorf("agentapi not ready after %d retries", maxRetries)
+}
+
+// waitForTCPConnect polls host:port with a plain TCP dial until the connection
+// succeeds or maxRetries is exhausted.  Used for servers (e.g. acp-ws-server)
+// that do not expose a standard HTTP /status endpoint.
+func waitForTCPConnect(ctx context.Context, host, port string, maxRetries int) error {
+	addr := net.JoinHostPort(host, port)
+	for i := 0; i < maxRetries; i++ {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled")
+		default:
+		}
+
+		conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("server not ready at %s after %d retries", addr, maxRetries)
 }
 
 // agentStatusResponse is the minimal shape of agentapi's /status response.

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3434,7 +3434,7 @@
           },
           "agent_type": {
             "type": "string",
-            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables), 'claude-acp' (uses acp-ws-server wrapping claude-agentapi; exposes ACP WebSocket endpoint — clients connect via ws://<session>/ws). If not specified, uses default agentapi.",
+            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables), 'claude-acp' (uses acp-ws-server wrapping @agentclientprotocol/claude-agent-acp; exposes ACP WebSocket endpoint — clients connect via ws://<session>/ws using ACP JSON-RPC protocol). If not specified, uses default agentapi.",
             "example": "claude-agentapi"
           },
           "slack": {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3434,7 +3434,7 @@
           },
           "agent_type": {
             "type": "string",
-            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables). If not specified, uses default agentapi.",
+            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables), 'claude-acp' (uses acp-ws-server wrapping claude-agentapi; exposes ACP WebSocket endpoint — clients connect via ws://<session>/ws). If not specified, uses default agentapi.",
             "example": "claude-agentapi"
           },
           "slack": {


### PR DESCRIPTION
## Summary

- Add HTTP stub handlers in `RouteToSession` for claude-acp sessions (`/messages`, `/status`, `/message`) that return appropriate responses without forwarding to the WebSocket-only acp-ws-server
- Fix `restoreSessionFromService` and `restoreSessionFromServiceWithDeployment` to restore `AgentType` from the `agentapi.proxy/agent-type` Service annotation (was lost on proxy restart)
- Return empty messages list from `GetMessages` for claude-acp sessions
- Skip `sendInitialMessage` for claude-acp sessions (HTTP POST not supported by acp-ws-server)

## Test plan

- [ ] Create a claude-acp session and verify `/messages` returns `{"messages":[],"total":0,"hasMore":false}`
- [ ] Verify `/status` returns `{"status":"active","message":""}`
- [ ] Restart/redeploy agentapi-proxy and verify restored sessions still have correct AgentType
- [ ] Test ACP WebSocket messaging in the browser UI

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)