### PR TITLE
feat: persist ACP session IDs server-side for page-reload session resume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,18 @@ RUN ARCH=$(dpkg --print-architecture) && \
       -o /usr/local/bin/claude-posts && \
     chmod +x /usr/local/bin/claude-posts
 
+# Download acp-ws-server binary for ACP WebSocket transport (used by claude-acp agent type)
+ARG ACP_WS_SERVER_VERSION=server/v0.1.0
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "$ARCH" in \
+      amd64) ACP_WS_ARCH="linux-amd64" ;; \
+      arm64) ACP_WS_ARCH="linux-arm64" ;; \
+      *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/takutakahashi/acp-transport-ws/releases/download/${ACP_WS_SERVER_VERSION}/acp-ws-server-${ACP_WS_ARCH}" \
+      -o /usr/local/bin/acp-ws-server && \
+    chmod +x /usr/local/bin/acp-ws-server
+
 # Download otelcol-contrib binary for in-process OpenTelemetry Collector support.
 # Used when OtelCollectorInProcess=true (e.g. when stock inventory is enabled) so
 # that otelcol starts after user context is known instead of at Pod creation time.
@@ -158,6 +170,9 @@ RUN bun install -g @takutakahashi/claude-agentapi
 
 # Install codex CLI
 RUN bun install -g @openai/codex
+
+# Install claude-agent-acp for ACP protocol support (used by claude-acp agent type)
+RUN bun install -g @agentclientprotocol/claude-agent-acp
 
 # Set default CLAUDE_MD_PATH for Docker environment
 ENV CLAUDE_MD_PATH=/tmp/config/CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/claude-posts
 
 # Download acp-ws-server binary for ACP WebSocket transport (used by claude-acp agent type)
-ARG ACP_WS_SERVER_VERSION=server/v0.2.0
+ARG ACP_WS_SERVER_VERSION=server/v0.3.0
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ACP_WS_ARCH="linux-amd64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/claude-posts
 
 # Download acp-ws-server binary for ACP WebSocket transport (used by claude-acp agent type)
-ARG ACP_WS_SERVER_VERSION=server/v0.3.0
+ARG ACP_WS_SERVER_VERSION=server/v0.4.0
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ACP_WS_ARCH="linux-amd64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/claude-posts
 
 # Download acp-ws-server binary for ACP WebSocket transport (used by claude-acp agent type)
-ARG ACP_WS_SERVER_VERSION=server/v0.4.0
+ARG ACP_WS_SERVER_VERSION=server/v0.5.0
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ACP_WS_ARCH="linux-amd64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     chmod +x /usr/local/bin/claude-posts
 
 # Download acp-ws-server binary for ACP WebSocket transport (used by claude-acp agent type)
-ARG ACP_WS_SERVER_VERSION=server/v0.1.0
+ARG ACP_WS_SERVER_VERSION=server/v0.2.0
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) ACP_WS_ARCH="linux-amd64" ;; \

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/google/go-github/v62 v62.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/jsonschema-go v0.3.0 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -207,6 +207,9 @@ func (r *Router) registerCoreRoutes() error {
 		log.Printf("[ROUTES] Session sharing endpoints registered")
 	}
 
+	// ACP session registration endpoint (must be before the catch-all)
+	r.echo.POST("/sessions/:sessionId/acp-session", r.handlers.sessionController.RegisterACPSession)
+
 	// Session proxy route
 	r.echo.Any("/:sessionId/*", r.handlers.sessionController.RouteToSession)
 	log.Printf("[ROUTES] Session management endpoints registered")

--- a/internal/infrastructure/services/kubernetes_session.go
+++ b/internal/infrastructure/services/kubernetes_session.go
@@ -31,6 +31,7 @@ type KubernetesSession struct {
 	provisionPayload  []byte                           // JSON body for POST /provision to agent-provisioner
 	provisionSettings *sessionsettings.SessionSettings // Settings used for provisioning (stored after successful provisioning)
 	isStock           bool                             // Whether this is a pre-warmed stock session
+	acpSessionID      string                           // ACP session ID for resuming claude-acp sessions
 }
 
 // NewKubernetesSession creates a new KubernetesSession
@@ -274,6 +275,20 @@ func (s *KubernetesSession) IsStock() bool { return s.isStock }
 
 // SetIsStock sets the stock flag for this session.
 func (s *KubernetesSession) SetIsStock(v bool) { s.isStock = v }
+
+// ACPSessionID returns the ACP session ID for resuming claude-acp sessions.
+func (s *KubernetesSession) ACPSessionID() string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.acpSessionID
+}
+
+// SetACPSessionID stores the ACP session ID for resuming claude-acp sessions.
+func (s *KubernetesSession) SetACPSessionID(id string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.acpSessionID = id
+}
 
 // Ensure KubernetesSession implements entities.Session
 var _ entities.Session = (*KubernetesSession)(nil)

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2367,6 +2367,9 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 		servicePort = int(svc.Spec.Ports[0].Port)
 	}
 
+	// Restore agent type from annotation (set at session creation time)
+	agentType := svc.Annotations["agentapi.proxy/agent-type"]
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Create session using constructor
@@ -2380,6 +2383,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 			InitialMessage: initialMessage,
 			MemoryKey:      memoryKey,
 			Teams:          teams,
+			AgentType:      agentType,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,
@@ -2404,7 +2408,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 	// Start watching deployment status
 	go m.watchDeploymentStatus(ctx, session)
 
-	log.Printf("[K8S_SESSION] Restored session %s from Service", sessionID)
+	log.Printf("[K8S_SESSION] Restored session %s from Service (agent_type=%q)", sessionID, agentType)
 
 	return session
 }
@@ -2484,6 +2488,9 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 		servicePort = int(svc.Spec.Ports[0].Port)
 	}
 
+	// Restore agent type from annotation (set at session creation time)
+	agentType := svc.Annotations["agentapi.proxy/agent-type"]
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Create session using constructor
@@ -2497,6 +2504,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 			InitialMessage: initialMessage,
 			MemoryKey:      memoryKey,
 			Teams:          teams,
+			AgentType:      agentType,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,
@@ -2521,7 +2529,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 	// Start watching deployment status
 	go m.watchDeploymentStatus(ctx, session)
 
-	log.Printf("[K8S_SESSION] Restored session %s from Service (with pre-fetched deployment)", sessionID)
+	log.Printf("[K8S_SESSION] Restored session %s from Service with pre-fetched deployment (agent_type=%q)", sessionID, agentType)
 
 	return session
 }

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1105,6 +1105,14 @@ func (m *KubernetesSessionManager) GetMessages(ctx context.Context, id string) (
 		return nil, fmt.Errorf("session not found: %s", id)
 	}
 
+	// ACP WebSocket sessions (claude-acp) do not expose an HTTP /messages endpoint.
+	// Messages are streamed via the ACP WebSocket protocol instead.
+	// Return an empty list so the UI can still initialize and use ACP WS for messaging.
+	if ks, ok := session.(*KubernetesSession); ok && ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
+		log.Printf("[K8S_SESSION] Skipping GetMessages for claude-acp session %s (ACP WS only)", id)
+		return []portrepos.Message{}, nil
+	}
+
 	// Build service name and endpoint URL
 	serviceName := fmt.Sprintf("agentapi-session-%s-svc", id)
 	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/messages",

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2047,8 +2047,10 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 	if req.AgentType != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_AGENT_TYPE", Value: req.AgentType})
 
-		// Add claude-agentapi / codex-agentapi specific environment variables
-		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" {
+		// Add HOST/PORT env vars so the agent binary knows where to bind.
+		// Required by: claude-agentapi, codex-agentapi, and claude-acp
+		// (acp-ws-server uses the same HOST/PORT convention).
+		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" || req.AgentType == "claude-acp" {
 			envVars = append(envVars, corev1.EnvVar{Name: "HOST", Value: "0.0.0.0"})
 			envVars = append(envVars, corev1.EnvVar{Name: "PORT", Value: fmt.Sprintf("%d", m.k8sConfig.BasePort)})
 		}
@@ -2776,8 +2778,9 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	if req.AgentType != "" {
 		env["AGENTAPI_AGENT_TYPE"] = req.AgentType
 
-		// Add claude-agentapi / codex-agentapi specific environment variables
-		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" {
+		// Add HOST/PORT env vars so the agent binary knows where to bind.
+		// Required by: claude-agentapi, codex-agentapi, and claude-acp.
+		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" || req.AgentType == "claude-acp" {
 			env["HOST"] = "0.0.0.0"
 			env["PORT"] = fmt.Sprintf("%d", m.k8sConfig.BasePort)
 		}
@@ -3021,11 +3024,18 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	}
 
 	// Startup command (simplified version for now - full command logic in pod)
-	if req.AgentType == "claude-agentapi" {
+	switch req.AgentType {
+	case "claude-agentapi":
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"claude-agentapi"},
 		}
-	} else {
+	case "claude-acp":
+		// acp-ws-server is the entry point; it spawns claude-agentapi per WS connection.
+		settings.Startup = sessionsettings.StartupConfig{
+			Command: []string{"acp-ws-server"},
+			Args:    []string{"--", "claude-agentapi", "--output-file", "/opt/claude-agentapi/history.jsonl"},
+		}
+	default:
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"agentapi", "server"},
 			Args:    []string{"--allowed-hosts", "*", "--allowed-origins", "*", "--port", fmt.Sprintf("%d", m.k8sConfig.BasePort)},

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2369,6 +2369,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 
 	// Restore agent type from annotation (set at session creation time)
 	agentType := svc.Annotations["agentapi.proxy/agent-type"]
+	acpSessionID := svc.Annotations["agentapi.proxy/acp-session-id"]
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -2399,6 +2400,9 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 	session.SetLastMessageAt(lastMessageAt)
 	session.SetStatus(m.getSessionStatusFromDeployment(sessionID))
 	session.SetDescription(initialMessage) // Cache initial message as description
+	if acpSessionID != "" {
+		session.SetACPSessionID(acpSessionID)
+	}
 
 	// Add to memory map
 	m.mutex.Lock()
@@ -2490,6 +2494,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 
 	// Restore agent type from annotation (set at session creation time)
 	agentType := svc.Annotations["agentapi.proxy/agent-type"]
+	acpSessionID := svc.Annotations["agentapi.proxy/acp-session-id"]
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -2520,6 +2525,9 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 	session.SetLastMessageAt(lastMessageAt)
 	session.SetStatus(m.getStatusFromDeploymentObject(deployment))
 	session.SetDescription(initialMessage) // Cache initial message as description
+	if acpSessionID != "" {
+		session.SetACPSessionID(acpSessionID)
+	}
 
 	// Add to memory map
 	m.mutex.Lock()
@@ -2532,6 +2540,34 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 	log.Printf("[K8S_SESSION] Restored session %s from Service with pre-fetched deployment (agent_type=%q)", sessionID, agentType)
 
 	return session
+}
+
+// PatchACPSessionID stores the ACP session ID in the Service annotation and in-memory.
+func (m *KubernetesSessionManager) PatchACPSessionID(ctx context.Context, agentapiSessionID, acpSessionID string) error {
+	session := m.GetSession(agentapiSessionID)
+	if session == nil {
+		return fmt.Errorf("session %s not found", agentapiSessionID)
+	}
+	ks, ok := session.(*KubernetesSession)
+	if !ok {
+		return fmt.Errorf("session %s is not a KubernetesSession", agentapiSessionID)
+	}
+	ks.SetACPSessionID(acpSessionID)
+
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				"agentapi.proxy/acp-session-id": acpSessionID,
+			},
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+	_, err = m.client.CoreV1().Services(m.namespace).Patch(
+		ctx, ks.ServiceName(), types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
 }
 
 // getStatusFromDeploymentObject determines session status from a pre-fetched Deployment object

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3030,10 +3030,11 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			Command: []string{"claude-agentapi"},
 		}
 	case "claude-acp":
-		// acp-ws-server is the entry point; it spawns claude-agentapi per WS connection.
+		// acp-ws-server is the entry point; it spawns claude-agent-acp
+		// (@agentclientprotocol/claude-agent-acp) per WS connection.
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"acp-ws-server"},
-			Args:    []string{"--", "claude-agentapi", "--output-file", "/opt/claude-agentapi/history.jsonl"},
+			Args:    []string{"--", "claude-agent-acp"},
 		}
 	default:
 		settings.Startup = sessionsettings.StartupConfig{

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -446,6 +446,39 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 		return c.handleWebSocketProxy(ctx, session)
 	}
 
+	// For claude-acp sessions (WebSocket-only), handle HTTP paths that have no
+	// equivalent on acp-ws-server to avoid 400/error responses that break the UI.
+	if ks, ok := session.(*services.KubernetesSession); ok && ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
+		requestPath := ctx.Request().URL.Path
+		// Strip the leading /{sessionId} prefix from the path
+		pathParts := strings.SplitN(requestPath, "/", 3)
+		subPath := ""
+		if len(pathParts) >= 3 {
+			subPath = "/" + pathParts[2]
+		}
+		switch {
+		case strings.HasPrefix(subPath, "/messages"):
+			// Return empty messages list; messages are streamed via ACP WebSocket
+			return ctx.JSON(http.StatusOK, map[string]interface{}{
+				"messages": []interface{}{},
+				"total":    0,
+				"hasMore":  false,
+			})
+		case strings.HasPrefix(subPath, "/status"):
+			// Return a minimal status so the UI knows the session is up
+			return ctx.JSON(http.StatusOK, map[string]interface{}{
+				"status":  session.Status(),
+				"message": "",
+			})
+		case strings.HasPrefix(subPath, "/message") && ctx.Request().Method == http.MethodPost:
+			// Sending messages to ACP sessions via HTTP is not supported;
+			// messages must be sent over the ACP WebSocket protocol.
+			return ctx.JSON(http.StatusBadRequest, map[string]interface{}{
+				"message": "claude-acp sessions require ACP WebSocket for messaging",
+			})
+		}
+	}
+
 	// Determine target URL using session address
 	targetURL := fmt.Sprintf("http://%s", session.Addr())
 	target, err := url.Parse(targetURL)

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -928,3 +928,31 @@ func (c *SessionController) setCORSHeaders(ctx echo.Context) {
 	ctx.Response().Header().Set("Access-Control-Allow-Credentials", "true")
 	ctx.Response().Header().Set("Access-Control-Max-Age", "86400")
 }
+
+// RegisterACPSession stores the ACP session ID for a claude-acp session.
+// Called by the agent-provisioner after it initializes the ACP WebSocket session.
+// POST /sessions/:sessionId/acp-session
+// Body: {"acp_session_id": "..."}
+func (c *SessionController) RegisterACPSession(ctx echo.Context) error {
+	sessionID := ctx.Param("sessionId")
+	var body struct {
+		ACPSessionID string `json:"acp_session_id"`
+	}
+	if err := ctx.Bind(&body); err != nil || body.ACPSessionID == "" {
+		return ctx.JSON(http.StatusBadRequest, map[string]string{"error": "acp_session_id required"})
+	}
+
+	sm := c.sessionManagerProvider.GetSessionManager()
+	ksm, ok := sm.(*services.KubernetesSessionManager)
+	if !ok {
+		return ctx.JSON(http.StatusNotImplemented, map[string]string{"error": "not supported"})
+	}
+
+	if err := ksm.PatchACPSessionID(ctx.Request().Context(), sessionID, body.ACPSessionID); err != nil {
+		log.Printf("[SESSION] Failed to patch ACP session ID for %s: %v", sessionID, err)
+		return ctx.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	log.Printf("[SESSION] Registered ACP session ID %s for session %s", body.ACPSessionID, sessionID)
+	return ctx.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -441,6 +441,11 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 		}
 	}
 
+	// If this is a WebSocket upgrade request, hand off to the WS proxy handler.
+	if isWebSocketUpgrade(ctx.Request()) {
+		return c.handleWebSocketProxy(ctx, session)
+	}
+
 	// Determine target URL using session address
 	targetURL := fmt.Sprintf("http://%s", session.Addr())
 	target, err := url.Parse(targetURL)

--- a/internal/interfaces/controllers/ws_proxy.go
+++ b/internal/interfaces/controllers/ws_proxy.go
@@ -1,6 +1,8 @@
 package controllers
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,6 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 )
 
 var wsUpgrader = websocket.Upgrader{
@@ -24,9 +27,41 @@ func isWebSocketUpgrade(r *http.Request) bool {
 		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 
+// jsonRPCMsg is a minimal JSON-RPC 2.0 envelope used for ACP session/new interception.
+type jsonRPCMsg struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+}
+
+// sessionNewParams is the params of session/new.
+type sessionNewParams struct {
+	CWD        string        `json:"cwd"`
+	MCPServers []interface{} `json:"mcpServers"`
+}
+
+// sessionResumeParams is the params of session/resume.
+type sessionResumeParams struct {
+	SessionID string `json:"sessionId"`
+	CWD       string `json:"cwd"`
+}
+
+// sessionNewResult is the result of session/new or session/resume.
+type sessionNewResult struct {
+	SessionID string `json:"sessionId"`
+}
+
 // handleWebSocketProxy upgrades the incoming HTTP connection to WebSocket and
 // bidirectionally proxies all frames to the downstream session's WebSocket
 // endpoint at ws://{session.Addr()}{subPath}.
+//
+// For claude-acp sessions it intercepts session/new JSON-RPC calls and
+// replaces them with session/resume when a previous ACP session ID is stored.
+// It also captures new ACP session IDs from responses and persists them to
+// the Kubernetes Service annotation.
 //
 // If the downstream is unreachable the client receives a Close frame and the
 // handler returns nil (so Echo does not write a second error response).
@@ -47,6 +82,18 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 
 	targetURL := fmt.Sprintf("ws://%s%s", session.Addr(), subPath)
 	log.Printf("[WS] Proxying WebSocket for session %s → %s", sessionID, targetURL)
+
+	// Determine if ACP session interception is needed.
+	isACP := false
+	var acpSavedID string
+	if ks, ok := session.(*services.KubernetesSession); ok &&
+		ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
+		isACP = true
+		acpSavedID = ks.ACPSessionID()
+		if acpSavedID != "" {
+			log.Printf("[WS] ACP session %s has saved ACP session ID: %s", sessionID, acpSavedID)
+		}
+	}
 
 	// 1. Upgrade the incoming HTTP connection to WebSocket.
 	clientConn, err := wsUpgrader.Upgrade(ctx.Response().Writer, ctx.Request(), nil)
@@ -72,7 +119,7 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 	// 3. Bidirectional bridge — two goroutines, one error channel.
 	errChan := make(chan error, 2)
 
-	// client → downstream
+	// client → downstream (with ACP session/new interception)
 	go func() {
 		for {
 			msgType, payload, err := clientConn.ReadMessage()
@@ -80,6 +127,31 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 				errChan <- fmt.Errorf("client read: %w", err)
 				return
 			}
+
+			// For claude-acp sessions: intercept session/new and replace with session/resume.
+			if isACP && msgType == websocket.TextMessage && acpSavedID != "" {
+				var msg jsonRPCMsg
+				if json.Unmarshal(payload, &msg) == nil && msg.Method == "session/new" {
+					log.Printf("[WS] Intercepting session/new for session %s → session/resume(%s)", sessionID, acpSavedID)
+					var origParams sessionNewParams
+					_ = json.Unmarshal(msg.Params, &origParams)
+					cwd := origParams.CWD
+					if cwd == "" {
+						cwd = "/"
+					}
+					resumeParams, _ := json.Marshal(sessionResumeParams{
+						SessionID: acpSavedID,
+						CWD:       cwd,
+					})
+					msg.Method = "session/resume"
+					msg.Params = json.RawMessage(resumeParams)
+					replaced, err := json.Marshal(msg)
+					if err == nil {
+						payload = replaced
+					}
+				}
+			}
+
 			if err := serverConn.WriteMessage(msgType, payload); err != nil {
 				errChan <- fmt.Errorf("downstream write: %w", err)
 				return
@@ -87,7 +159,7 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 		}
 	}()
 
-	// downstream → client
+	// downstream → client (with ACP session ID capture)
 	go func() {
 		for {
 			msgType, payload, err := serverConn.ReadMessage()
@@ -95,6 +167,27 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 				errChan <- fmt.Errorf("downstream read: %w", err)
 				return
 			}
+
+			// For claude-acp sessions: capture ACP session ID from session/new or session/resume responses.
+			if isACP && msgType == websocket.TextMessage {
+				var msg jsonRPCMsg
+				if json.Unmarshal(payload, &msg) == nil && msg.ID != nil && msg.Result != nil && msg.Error == nil {
+					var result sessionNewResult
+					if json.Unmarshal(msg.Result, &result) == nil && result.SessionID != "" {
+						if result.SessionID != acpSavedID {
+							log.Printf("[WS] Saving ACP session ID for agentapi session %s: %s", sessionID, result.SessionID)
+							acpSavedID = result.SessionID
+							// Persist to Kubernetes Service annotation.
+							if sm, ok := c.sessionManagerProvider.GetSessionManager().(*services.KubernetesSessionManager); ok {
+								if patchErr := sm.PatchACPSessionID(context.Background(), sessionID, result.SessionID); patchErr != nil {
+									log.Printf("[WS] Failed to patch ACP session ID for %s: %v", sessionID, patchErr)
+								}
+							}
+						}
+					}
+				}
+			}
+
 			if err := clientConn.WriteMessage(msgType, payload); err != nil {
 				errChan <- fmt.Errorf("client write: %w", err)
 				return

--- a/internal/interfaces/controllers/ws_proxy.go
+++ b/internal/interfaces/controllers/ws_proxy.go
@@ -37,7 +37,19 @@ type jsonRPCMsg struct {
 	Error   json.RawMessage `json:"error,omitempty"`
 }
 
-// sessionNewResult is the result of session/new.
+// sessionNewParams is the params of session/new.
+type sessionNewParams struct {
+	CWD        string        `json:"cwd"`
+	MCPServers []interface{} `json:"mcpServers"`
+}
+
+// sessionResumeParams is the params of session/resume.
+type sessionResumeParams struct {
+	SessionID string `json:"sessionId"`
+	CWD       string `json:"cwd"`
+}
+
+// sessionNewResult is the result of session/new or session/resume.
 type sessionNewResult struct {
 	SessionID string `json:"sessionId"`
 }
@@ -71,11 +83,16 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 	targetURL := fmt.Sprintf("ws://%s%s", session.Addr(), subPath)
 	log.Printf("[WS] Proxying WebSocket for session %s → %s", sessionID, targetURL)
 
-	// Determine if ACP session ID capture is needed (for persisting new session IDs).
+	// Determine if ACP session interception is needed.
 	isACP := false
+	var acpSavedID string
 	if ks, ok := session.(*services.KubernetesSession); ok &&
 		ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
 		isACP = true
+		acpSavedID = ks.ACPSessionID()
+		if acpSavedID != "" {
+			log.Printf("[WS] ACP session %s has saved ACP session ID: %s", sessionID, acpSavedID)
+		}
 	}
 
 	// 1. Upgrade the incoming HTTP connection to WebSocket.
@@ -102,13 +119,37 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 	// 3. Bidirectional bridge — two goroutines, one error channel.
 	errChan := make(chan error, 2)
 
-	// client → downstream
+	// client → downstream (with ACP session/new interception)
 	go func() {
 		for {
 			msgType, payload, err := clientConn.ReadMessage()
 			if err != nil {
 				errChan <- fmt.Errorf("client read: %w", err)
 				return
+			}
+
+			// For claude-acp sessions: intercept session/new and replace with session/resume.
+			if isACP && msgType == websocket.TextMessage && acpSavedID != "" {
+				var msg jsonRPCMsg
+				if json.Unmarshal(payload, &msg) == nil && msg.Method == "session/new" {
+					log.Printf("[WS] Intercepting session/new for session %s → session/resume(%s)", sessionID, acpSavedID)
+					var origParams sessionNewParams
+					_ = json.Unmarshal(msg.Params, &origParams)
+					cwd := origParams.CWD
+					if cwd == "" {
+						cwd = "/"
+					}
+					resumeParams, _ := json.Marshal(sessionResumeParams{
+						SessionID: acpSavedID,
+						CWD:       cwd,
+					})
+					msg.Method = "session/resume"
+					msg.Params = json.RawMessage(resumeParams)
+					replaced, err := json.Marshal(msg)
+					if err == nil {
+						payload = replaced
+					}
+				}
 			}
 
 			if err := serverConn.WriteMessage(msgType, payload); err != nil {
@@ -127,17 +168,20 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 				return
 			}
 
-			// For claude-acp sessions: capture ACP session ID from session/new responses
-			// and persist to Kubernetes Service annotation (for diagnostics / future use).
+			// For claude-acp sessions: capture ACP session ID from session/new or session/resume responses.
 			if isACP && msgType == websocket.TextMessage {
 				var msg jsonRPCMsg
 				if json.Unmarshal(payload, &msg) == nil && msg.ID != nil && msg.Result != nil && msg.Error == nil {
 					var result sessionNewResult
 					if json.Unmarshal(msg.Result, &result) == nil && result.SessionID != "" {
-						log.Printf("[WS] ACP session created for agentapi session %s: %s", sessionID, result.SessionID)
-						if sm, ok := c.sessionManagerProvider.GetSessionManager().(*services.KubernetesSessionManager); ok {
-							if patchErr := sm.PatchACPSessionID(context.Background(), sessionID, result.SessionID); patchErr != nil {
-								log.Printf("[WS] Failed to patch ACP session ID for %s: %v", sessionID, patchErr)
+						if result.SessionID != acpSavedID {
+							log.Printf("[WS] Saving ACP session ID for agentapi session %s: %s", sessionID, result.SessionID)
+							acpSavedID = result.SessionID
+							// Persist to Kubernetes Service annotation.
+							if sm, ok := c.sessionManagerProvider.GetSessionManager().(*services.KubernetesSessionManager); ok {
+								if patchErr := sm.PatchACPSessionID(context.Background(), sessionID, result.SessionID); patchErr != nil {
+									log.Printf("[WS] Failed to patch ACP session ID for %s: %v", sessionID, patchErr)
+								}
 							}
 						}
 					}

--- a/internal/interfaces/controllers/ws_proxy.go
+++ b/internal/interfaces/controllers/ws_proxy.go
@@ -37,19 +37,7 @@ type jsonRPCMsg struct {
 	Error   json.RawMessage `json:"error,omitempty"`
 }
 
-// sessionNewParams is the params of session/new.
-type sessionNewParams struct {
-	CWD        string        `json:"cwd"`
-	MCPServers []interface{} `json:"mcpServers"`
-}
-
-// sessionResumeParams is the params of session/resume.
-type sessionResumeParams struct {
-	SessionID string `json:"sessionId"`
-	CWD       string `json:"cwd"`
-}
-
-// sessionNewResult is the result of session/new or session/resume.
+// sessionNewResult is the result of session/new.
 type sessionNewResult struct {
 	SessionID string `json:"sessionId"`
 }
@@ -83,16 +71,11 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 	targetURL := fmt.Sprintf("ws://%s%s", session.Addr(), subPath)
 	log.Printf("[WS] Proxying WebSocket for session %s → %s", sessionID, targetURL)
 
-	// Determine if ACP session interception is needed.
+	// Determine if ACP session ID capture is needed (for persisting new session IDs).
 	isACP := false
-	var acpSavedID string
 	if ks, ok := session.(*services.KubernetesSession); ok &&
 		ks.Request() != nil && ks.Request().AgentType == "claude-acp" {
 		isACP = true
-		acpSavedID = ks.ACPSessionID()
-		if acpSavedID != "" {
-			log.Printf("[WS] ACP session %s has saved ACP session ID: %s", sessionID, acpSavedID)
-		}
 	}
 
 	// 1. Upgrade the incoming HTTP connection to WebSocket.
@@ -119,37 +102,13 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 	// 3. Bidirectional bridge — two goroutines, one error channel.
 	errChan := make(chan error, 2)
 
-	// client → downstream (with ACP session/new interception)
+	// client → downstream
 	go func() {
 		for {
 			msgType, payload, err := clientConn.ReadMessage()
 			if err != nil {
 				errChan <- fmt.Errorf("client read: %w", err)
 				return
-			}
-
-			// For claude-acp sessions: intercept session/new and replace with session/resume.
-			if isACP && msgType == websocket.TextMessage && acpSavedID != "" {
-				var msg jsonRPCMsg
-				if json.Unmarshal(payload, &msg) == nil && msg.Method == "session/new" {
-					log.Printf("[WS] Intercepting session/new for session %s → session/resume(%s)", sessionID, acpSavedID)
-					var origParams sessionNewParams
-					_ = json.Unmarshal(msg.Params, &origParams)
-					cwd := origParams.CWD
-					if cwd == "" {
-						cwd = "/"
-					}
-					resumeParams, _ := json.Marshal(sessionResumeParams{
-						SessionID: acpSavedID,
-						CWD:       cwd,
-					})
-					msg.Method = "session/resume"
-					msg.Params = json.RawMessage(resumeParams)
-					replaced, err := json.Marshal(msg)
-					if err == nil {
-						payload = replaced
-					}
-				}
 			}
 
 			if err := serverConn.WriteMessage(msgType, payload); err != nil {
@@ -168,20 +127,17 @@ func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entit
 				return
 			}
 
-			// For claude-acp sessions: capture ACP session ID from session/new or session/resume responses.
+			// For claude-acp sessions: capture ACP session ID from session/new responses
+			// and persist to Kubernetes Service annotation (for diagnostics / future use).
 			if isACP && msgType == websocket.TextMessage {
 				var msg jsonRPCMsg
 				if json.Unmarshal(payload, &msg) == nil && msg.ID != nil && msg.Result != nil && msg.Error == nil {
 					var result sessionNewResult
 					if json.Unmarshal(msg.Result, &result) == nil && result.SessionID != "" {
-						if result.SessionID != acpSavedID {
-							log.Printf("[WS] Saving ACP session ID for agentapi session %s: %s", sessionID, result.SessionID)
-							acpSavedID = result.SessionID
-							// Persist to Kubernetes Service annotation.
-							if sm, ok := c.sessionManagerProvider.GetSessionManager().(*services.KubernetesSessionManager); ok {
-								if patchErr := sm.PatchACPSessionID(context.Background(), sessionID, result.SessionID); patchErr != nil {
-									log.Printf("[WS] Failed to patch ACP session ID for %s: %v", sessionID, patchErr)
-								}
+						log.Printf("[WS] ACP session created for agentapi session %s: %s", sessionID, result.SessionID)
+						if sm, ok := c.sessionManagerProvider.GetSessionManager().(*services.KubernetesSessionManager); ok {
+							if patchErr := sm.PatchACPSessionID(context.Background(), sessionID, result.SessionID); patchErr != nil {
+								log.Printf("[WS] Failed to patch ACP session ID for %s: %v", sessionID, patchErr)
 							}
 						}
 					}

--- a/internal/interfaces/controllers/ws_proxy.go
+++ b/internal/interfaces/controllers/ws_proxy.go
@@ -1,0 +1,109 @@
+package controllers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+var wsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	// Allow all origins — CORS is handled by the proxy middleware.
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// isWebSocketUpgrade reports whether r is an HTTP → WebSocket upgrade request.
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
+}
+
+// handleWebSocketProxy upgrades the incoming HTTP connection to WebSocket and
+// bidirectionally proxies all frames to the downstream session's WebSocket
+// endpoint at ws://{session.Addr()}{subPath}.
+//
+// If the downstream is unreachable the client receives a Close frame and the
+// handler returns nil (so Echo does not write a second error response).
+func (c *SessionController) handleWebSocketProxy(ctx echo.Context, session entities.Session) error {
+	sessionID := session.ID()
+
+	// Strip the leading /:sessionId segment to derive the downstream sub-path.
+	//   /abc123/ws  → /ws
+	//   /abc123     → /
+	originalPath := ctx.Request().URL.Path
+	pathParts := strings.SplitN(originalPath, "/", 3)
+	var subPath string
+	if len(pathParts) >= 3 {
+		subPath = "/" + pathParts[2]
+	} else {
+		subPath = "/"
+	}
+
+	targetURL := fmt.Sprintf("ws://%s%s", session.Addr(), subPath)
+	log.Printf("[WS] Proxying WebSocket for session %s → %s", sessionID, targetURL)
+
+	// 1. Upgrade the incoming HTTP connection to WebSocket.
+	clientConn, err := wsUpgrader.Upgrade(ctx.Response().Writer, ctx.Request(), nil)
+	if err != nil {
+		// Upgrader writes its own 400/500 response; just log and return nil.
+		log.Printf("[WS] Failed to upgrade client connection for session %s: %v", sessionID, err)
+		return nil
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	// 2. Dial the downstream WebSocket endpoint.
+	serverConn, _, err := websocket.DefaultDialer.Dial(targetURL, nil)
+	if err != nil {
+		log.Printf("[WS] Failed to dial downstream for session %s at %s: %v", sessionID, targetURL, err)
+		_ = clientConn.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "backend unavailable"),
+		)
+		return nil
+	}
+	defer func() { _ = serverConn.Close() }()
+
+	// 3. Bidirectional bridge — two goroutines, one error channel.
+	errChan := make(chan error, 2)
+
+	// client → downstream
+	go func() {
+		for {
+			msgType, payload, err := clientConn.ReadMessage()
+			if err != nil {
+				errChan <- fmt.Errorf("client read: %w", err)
+				return
+			}
+			if err := serverConn.WriteMessage(msgType, payload); err != nil {
+				errChan <- fmt.Errorf("downstream write: %w", err)
+				return
+			}
+		}
+	}()
+
+	// downstream → client
+	go func() {
+		for {
+			msgType, payload, err := serverConn.ReadMessage()
+			if err != nil {
+				errChan <- fmt.Errorf("downstream read: %w", err)
+				return
+			}
+			if err := clientConn.WriteMessage(msgType, payload); err != nil {
+				errChan <- fmt.Errorf("client write: %w", err)
+				return
+			}
+		}
+	}()
+
+	if err := <-errChan; err != nil {
+		log.Printf("[WS] WebSocket proxy closed for session %s: %v", sessionID, err)
+	}
+	return nil
+}

--- a/pkg/provisioner/acp_client.go
+++ b/pkg/provisioner/acp_client.go
@@ -1,0 +1,122 @@
+package provisioner
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// acpClient is a minimal JSON-RPC 2.0 client over WebSocket for ACP.
+type acpClient struct {
+	conn    *websocket.Conn
+	mu      sync.Mutex
+	pending map[int64]chan json.RawMessage
+	idSeq   atomic.Int64
+	done    chan struct{}
+}
+
+type acpMsg struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+}
+
+func dialACP(url string) (*acpClient, error) {
+	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c := &acpClient{
+		conn:    conn,
+		pending: make(map[int64]chan json.RawMessage),
+		done:    make(chan struct{}),
+	}
+	go c.readLoop()
+	return c, nil
+}
+
+func (c *acpClient) readLoop() {
+	defer close(c.done)
+	for {
+		_, data, err := c.conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		var msg acpMsg
+		if err := json.Unmarshal(data, &msg); err != nil {
+			continue
+		}
+		if msg.ID != 0 {
+			c.mu.Lock()
+			ch, ok := c.pending[msg.ID]
+			if ok {
+				delete(c.pending, msg.ID)
+			}
+			c.mu.Unlock()
+			if ok {
+				if msg.Error != nil {
+					ch <- msg.Error
+				} else {
+					ch <- msg.Result
+				}
+			}
+		}
+	}
+	// drain pending on disconnect
+	c.mu.Lock()
+	for _, ch := range c.pending {
+		ch <- json.RawMessage(`{"error":"disconnected"}`)
+	}
+	c.pending = make(map[int64]chan json.RawMessage)
+	c.mu.Unlock()
+}
+
+func (c *acpClient) call(method string, params interface{}, timeout time.Duration) (json.RawMessage, error) {
+	id := c.idSeq.Add(1)
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	msg := acpMsg{
+		JSONRPC: "2.0",
+		ID:      id,
+		Method:  method,
+		Params:  paramsJSON,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+	ch := make(chan json.RawMessage, 1)
+	c.mu.Lock()
+	c.pending[id] = ch
+	c.mu.Unlock()
+	if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
+	select {
+	case result := <-ch:
+		return result, nil
+	case <-time.After(timeout):
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, fmt.Errorf("ACP call %q timed out after %v", method, timeout)
+	case <-c.done:
+		return nil, fmt.Errorf("ACP connection closed")
+	}
+}
+
+func (c *acpClient) close() {
+	_ = c.conn.Close()
+}

--- a/pkg/provisioner/acp_init.go
+++ b/pkg/provisioner/acp_init.go
@@ -27,8 +27,8 @@ func initACPSession(ctx context.Context, port, agentapiSessionID, initialMessage
 
 	// 1. initialize
 	_, err = client.call("initialize", map[string]interface{}{
-		"protocolVersion":    0,
-		"clientInfo":         map[string]string{"name": "agentapi-proxy-provisioner", "version": "1.0.0"},
+		"protocolVersion": 0,
+		"clientInfo":      map[string]string{"name": "agentapi-proxy-provisioner", "version": "1.0.0"},
 		"clientCapabilities": map[string]interface{}{},
 	}, 15*time.Second)
 	if err != nil {
@@ -92,7 +92,7 @@ func initACPSession(ctx context.Context, port, agentapiSessionID, initialMessage
 		log.Printf("[ACP_INIT] Failed to register ACP session ID with proxy: %v", err)
 		return
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("[ACP_INIT] Proxy returned non-OK status %d", resp.StatusCode)
 		return

--- a/pkg/provisioner/acp_init.go
+++ b/pkg/provisioner/acp_init.go
@@ -27,8 +27,8 @@ func initACPSession(ctx context.Context, port, agentapiSessionID, initialMessage
 
 	// 1. initialize
 	_, err = client.call("initialize", map[string]interface{}{
-		"protocolVersion": 0,
-		"clientInfo":      map[string]string{"name": "agentapi-proxy-provisioner", "version": "1.0.0"},
+		"protocolVersion":    0,
+		"clientInfo":         map[string]string{"name": "agentapi-proxy-provisioner", "version": "1.0.0"},
 		"clientCapabilities": map[string]interface{}{},
 	}, 15*time.Second)
 	if err != nil {
@@ -92,7 +92,7 @@ func initACPSession(ctx context.Context, port, agentapiSessionID, initialMessage
 		log.Printf("[ACP_INIT] Failed to register ACP session ID with proxy: %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("[ACP_INIT] Proxy returned non-OK status %d", resp.StatusCode)
 		return

--- a/pkg/provisioner/acp_init.go
+++ b/pkg/provisioner/acp_init.go
@@ -1,0 +1,101 @@
+package provisioner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// initACPSession connects to the local acp-ws-server, performs the ACP handshake,
+// optionally sends an initial message, and registers the resulting ACP session ID
+// with agentapi-proxy so it can resume the session on reconnect.
+func initACPSession(ctx context.Context, port, agentapiSessionID, initialMessage string) {
+	wsURL := fmt.Sprintf("ws://localhost:%s/ws", port)
+	log.Printf("[ACP_INIT] Connecting to acp-ws-server at %s", wsURL)
+
+	client, err := dialACP(wsURL)
+	if err != nil {
+		log.Printf("[ACP_INIT] Failed to connect: %v", err)
+		return
+	}
+	defer client.close()
+
+	// 1. initialize
+	_, err = client.call("initialize", map[string]interface{}{
+		"protocolVersion": 0,
+		"clientInfo":      map[string]string{"name": "agentapi-proxy-provisioner", "version": "1.0.0"},
+		"clientCapabilities": map[string]interface{}{},
+	}, 15*time.Second)
+	if err != nil {
+		log.Printf("[ACP_INIT] initialize failed: %v", err)
+		return
+	}
+
+	// 2. session/new
+	result, err := client.call("session/new", map[string]interface{}{
+		"cwd":        "/",
+		"mcpServers": []interface{}{},
+	}, 30*time.Second)
+	if err != nil {
+		log.Printf("[ACP_INIT] session/new failed: %v", err)
+		return
+	}
+	var newResult struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(result, &newResult); err != nil || newResult.SessionID == "" {
+		log.Printf("[ACP_INIT] Failed to parse session/new result: %v (raw: %s)", err, result)
+		return
+	}
+	acpSessionID := newResult.SessionID
+	log.Printf("[ACP_INIT] ACP session created: %s", acpSessionID)
+
+	// 3. send initial message if provided
+	if initialMessage != "" {
+		log.Printf("[ACP_INIT] Sending initial message via ACP")
+		_, err = client.call("session/prompt", map[string]interface{}{
+			"sessionId": acpSessionID,
+			"prompt":    []map[string]string{{"type": "text", "text": initialMessage}},
+		}, 30*time.Second)
+		if err != nil {
+			log.Printf("[ACP_INIT] session/prompt failed: %v", err)
+			// Non-fatal: still save the session ID
+		}
+	}
+
+	// 4. POST the ACP session ID to agentapi-proxy
+	proxyHost := os.Getenv("AGENTAPI_PROXY_SERVICE_HOST")
+	proxyPort := os.Getenv("AGENTAPI_PROXY_SERVICE_PORT")
+	agentapiKey := os.Getenv("AGENTAPI_KEY")
+	if proxyHost == "" || proxyPort == "" || agentapiKey == "" {
+		log.Printf("[ACP_INIT] Missing proxy env vars (AGENTAPI_PROXY_SERVICE_HOST/PORT/KEY), skipping registration")
+		return
+	}
+
+	proxyURL := fmt.Sprintf("http://%s:%s/sessions/%s/acp-session", proxyHost, proxyPort, agentapiSessionID)
+	body, _ := json.Marshal(map[string]string{"acp_session_id": acpSessionID})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, proxyURL, bytes.NewReader(body))
+	if err != nil {
+		log.Printf("[ACP_INIT] Failed to create request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+agentapiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("[ACP_INIT] Failed to register ACP session ID with proxy: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[ACP_INIT] Proxy returned non-OK status %d", resp.StatusCode)
+		return
+	}
+	log.Printf("[ACP_INIT] ACP session ID %s registered with proxy for agentapi session %s", acpSessionID, agentapiSessionID)
+}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -578,6 +578,18 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	case "codex-agentapi":
 		return "bunx", []string{"@takutakahashi/codex-agentapi"}
 
+	case "claude-acp":
+		// acp-ws-server bridges WebSocket ↔ stdio of the ACP agent.
+		// It listens on HOST:PORT (injected as env vars) and spawns
+		// claude-agentapi as a subprocess per WebSocket connection.
+		claudeAcpArgs := []string{"--output-file", "/opt/claude-agentapi/history.jsonl"}
+		if claudeArgs := os.Getenv("CLAUDE_ARGS"); claudeArgs != "" {
+			claudeAcpArgs = append(claudeAcpArgs, strings.Fields(claudeArgs)...)
+		}
+		args := []string{"--", "claude-agentapi"}
+		args = append(args, claudeAcpArgs...)
+		return "acp-ws-server", args
+
 	default:
 		// Default: agentapi server wrapping claude
 		claudeCmd := "claude"

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -581,14 +581,10 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	case "claude-acp":
 		// acp-ws-server bridges WebSocket ↔ stdio of the ACP agent.
 		// It listens on HOST:PORT (injected as env vars) and spawns
-		// claude-agentapi as a subprocess per WebSocket connection.
-		claudeAcpArgs := []string{"--output-file", "/opt/claude-agentapi/history.jsonl"}
-		if claudeArgs := os.Getenv("CLAUDE_ARGS"); claudeArgs != "" {
-			claudeAcpArgs = append(claudeAcpArgs, strings.Fields(claudeArgs)...)
-		}
-		args := []string{"--", "claude-agentapi"}
-		args = append(args, claudeAcpArgs...)
-		return "acp-ws-server", args
+		// claude-agent-acp (@agentclientprotocol/claude-agent-acp) as a
+		// subprocess per WebSocket connection.
+		// claude-agent-acp speaks the ACP protocol over stdio (ndjson).
+		return "acp-ws-server", []string{"--", "claude-agent-acp"}
 
 	default:
 		// Default: agentapi server wrapping claude

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -182,7 +182,9 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}
 
 	// ── Step 9: send initial message ─────────────────────────────────────────
-	if settings.InitialMessage != "" {
+	// claude-acp sessions use ACP WebSocket protocol and do not expose an HTTP
+	// message endpoint, so initial messages cannot be sent via HTTP.
+	if settings.InitialMessage != "" && settings.Session.AgentType != "claude-acp" {
 		log.Printf("[PROVISIONER] Sending initial message")
 		agentType := settings.Session.AgentType
 		waitSec := 2
@@ -192,6 +194,8 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 			}
 		}
 		sendInitialMessage(ctx, agentapiURL, settings.InitialMessage, agentType, waitSec)
+	} else if settings.InitialMessage != "" && settings.Session.AgentType == "claude-acp" {
+		log.Printf("[PROVISIONER] Skipping initial message for claude-acp session (ACP WS only)")
 	}
 
 	// ── Step 10: mark ready and supervise ────────────────────────────────────

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -159,13 +160,26 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}
 	agentapiURL := fmt.Sprintf("http://localhost:%s", agentapiPort)
 
-	log.Printf("[PROVISIONER] Waiting for agentapi to be ready at %s", agentapiURL)
-	if err := waitForAgentAPI(ctx, agentapiURL, 120); err != nil {
-		s.setStatus(StatusError, fmt.Sprintf("agentapi not ready: %v", err))
-		_ = cmd.Process.Kill()
-		return
+	if settings.Session.AgentType == "claude-acp" {
+		// acp-ws-server is a WebSocket-only server; it does not serve the
+		// agentapi HTTP /status endpoint.  Use a plain TCP connect check
+		// to confirm the server is accepting connections.
+		log.Printf("[PROVISIONER] Waiting for acp-ws-server to be ready on port %s", agentapiPort)
+		if err := waitForTCPConnect(ctx, "localhost", agentapiPort, 120); err != nil {
+			s.setStatus(StatusError, fmt.Sprintf("acp-ws-server not ready: %v", err))
+			_ = cmd.Process.Kill()
+			return
+		}
+		log.Printf("[PROVISIONER] acp-ws-server is ready")
+	} else {
+		log.Printf("[PROVISIONER] Waiting for agentapi to be ready at %s", agentapiURL)
+		if err := waitForAgentAPI(ctx, agentapiURL, 120); err != nil {
+			s.setStatus(StatusError, fmt.Sprintf("agentapi not ready: %v", err))
+			_ = cmd.Process.Kill()
+			return
+		}
+		log.Printf("[PROVISIONER] agentapi is ready")
 	}
-	log.Printf("[PROVISIONER] agentapi is ready")
 
 	// ── Step 9: send initial message ─────────────────────────────────────────
 	if settings.InitialMessage != "" {
@@ -584,7 +598,9 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 		// claude-agent-acp (@agentclientprotocol/claude-agent-acp) as a
 		// subprocess per WebSocket connection.
 		// claude-agent-acp speaks the ACP protocol over stdio (ndjson).
-		return "acp-ws-server", []string{"--", "claude-agent-acp"}
+		// acp-ws-server uses --host/--port flags (not env vars), so we
+		// pass them explicitly using the same port as the agentapi proxy expects.
+		return "acp-ws-server", []string{"--host", "0.0.0.0", "--port", agentapiPort, "--", "claude-agent-acp"}
 
 	default:
 		// Default: agentapi server wrapping claude
@@ -627,6 +643,29 @@ func waitForAgentAPI(ctx context.Context, agentapiURL string, maxRetries int) er
 		time.Sleep(500 * time.Millisecond)
 	}
 	return fmt.Errorf("agentapi not ready after %d retries", maxRetries)
+}
+
+// waitForTCPConnect polls host:port with a plain TCP dial until the connection
+// succeeds or maxRetries is exhausted.  Used for servers (e.g. acp-ws-server)
+// that do not expose a standard HTTP /status endpoint.
+func waitForTCPConnect(ctx context.Context, host, port string, maxRetries int) error {
+	addr := net.JoinHostPort(host, port)
+	for i := 0; i < maxRetries; i++ {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled")
+		default:
+		}
+
+		conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("server not ready at %s after %d retries", addr, maxRetries)
 }
 
 // agentStatusResponse is the minimal shape of agentapi's /status response.

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -171,6 +171,8 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 			return
 		}
 		log.Printf("[PROVISIONER] acp-ws-server is ready")
+		// Initialize ACP session and register ID with proxy
+		go initACPSession(ctx, agentapiPort, settings.Session.ID, settings.InitialMessage)
 	} else {
 		log.Printf("[PROVISIONER] Waiting for agentapi to be ready at %s", agentapiURL)
 		if err := waitForAgentAPI(ctx, agentapiURL, 120); err != nil {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3434,7 +3434,7 @@
           },
           "agent_type": {
             "type": "string",
-            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables), 'claude-acp' (uses acp-ws-server wrapping claude-agentapi; exposes ACP WebSocket endpoint — clients connect via ws://<session>/ws). If not specified, uses default agentapi.",
+            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables), 'claude-acp' (uses acp-ws-server wrapping @agentclientprotocol/claude-agent-acp; exposes ACP WebSocket endpoint — clients connect via ws://<session>/ws using ACP JSON-RPC protocol). If not specified, uses default agentapi.",
             "example": "claude-agentapi"
           },
           "slack": {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3434,7 +3434,7 @@
           },
           "agent_type": {
             "type": "string",
-            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables). If not specified, uses default agentapi.",
+            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables), 'claude-acp' (uses acp-ws-server wrapping claude-agentapi; exposes ACP WebSocket endpoint — clients connect via ws://<session>/ws). If not specified, uses default agentapi.",
             "example": "claude-agentapi"
           },
           "slack": {


### PR DESCRIPTION
## Summary

Fix: UIからのメッセージ送信に失敗する問題を修正 (claude-acpセッションでのWebSocket再接続時)

### 問題の根本原因

`acp-ws-server` がWebSocket切断時にエージェントプロセスを終了させていたため、ブラウザが再接続した際に `session/resume` が "Resource not found" エラーで失敗していた。

### 修正内容

**1. acp-ws-server 側 ([takutakahashi/acp-transport-ws PR#3](https://github.com/takutakahashi/acp-transport-ws/pull/3)):**
- WebSocket切断後もエージェントプロセスを **プロセス終了まで** 維持するセッション永続化を実装
  - 従来の2時間TTLによる自動削除を廃止
  - エージェントが自然に終了した場合のみセッションをストアから削除
- `session/resume` で既存エージェントに再接続できるようにした
- 接続時に一時エージェントを即座にspawnして `initialize` への応答遅延を防ぐ
- `session/resume` でIDが見つからない場合は新セッションを作成して `session/new` に変換
- リリース: `server/v0.5.0`

**2. agentapi-proxy 側 (本PR):**
- `KubernetesSession` に `acpSessionID` フィールドと `ACPSessionID()`/`SetACPSessionID()` を追加
- Kubernetesサービスのアノテーション (`agentapi.proxy/acp-session-id`) からセッション復元時にACP session IDを読み込む
- `PatchACPSessionID()` メソッドでACP session IDをサービスアノテーションに永続化
- `ws_proxy.go` で `session/new` を `session/resume` に変換するインターセプトを実装
- セッション起動時に `ACP_INIT` でACP session IDを作成・プロキシに登録
- Dockerfile: `acp-ws-server v0.5.0` を使用

### 動作フロー

1. セッション起動時: provisioner が `acp-ws-server` に接続し `initialize` + `session/new` を送信
2. ACP session ID (`session/new` レスポンス) をサービスアノテーションに保存
3. ブラウザ接続時: プロキシが `session/new` をインターセプトして `session/resume(保存済みID)` に変換
4. `acp-ws-server` が globalStore で既存エージェントを見つけて再接続
5. Claude のセッションコンテキスト (会話履歴) が維持される
6. エージェントは acp-ws-server プロセスが終了するまで生存し続ける

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] dev環境でACP session IDが正しくK8sアノテーションに保存される
- [x] エージェントがWS切断後も生存する
- [ ] ブラウザからUIでメッセージ送信が正常動作することを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)