### PR TITLE
feat: add acp subcommand – ACP-to-agentapi bridge server

### DIFF
--- a/cmd/acp.go
+++ b/cmd/acp.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
+)
+
+// ACPCmd is the "acp" sub-command.
+// It starts a WebSocket server that speaks the Agent Client Protocol (ACP)
+// and proxies incoming requests to a locally running claude-agentapi HTTP
+// server (e.g. started by the agent-provisioner).
+//
+// Usage:
+//
+//	agentapi-proxy acp [--port 9002] [--agentapi-url http://localhost:8080]
+//
+// The WebSocket endpoint is ws://<host>:<port>/acp.
+// A liveness probe is available at GET /healthz.
+var ACPCmd = &cobra.Command{
+	Use:   "acp",
+	Short: "ACP-to-agentapi bridge server",
+	Long: `Starts a WebSocket server implementing the Agent Client Protocol (ACP).
+
+ACP clients (e.g. code editors) connect to the WebSocket endpoint and can
+interact with the claude-agentapi session via the standardised ACP protocol.
+
+The server translates each ACP method call into the corresponding
+claude-agentapi HTTP API call:
+
+  initialize         → capability negotiation (no backend call)
+  session/new        → generate a new session UUID (agentapi is single-session)
+  session/prompt     → POST /message + stream GET /events as session/update
+  session/cancel     → POST /action {type:"stop_agent"}
+  session/list       → returns the active session ID
+
+Pending actions (approve_plan / answer_question) surfaced by GET /action are
+forwarded to the ACP client as session/request_permission requests; the
+client's response is forwarded to POST /action.
+
+Endpoints:
+  WS  /acp      – ACP WebSocket endpoint
+  GET /healthz  – liveness probe
+
+Reference:
+  https://github.com/agentclientprotocol/agent-client-protocol
+  https://github.com/agentclientprotocol/claude-agent-acp`,
+	RunE: runACP,
+}
+
+func init() {
+	ACPCmd.Flags().Int("port", 9002,
+		"TCP port for the ACP WebSocket server")
+	ACPCmd.Flags().String("agentapi-url", "",
+		"URL of the claude-agentapi HTTP server "+
+			"(default: http://localhost:<AGENTAPI_PORT>, AGENTAPI_PORT defaults to 8080)")
+}
+
+func runACP(cmd *cobra.Command, args []string) error {
+	port, err := cmd.Flags().GetInt("port")
+	if err != nil {
+		return err
+	}
+
+	agentapiURL, err := cmd.Flags().GetString("agentapi-url")
+	if err != nil {
+		return err
+	}
+	if agentapiURL == "" {
+		agentapiURL = defaultAgentapiURL()
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	srv := acp.NewServer(port, agentapiURL)
+	return srv.Start(ctx)
+}
+
+// defaultAgentapiURL constructs the default agentapi URL from the AGENTAPI_PORT
+// environment variable (falls back to 8080).
+func defaultAgentapiURL() string {
+	port := os.Getenv("AGENTAPI_PORT")
+	if port == "" {
+		port = "8080"
+	}
+	return fmt.Sprintf("http://localhost:%s", port)
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func init() {
 	rootCmd.AddCommand(cmd.ClientCmd)
 	rootCmd.AddCommand(cmd.AgentProvisionerCmd)
 	rootCmd.AddCommand(cmd.OneshotCmd)
+	rootCmd.AddCommand(cmd.ACPCmd)
 }
 
 func main() {

--- a/pkg/acp/agentapi.go
+++ b/pkg/acp/agentapi.go
@@ -1,0 +1,257 @@
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// AgentapiClient is a minimal HTTP client for the claude-agentapi HTTP API
+// (https://github.com/takutakahashi/claude-agentapi).
+//
+// All methods target the single-session API running at baseURL (e.g.
+// http://localhost:8080).
+type AgentapiClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewAgentapiClient creates a client that talks to the agentapi at baseURL.
+func NewAgentapiClient(baseURL string) *AgentapiClient {
+	return &AgentapiClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// ---- response types -----------------------------------------------------
+
+// AgentStatus is the response from GET /status.
+type AgentStatus struct {
+	AgentType string `json:"agent_type"`
+	Status    string `json:"status"` // "running" | "stable"
+}
+
+// AgentMessage is one entry in the conversation history.
+type AgentMessage struct {
+	ID              int    `json:"id"`
+	Role            string `json:"role"` // "user","assistant","agent","tool_result"
+	Content         string `json:"content"`
+	Time            string `json:"time"`
+	Type            string `json:"type,omitempty"` // "normal","question","plan"
+	ToolUseID       string `json:"toolUseId,omitempty"`
+	ParentToolUseID string `json:"parentToolUseId,omitempty"`
+	Status          string `json:"status,omitempty"` // "success","error"
+	Error           string `json:"error,omitempty"`
+}
+
+// MessagesResponse is the response from GET /messages.
+type MessagesResponse struct {
+	Messages []AgentMessage `json:"messages"`
+	Total    int            `json:"total"`
+	HasMore  bool           `json:"hasMore"`
+}
+
+// PendingAction is an action awaiting a user response from GET /action.
+type PendingAction struct {
+	Type      string          `json:"type"` // "answer_question","approve_plan"
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+}
+
+// ActionsResponse is the response from GET /action.
+type ActionsResponse struct {
+	PendingActions []PendingAction `json:"pending_actions"`
+}
+
+// SSEEvent is a single event received from GET /events (Server-Sent Events).
+type SSEEvent struct {
+	Event string // "init","message_update","status_change"
+	Data  json.RawMessage
+}
+
+// ---- HTTP methods -------------------------------------------------------
+
+// GetStatus calls GET /status.
+func (c *AgentapiClient) GetStatus(ctx context.Context) (*AgentStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/status", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var s AgentStatus
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// GetMessages calls GET /messages and returns the full history.
+func (c *AgentapiClient) GetMessages(ctx context.Context) (*MessagesResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/messages", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var m MessagesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// PostMessage calls POST /message.  msgType should be "user".
+func (c *AgentapiClient) PostMessage(ctx context.Context, content, msgType string) error {
+	payload := map[string]string{"content": content, "type": msgType}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/message", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("POST /message returned %s", resp.Status)
+	}
+	return nil
+}
+
+// PostAction calls POST /action.
+//   - actionType: "stop_agent", "approve_plan", or "answer_question"
+//   - approved:   pointer to bool (only for "approve_plan")
+//   - answers:    map[toolUseId]answer (only for "answer_question")
+func (c *AgentapiClient) PostAction(ctx context.Context, actionType string, approved *bool, answers map[string]string) error {
+	payload := map[string]interface{}{"type": actionType}
+	if approved != nil {
+		payload["approved"] = *approved
+	}
+	if answers != nil {
+		payload["answers"] = answers
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/action", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("POST /action returned %s", resp.Status)
+	}
+	return nil
+}
+
+// GetActions calls GET /action and returns any pending actions.
+func (c *AgentapiClient) GetActions(ctx context.Context) (*ActionsResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/action", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var a ActionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+// StreamEvents subscribes to GET /events and streams parsed SSE events.
+//
+// The returned eventCh is closed when the connection ends (context cancelled
+// or server closes the stream).  errCh receives at most one non-nil error.
+// Callers should drain eventCh until it is closed.
+func (c *AgentapiClient) StreamEvents(ctx context.Context) (<-chan SSEEvent, <-chan error) {
+	eventCh := make(chan SSEEvent, 64)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(eventCh)
+		defer close(errCh)
+
+		// The SSE connection must not timeout while the agent is thinking.
+		sseHTTP := &http.Client{}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/events", nil)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("Cache-Control", "no-cache")
+
+		resp, err := sseHTTP.Do(req)
+		if err != nil {
+			if ctx.Err() == nil {
+				errCh <- err
+			}
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		scanner := bufio.NewScanner(resp.Body)
+		var eventType string
+		var dataLines []string
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if line == "" {
+				// Blank line → end of one event block.
+				if len(dataLines) > 0 {
+					evt := SSEEvent{
+						Event: eventType,
+						Data:  json.RawMessage(strings.Join(dataLines, "\n")),
+					}
+					select {
+					case eventCh <- evt:
+					case <-ctx.Done():
+						return
+					}
+				}
+				eventType = ""
+				dataLines = nil
+				continue
+			}
+
+			if after, ok := strings.CutPrefix(line, "event: "); ok {
+				eventType = after
+			} else if after, ok := strings.CutPrefix(line, "data: "); ok {
+				dataLines = append(dataLines, after)
+			}
+		}
+
+		if err := scanner.Err(); err != nil && ctx.Err() == nil {
+			errCh <- err
+		}
+	}()
+
+	return eventCh, errCh
+}

--- a/pkg/acp/handler.go
+++ b/pkg/acp/handler.go
@@ -1,0 +1,701 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+var wsUpgrader = websocket.Upgrader{
+	// Accept connections from any origin so that browser-based editors and
+	// local tools can connect without CORS issues.
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+// Handler is an http.Handler that upgrades each incoming request to a
+// WebSocket connection and runs the ACP server protocol for the lifetime of
+// that connection.
+type Handler struct {
+	agentapiURL string
+}
+
+// NewHandler creates an ACP handler that proxies to the agentapi server at
+// agentapiURL (e.g. "http://localhost:8080").
+func NewHandler(agentapiURL string) *Handler {
+	return &Handler{agentapiURL: agentapiURL}
+}
+
+// ServeHTTP implements http.Handler.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("[ACP] WebSocket upgrade failed: %v", err)
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	sess := &session{
+		conn:         conn,
+		agentapi:     NewAgentapiClient(h.agentapiURL),
+		sendMu:       &sync.Mutex{},
+		pendingPerms: make(map[string]chan *RequestPermissionResult),
+	}
+
+	log.Printf("[ACP] New connection from %s", r.RemoteAddr)
+	if err := sess.run(r.Context()); err != nil {
+		log.Printf("[ACP] Session error from %s: %v", r.RemoteAddr, err)
+	}
+	log.Printf("[ACP] Connection closed for %s", r.RemoteAddr)
+}
+
+// ---- session ------------------------------------------------------------
+
+// session holds all state for a single ACP WebSocket connection.
+type session struct {
+	conn        *websocket.Conn
+	agentapi    *AgentapiClient
+	sendMu      *sync.Mutex
+	sessionID   string // ACP session ID (generated on session/new)
+	initialized bool
+
+	// pendingPerms: maps permReqID → channel that receives the client's
+	// response to a session/request_permission call we sent.
+	pendingPerms   map[string]chan *RequestPermissionResult
+	pendingPermsMu sync.Mutex
+
+	// promptCancel cancels the currently in-flight session/prompt goroutine.
+	// promptID is a counter that identifies the active prompt; it is
+	// incremented each time a new prompt starts so that the deferred cleanup
+	// can skip cancelling a prompt that has already been superseded.
+	promptCancel context.CancelFunc
+	promptID     uint64
+	promptMu     sync.Mutex
+}
+
+// run reads messages from the WebSocket connection and dispatches them.
+// It returns when the connection is closed or an unrecoverable error occurs.
+func (s *session) run(ctx context.Context) error {
+	for {
+		_, raw, err := s.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway,
+				websocket.CloseNoStatusReceived,
+			) {
+				return nil
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+
+		var msg Message
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			log.Printf("[ACP] Malformed message from client: %v", err)
+			continue
+		}
+
+		log.Printf("[ACP] ← method=%q id=%v", msg.Method, msg.ID)
+
+		switch {
+		// ---- responses to requests we sent (e.g. session/request_permission)
+		case msg.Method == "" && msg.ID != nil:
+			s.handleResponse(&msg)
+
+		// ---- requests / notifications from the client
+		case msg.Method == MethodInitialize:
+			s.handleInitialize(&msg)
+		case msg.Method == MethodAuthenticate:
+			s.handleAuthenticate(&msg)
+		case msg.Method == MethodSessionNew:
+			s.handleSessionNew(&msg)
+		case msg.Method == MethodSessionLoad:
+			s.handleSessionLoad(&msg)
+		case msg.Method == MethodSessionPrompt:
+			// Run in a goroutine so that the read loop stays alive and can
+			// receive session/cancel notifications while the prompt is running.
+			go s.handleSessionPrompt(ctx, &msg)
+		case msg.Method == MethodSessionCancel:
+			s.handleSessionCancel(ctx, &msg)
+		case msg.Method == MethodSessionList:
+			s.handleSessionList(&msg)
+		case msg.Method == MethodSessionSetMode:
+			s.handleSessionSetMode(&msg)
+		default:
+			log.Printf("[ACP] Unknown method: %q", msg.Method)
+			if msg.ID != nil {
+				s.sendError(msg.ID, -32601, "method not found: "+msg.Method)
+			}
+		}
+	}
+}
+
+// ---- request handlers ---------------------------------------------------
+
+func (s *session) handleInitialize(msg *Message) {
+	var params InitializeParams
+	if msg.Params != nil {
+		_ = json.Unmarshal(msg.Params, &params)
+	}
+	s.initialized = true
+
+	s.sendResult(msg.ID, InitializeResult{
+		ProtocolVersion: ProtocolVersion,
+		AgentInfo: &AgentInfo{
+			Name:    "agentapi-proxy-acp",
+			Version: "1.0.0",
+		},
+		AuthMethods: []string{},
+		AgentCapabilities: AgentCapabilities{
+			SessionCapabilities: SessionCapabilities{
+				List: true,
+			},
+		},
+	})
+}
+
+func (s *session) handleAuthenticate(msg *Message) {
+	// No authentication required; accept all credentials.
+	s.sendResult(msg.ID, map[string]interface{}{})
+}
+
+func (s *session) handleSessionNew(msg *Message) {
+	s.sessionID = uuid.New().String()
+	log.Printf("[ACP] session/new → sessionId=%s", s.sessionID)
+	s.sendResult(msg.ID, NewSessionResult{SessionID: s.sessionID})
+}
+
+// handleSessionLoad tries to resume a previously identified session.
+// Since claude-agentapi is single-session there is nothing to restore; we
+// just reuse the requested sessionId.
+func (s *session) handleSessionLoad(msg *Message) {
+	var params struct {
+		SessionID string `json:"sessionId"`
+	}
+	if msg.Params != nil {
+		_ = json.Unmarshal(msg.Params, &params)
+	}
+	if params.SessionID != "" {
+		s.sessionID = params.SessionID
+	} else {
+		s.sessionID = uuid.New().String()
+	}
+	log.Printf("[ACP] session/load → sessionId=%s", s.sessionID)
+	s.sendResult(msg.ID, map[string]interface{}{
+		"sessionId": s.sessionID,
+		"messages":  []interface{}{},
+	})
+}
+
+// handleSessionPrompt is the core ACP method.  It:
+//  1. Converts the ACP prompt ContentBlocks to plain text.
+//  2. POSTs the message to claude-agentapi.
+//  3. Subscribes to the SSE /events stream and translates events to
+//     session/update notifications sent to the ACP client.
+//  4. Handles pending actions (approve_plan / answer_question) by sending
+//     session/request_permission requests to the ACP client and forwarding
+//     the client's response back to agentapi.
+//  5. Replies to the original session/prompt request once the agent is stable.
+func (s *session) handleSessionPrompt(ctx context.Context, msg *Message) {
+	var params PromptParams
+	if msg.Params != nil {
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			s.sendError(msg.ID, -32602, fmt.Sprintf("invalid params: %v", err))
+			return
+		}
+	}
+
+	// Build plain-text content from the ACP ContentBlocks.
+	content := blocksToText(params.Prompt)
+	if content == "" {
+		s.sendError(msg.ID, -32602, "no text content in prompt")
+		return
+	}
+
+	// Create a context that can be cancelled by session/cancel.
+	promptCtx, cancel := context.WithCancel(ctx)
+	s.promptMu.Lock()
+	if s.promptCancel != nil {
+		s.promptCancel() // cancel any previous in-flight prompt
+	}
+	s.promptCancel = cancel
+	myPromptID := s.promptID + 1
+	s.promptID = myPromptID
+	s.promptMu.Unlock()
+	defer func() {
+		cancel()
+		s.promptMu.Lock()
+		// Only clear promptCancel if it still belongs to this prompt.
+		if s.promptID == myPromptID {
+			s.promptCancel = nil
+		}
+		s.promptMu.Unlock()
+	}()
+
+	sessionID := params.SessionID
+	if sessionID == "" {
+		sessionID = s.sessionID
+	}
+
+	// Snapshot message count before sending so we can detect completion even
+	// if we miss the running→stable status transition.
+	initialCount := s.getMessageCount(promptCtx)
+
+	// Subscribe to the SSE stream BEFORE posting the message so we do not
+	// miss any events.
+	eventCh, errCh := s.agentapi.StreamEvents(promptCtx)
+
+	log.Printf("[ACP] Sending message to agentapi (len=%d)", len(content))
+	if err := s.agentapi.PostMessage(promptCtx, content, "user"); err != nil {
+		s.sendError(msg.ID, -32000, fmt.Sprintf("failed to send message: %v", err))
+		return
+	}
+
+	stopReason, err := s.streamLoop(promptCtx, sessionID, initialCount, eventCh, errCh)
+	if err != nil {
+		if promptCtx.Err() != nil {
+			// Context was cancelled (session/cancel).
+			s.sendResult(msg.ID, PromptResult{StopReason: "cancelled"})
+			return
+		}
+		s.sendError(msg.ID, -32000, fmt.Sprintf("streaming error: %v", err))
+		return
+	}
+
+	log.Printf("[ACP] session/prompt done, stopReason=%s", stopReason)
+	s.sendResult(msg.ID, PromptResult{StopReason: stopReason})
+}
+
+// streamLoop reads SSE events from the agentapi, translates them to ACP
+// session/update notifications, handles pending actions, and returns when
+// the agent becomes stable after the new message.
+func (s *session) streamLoop(
+	ctx context.Context,
+	sessionID string,
+	initialMsgCount int,
+	eventCh <-chan SSEEvent,
+	errCh <-chan error,
+) (string, error) {
+	// seenIDs prevents emitting duplicate session/update notifications for
+	// messages that appear in both the init snapshot and later message_update
+	// events.
+	seenIDs := make(map[int]bool)
+	sawRunning := false
+
+	// Poll for pending actions at regular intervals while the agent runs.
+	actionCh := make(chan PendingAction, 8)
+	go s.pollActions(ctx, actionCh)
+
+	// Overall timeout: 10 minutes for a single prompt.
+	timeout := time.NewTimer(10 * time.Minute)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "cancelled", nil
+
+		case <-timeout.C:
+			log.Printf("[ACP] Prompt timed out after 10 minutes")
+			return "max_turn_requests", nil
+
+		case err, ok := <-errCh:
+			if !ok {
+				// errCh closed without error; the eventCh will close too.
+				return "end_turn", nil
+			}
+			return "", err
+
+		case evt, ok := <-eventCh:
+			if !ok {
+				// SSE stream closed.
+				return "end_turn", nil
+			}
+			stop, err := s.handleSSEEvent(ctx, sessionID, evt, seenIDs, &sawRunning, initialMsgCount)
+			if err != nil {
+				return "", err
+			}
+			if stop != "" {
+				return stop, nil
+			}
+
+		case action, ok := <-actionCh:
+			if !ok {
+				continue
+			}
+			if err := s.handlePendingAction(ctx, sessionID, action); err != nil {
+				log.Printf("[ACP] handlePendingAction error: %v", err)
+			}
+		}
+	}
+}
+
+// handleSSEEvent processes a single SSE event and returns ("stop_reason","")
+// when the agent turn is over, or ("","") to continue.
+func (s *session) handleSSEEvent(
+	ctx context.Context,
+	sessionID string,
+	evt SSEEvent,
+	seenIDs map[int]bool,
+	sawRunning *bool,
+	initialMsgCount int,
+) (string, error) {
+	switch evt.Event {
+	case "init":
+		// The init event carries the current snapshot; emit any messages the
+		// agent has already produced and note the current status.
+		var initData struct {
+			Messages []AgentMessage `json:"messages"`
+			Status   string         `json:"status"`
+		}
+		if err := json.Unmarshal(evt.Data, &initData); err != nil {
+			log.Printf("[ACP] failed to parse init event: %v", err)
+			return "", nil
+		}
+		if initData.Status == "running" {
+			*sawRunning = true
+		}
+		for i := range initData.Messages {
+			m := &initData.Messages[i]
+			seenIDs[m.ID] = true
+		}
+
+	case "message_update":
+		var m AgentMessage
+		if err := json.Unmarshal(evt.Data, &m); err != nil {
+			log.Printf("[ACP] failed to parse message_update: %v", err)
+			return "", nil
+		}
+		if seenIDs[m.ID] {
+			return "", nil
+		}
+		seenIDs[m.ID] = true
+
+		if notif := messageToUpdate(sessionID, &m); notif != nil {
+			s.sendNotification(MethodSessionUpdate, notif)
+		}
+
+	case "status_change":
+		var sc struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(evt.Data, &sc); err != nil {
+			log.Printf("[ACP] failed to parse status_change: %v", err)
+			return "", nil
+		}
+		log.Printf("[ACP] agentapi status → %s", sc.Status)
+
+		switch sc.Status {
+		case "running":
+			*sawRunning = true
+		case "stable":
+			// We are done when:
+			//   (a) we observed the agent transition to running (normal path), OR
+			//   (b) the message count grew (agent finished very quickly).
+			currentCount := s.getMessageCount(ctx)
+			if *sawRunning || currentCount > initialMsgCount {
+				return "end_turn", nil
+			}
+			// Otherwise this "stable" is the pre-existing idle state; ignore.
+		}
+	}
+	return "", nil
+}
+
+// handleSessionCancel aborts the current in-flight session/prompt.
+func (s *session) handleSessionCancel(ctx context.Context, msg *Message) {
+	s.promptMu.Lock()
+	cancel := s.promptCancel
+	s.promptMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	// Also tell agentapi to stop the running agent.
+	if err := s.agentapi.PostAction(ctx, "stop_agent", nil, nil); err != nil {
+		log.Printf("[ACP] stop_agent action failed: %v", err)
+	}
+}
+
+func (s *session) handleSessionList(msg *Message) {
+	sessions := []map[string]interface{}{}
+	if s.sessionID != "" {
+		sessions = append(sessions, map[string]interface{}{
+			"sessionId": s.sessionID,
+		})
+	}
+	s.sendResult(msg.ID, map[string]interface{}{"sessions": sessions})
+}
+
+func (s *session) handleSessionSetMode(msg *Message) {
+	// claude-agentapi does not expose a mode-change API; accept silently.
+	s.sendResult(msg.ID, map[string]interface{}{})
+}
+
+// ---- action / permission handling ---------------------------------------
+
+// pollActions polls GET /action every 500 ms and forwards newly seen pending
+// actions to actionCh.  It runs until ctx is cancelled.
+func (s *session) pollActions(ctx context.Context, actionCh chan<- PendingAction) {
+	defer close(actionCh)
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	seen := make(map[string]bool)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			actions, err := s.agentapi.GetActions(ctx)
+			if err != nil {
+				continue
+			}
+			for _, a := range actions.PendingActions {
+				key := a.ToolUseID + "|" + a.Type
+				if !seen[key] {
+					seen[key] = true
+					select {
+					case actionCh <- a:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// handlePendingAction sends a session/request_permission request to the ACP
+// client and posts the client's response back to agentapi.
+func (s *session) handlePendingAction(ctx context.Context, sessionID string, action PendingAction) error {
+	permReqID := uuid.New().String()
+	replyCh := make(chan *RequestPermissionResult, 1)
+
+	s.pendingPermsMu.Lock()
+	s.pendingPerms[permReqID] = replyCh
+	s.pendingPermsMu.Unlock()
+	defer func() {
+		s.pendingPermsMu.Lock()
+		delete(s.pendingPerms, permReqID)
+		s.pendingPermsMu.Unlock()
+	}()
+
+	// Build human-readable content for the permission request.
+	var contentText string
+	_ = json.Unmarshal(action.Content, &contentText)
+
+	var content []ContentBlock
+	if contentText != "" {
+		content = []ContentBlock{{Type: "text", Text: contentText}}
+	}
+
+	s.sendRequest(permReqID, MethodSessionRequestPerm, RequestPermissionParams{
+		SessionID: sessionID,
+		PermissionRequest: PermReq{
+			ToolUseID:   action.ToolUseID,
+			Description: action.Type,
+			Content:     content,
+		},
+	})
+
+	// Wait for the client's response with a generous timeout.
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-time.After(5 * time.Minute):
+		log.Printf("[ACP] Timeout waiting for permission response (toolUseId=%s), auto-denying", action.ToolUseID)
+		// Auto-deny on timeout to unblock the agent.
+		switch action.Type {
+		case "approve_plan":
+			f := false
+			_ = s.agentapi.PostAction(ctx, "approve_plan", &f, nil)
+		case "answer_question":
+			_ = s.agentapi.PostAction(ctx, "answer_question", nil, map[string]string{action.ToolUseID: ""})
+		}
+	case result, ok := <-replyCh:
+		if !ok || result == nil {
+			return nil
+		}
+		switch action.Type {
+		case "approve_plan":
+			approved := result.Permission == "allow" || result.Permission == "allow_always"
+			if err := s.agentapi.PostAction(ctx, "approve_plan", &approved, nil); err != nil {
+				return fmt.Errorf("approve_plan action: %w", err)
+			}
+		case "answer_question":
+			answer := result.Answer
+			if err := s.agentapi.PostAction(ctx, "answer_question", nil, map[string]string{action.ToolUseID: answer}); err != nil {
+				return fmt.Errorf("answer_question action: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// handleResponse routes an incoming JSON-RPC response (from the client) to
+// the goroutine waiting for a permission reply.
+func (s *session) handleResponse(msg *Message) {
+	idStr := fmt.Sprintf("%v", msg.ID)
+	s.pendingPermsMu.Lock()
+	ch, ok := s.pendingPerms[idStr]
+	s.pendingPermsMu.Unlock()
+
+	if !ok {
+		log.Printf("[ACP] Unexpected response id=%v (no pending request)", msg.ID)
+		return
+	}
+
+	var result RequestPermissionResult
+	if msg.Result != nil {
+		_ = json.Unmarshal(msg.Result, &result)
+	}
+	ch <- &result
+}
+
+// ---- helpers ------------------------------------------------------------
+
+// getMessageCount fetches the current message count from agentapi.
+func (s *session) getMessageCount(ctx context.Context) int {
+	msgs, err := s.agentapi.GetMessages(ctx)
+	if err != nil || msgs == nil {
+		return 0
+	}
+	return len(msgs.Messages)
+}
+
+// blocksToText extracts plain text from a slice of ACP ContentBlocks.
+func blocksToText(blocks []ContentBlock) string {
+	var parts []string
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		case "resource_link":
+			if b.URI != "" {
+				parts = append(parts, b.URI)
+			}
+		}
+	}
+	return joinLines(parts)
+}
+
+func joinLines(ss []string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	out := ss[0]
+	for _, s := range ss[1:] {
+		out += "\n" + s
+	}
+	return out
+}
+
+// messageToUpdate converts one AgentMessage to an ACP SessionUpdateNotification.
+// Returns nil if the message should not produce a notification (e.g. empty
+// content with no known role mapping).
+func messageToUpdate(sessionID string, m *AgentMessage) *SessionUpdateNotification {
+	var update SessionUpdate
+
+	switch {
+	case m.Role == "user":
+		update = SessionUpdate{
+			Type:  "user_message_chunk",
+			Chunk: &ContentBlock{Type: "text", Text: m.Content},
+		}
+
+	case m.Role == "assistant":
+		update = SessionUpdate{
+			Type:  "agent_message_chunk",
+			Chunk: &ContentBlock{Type: "text", Text: m.Content},
+		}
+
+	case m.Role == "agent" && m.Type == "plan":
+		// Plan update – surface as a single item.
+		update = SessionUpdate{
+			Type: "plan",
+			Plan: &PlanUpdate{
+				Items: []PlanItem{{Content: m.Content, Status: "in_progress"}},
+			},
+		}
+
+	case m.Role == "agent" && m.ToolUseID != "":
+		// In-flight tool invocation.
+		update = SessionUpdate{
+			Type:       "tool_call",
+			ToolCallID: m.ToolUseID,
+			Title:      m.Content,
+			Kind:       "other",
+			Status:     "in_progress",
+			Content: []ToolCallContent{{
+				Type:    "content",
+				Content: []ContentBlock{{Type: "text", Text: m.Content}},
+			}},
+		}
+
+	case m.Role == "tool_result":
+		status := "completed"
+		if m.Status == "error" {
+			status = "failed"
+		}
+		update = SessionUpdate{
+			Type:       "tool_call_update",
+			ToolCallID: m.ParentToolUseID,
+			Status:     status,
+			Content: []ToolCallContent{{
+				Type:    "content",
+				Content: []ContentBlock{{Type: "text", Text: m.Content}},
+			}},
+		}
+
+	default:
+		if m.Content == "" {
+			return nil
+		}
+		// Fallback: emit as an agent message chunk.
+		update = SessionUpdate{
+			Type:  "agent_message_chunk",
+			Chunk: &ContentBlock{Type: "text", Text: m.Content},
+		}
+	}
+
+	return &SessionUpdateNotification{SessionID: sessionID, Update: update}
+}
+
+// ---- WebSocket send helpers ---------------------------------------------
+
+func (s *session) sendResult(id interface{}, result interface{}) {
+	s.writeJSON(map[string]interface{}{"id": id, "result": result})
+}
+
+func (s *session) sendError(id interface{}, code int, message string) {
+	s.writeJSON(map[string]interface{}{
+		"id":    id,
+		"error": map[string]interface{}{"code": code, "message": message},
+	})
+}
+
+// sendNotification sends a JSON-RPC notification (no id, no response expected).
+func (s *session) sendNotification(method string, params interface{}) {
+	s.writeJSON(map[string]interface{}{"method": method, "params": params})
+}
+
+// sendRequest sends a JSON-RPC request from agent→client (has id, expects response).
+func (s *session) sendRequest(id interface{}, method string, params interface{}) {
+	s.writeJSON(map[string]interface{}{"id": id, "method": method, "params": params})
+}
+
+func (s *session) writeJSON(v interface{}) {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	if err := s.conn.WriteJSON(v); err != nil {
+		log.Printf("[ACP] writeJSON error: %v", err)
+	}
+}

--- a/pkg/acp/server.go
+++ b/pkg/acp/server.go
@@ -1,0 +1,52 @@
+package acp
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+// Server is a standalone HTTP server that exposes the ACP WebSocket endpoint.
+type Server struct {
+	port        int
+	agentapiURL string
+}
+
+// NewServer creates an ACP server that listens on port and proxies ACP
+// protocol traffic to the claude-agentapi server at agentapiURL.
+func NewServer(port int, agentapiURL string) *Server {
+	return &Server{port: port, agentapiURL: agentapiURL}
+}
+
+// Start starts the HTTP server and blocks until ctx is cancelled or a fatal
+// error occurs.
+func (s *Server) Start(ctx context.Context) error {
+	handler := NewHandler(s.agentapiURL)
+
+	mux := http.NewServeMux()
+	// WebSocket ACP endpoint
+	mux.Handle("/acp", handler)
+	// Liveness probe
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", s.port),
+		Handler: mux,
+	}
+
+	go func() {
+		<-ctx.Done()
+		log.Printf("[ACP] Shutting down")
+		_ = srv.Shutdown(context.Background())
+	}()
+
+	log.Printf("[ACP] Listening on :%d (agentapi=%s)", s.port, s.agentapiURL)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("acp server: %w", err)
+	}
+	return nil
+}

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -1,0 +1,218 @@
+// Package acp implements an Agent Client Protocol (ACP) server that bridges
+// ACP clients (e.g. code editors) to a locally running claude-agentapi HTTP
+// server.
+//
+// Protocol reference:
+//
+//	https://github.com/agentclientprotocol/agent-client-protocol
+//
+// Compatibility target:
+//
+//	https://github.com/agentclientprotocol/claude-agent-acp
+//
+// Transport: WebSocket. Each WebSocket text frame carries exactly one
+// JSON-RPC-style message (no extra ndjson framing is needed because WebSocket
+// frames are already self-delimiting).
+package acp
+
+import "encoding/json"
+
+// ProtocolVersion is the ACP protocol version this server implements.
+const ProtocolVersion = 1
+
+// ---- JSON-RPC base types ------------------------------------------------
+
+// Message is the universal envelope for all ACP messages.
+//
+//   - Request:      has Method + Params (+optional ID)
+//   - Response:     has ID + Result or Error  (no Method)
+//   - Notification: has Method + Params       (no ID)
+type Message struct {
+	ID     interface{}     `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is a JSON-RPC error object.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ---- ACP method name constants ------------------------------------------
+
+const (
+	// Client → Agent
+	MethodInitialize     = "initialize"
+	MethodAuthenticate   = "authenticate"
+	MethodSessionNew     = "session/new"
+	MethodSessionLoad    = "session/load"
+	MethodSessionPrompt  = "session/prompt"
+	MethodSessionCancel  = "session/cancel"
+	MethodSessionList    = "session/list"
+	MethodSessionSetMode = "session/set_mode"
+
+	// Agent → Client (notifications / requests)
+	MethodSessionUpdate      = "session/update"
+	MethodSessionRequestPerm = "session/request_permission"
+)
+
+// ---- initialize ---------------------------------------------------------
+
+// InitializeParams is the params block for the "initialize" request.
+type InitializeParams struct {
+	ProtocolVersion    int                 `json:"protocolVersion"`
+	ClientCapabilities *ClientCapabilities `json:"clientCapabilities,omitempty"`
+	ClientInfo         *AgentInfo          `json:"clientInfo,omitempty"`
+}
+
+// ClientCapabilities describes what the connecting client supports.
+type ClientCapabilities struct {
+	FS struct {
+		ReadTextFile  bool `json:"readTextFile,omitempty"`
+		WriteTextFile bool `json:"writeTextFile,omitempty"`
+	} `json:"fs,omitempty"`
+	Terminal bool `json:"terminal,omitempty"`
+}
+
+// InitializeResult is the result for an "initialize" request.
+type InitializeResult struct {
+	ProtocolVersion   int               `json:"protocolVersion"`
+	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
+	AgentInfo         *AgentInfo        `json:"agentInfo,omitempty"`
+	AuthMethods       []string          `json:"authMethods"`
+}
+
+// AgentInfo carries name / version metadata about the agent.
+type AgentInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// AgentCapabilities describes what the server supports.
+type AgentCapabilities struct {
+	SessionCapabilities SessionCapabilities `json:"sessionCapabilities"`
+}
+
+// SessionCapabilities describes per-session feature availability.
+type SessionCapabilities struct {
+	List   bool `json:"list,omitempty"`
+	Fork   bool `json:"fork,omitempty"`
+	Resume bool `json:"resume,omitempty"`
+	Close  bool `json:"close,omitempty"`
+}
+
+// ---- session/new --------------------------------------------------------
+
+// NewSessionParams is the params block for "session/new".
+type NewSessionParams struct {
+	CWD        string      `json:"cwd"`
+	MCPServers interface{} `json:"mcpServers,omitempty"`
+}
+
+// NewSessionResult is the result for "session/new".
+type NewSessionResult struct {
+	SessionID string `json:"sessionId"`
+}
+
+// ---- session/prompt -----------------------------------------------------
+
+// PromptParams is the params block for "session/prompt".
+type PromptParams struct {
+	SessionID string         `json:"sessionId"`
+	Prompt    []ContentBlock `json:"prompt"`
+}
+
+// PromptResult is the result for "session/prompt".
+// StopReason values: "end_turn", "max_tokens", "max_turn_requests",
+// "refusal", "cancelled".
+type PromptResult struct {
+	StopReason string `json:"stopReason"`
+}
+
+// ContentBlock is a single content element in a prompt or agent message.
+type ContentBlock struct {
+	Type     string `json:"type"` // "text", "image", "resource", "resource_link"
+	Text     string `json:"text,omitempty"`
+	Data     string `json:"data,omitempty"`     // base64 for image
+	MimeType string `json:"mimeType,omitempty"` // for image
+	URI      string `json:"uri,omitempty"`      // for resource_link
+}
+
+// ---- session/cancel (notification, client → agent) ----------------------
+
+// CancelParams is the params block for the "session/cancel" notification.
+type CancelParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// ---- session/update (notification, agent → client) ----------------------
+
+// SessionUpdateNotification is the params block for "session/update"
+// notifications sent by the agent to the client during prompt processing.
+type SessionUpdateNotification struct {
+	SessionID string        `json:"sessionId"`
+	Update    SessionUpdate `json:"update"`
+}
+
+// SessionUpdate is discriminated by the Type ("sessionUpdate") field.
+// Only fields relevant to the active update type are populated.
+type SessionUpdate struct {
+	// Type maps to the "sessionUpdate" discriminator in the spec.
+	Type string `json:"sessionUpdate"`
+
+	// agent_message_chunk / user_message_chunk
+	Chunk *ContentBlock `json:"chunk,omitempty"`
+
+	// tool_call / tool_call_update
+	ToolCallID string            `json:"toolCallId,omitempty"`
+	Title      string            `json:"title,omitempty"`
+	Kind       string            `json:"kind,omitempty"`   // "read","edit","execute","search","fetch","think","other"
+	Status     string            `json:"status,omitempty"` // "pending","in_progress","completed","failed"
+	Content    []ToolCallContent `json:"content,omitempty"`
+
+	// plan
+	Plan *PlanUpdate `json:"plan,omitempty"`
+}
+
+// ToolCallContent wraps content produced by or about a tool call.
+type ToolCallContent struct {
+	Type    string         `json:"type"` // "content", "diff", "terminal"
+	Content []ContentBlock `json:"content,omitempty"`
+}
+
+// PlanUpdate carries the current todo list from a plan-mode agent.
+type PlanUpdate struct {
+	Items []PlanItem `json:"items"`
+}
+
+// PlanItem is one entry in a plan list.
+type PlanItem struct {
+	Content string `json:"content"`
+	Status  string `json:"status"` // "pending", "completed", "in_progress"
+}
+
+// ---- session/request_permission (agent → client, requires response) -----
+
+// RequestPermissionParams is the params block for "session/request_permission".
+type RequestPermissionParams struct {
+	SessionID         string  `json:"sessionId"`
+	PermissionRequest PermReq `json:"permissionRequest"`
+}
+
+// PermReq describes the pending tool use that needs approval.
+type PermReq struct {
+	ToolUseID   string         `json:"toolUseId"`
+	Description string         `json:"description"`
+	Content     []ContentBlock `json:"content,omitempty"`
+}
+
+// RequestPermissionResult is the client's reply to a permission request.
+// Permission values: "allow_always", "allow", "reject".
+type RequestPermissionResult struct {
+	Permission string `json:"permission"`
+	// Answer is present only for answer_question actions.
+	Answer string `json:"answer,omitempty"`
+}


### PR DESCRIPTION
## Summary

- `agentapi-proxy acp` サブコマンドを新設。WebSocket サーバーを起動して [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol) を喋り、ローカルで動いている claude-agentapi HTTP サーバーへブリッジする
- [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp) が実現するすべての操作を claude-agentapi の HTTP インターフェース (`POST /message`, `GET /events`, `GET/POST /action`) 経由で完全に操作できるようにした

## 追加ファイル

| ファイル | 役割 |
|---|---|
| `pkg/acp/types.go` | ACP プロトコル型（JSON-RPC メッセージ形状） |
| `pkg/acp/agentapi.go` | claude-agentapi HTTP API クライアント |
| `pkg/acp/handler.go` | WebSocket ハンドラ：ACP セッション管理・イベントストリーミング・権限処理 |
| `pkg/acp/server.go` | HTTP サーバー |
| `cmd/acp.go` | cobra コマンド |
| `main.go` | `ACPCmd` 登録 |

## プロトコルマッピング (ACP → claude-agentapi)

| ACP method | claude-agentapi |
|---|---|
| `initialize` | ケーパビリティネゴシエーション (HTTP なし) |
| `session/new` | セッション UUID 生成 |
| `session/prompt` | POST /message + GET /events SSE ストリーミング |
| `session/cancel` | POST /action {"type":"stop_agent"} |
| `session/list` | アクティブセッション ID を返す |
| `session/request_permission` | GET /action ポーリング → POST /action で回答 |

agentapi の SSE イベントは ACP session/update 通知に変換:
- message_update (role=assistant) → agent_message_chunk
- message_update (role=user) → user_message_chunk
- message_update (role=agent, type=plan) → plan
- message_update (role=agent, toolUseId あり) → tool_call
- message_update (role=tool_result) → tool_call_update

## 使い方

agentapi-proxy acp [--port 9002] [--agentapi-url http://localhost:8080]

WebSocket エンドポイント: ws://<host>:<port>/acp
ライブネスプローブ: GET /healthz

## Test plan

- [ ] go build が通ること（CI で確認）
- [ ] go test ./... (CGO_ENABLED=0) が全パッケージ pass すること
- [ ] golangci-lint がクリアなこと
- [ ] agentapi-proxy acp --help でヘルプが表示されること
- [ ] ACP クライアントから接続して initialize → session/new → session/prompt のフローが動作すること

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)