### PR TITLE
feat: add acp-server subcommand (ACP stdio → agentapi HTTP bridge)

### DIFF
--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp/bridge"
+)
+
+var (
+	acpPort      string
+	acpCwd       string
+	acpSessionID string
+	acpVerbose   bool
+)
+
+// AcpServerCmd starts an ACP agent over stdio and exposes it as an
+// agentapi-compatible HTTP server (compatible with takutakahashi/claude-agentapi).
+var AcpServerCmd = &cobra.Command{
+	Use:   "acp-server [flags] -- <agent-command> [agent-args...]",
+	Short: "Run an ACP agent over stdio and expose it as an agentapi-compatible HTTP server",
+	Long: `acp-server launches an ACP-compatible agent as a subprocess via stdio (stdin/stdout)
+and exposes its interface as an agentapi-compatible HTTP API.
+
+The HTTP interface is compatible with takutakahashi/claude-agentapi and coder/agentapi.
+
+Endpoints exposed:
+  GET  /health    - health check
+  GET  /status    - agent status (running|stable)
+  GET  /messages  - conversation history
+  POST /message   - send a user message
+  GET  /events    - SSE event stream (message_update, status_change, agent_error)
+  GET  /action    - list pending actions (permission requests, plan approvals)
+  POST /action    - submit a response to a pending action
+
+Example:
+  agentapi-proxy acp-server --port 3284 -- my-acp-agent --model gpt-4`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runAcpServer,
+}
+
+func init() {
+	AcpServerCmd.Flags().StringVarP(&acpPort, "port", "p", "3284", "HTTP port to listen on")
+	AcpServerCmd.Flags().StringVar(&acpCwd, "cwd", "", "Working directory for the ACP session (defaults to current directory)")
+	AcpServerCmd.Flags().StringVar(&acpSessionID, "session-id", "", "Session ID to use (defaults to auto-generated)")
+	AcpServerCmd.Flags().BoolVarP(&acpVerbose, "verbose", "v", false, "Enable verbose logging")
+}
+
+func runAcpServer(cmd *cobra.Command, args []string) error {
+	if acpVerbose {
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
+
+	// Parse agent command from args (everything after "--" separator or all args).
+	agentArgs, err := parseACPAgentArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	if len(agentArgs) == 0 {
+		return fmt.Errorf("no agent command specified; usage: acp-server [flags] -- <agent-command> [args...]")
+	}
+
+	// Resolve working directory.
+	cwd := acpCwd
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+	}
+
+	// Set up root context that cancels on SIGINT/SIGTERM.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	log.Printf("[acp-server] starting agent: %v", agentArgs)
+
+	// Launch the ACP agent subprocess.
+	proc := exec.CommandContext(ctx, agentArgs[0], agentArgs[1:]...)
+	proc.Stderr = os.Stderr
+
+	agentStdin, err := proc.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	agentStdout, err := proc.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	if err := proc.Start(); err != nil {
+		return fmt.Errorf("failed to start agent %q: %w", agentArgs[0], err)
+	}
+	log.Printf("[acp-server] agent started (pid=%d)", proc.Process.Pid)
+
+	// Create ACP client and wire it to the subprocess pipes.
+	acpClient := acp.NewClient(agentStdout, agentStdin, acpVerbose)
+
+	// Start the JSON-RPC read loop.
+	listenErrCh := make(chan error, 1)
+	go func() {
+		listenErrCh <- acpClient.Listen(ctx)
+	}()
+
+	// Perform the ACP handshake.
+	if err := acpClient.Initialize(ctx); err != nil {
+		return fmt.Errorf("ACP initialization failed: %w", err)
+	}
+
+	// Create the ACP session.
+	if err := acpClient.NewSession(ctx, cwd, nil); err != nil {
+		return fmt.Errorf("ACP session creation failed: %w", err)
+	}
+	log.Printf("[acp-server] ACP session ready (session=%s)", acpClient.SessionID())
+
+	// Create the bridge and start its event loop.
+	b := bridge.New(acpClient, acpVerbose)
+	go b.Run(ctx)
+
+	// Start the HTTP server.
+	srv := bridge.NewServer(b, acpVerbose)
+	addr := ":" + acpPort
+	log.Printf("[acp-server] HTTP server listening on %s", addr)
+
+	httpErrCh := make(chan error, 1)
+	go func() {
+		httpErrCh <- srv.Start(ctx, addr)
+	}()
+
+	// Watch for the process exiting unexpectedly.
+	procDoneCh := make(chan error, 1)
+	go func() {
+		procDoneCh <- proc.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Printf("[acp-server] shutting down")
+		return nil
+
+	case err := <-httpErrCh:
+		if err != nil {
+			return fmt.Errorf("HTTP server error: %w", err)
+		}
+		return nil
+
+	case err := <-listenErrCh:
+		if err != nil && ctx.Err() == nil {
+			log.Printf("[acp-server] JSON-RPC listener closed: %v", err)
+		}
+		return nil
+
+	case err := <-procDoneCh:
+		if err != nil && ctx.Err() == nil {
+			return fmt.Errorf("agent process exited unexpectedly: %w", err)
+		}
+		return nil
+	}
+}
+
+// parseACPAgentArgs extracts the agent command from cobra args.
+// Cobra collects everything after "--" in ArgsLenAtDash() and args slice.
+func parseACPAgentArgs(cmd *cobra.Command, args []string) ([]string, error) {
+	dashIdx := cmd.ArgsLenAtDash()
+	if dashIdx >= 0 {
+		// User used "--" separator; everything after is the agent command.
+		return args[dashIdx:], nil
+	}
+	// No "--": all positional args are the agent command.
+	return args, nil
+}

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -534,16 +534,26 @@ func applySessionEnv(env map[string]string, sessionEnv map[string]string) {
 
 // buildStartupConfig returns the startup command config for the given agent type.
 func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
-	if agentType == "claude-agentapi" {
+	switch agentType {
+	case "claude-agentapi":
 		log.Printf("[GENERATE-SETTING]   startup.command: [claude-agentapi]")
 		return sessionsettings.StartupConfig{
 			Command: []string{"claude-agentapi"},
 		}
-	}
-	log.Printf("[GENERATE-SETTING]   startup.command: [agentapi server --allowed-hosts * --allowed-origins *]")
-	return sessionsettings.StartupConfig{
-		Command: []string{"agentapi", "server"},
-		Args:    []string{"--allowed-hosts", "*", "--allowed-origins", "*"},
+	case "claude-acp":
+		// acp-server bridges claude-agent-acp (ACP over stdio) to the agentapi HTTP interface.
+		// Port is determined at runtime via AGENTAPI_PORT env var.
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- bunx @agentclientprotocol/claude-agent-acp]")
+		return sessionsettings.StartupConfig{
+			Command: []string{"agentapi-proxy"},
+			Args:    []string{"acp-server", "--", "bunx", "@agentclientprotocol/claude-agent-acp"},
+		}
+	default:
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi server --allowed-hosts * --allowed-origins *]")
+		return sessionsettings.StartupConfig{
+			Command: []string{"agentapi", "server"},
+			Args:    []string{"--allowed-hosts", "*", "--allowed-origins", "*"},
+		}
 	}
 }
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3037,6 +3037,14 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"bunx", "@agentclientprotocol/claude-agent-acp",
 			},
 		}
+		// Bypass permission prompts for claude-acp sessions so tool calls
+		// proceed without waiting for user approval.
+		if settingsJSON == nil {
+			settingsJSON = make(map[string]interface{})
+		}
+		settingsJSON["permissions"] = map[string]interface{}{
+			"defaultMode": "bypassPermissions",
+		}
 	default:
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"agentapi", "server"},

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3021,11 +3021,23 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	}
 
 	// Startup command (simplified version for now - full command logic in pod)
-	if req.AgentType == "claude-agentapi" {
+	switch req.AgentType {
+	case "claude-agentapi":
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"claude-agentapi"},
 		}
-	} else {
+	case "claude-acp":
+		// acp-server bridges claude-agent-acp (ACP over stdio) to the agentapi HTTP interface.
+		settings.Startup = sessionsettings.StartupConfig{
+			Command: []string{"agentapi-proxy"},
+			Args: []string{
+				"acp-server",
+				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
+				"--",
+				"bunx", "@agentclientprotocol/claude-agent-acp",
+			},
+		}
+	default:
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"agentapi", "server"},
 			Args:    []string{"--allowed-hosts", "*", "--allowed-origins", "*", "--port", fmt.Sprintf("%d", m.k8sConfig.BasePort)},

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func init() {
 	rootCmd.AddCommand(cmd.ClientCmd)
 	rootCmd.AddCommand(cmd.AgentProvisionerCmd)
 	rootCmd.AddCommand(cmd.OneshotCmd)
+	rootCmd.AddCommand(cmd.AcpServerCmd)
 }
 
 func main() {

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -615,11 +615,14 @@ func (b *Bridge) GetMessages() []Message {
 }
 
 // GetStatus returns the current agent status.
+// AgentType is reported as "claude" so the frontend routes stop_agent via
+// the /action endpoint (which the ACP bridge supports) rather than sending
+// a raw Ctrl-C character (which the ACP bridge does not support).
 func (b *Bridge) GetStatus() StatusResponse {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	return StatusResponse{
-		AgentType: "acp",
+		AgentType: "claude",
 		Status:    b.status,
 		Transport: "acp",
 	}

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -151,6 +151,10 @@ type Bridge struct {
 	acp     *acp.Client
 	verbose bool
 
+	// serverCtx is the long-lived context from Run(); used for ACP Prompt calls
+	// so they survive beyond the HTTP request that triggered them.
+	serverCtx context.Context
+
 	mu       sync.RWMutex
 	status   AgentStatus
 	messages []Message
@@ -176,7 +180,10 @@ func New(client *acp.Client, verbose bool) *Bridge {
 
 // Run starts the background goroutines that consume ACP notifications and
 // feed the bridge state. Call this in a goroutine; it blocks until ctx is done.
+// The ctx is stored as the server context for use in background operations
+// (e.g., ACP Prompt calls that outlive the HTTP request that triggered them).
 func (b *Bridge) Run(ctx context.Context) {
+	b.serverCtx = ctx
 	updates := b.acp.Updates()
 	perms := b.acp.PermissionRequests()
 
@@ -209,16 +216,18 @@ func (b *Bridge) Run(ctx context.Context) {
 
 func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 	if b.verbose {
-		log.Printf("[bridge] update kind=%s content=%q", update.Kind, update.Content)
+		log.Printf("[bridge] update kind=%s content=%s", update.Kind, update.Content)
 	}
 
 	switch update.Kind {
 	case acp.SessionUpdateKindAgentMessageChunk:
-		b.appendOrCreateMessage(MessageRoleAgent, update.Content, MessageTypeNormal, "", "")
+		text := acp.ExtractTextContent(update.Content)
+		b.appendOrCreateMessage(MessageRoleAgent, text, MessageTypeNormal, "", "")
 
 	case acp.SessionUpdateKindAgentThoughtChunk:
 		// Thoughts are surfaced as assistant messages for transparency.
-		b.appendOrCreateMessage(MessageRoleAssistant, update.Content, MessageTypeNormal, "", "")
+		text := acp.ExtractTextContent(update.Content)
+		b.appendOrCreateMessage(MessageRoleAssistant, text, MessageTypeNormal, "", "")
 
 	case acp.SessionUpdateKindToolCall:
 		// New tool invocation – create a distinct message.
@@ -369,9 +378,14 @@ func (b *Bridge) SendMessage(ctx context.Context, content string) error {
 		Data: StatusChangeData{Status: AgentStatusRunning, AgentType: "acp"},
 	})
 
-	// Run the prompt in the background; restore stable status when done.
+	// Run the prompt in the background using the long-lived server context,
+	// NOT the HTTP request context (which is cancelled when the response returns).
+	promptCtx := b.serverCtx
+	if promptCtx == nil {
+		promptCtx = ctx
+	}
 	go func() {
-		stopReason, err := b.acp.Prompt(ctx, content)
+		stopReason, err := b.acp.Prompt(promptCtx, content)
 		if err != nil {
 			log.Printf("[bridge] prompt error: %v", err)
 			b.broadcastError(err.Error())

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -305,7 +306,12 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 		}
 
 	case acp.SessionUpdateKindPlan:
-		b.addNewMessage(MessageRoleAgent, update.Plan, MessageTypePlan, "", "")
+		// ACP sends plan as a structured entries list (from TodoWrite), not a plain string.
+		// Convert to a markdown task list for display in the frontend plan modal.
+		if len(update.Entries) > 0 {
+			planMD := planEntriesToMarkdown(update.Entries)
+			b.addNewMessage(MessageRoleAgent, planMD, MessageTypePlan, "", "")
+		}
 	}
 }
 
@@ -362,6 +368,17 @@ func (b *Bridge) addNewMessage(role MessageRole, content string, msgType Message
 
 func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 	p := req.Params
+	toolCallId := p.ToolCall.ToolCallId
+
+	// ExitPlanMode sends kind="switch_mode" with rawInput.plan containing the plan markdown.
+	// Show it as a type="plan" message with an approve_plan action so the user can review
+	// and approve/reject from the PlanApprovalModal.
+	if p.ToolCall.Kind == "switch_mode" {
+		b.handleExitPlanModePermission(req, toolCallId)
+		return
+	}
+
+	// ── Generic permission request ──────────────────────────────────────────────
 
 	// Build frontend-compatible options (QuestionOption[]).
 	// The frontend expects { label, description } per option.
@@ -405,10 +422,7 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 		}
 	}
 
-	// Use the toolCallId from the nested toolCall object.
-	toolCallId := p.ToolCall.ToolCallId
-
-	// Build a human-readable description from the options or use a default.
+	// Build a human-readable description or use a default.
 	desc := "Permission required"
 
 	// Build one Question object (frontend type).
@@ -451,6 +465,84 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 	// Wait for the HTTP client to POST /action and provide an answer.
 	go func() {
 		optionId := <-replyCh
+		_ = req.Reply(optionId)
+	}()
+}
+
+// handleExitPlanModePermission handles ExitPlanMode permission requests (kind="switch_mode").
+// It extracts the plan markdown from rawInput, emits a type="plan" message, and waits for
+// an approve_plan action from the user. Approve maps to the first allow option; reject maps
+// to "plan" (stay in plan mode).
+func (b *Bridge) handleExitPlanModePermission(req acp.PermissionRequest, toolCallId string) {
+	p := req.Params
+
+	// Extract plan text from rawInput.
+	planText := ""
+	if len(p.ToolCall.RawInput) > 0 {
+		var rawInput map[string]interface{}
+		if err := json.Unmarshal(p.ToolCall.RawInput, &rawInput); err == nil {
+			if v, ok := rawInput["plan"]; ok {
+				if s, ok := v.(string); ok {
+					planText = s
+				}
+			}
+		}
+	}
+	if planText == "" {
+		planText = "Plan ready for review."
+	}
+
+	// Emit the plan message (type="plan") so the frontend shows PlanApprovalModal.
+	b.mu.Lock()
+	b.nextID++
+	planMsg := Message{
+		ID:        b.nextID,
+		Role:      MessageRoleAgent,
+		Content:   planText,
+		Time:      time.Now(),
+		Type:      MessageTypePlan,
+		ToolUseId: toolCallId,
+	}
+	b.messages = append(b.messages, planMsg)
+	b.broadcastMessageUpdateLocked(planMsg)
+	b.mu.Unlock()
+
+	// Determine the "allow" and "reject" optionIds from the ACP options.
+	allowOptionId := ""
+	rejectOptionId := "plan"
+	for _, opt := range p.Options {
+		if opt.Kind == "allow_always" || opt.Kind == "allow_once" {
+			if allowOptionId == "" {
+				allowOptionId = opt.OptionId
+			}
+		}
+		if opt.OptionId == "plan" {
+			rejectOptionId = "plan"
+		}
+	}
+	if allowOptionId == "" && len(p.Options) > 0 {
+		allowOptionId = p.Options[0].OptionId
+	}
+
+	// Register an approve_plan pending action.
+	replyCh := make(chan string, 1)
+	b.actionsMu.Lock()
+	b.pendingActions = append(b.pendingActions, PendingAction{
+		Type:      ActionTypeApprovePlan,
+		ToolUseId: toolCallId,
+	})
+	b.actionReplyCh[toolCallId] = replyCh
+	b.actionsMu.Unlock()
+
+	capturedAllow := allowOptionId
+	capturedReject := rejectOptionId
+
+	go func() {
+		answer := <-replyCh
+		optionId := capturedReject
+		if answer == "approve" {
+			optionId = capturedAllow
+		}
 		_ = req.Reply(optionId)
 	}()
 }
@@ -777,4 +869,36 @@ func (b *Bridge) updateToolUseInput(toolCallId string, rawInput interface{}) {
 		b.broadcastMessageUpdateLocked(*msg)
 		return
 	}
+}
+
+// planEntriesToMarkdown converts ACP plan entries (from TodoWrite) into a markdown
+// task list suitable for display in the frontend's PlanApprovalModal.
+func planEntriesToMarkdown(entries []acp.PlanEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("## Plan\n\n")
+	for _, e := range entries {
+		var marker string
+		switch e.Status {
+		case "completed":
+			marker = "- [x]"
+		case "in_progress":
+			marker = "- [~]"
+		case "cancelled":
+			marker = "- [!]"
+		default: // "pending"
+			marker = "- [ ]"
+		}
+		priority := ""
+		switch e.Priority {
+		case "high":
+			priority = " 🔴"
+		case "low":
+			priority = " 🔵"
+		}
+		fmt.Fprintf(&sb, "%s %s%s\n", marker, e.Content, priority)
+	}
+	return sb.String()
 }

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -354,20 +354,33 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 
 	// Build frontend-compatible options (QuestionOption[]).
 	// The frontend expects { label, description } per option, NOT { id, label, description }.
-	opts := make([]frontendQuestionOption, 0, len(p.Options))
+	//
+	// Check whether the ACP agent provided any meaningful option content.
+	hasMeaningfulOptions := false
 	for _, opt := range p.Options {
-		label := opt.Label
-		if label == "" {
-			label = opt.Id // Fall back to id when label is empty.
+		if opt.Label != "" || opt.Id != "" {
+			hasMeaningfulOptions = true
+			break
 		}
-		opts = append(opts, frontendQuestionOption{
-			Label:       label,
-			Description: opt.Description,
-		})
 	}
-	// Provide sensible defaults when the ACP agent sends no options.
+
+	opts := make([]frontendQuestionOption, 0, len(p.Options))
+	if hasMeaningfulOptions {
+		for _, opt := range p.Options {
+			label := opt.Label
+			if label == "" {
+				label = opt.Id // Fall back to id when label is empty.
+			}
+			opts = append(opts, frontendQuestionOption{
+				Label:       label,
+				Description: opt.Description,
+			})
+		}
+	}
+
+	// Provide sensible defaults when the ACP agent sends no options or empty options.
 	originalOptions := p.Options
-	if len(opts) == 0 {
+	if !hasMeaningfulOptions {
 		opts = []frontendQuestionOption{
 			{Label: "Yes", Description: "Allow this action"},
 			{Label: "No, and don't ask again", Description: "Deny and remember"},

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -1,0 +1,580 @@
+// Package bridge translates between the ACP client and an agentapi-compatible
+// HTTP interface (compatible with takutakahashi/claude-agentapi).
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
+)
+
+// ----------------------------------------------------------------------------
+// agentapi-compatible types
+// ----------------------------------------------------------------------------
+
+// AgentStatus mirrors coder/agentapi status values.
+type AgentStatus string
+
+const (
+	AgentStatusRunning AgentStatus = "running"
+	AgentStatusStable  AgentStatus = "stable"
+)
+
+// MessageRole mirrors takutakahashi/claude-agentapi message roles.
+type MessageRole string
+
+const (
+	MessageRoleUser       MessageRole = "user"
+	MessageRoleAssistant  MessageRole = "assistant"
+	MessageRoleAgent      MessageRole = "agent"
+	MessageRoleToolResult MessageRole = "tool_result"
+)
+
+// MessageType mirrors takutakahashi/claude-agentapi message types.
+type MessageType string
+
+const (
+	MessageTypeNormal   MessageType = "normal"
+	MessageTypeQuestion MessageType = "question"
+	MessageTypePlan     MessageType = "plan"
+)
+
+// Message is an agentapi-compatible message entry.
+type Message struct {
+	ID              int64       `json:"id"`
+	Role            MessageRole `json:"role"`
+	Content         string      `json:"content"`
+	Time            time.Time   `json:"time"`
+	Type            MessageType `json:"type"`
+	ToolUseId       string      `json:"toolUseId,omitempty"`
+	ParentToolUseId string      `json:"parentToolUseId,omitempty"`
+	Status          string      `json:"status,omitempty"` // "success"|"error"
+}
+
+// StatusResponse mirrors coder/agentapi /status response.
+type StatusResponse struct {
+	AgentType string      `json:"agent_type"`
+	Status    AgentStatus `json:"status"`
+	Transport string      `json:"transport"`
+}
+
+// ----------------------------------------------------------------------------
+// SSE events
+// ----------------------------------------------------------------------------
+
+// EventType names the SSE event.
+type EventType string
+
+const (
+	EventTypeMessageUpdate EventType = "message_update"
+	EventTypeStatusChange  EventType = "status_change"
+	EventTypeAgentError    EventType = "agent_error"
+)
+
+// Event is a single SSE event.
+type Event struct {
+	Type EventType
+	Data interface{}
+}
+
+// MessageUpdateData is the data for message_update events.
+type MessageUpdateData struct {
+	ID      int64       `json:"id"`
+	Message string      `json:"message"`
+	Role    MessageRole `json:"role"`
+	Time    time.Time   `json:"time"`
+}
+
+// StatusChangeData is the data for status_change events.
+type StatusChangeData struct {
+	Status    AgentStatus `json:"status"`
+	AgentType string      `json:"agent_type"`
+}
+
+// AgentErrorData is the data for agent_error events.
+type AgentErrorData struct {
+	Level   string    `json:"level"`
+	Message string    `json:"message"`
+	Time    time.Time `json:"time"`
+}
+
+// ----------------------------------------------------------------------------
+// Actions (takutakahashi/claude-agentapi extension)
+// ----------------------------------------------------------------------------
+
+// ActionType names a pending action.
+type ActionType string
+
+const (
+	ActionTypeAnswerQuestion ActionType = "answer_question"
+	ActionTypeApprovePlan    ActionType = "approve_plan"
+	ActionTypeStopAgent      ActionType = "stop_agent"
+)
+
+// PendingAction is an action waiting for the HTTP client to respond.
+type PendingAction struct {
+	Type      ActionType  `json:"type"`
+	ToolUseId string      `json:"tool_use_id,omitempty"`
+	Content   interface{} `json:"content,omitempty"`
+}
+
+// PendingActionsResponse is the body for GET /action.
+type PendingActionsResponse struct {
+	PendingActions []PendingAction `json:"pending_actions"`
+}
+
+// ActionRequest is the body for POST /action.
+type ActionRequest struct {
+	Type     ActionType        `json:"type"`
+	Answers  map[string]string `json:"answers,omitempty"`  // answer_question
+	Approved *bool             `json:"approved,omitempty"` // approve_plan
+}
+
+// ----------------------------------------------------------------------------
+// subscriber
+// ----------------------------------------------------------------------------
+
+type subscriber struct {
+	ch chan Event
+}
+
+// ----------------------------------------------------------------------------
+// Bridge
+// ----------------------------------------------------------------------------
+
+// Bridge holds all state for bridging an ACP client to the agentapi HTTP interface.
+type Bridge struct {
+	acp     *acp.Client
+	verbose bool
+
+	mu       sync.RWMutex
+	status   AgentStatus
+	messages []Message
+	nextID   int64
+
+	subsMu sync.Mutex
+	subs   []*subscriber
+
+	actionsMu      sync.Mutex
+	pendingActions []PendingAction
+	actionReplyCh  map[string]chan string // toolUseId → selected optionId
+}
+
+// New creates a Bridge backed by the given ACP client.
+func New(client *acp.Client, verbose bool) *Bridge {
+	return &Bridge{
+		acp:           client,
+		verbose:       verbose,
+		status:        AgentStatusStable,
+		actionReplyCh: make(map[string]chan string),
+	}
+}
+
+// Run starts the background goroutines that consume ACP notifications and
+// feed the bridge state. Call this in a goroutine; it blocks until ctx is done.
+func (b *Bridge) Run(ctx context.Context) {
+	updates := b.acp.Updates()
+	perms := b.acp.PermissionRequests()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case update, ok := <-updates:
+			if !ok {
+				// ACP client closed – mark error
+				b.setStatus(AgentStatusStable)
+				b.broadcastError("agent connection closed")
+				return
+			}
+			b.handleUpdate(update)
+
+		case req, ok := <-perms:
+			if !ok {
+				return
+			}
+			b.handlePermissionRequest(req)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Update handling
+// ----------------------------------------------------------------------------
+
+func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
+	if b.verbose {
+		log.Printf("[bridge] update kind=%s content=%q", update.Kind, update.Content)
+	}
+
+	switch update.Kind {
+	case acp.SessionUpdateKindAgentMessageChunk:
+		b.appendOrCreateMessage(MessageRoleAgent, update.Content, MessageTypeNormal, "", "")
+
+	case acp.SessionUpdateKindAgentThoughtChunk:
+		// Thoughts are surfaced as assistant messages for transparency.
+		b.appendOrCreateMessage(MessageRoleAssistant, update.Content, MessageTypeNormal, "", "")
+
+	case acp.SessionUpdateKindToolCall:
+		// New tool invocation – create a distinct message.
+		content := fmt.Sprintf("[tool:%s] %v", update.ToolKind, update.RawInput)
+		b.addNewMessage(MessageRoleAgent, content, MessageTypeNormal, update.ToolCallId, "")
+
+	case acp.SessionUpdateKindToolCallUpdate:
+		// Update existing tool message status.
+		statusStr := string(update.Status)
+		if update.Status == acp.ToolCallStatusSuccess || update.Status == acp.ToolCallStatusError {
+			content := fmt.Sprintf("%v", update.RawOutput)
+			b.addNewMessage(MessageRoleToolResult, content, MessageTypeNormal, "", update.ToolCallId)
+			_ = statusStr
+		}
+
+	case acp.SessionUpdateKindPlan:
+		b.addNewMessage(MessageRoleAgent, update.Plan, MessageTypePlan, "", "")
+	}
+}
+
+// appendOrCreateMessage appends content to the last agent/assistant message if
+// it has the same role and is not a tool message; otherwise creates a new one.
+func (b *Bridge) appendOrCreateMessage(role MessageRole, content string, msgType MessageType, toolUseId, parentToolUseId string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if len(b.messages) > 0 {
+		last := &b.messages[len(b.messages)-1]
+		if last.Role == role && last.ToolUseId == "" && last.Type == msgType {
+			last.Content += content
+			last.Time = time.Now()
+			b.broadcastMessageUpdateLocked(*last)
+			return
+		}
+	}
+	b.nextID++
+	msg := Message{
+		ID:              b.nextID,
+		Role:            role,
+		Content:         content,
+		Time:            time.Now(),
+		Type:            msgType,
+		ToolUseId:       toolUseId,
+		ParentToolUseId: parentToolUseId,
+	}
+	b.messages = append(b.messages, msg)
+	b.broadcastMessageUpdateLocked(msg)
+}
+
+func (b *Bridge) addNewMessage(role MessageRole, content string, msgType MessageType, toolUseId, parentToolUseId string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.nextID++
+	msg := Message{
+		ID:              b.nextID,
+		Role:            role,
+		Content:         content,
+		Time:            time.Now(),
+		Type:            msgType,
+		ToolUseId:       toolUseId,
+		ParentToolUseId: parentToolUseId,
+	}
+	b.messages = append(b.messages, msg)
+	b.broadcastMessageUpdateLocked(msg)
+}
+
+// ----------------------------------------------------------------------------
+// Permission request handling
+// ----------------------------------------------------------------------------
+
+func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
+	p := req.Params
+
+	// Build the "question" message visible in the HTTP conversation.
+	questions := make([]map[string]string, 0, len(p.Options))
+	for _, opt := range p.Options {
+		questions = append(questions, map[string]string{
+			"id":          opt.Id,
+			"label":       opt.Label,
+			"description": opt.Description,
+		})
+	}
+	b.mu.Lock()
+	b.nextID++
+	qMsg := Message{
+		ID:        b.nextID,
+		Role:      MessageRoleAgent,
+		Content:   p.Description,
+		Time:      time.Now(),
+		Type:      MessageTypeQuestion,
+		ToolUseId: p.ToolCallId,
+	}
+	b.messages = append(b.messages, qMsg)
+	b.broadcastMessageUpdateLocked(qMsg)
+	b.mu.Unlock()
+
+	// Register a pending action.
+	replyCh := make(chan string, 1)
+	b.actionsMu.Lock()
+	b.pendingActions = append(b.pendingActions, PendingAction{
+		Type:      ActionTypeAnswerQuestion,
+		ToolUseId: p.ToolCallId,
+		Content: map[string]interface{}{
+			"description": p.Description,
+			"questions":   questions,
+		},
+	})
+	b.actionReplyCh[p.ToolCallId] = replyCh
+	b.actionsMu.Unlock()
+
+	// Wait for the HTTP client to POST /action and provide an answer.
+	go func() {
+		optionId := <-replyCh
+		_ = req.Reply(optionId)
+	}()
+}
+
+// ----------------------------------------------------------------------------
+// Public API (called by HTTP handlers)
+// ----------------------------------------------------------------------------
+
+// SendMessage posts a user message to the ACP agent. It sets status to
+// "running" immediately and returns; the status reverts to "stable" when
+// the agent finishes (via a goroutine watching the Prompt call).
+func (b *Bridge) SendMessage(ctx context.Context, content string) error {
+	b.mu.Lock()
+	if b.status == AgentStatusRunning {
+		b.mu.Unlock()
+		return fmt.Errorf("agent is busy")
+	}
+	// Add the user message to history.
+	b.nextID++
+	userMsg := Message{
+		ID:      b.nextID,
+		Role:    MessageRoleUser,
+		Content: content,
+		Time:    time.Now(),
+		Type:    MessageTypeNormal,
+	}
+	b.messages = append(b.messages, userMsg)
+	b.broadcastMessageUpdateLocked(userMsg)
+	b.status = AgentStatusRunning
+	b.mu.Unlock()
+
+	b.broadcast(Event{
+		Type: EventTypeStatusChange,
+		Data: StatusChangeData{Status: AgentStatusRunning, AgentType: "acp"},
+	})
+
+	// Run the prompt in the background; restore stable status when done.
+	go func() {
+		stopReason, err := b.acp.Prompt(ctx, content)
+		if err != nil {
+			log.Printf("[bridge] prompt error: %v", err)
+			b.broadcastError(err.Error())
+		}
+		if b.verbose {
+			log.Printf("[bridge] prompt done: stopReason=%s", stopReason)
+		}
+		b.setStatus(AgentStatusStable)
+	}()
+
+	return nil
+}
+
+// StopAgent cancels the current agent turn.
+func (b *Bridge) StopAgent(ctx context.Context) error {
+	return b.acp.Cancel(ctx)
+}
+
+// GetMessages returns the current conversation history.
+func (b *Bridge) GetMessages() []Message {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	result := make([]Message, len(b.messages))
+	copy(result, b.messages)
+	return result
+}
+
+// GetStatus returns the current agent status.
+func (b *Bridge) GetStatus() StatusResponse {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return StatusResponse{
+		AgentType: "acp",
+		Status:    b.status,
+		Transport: "acp",
+	}
+}
+
+// Subscribe returns a channel that receives SSE events and a cancel function.
+// On subscription, the subscriber immediately receives replayed events to
+// reconstruct the current state.
+func (b *Bridge) Subscribe() (<-chan Event, func()) {
+	sub := &subscriber{ch: make(chan Event, 128)}
+
+	b.subsMu.Lock()
+	b.subs = append(b.subs, sub)
+	b.subsMu.Unlock()
+
+	// Replay all existing messages.
+	b.mu.RLock()
+	msgs := make([]Message, len(b.messages))
+	copy(msgs, b.messages)
+	status := b.status
+	b.mu.RUnlock()
+
+	go func() {
+		for _, msg := range msgs {
+			sub.ch <- Event{
+				Type: EventTypeMessageUpdate,
+				Data: MessageUpdateData{
+					ID:      msg.ID,
+					Message: msg.Content,
+					Role:    msg.Role,
+					Time:    msg.Time,
+				},
+			}
+		}
+		sub.ch <- Event{
+			Type: EventTypeStatusChange,
+			Data: StatusChangeData{Status: status, AgentType: "acp"},
+		}
+	}()
+
+	cancel := func() {
+		b.subsMu.Lock()
+		defer b.subsMu.Unlock()
+		for i, s := range b.subs {
+			if s == sub {
+				b.subs = append(b.subs[:i], b.subs[i+1:]...)
+				break
+			}
+		}
+		close(sub.ch)
+	}
+	return sub.ch, cancel
+}
+
+// GetPendingActions returns the list of actions waiting for a user response.
+func (b *Bridge) GetPendingActions() PendingActionsResponse {
+	b.actionsMu.Lock()
+	defer b.actionsMu.Unlock()
+	result := make([]PendingAction, len(b.pendingActions))
+	copy(result, b.pendingActions)
+	return PendingActionsResponse{PendingActions: result}
+}
+
+// SubmitAction processes a user response to a pending action.
+func (b *Bridge) SubmitAction(ctx context.Context, req ActionRequest) error {
+	switch req.Type {
+	case ActionTypeStopAgent:
+		return b.StopAgent(ctx)
+
+	case ActionTypeAnswerQuestion:
+		b.actionsMu.Lock()
+		defer b.actionsMu.Unlock()
+
+		// req.Answers maps toolUseId → optionId
+		for toolUseId, optionId := range req.Answers {
+			ch, ok := b.actionReplyCh[toolUseId]
+			if !ok {
+				return fmt.Errorf("no pending action for tool_use_id %q", toolUseId)
+			}
+			ch <- optionId
+			delete(b.actionReplyCh, toolUseId)
+			// Remove from pending list.
+			b.removePendingActionLocked(toolUseId)
+		}
+		return nil
+
+	case ActionTypeApprovePlan:
+		// Find the plan action (no specific toolUseId – pick first plan).
+		b.actionsMu.Lock()
+		defer b.actionsMu.Unlock()
+		for i, pa := range b.pendingActions {
+			if pa.Type == ActionTypeApprovePlan {
+				ch, ok := b.actionReplyCh[pa.ToolUseId]
+				if ok {
+					if req.Approved != nil && *req.Approved {
+						ch <- "approve"
+					} else {
+						ch <- "reject"
+					}
+					delete(b.actionReplyCh, pa.ToolUseId)
+					b.pendingActions = append(b.pendingActions[:i], b.pendingActions[i+1:]...)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("no pending approve_plan action")
+
+	default:
+		return fmt.Errorf("unknown action type: %s", req.Type)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Internal helpers
+// ----------------------------------------------------------------------------
+
+func (b *Bridge) setStatus(s AgentStatus) {
+	b.mu.Lock()
+	b.status = s
+	b.mu.Unlock()
+	b.broadcast(Event{
+		Type: EventTypeStatusChange,
+		Data: StatusChangeData{Status: s, AgentType: "acp"},
+	})
+}
+
+func (b *Bridge) broadcastError(msg string) {
+	b.broadcast(Event{
+		Type: EventTypeAgentError,
+		Data: AgentErrorData{Level: "error", Message: msg, Time: time.Now()},
+	})
+}
+
+func (b *Bridge) broadcast(e Event) {
+	b.subsMu.Lock()
+	defer b.subsMu.Unlock()
+	for _, sub := range b.subs {
+		select {
+		case sub.ch <- e:
+		default:
+		}
+	}
+}
+
+// broadcastMessageUpdateLocked must be called with b.mu held (at least read).
+func (b *Bridge) broadcastMessageUpdateLocked(msg Message) {
+	e := Event{
+		Type: EventTypeMessageUpdate,
+		Data: MessageUpdateData{
+			ID:      msg.ID,
+			Message: msg.Content,
+			Role:    msg.Role,
+			Time:    msg.Time,
+		},
+	}
+	b.subsMu.Lock()
+	defer b.subsMu.Unlock()
+	for _, sub := range b.subs {
+		select {
+		case sub.ch <- e:
+		default:
+		}
+	}
+}
+
+func (b *Bridge) removePendingActionLocked(toolUseId string) {
+	for i, pa := range b.pendingActions {
+		if pa.ToolUseId == toolUseId {
+			b.pendingActions = append(b.pendingActions[:i], b.pendingActions[i+1:]...)
+			return
+		}
+	}
+}

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -243,9 +243,7 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 		b.appendOrCreateMessage(MessageRoleAgent, text, MessageTypeNormal, "", "")
 
 	case acp.SessionUpdateKindAgentThoughtChunk:
-		// Thoughts are surfaced as assistant messages for transparency.
-		text := acp.ExtractTextContent(update.Content)
-		b.appendOrCreateMessage(MessageRoleAssistant, text, MessageTypeNormal, "", "")
+		// Thinking/reasoning content – intentionally not surfaced to the frontend.
 
 	case acp.SessionUpdateKindToolCall:
 		// New tool invocation – serialize as JSON string matching claude-agentapi format.

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -262,11 +262,22 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 		b.addNewMessage(MessageRoleAgent, string(toolJSON), MessageTypeNormal, update.ToolCallId, "")
 
 	case acp.SessionUpdateKindToolCallUpdate:
-		// Add a tool_result message when the tool finishes.
-		if update.Status == acp.ToolCallStatusSuccess || update.Status == acp.ToolCallStatusError {
-			statusStr := "success"
-			if update.Status == acp.ToolCallStatusError {
-				statusStr = "error"
+		// If rawInput is provided, refine the existing tool_use message.
+		// claude-agent-acp sends an initial tool_call with empty input (streaming start),
+		// then a tool_call_update with the actual input once the full params are known.
+		if update.RawInput != nil {
+			b.updateToolUseInput(update.ToolCallId, update.RawInput)
+		}
+
+		// Map status: ACP spec uses "success"/"error", claude-agent-acp uses "completed"/"failed".
+		statusStr := string(update.Status)
+		isSuccess := update.Status == acp.ToolCallStatusSuccess || statusStr == "completed"
+		isError := update.Status == acp.ToolCallStatusError || statusStr == "failed"
+
+		if isSuccess || isError {
+			resolvedStatus := "success"
+			if isError {
+				resolvedStatus = "error"
 			}
 			// Serialize raw output as string content.
 			var content string
@@ -286,7 +297,7 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 				Time:            time.Now(),
 				Type:            MessageTypeNormal,
 				ParentToolUseId: update.ToolCallId,
-				Status:          statusStr,
+				Status:          resolvedStatus,
 			}
 			b.messages = append(b.messages, msg)
 			b.broadcastMessageUpdateLocked(msg)
@@ -728,5 +739,39 @@ func (b *Bridge) removePendingActionLocked(toolUseId string) {
 			b.pendingActions = append(b.pendingActions[:i], b.pendingActions[i+1:]...)
 			return
 		}
+	}
+}
+
+// updateToolUseInput refines the input of an existing tool_use message.
+// claude-agent-acp emits an initial tool_call with empty input during streaming,
+// then sends a tool_call_update with the full rawInput once the block is complete.
+func (b *Bridge) updateToolUseInput(toolCallId string, rawInput interface{}) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for i := len(b.messages) - 1; i >= 0; i-- {
+		msg := &b.messages[i]
+		if msg.ToolUseId != toolCallId {
+			continue
+		}
+		// Parse the existing content JSON.
+		var toolObj map[string]interface{}
+		if err := json.Unmarshal([]byte(msg.Content), &toolObj); err != nil {
+			return
+		}
+		// Only update if the current input is nil/empty.
+		if existing, ok := toolObj["input"]; ok {
+			if m, ok := existing.(map[string]interface{}); ok && len(m) > 0 {
+				return // already has input, don't overwrite
+			}
+		}
+		toolObj["input"] = rawInput
+		updated, err := json.Marshal(toolObj)
+		if err != nil {
+			return
+		}
+		msg.Content = string(updated)
+		b.broadcastMessageUpdateLocked(*msg)
+		return
 	}
 }

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -364,12 +364,13 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 	p := req.Params
 
 	// Build frontend-compatible options (QuestionOption[]).
-	// The frontend expects { label, description } per option, NOT { id, label, description }.
+	// The frontend expects { label, description } per option.
+	// ACP options have: { kind, name, optionId }.
 	//
 	// Check whether the ACP agent provided any meaningful option content.
 	hasMeaningfulOptions := false
 	for _, opt := range p.Options {
-		if opt.Label != "" || opt.Id != "" {
+		if opt.Name != "" || opt.OptionId != "" {
 			hasMeaningfulOptions = true
 			break
 		}
@@ -378,13 +379,13 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 	opts := make([]frontendQuestionOption, 0, len(p.Options))
 	if hasMeaningfulOptions {
 		for _, opt := range p.Options {
-			label := opt.Label
+			label := opt.Name
 			if label == "" {
-				label = opt.Id // Fall back to id when label is empty.
+				label = opt.OptionId // Fall back to optionId when name is empty.
 			}
 			opts = append(opts, frontendQuestionOption{
 				Label:       label,
-				Description: opt.Description,
+				Description: "",
 			})
 		}
 	}
@@ -398,16 +399,17 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 			{Label: "No", Description: "Deny this action"},
 		}
 		originalOptions = []acp.PermissionOption{
-			{Id: "yes", Label: "Yes"},
-			{Id: "no_dont_ask", Label: "No, and don't ask again"},
-			{Id: "no", Label: "No"},
+			{OptionId: "yes", Name: "Yes"},
+			{OptionId: "no_dont_ask", Name: "No, and don't ask again"},
+			{OptionId: "no", Name: "No"},
 		}
 	}
 
-	desc := p.Description
-	if desc == "" {
-		desc = "Permission required"
-	}
+	// Use the toolCallId from the nested toolCall object.
+	toolCallId := p.ToolCall.ToolCallId
+
+	// Build a human-readable description from the options or use a default.
+	desc := "Permission required"
 
 	// Build one Question object (frontend type).
 	question := frontendQuestion{
@@ -425,7 +427,7 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 		Content:   desc,
 		Time:      time.Now(),
 		Type:      MessageTypeQuestion,
-		ToolUseId: p.ToolCallId,
+		ToolUseId: toolCallId,
 	}
 	b.messages = append(b.messages, qMsg)
 	b.broadcastMessageUpdateLocked(qMsg)
@@ -436,14 +438,14 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 	b.actionsMu.Lock()
 	b.pendingActions = append(b.pendingActions, PendingAction{
 		Type:      ActionTypeAnswerQuestion,
-		ToolUseId: p.ToolCallId,
+		ToolUseId: toolCallId,
 		Content: map[string]interface{}{
 			"questions": []frontendQuestion{question},
 		},
 	})
-	b.actionReplyCh[p.ToolCallId] = replyCh
+	b.actionReplyCh[toolCallId] = replyCh
 	// Store the original options so we can map label → optionId when the user answers.
-	b.permOptionMaps[p.ToolCallId] = originalOptions
+	b.permOptionMaps[toolCallId] = originalOptions
 	b.actionsMu.Unlock()
 
 	// Wait for the HTTP client to POST /action and provide an answer.
@@ -623,12 +625,13 @@ func (b *Bridge) SubmitAction(ctx context.Context, req ActionRequest) error {
 				toolUseId := pendingQToolUseIds[idx]
 
 				// Map the selected label back to the original ACP option ID.
+				// ACP options have Name (display) and OptionId (machine id).
 				optionId := selectedLabel // Default: use label as ID.
 				if opts, ok := b.permOptionMaps[toolUseId]; ok {
 					for _, opt := range opts {
-						if opt.Label == selectedLabel {
-							if opt.Id != "" {
-								optionId = opt.Id
+						if opt.Name == selectedLabel {
+							if opt.OptionId != "" {
+								optionId = opt.OptionId
 							}
 							break
 						}

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -4,6 +4,7 @@ package bridge
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"sync"
@@ -53,6 +54,7 @@ type Message struct {
 	ToolUseId       string      `json:"toolUseId,omitempty"`
 	ParentToolUseId string      `json:"parentToolUseId,omitempty"`
 	Status          string      `json:"status,omitempty"` // "success"|"error"
+	Error           string      `json:"error,omitempty"`  // present when status=="error"
 }
 
 // StatusResponse mirrors coder/agentapi /status response.
@@ -82,12 +84,9 @@ type Event struct {
 }
 
 // MessageUpdateData is the data for message_update events.
-type MessageUpdateData struct {
-	ID      int64       `json:"id"`
-	Message string      `json:"message"`
-	Role    MessageRole `json:"role"`
-	Time    time.Time   `json:"time"`
-}
+// It sends the full Message object (matching takutakahashi/claude-agentapi format).
+// The content key is "content" (not "message") as expected by the frontend.
+type MessageUpdateData = Message
 
 // StatusChangeData is the data for status_change events.
 type StatusChangeData struct {
@@ -230,17 +229,50 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 		b.appendOrCreateMessage(MessageRoleAssistant, text, MessageTypeNormal, "", "")
 
 	case acp.SessionUpdateKindToolCall:
-		// New tool invocation – create a distinct message.
-		content := fmt.Sprintf("[tool:%s] %v", update.ToolKind, update.RawInput)
-		b.addNewMessage(MessageRoleAgent, content, MessageTypeNormal, update.ToolCallId, "")
+		// New tool invocation – serialize as JSON string matching claude-agentapi format.
+		// Frontend expects: {"type":"tool_use","name":"<kind>","id":"<toolCallId>","input":{...}}
+		toolObj := map[string]interface{}{
+			"type":  "tool_use",
+			"name":  update.ToolKind,
+			"id":    update.ToolCallId,
+			"input": update.RawInput,
+		}
+		toolJSON, err := json.Marshal(toolObj)
+		if err != nil {
+			toolJSON = []byte(fmt.Sprintf(`{"type":"tool_use","name":%q,"id":%q}`, update.ToolKind, update.ToolCallId))
+		}
+		b.addNewMessage(MessageRoleAgent, string(toolJSON), MessageTypeNormal, update.ToolCallId, "")
 
 	case acp.SessionUpdateKindToolCallUpdate:
-		// Update existing tool message status.
-		statusStr := string(update.Status)
+		// Add a tool_result message when the tool finishes.
 		if update.Status == acp.ToolCallStatusSuccess || update.Status == acp.ToolCallStatusError {
-			content := fmt.Sprintf("%v", update.RawOutput)
-			b.addNewMessage(MessageRoleToolResult, content, MessageTypeNormal, "", update.ToolCallId)
-			_ = statusStr
+			statusStr := "success"
+			if update.Status == acp.ToolCallStatusError {
+				statusStr = "error"
+			}
+			// Serialize raw output as string content.
+			var content string
+			if update.RawOutput != nil {
+				if b, err := json.Marshal(update.RawOutput); err == nil {
+					content = string(b)
+				} else {
+					content = fmt.Sprintf("%v", update.RawOutput)
+				}
+			}
+			b.mu.Lock()
+			b.nextID++
+			msg := Message{
+				ID:              b.nextID,
+				Role:            MessageRoleToolResult,
+				Content:         content,
+				Time:            time.Now(),
+				Type:            MessageTypeNormal,
+				ParentToolUseId: update.ToolCallId,
+				Status:          statusStr,
+			}
+			b.messages = append(b.messages, msg)
+			b.broadcastMessageUpdateLocked(msg)
+			b.mu.Unlock()
 		}
 
 	case acp.SessionUpdateKindPlan:
@@ -445,12 +477,7 @@ func (b *Bridge) Subscribe() (<-chan Event, func()) {
 		for _, msg := range msgs {
 			sub.ch <- Event{
 				Type: EventTypeMessageUpdate,
-				Data: MessageUpdateData{
-					ID:      msg.ID,
-					Message: msg.Content,
-					Role:    msg.Role,
-					Time:    msg.Time,
-				},
+				Data: msg, // Full Message object
 			}
 		}
 		sub.ch <- Event{
@@ -567,12 +594,7 @@ func (b *Bridge) broadcast(e Event) {
 func (b *Bridge) broadcastMessageUpdateLocked(msg Message) {
 	e := Event{
 		Type: EventTypeMessageUpdate,
-		Data: MessageUpdateData{
-			ID:      msg.ID,
-			Message: msg.Content,
-			Role:    msg.Role,
-			Time:    msg.Time,
-		},
+		Data: msg, // Send full Message object (matches takutakahashi/claude-agentapi format)
 	}
 	b.subsMu.Lock()
 	defer b.subsMu.Unlock()

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 	"time"
 
@@ -121,6 +122,21 @@ type PendingAction struct {
 	Content   interface{} `json:"content,omitempty"`
 }
 
+// frontendQuestionOption matches the QuestionOption interface in the frontend.
+type frontendQuestionOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// frontendQuestion matches the Question interface in the frontend
+// (src/types/agentapi.ts: { question, header, options, multiSelect }).
+type frontendQuestion struct {
+	Question    string                   `json:"question"`
+	Header      string                   `json:"header"`
+	Options     []frontendQuestionOption `json:"options"`
+	MultiSelect bool                     `json:"multiSelect"`
+}
+
 // PendingActionsResponse is the body for GET /action.
 type PendingActionsResponse struct {
 	PendingActions []PendingAction `json:"pending_actions"`
@@ -164,16 +180,18 @@ type Bridge struct {
 
 	actionsMu      sync.Mutex
 	pendingActions []PendingAction
-	actionReplyCh  map[string]chan string // toolUseId → selected optionId
+	actionReplyCh  map[string]chan string            // toolUseId → selected optionId
+	permOptionMaps map[string][]acp.PermissionOption // toolUseId → original ACP options (for label→id mapping)
 }
 
 // New creates a Bridge backed by the given ACP client.
 func New(client *acp.Client, verbose bool) *Bridge {
 	return &Bridge{
-		acp:           client,
-		verbose:       verbose,
-		status:        AgentStatusStable,
-		actionReplyCh: make(map[string]chan string),
+		acp:            client,
+		verbose:        verbose,
+		status:         AgentStatusStable,
+		actionReplyCh:  make(map[string]chan string),
+		permOptionMaps: make(map[string][]acp.PermissionOption),
 	}
 }
 
@@ -334,21 +352,53 @@ func (b *Bridge) addNewMessage(role MessageRole, content string, msgType Message
 func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 	p := req.Params
 
-	// Build the "question" message visible in the HTTP conversation.
-	questions := make([]map[string]string, 0, len(p.Options))
+	// Build frontend-compatible options (QuestionOption[]).
+	// The frontend expects { label, description } per option, NOT { id, label, description }.
+	opts := make([]frontendQuestionOption, 0, len(p.Options))
 	for _, opt := range p.Options {
-		questions = append(questions, map[string]string{
-			"id":          opt.Id,
-			"label":       opt.Label,
-			"description": opt.Description,
+		label := opt.Label
+		if label == "" {
+			label = opt.Id // Fall back to id when label is empty.
+		}
+		opts = append(opts, frontendQuestionOption{
+			Label:       label,
+			Description: opt.Description,
 		})
 	}
+	// Provide sensible defaults when the ACP agent sends no options.
+	originalOptions := p.Options
+	if len(opts) == 0 {
+		opts = []frontendQuestionOption{
+			{Label: "Yes", Description: "Allow this action"},
+			{Label: "No, and don't ask again", Description: "Deny and remember"},
+			{Label: "No", Description: "Deny this action"},
+		}
+		originalOptions = []acp.PermissionOption{
+			{Id: "yes", Label: "Yes"},
+			{Id: "no_dont_ask", Label: "No, and don't ask again"},
+			{Id: "no", Label: "No"},
+		}
+	}
+
+	desc := p.Description
+	if desc == "" {
+		desc = "Permission required"
+	}
+
+	// Build one Question object (frontend type).
+	question := frontendQuestion{
+		Question:    desc,
+		Header:      "Permission Required",
+		Options:     opts,
+		MultiSelect: false,
+	}
+
 	b.mu.Lock()
 	b.nextID++
 	qMsg := Message{
 		ID:        b.nextID,
 		Role:      MessageRoleAgent,
-		Content:   p.Description,
+		Content:   desc,
 		Time:      time.Now(),
 		Type:      MessageTypeQuestion,
 		ToolUseId: p.ToolCallId,
@@ -364,11 +414,12 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 		Type:      ActionTypeAnswerQuestion,
 		ToolUseId: p.ToolCallId,
 		Content: map[string]interface{}{
-			"description": p.Description,
-			"questions":   questions,
+			"questions": []frontendQuestion{question},
 		},
 	})
 	b.actionReplyCh[p.ToolCallId] = replyCh
+	// Store the original options so we can map label → optionId when the user answers.
+	b.permOptionMaps[p.ToolCallId] = originalOptions
 	b.actionsMu.Unlock()
 
 	// Wait for the HTTP client to POST /action and provide an answer.
@@ -519,16 +570,68 @@ func (b *Bridge) SubmitAction(ctx context.Context, req ActionRequest) error {
 		b.actionsMu.Lock()
 		defer b.actionsMu.Unlock()
 
-		// req.Answers maps toolUseId → optionId
-		for toolUseId, optionId := range req.Answers {
-			ch, ok := b.actionReplyCh[toolUseId]
-			if !ok {
-				return fmt.Errorf("no pending action for tool_use_id %q", toolUseId)
+		// The frontend sends answers as {"0": "optionLabel"} (question index → label).
+		// The legacy format is {toolUseId: optionId}.
+		// Detect format by checking whether all keys are numeric.
+		allNumeric := len(req.Answers) > 0
+		for k := range req.Answers {
+			if _, err := strconv.Atoi(k); err != nil {
+				allNumeric = false
+				break
 			}
-			ch <- optionId
-			delete(b.actionReplyCh, toolUseId)
-			// Remove from pending list.
-			b.removePendingActionLocked(toolUseId)
+		}
+
+		if allNumeric {
+			// New format from frontend: question index → selected option label.
+			// Collect pending answer_question actions in insertion order.
+			pendingQToolUseIds := make([]string, 0)
+			for _, pa := range b.pendingActions {
+				if pa.Type == ActionTypeAnswerQuestion {
+					pendingQToolUseIds = append(pendingQToolUseIds, pa.ToolUseId)
+				}
+			}
+
+			for idxStr, selectedLabel := range req.Answers {
+				idx, _ := strconv.Atoi(idxStr)
+				if idx >= len(pendingQToolUseIds) {
+					return fmt.Errorf("no pending action at question index %d", idx)
+				}
+				toolUseId := pendingQToolUseIds[idx]
+
+				// Map the selected label back to the original ACP option ID.
+				optionId := selectedLabel // Default: use label as ID.
+				if opts, ok := b.permOptionMaps[toolUseId]; ok {
+					for _, opt := range opts {
+						if opt.Label == selectedLabel {
+							if opt.Id != "" {
+								optionId = opt.Id
+							}
+							break
+						}
+					}
+					delete(b.permOptionMaps, toolUseId)
+				}
+
+				ch, ok := b.actionReplyCh[toolUseId]
+				if !ok {
+					return fmt.Errorf("no pending action for question index %d", idx)
+				}
+				ch <- optionId
+				delete(b.actionReplyCh, toolUseId)
+				b.removePendingActionLocked(toolUseId)
+			}
+		} else {
+			// Legacy format: toolUseId → optionId.
+			for toolUseId, optionId := range req.Answers {
+				ch, ok := b.actionReplyCh[toolUseId]
+				if !ok {
+					return fmt.Errorf("no pending action for tool_use_id %q", toolUseId)
+				}
+				ch <- optionId
+				delete(b.actionReplyCh, toolUseId)
+				delete(b.permOptionMaps, toolUseId)
+				b.removePendingActionLocked(toolUseId)
+			}
 		}
 		return nil
 

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -1,0 +1,295 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// Server is an agentapi-compatible HTTP server backed by a Bridge.
+// It exposes the following endpoints (compatible with takutakahashi/claude-agentapi):
+//
+//	GET  /health
+//	GET  /status
+//	GET  /messages
+//	POST /message
+//	GET  /events   (SSE)
+//	GET  /action
+//	POST /action
+type Server struct {
+	bridge  *Bridge
+	echo    *echo.Echo
+	verbose bool
+}
+
+// NewServer creates a new HTTP server wrapping the given Bridge.
+func NewServer(b *Bridge, verbose bool) *Server {
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+
+	e.Use(middleware.Recover())
+	e.Use(middleware.CORS())
+	if verbose {
+		e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+			LogStatus: true,
+			LogURI:    true,
+			LogMethod: true,
+			LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+				log.Printf("[acp-server] %s %s -> %d", v.Method, v.URI, v.Status)
+				return nil
+			},
+		}))
+	}
+
+	s := &Server{bridge: b, echo: e, verbose: verbose}
+	s.registerRoutes()
+	return s
+}
+
+func (s *Server) registerRoutes() {
+	s.echo.GET("/health", s.handleHealth)
+	s.echo.GET("/status", s.handleStatus)
+	s.echo.GET("/messages", s.handleGetMessages)
+	s.echo.POST("/message", s.handlePostMessage)
+	s.echo.GET("/events", s.handleEvents)
+	s.echo.GET("/action", s.handleGetAction)
+	s.echo.POST("/action", s.handlePostAction)
+}
+
+// Start starts the HTTP server on the given address (e.g. ":3284").
+// It blocks until ctx is cancelled.
+func (s *Server) Start(ctx context.Context, addr string) error {
+	errCh := make(chan error, 1)
+	go func() {
+		if err := s.echo.Start(addr); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*1e9) // 5s
+		defer cancel()
+		return s.echo.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return err
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Handlers
+// ----------------------------------------------------------------------------
+
+// GET /health
+func (s *Server) handleHealth(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// GET /status
+func (s *Server) handleStatus(c echo.Context) error {
+	return c.JSON(http.StatusOK, s.bridge.GetStatus())
+}
+
+// GET /messages
+//
+// Query parameters (takutakahashi/claude-agentapi compatible):
+//
+//	limit     int    – max messages to return (default 50)
+//	direction string – "head" | "tail" (default "tail")
+//	around    int    – message ID to centre the window on
+//	context   int    – number of messages before/after `around` (default 10)
+//	after     int    – cursor: messages with ID > after
+//	before    int    – cursor: messages with ID < before
+func (s *Server) handleGetMessages(c echo.Context) error {
+	all := s.bridge.GetMessages()
+
+	limit := 50
+	if v := c.QueryParam("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	direction := c.QueryParam("direction")
+	if direction == "" {
+		direction = "tail"
+	}
+
+	// Cursor filters
+	if after := c.QueryParam("after"); after != "" {
+		if id, err := strconv.ParseInt(after, 10, 64); err == nil {
+			filtered := all[:0]
+			for _, m := range all {
+				if m.ID > id {
+					filtered = append(filtered, m)
+				}
+			}
+			all = filtered
+		}
+	}
+	if before := c.QueryParam("before"); before != "" {
+		if id, err := strconv.ParseInt(before, 10, 64); err == nil {
+			filtered := all[:0]
+			for _, m := range all {
+				if m.ID < id {
+					filtered = append(filtered, m)
+				}
+			}
+			all = filtered
+		}
+	}
+
+	// around / context window
+	if aroundStr := c.QueryParam("around"); aroundStr != "" {
+		if aroundID, err := strconv.ParseInt(aroundStr, 10, 64); err == nil {
+			ctx := 10
+			if v := c.QueryParam("context"); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+					ctx = n
+				}
+			}
+			centerIdx := -1
+			for i, m := range all {
+				if m.ID == aroundID {
+					centerIdx = i
+					break
+				}
+			}
+			if centerIdx >= 0 {
+				start := centerIdx - ctx
+				if start < 0 {
+					start = 0
+				}
+				end := centerIdx + ctx + 1
+				if end > len(all) {
+					end = len(all)
+				}
+				all = all[start:end]
+			}
+		}
+	}
+
+	total := len(all)
+	hasMore := false
+
+	if direction == "tail" {
+		if len(all) > limit {
+			all = all[len(all)-limit:]
+			hasMore = true
+		}
+	} else {
+		if len(all) > limit {
+			all = all[:limit]
+			hasMore = true
+		}
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"messages": all,
+		"total":    total,
+		"hasMore":  hasMore,
+	})
+}
+
+// postMessageRequest is the body for POST /message.
+type postMessageRequest struct {
+	Content string `json:"content"`
+	Type    string `json:"type"` // "user" | "raw"
+}
+
+// POST /message
+func (s *Server) handlePostMessage(c echo.Context) error {
+	var req postMessageRequest
+	if err := c.Bind(&req); err != nil {
+		return problemJSON(c, http.StatusBadRequest, "invalid request body", err.Error())
+	}
+	if req.Content == "" {
+		return problemJSON(c, http.StatusBadRequest, "content is required", "")
+	}
+
+	// "raw" type is not applicable for ACP (no PTY) – treat same as user.
+	if err := s.bridge.SendMessage(c.Request().Context(), req.Content); err != nil {
+		if err.Error() == "agent is busy" {
+			return problemJSON(c, http.StatusConflict, "agent is busy", "wait for status to become stable")
+		}
+		return problemJSON(c, http.StatusInternalServerError, "failed to send message", err.Error())
+	}
+
+	return c.JSON(http.StatusOK, map[string]bool{"ok": true})
+}
+
+// GET /events – Server-Sent Events
+func (s *Server) handleEvents(c echo.Context) error {
+	w := c.Response()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	ch, cancel := s.bridge.Subscribe()
+	defer cancel()
+
+	flusher, ok := w.Writer.(http.Flusher)
+
+	ctx := c.Request().Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, open := <-ch:
+			if !open {
+				return nil
+			}
+			data, err := json.Marshal(event.Data)
+			if err != nil {
+				continue
+			}
+			_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, data)
+			if ok {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// GET /action
+func (s *Server) handleGetAction(c echo.Context) error {
+	return c.JSON(http.StatusOK, s.bridge.GetPendingActions())
+}
+
+// POST /action
+func (s *Server) handlePostAction(c echo.Context) error {
+	var req ActionRequest
+	if err := c.Bind(&req); err != nil {
+		return problemJSON(c, http.StatusBadRequest, "invalid request body", err.Error())
+	}
+
+	if err := s.bridge.SubmitAction(c.Request().Context(), req); err != nil {
+		return problemJSON(c, http.StatusBadRequest, "action failed", err.Error())
+	}
+	return c.JSON(http.StatusOK, map[string]bool{"ok": true})
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+// problemJSON returns an RFC 9457 problem detail response.
+func problemJSON(c echo.Context, status int, title, detail string) error {
+	body := map[string]interface{}{
+		"type":   fmt.Sprintf("https://httpstatuses.io/%d", status),
+		"title":  title,
+		"status": status,
+	}
+	if detail != "" {
+		body["detail"] = detail
+	}
+	return c.JSON(status, body)
+}

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -159,6 +159,9 @@ func (c *Client) Initialize(ctx context.Context) error {
 
 // NewSession creates a new ACP session and stores the session ID.
 func (c *Client) NewSession(ctx context.Context, cwd string, mcpServers []McpServer) error {
+	if mcpServers == nil {
+		mcpServers = []McpServer{}
+	}
 	params := SessionNewParams{
 		Cwd:        cwd,
 		McpServers: mcpServers,

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -12,7 +12,8 @@ import (
 )
 
 // ProtocolVersion is the ACP version this client targets.
-const ProtocolVersion = "0.1"
+// Per spec: uint16, only bumped for breaking changes.
+const ProtocolVersion = 0
 
 // PermissionRequest is an inbound permission request from the agent.
 type PermissionRequest struct {
@@ -151,7 +152,7 @@ func (c *Client) Initialize(ctx context.Context) error {
 		return fmt.Errorf("acp initialize: parse result: %w", err)
 	}
 	if c.verbose {
-		log.Printf("[acp] initialized: protocol=%s agentCaps=%+v", result.ProtocolVersion, result.AgentCapabilities)
+		log.Printf("[acp] initialized: protocol=%d agentCaps=%+v", result.ProtocolVersion, result.AgentCapabilities)
 	}
 	return nil
 }

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -85,9 +85,14 @@ func (c *Client) registerHandlers() {
 		select {
 		case c.permCh <- req:
 		default:
-			// If nobody is listening, auto-deny with first option.
+			// If nobody is listening, auto-approve with first option.
 			if len(p.Options) > 0 {
-				return RequestPermissionResult{OptionId: p.Options[0].Id}, nil
+				return RequestPermissionResult{
+					Outcome: RequestPermissionOutcome{
+						Outcome:  "selected",
+						OptionId: p.Options[0].OptionId,
+					},
+				}, nil
 			}
 			return nil, fmt.Errorf("no options available")
 		}
@@ -95,9 +100,16 @@ func (c *Client) registerHandlers() {
 		// Wait for the reply (or context cancellation).
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return RequestPermissionResult{
+				Outcome: RequestPermissionOutcome{Outcome: "cancelled"},
+			}, nil
 		case optionId := <-replyCh:
-			return RequestPermissionResult{OptionId: optionId}, nil
+			return RequestPermissionResult{
+				Outcome: RequestPermissionOutcome{
+					Outcome:  "selected",
+					OptionId: optionId,
+				},
+			}, nil
 		}
 	})
 

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -1,0 +1,227 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp/jsonrpc"
+)
+
+// ProtocolVersion is the ACP version this client targets.
+const ProtocolVersion = "0.1"
+
+// PermissionRequest is an inbound permission request from the agent.
+type PermissionRequest struct {
+	Params RequestPermissionParams
+	// Reply must be called exactly once to unblock the agent.
+	Reply func(optionId string) error
+}
+
+// Client is a high-level ACP client backed by a JSON-RPC 2.0 connection.
+// It manages the lifecycle of a single ACP session.
+type Client struct {
+	rpc     *jsonrpc.Client
+	verbose bool
+
+	sessionId string
+
+	// updateCh is closed when the client is stopped.
+	updateCh chan SessionUpdate
+	// permCh receives inbound permission requests from the agent.
+	permCh chan PermissionRequest
+}
+
+// NewClient creates an ACP client using the given reader (agent stdout) and
+// writer (agent stdin).
+func NewClient(r io.Reader, w io.Writer, verbose bool) *Client {
+	c := &Client{
+		rpc:      jsonrpc.New(r, w, verbose),
+		verbose:  verbose,
+		updateCh: make(chan SessionUpdate, 64),
+		permCh:   make(chan PermissionRequest, 8),
+	}
+	c.registerHandlers()
+	return c
+}
+
+// registerHandlers wires up the inbound handlers before Listen is called.
+func (c *Client) registerHandlers() {
+	// session/update notifications (agent→client)
+	c.rpc.RegisterNotificationHandler("session/update", func(raw json.RawMessage) {
+		var n SessionUpdateNotification
+		if err := json.Unmarshal(raw, &n); err != nil {
+			log.Printf("[acp] session/update parse error: %v", err)
+			return
+		}
+		select {
+		case c.updateCh <- n.Update:
+		default:
+			log.Printf("[acp] updateCh full, dropping update kind=%s", n.Update.Kind)
+		}
+	})
+
+	// session/request_permission (agent→client, bidirectional RPC)
+	c.rpc.RegisterRequestHandler("session/request_permission", func(ctx context.Context, raw json.RawMessage) (interface{}, error) {
+		var p RequestPermissionParams
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("parse request_permission: %w", err)
+		}
+
+		// We use a reply channel so the bridge can asynchronously respond.
+		replyCh := make(chan string, 1)
+		req := PermissionRequest{
+			Params: p,
+			Reply: func(optionId string) error {
+				replyCh <- optionId
+				return nil
+			},
+		}
+
+		select {
+		case c.permCh <- req:
+		default:
+			// If nobody is listening, auto-deny with first option.
+			if len(p.Options) > 0 {
+				return RequestPermissionResult{OptionId: p.Options[0].Id}, nil
+			}
+			return nil, fmt.Errorf("no options available")
+		}
+
+		// Wait for the reply (or context cancellation).
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case optionId := <-replyCh:
+			return RequestPermissionResult{OptionId: optionId}, nil
+		}
+	})
+
+	// fs/read_text_file (agent→client, bidirectional RPC)
+	c.rpc.RegisterRequestHandler("fs/read_text_file", func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+		var p FsReadTextFileParams
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("parse fs/read_text_file: %w", err)
+		}
+		data, err := os.ReadFile(p.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read file %s: %w", p.Path, err)
+		}
+		return FsReadTextFileResult{Text: string(data)}, nil
+	})
+
+	// fs/write_text_file (agent→client, bidirectional RPC)
+	c.rpc.RegisterRequestHandler("fs/write_text_file", func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+		var p FsWriteTextFileParams
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("parse fs/write_text_file: %w", err)
+		}
+		if err := os.WriteFile(p.Path, []byte(p.Text), 0644); err != nil {
+			return nil, fmt.Errorf("write file %s: %w", p.Path, err)
+		}
+		return FsWriteTextFileResult{}, nil
+	})
+}
+
+// Listen starts the read loop. It blocks until the context is cancelled or
+// the underlying connection closes. Call this in a goroutine.
+func (c *Client) Listen(ctx context.Context) error {
+	err := c.rpc.Listen(ctx)
+	close(c.updateCh)
+	return err
+}
+
+// Initialize performs the ACP handshake. Must be called before any other method.
+func (c *Client) Initialize(ctx context.Context) error {
+	params := InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		ClientCapabilities: ClientCapabilities{
+			Filesystem: &FilesystemCapability{Enabled: true},
+		},
+	}
+	raw, err := c.rpc.Call(ctx, "initialize", params)
+	if err != nil {
+		return fmt.Errorf("acp initialize: %w", err)
+	}
+	var result InitializeResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return fmt.Errorf("acp initialize: parse result: %w", err)
+	}
+	if c.verbose {
+		log.Printf("[acp] initialized: protocol=%s agentCaps=%+v", result.ProtocolVersion, result.AgentCapabilities)
+	}
+	return nil
+}
+
+// NewSession creates a new ACP session and stores the session ID.
+func (c *Client) NewSession(ctx context.Context, cwd string, mcpServers []McpServer) error {
+	params := SessionNewParams{
+		Cwd:        cwd,
+		McpServers: mcpServers,
+	}
+	raw, err := c.rpc.Call(ctx, "session/new", params)
+	if err != nil {
+		return fmt.Errorf("acp session/new: %w", err)
+	}
+	var result SessionNewResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return fmt.Errorf("acp session/new: parse result: %w", err)
+	}
+	c.sessionId = result.SessionId
+	if c.verbose {
+		log.Printf("[acp] session created: id=%s modes=%v", result.SessionId, result.Modes)
+	}
+	return nil
+}
+
+// SessionID returns the current session ID (set after NewSession).
+func (c *Client) SessionID() string {
+	return c.sessionId
+}
+
+// Prompt sends a user message and returns when the agent has finished the turn.
+// While the agent is working, session/update notifications are dispatched to
+// the channel returned by Updates().
+func (c *Client) Prompt(ctx context.Context, text string) (StopReason, error) {
+	if c.sessionId == "" {
+		return "", fmt.Errorf("acp: no active session; call NewSession first")
+	}
+	params := PromptParams{
+		SessionId: c.sessionId,
+		Prompt: []ContentBlock{
+			{Type: ContentBlockTypeText, Text: text},
+		},
+	}
+	raw, err := c.rpc.Call(ctx, "session/prompt", params)
+	if err != nil {
+		return StopReasonCancelled, fmt.Errorf("acp session/prompt: %w", err)
+	}
+	var result PromptResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("acp session/prompt: parse result: %w", err)
+	}
+	return result.StopReason, nil
+}
+
+// Cancel sends a session/cancel notification to abort the current turn.
+func (c *Client) Cancel(ctx context.Context) error {
+	if c.sessionId == "" {
+		return nil
+	}
+	return c.rpc.Notify("session/cancel", SessionCancelParams{SessionId: c.sessionId})
+}
+
+// Updates returns a channel that receives session/update notifications from
+// the agent. The channel is closed when the client stops.
+func (c *Client) Updates() <-chan SessionUpdate {
+	return c.updateCh
+}
+
+// PermissionRequests returns a channel that receives inbound permission
+// requests from the agent.
+func (c *Client) PermissionRequests() <-chan PermissionRequest {
+	return c.permCh
+}

--- a/pkg/acp/jsonrpc/client.go
+++ b/pkg/acp/jsonrpc/client.go
@@ -1,0 +1,253 @@
+// Package jsonrpc implements a JSON-RPC 2.0 client over an io.ReadWriter (e.g. stdio).
+// It supports bidirectional RPC: both the caller and the remote peer can initiate requests,
+// and either side may send notifications (messages without an id).
+package jsonrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+	"sync/atomic"
+)
+
+// ----------------------------------------------------------------------------
+// Wire types
+// ----------------------------------------------------------------------------
+
+// Message is the union type for all JSON-RPC 2.0 messages.
+type Message struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method,omitempty"`
+	Params  json.RawMessage  `json:"params,omitempty"`
+	Result  json.RawMessage  `json:"result,omitempty"`
+	Error   *RPCError        `json:"error,omitempty"`
+}
+
+// RPCError is a JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("json-rpc error %d: %s", e.Code, e.Message)
+}
+
+// ----------------------------------------------------------------------------
+// Handler types
+// ----------------------------------------------------------------------------
+
+// RequestHandler handles an inbound request from the remote peer.
+// It must return a result (to be serialised) or an error.
+type RequestHandler func(ctx context.Context, params json.RawMessage) (interface{}, error)
+
+// NotificationHandler handles an inbound notification (no response expected).
+type NotificationHandler func(params json.RawMessage)
+
+// ----------------------------------------------------------------------------
+// Client
+// ----------------------------------------------------------------------------
+
+// Client is a bidirectional JSON-RPC 2.0 client that communicates over a
+// pair of io.Reader/io.Writer (typically stdin/stdout of a subprocess).
+type Client struct {
+	encoder *json.Encoder
+	decoder *json.Decoder
+
+	mu     sync.Mutex // guards encoder
+	nextID atomic.Int64
+
+	pendingMu sync.Mutex
+	pending   map[string]chan *Message // id → response channel
+
+	reqHandlers   map[string]RequestHandler
+	notifHandlers map[string]NotificationHandler
+
+	verbose bool
+}
+
+// New creates a new Client.
+func New(r io.Reader, w io.Writer, verbose bool) *Client {
+	return &Client{
+		encoder:       json.NewEncoder(w),
+		decoder:       json.NewDecoder(r),
+		pending:       make(map[string]chan *Message),
+		reqHandlers:   make(map[string]RequestHandler),
+		notifHandlers: make(map[string]NotificationHandler),
+		verbose:       verbose,
+	}
+}
+
+// RegisterRequestHandler registers a handler for inbound requests from the
+// remote peer (bidirectional RPC – the peer initiates the call).
+func (c *Client) RegisterRequestHandler(method string, h RequestHandler) {
+	c.reqHandlers[method] = h
+}
+
+// RegisterNotificationHandler registers a handler for inbound notifications.
+func (c *Client) RegisterNotificationHandler(method string, h NotificationHandler) {
+	c.notifHandlers[method] = h
+}
+
+// Call sends a JSON-RPC request and waits for the response.
+func (c *Client) Call(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+	id := c.nextID.Add(1)
+	idStr := fmt.Sprintf("%d", id)
+	idRaw, _ := json.Marshal(idStr)
+
+	paramBytes, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("jsonrpc: marshal params: %w", err)
+	}
+
+	msg := Message{
+		JSONRPC: "2.0",
+		ID:      (*json.RawMessage)(&idRaw),
+		Method:  method,
+		Params:  paramBytes,
+	}
+
+	replyCh := make(chan *Message, 1)
+	c.pendingMu.Lock()
+	c.pending[idStr] = replyCh
+	c.pendingMu.Unlock()
+
+	if err := c.send(msg); err != nil {
+		c.pendingMu.Lock()
+		delete(c.pending, idStr)
+		c.pendingMu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case <-ctx.Done():
+		c.pendingMu.Lock()
+		delete(c.pending, idStr)
+		c.pendingMu.Unlock()
+		return nil, ctx.Err()
+	case reply := <-replyCh:
+		if reply.Error != nil {
+			return nil, reply.Error
+		}
+		return reply.Result, nil
+	}
+}
+
+// Notify sends a JSON-RPC notification (no id, no response expected).
+func (c *Client) Notify(method string, params interface{}) error {
+	paramBytes, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("jsonrpc: marshal params: %w", err)
+	}
+	msg := Message{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  paramBytes,
+	}
+	return c.send(msg)
+}
+
+// Respond sends a JSON-RPC response to a remote request.
+func (c *Client) Respond(id json.RawMessage, result interface{}, rpcErr *RPCError) error {
+	msg := Message{
+		JSONRPC: "2.0",
+		ID:      (*json.RawMessage)(&id),
+	}
+	if rpcErr != nil {
+		msg.Error = rpcErr
+	} else {
+		b, err := json.Marshal(result)
+		if err != nil {
+			return fmt.Errorf("jsonrpc: marshal result: %w", err)
+		}
+		msg.Result = b
+	}
+	return c.send(msg)
+}
+
+func (c *Client) send(msg Message) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.verbose {
+		b, _ := json.Marshal(msg)
+		log.Printf("[jsonrpc] --> %s", b)
+	}
+	return c.encoder.Encode(msg)
+}
+
+// Listen starts the receive loop. It blocks until the context is cancelled or
+// the underlying reader returns an error (e.g. EOF on process exit).
+// Call this in a goroutine.
+func (c *Client) Listen(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		var msg Message
+		if err := c.decoder.Decode(&msg); err != nil {
+			if err == io.EOF {
+				return fmt.Errorf("jsonrpc: connection closed")
+			}
+			return fmt.Errorf("jsonrpc: decode: %w", err)
+		}
+
+		if c.verbose {
+			b, _ := json.Marshal(msg)
+			log.Printf("[jsonrpc] <-- %s", b)
+		}
+
+		c.dispatch(ctx, &msg)
+	}
+}
+
+func (c *Client) dispatch(ctx context.Context, msg *Message) {
+	switch {
+	// Response to one of our outgoing calls
+	case msg.ID != nil && msg.Method == "":
+		idStr := ""
+		_ = json.Unmarshal(*msg.ID, &idStr)
+		c.pendingMu.Lock()
+		ch, ok := c.pending[idStr]
+		if ok {
+			delete(c.pending, idStr)
+		}
+		c.pendingMu.Unlock()
+		if ok {
+			ch <- msg
+		}
+
+	// Inbound request from the remote peer (bidirectional RPC)
+	case msg.ID != nil && msg.Method != "":
+		id := *msg.ID
+		h, ok := c.reqHandlers[msg.Method]
+		if !ok {
+			_ = c.Respond(id, nil, &RPCError{
+				Code:    -32601,
+				Message: "Method not found: " + msg.Method,
+			})
+			return
+		}
+		go func() {
+			result, err := h(ctx, msg.Params)
+			if err != nil {
+				_ = c.Respond(id, nil, &RPCError{Code: -32000, Message: err.Error()})
+				return
+			}
+			_ = c.Respond(id, result, nil)
+		}()
+
+	// Notification (no id)
+	case msg.ID == nil && msg.Method != "":
+		if h, ok := c.notifHandlers[msg.Method]; ok {
+			go h(msg.Params)
+		}
+	}
+}

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -206,6 +206,14 @@ const (
 	ToolCallStatusCancelled ToolCallStatus = "cancelled"
 )
 
+// PlanEntry is a single entry in an ACP plan update.
+// See ACP spec: sessionUpdate="plan" entries field.
+type PlanEntry struct {
+	Content  string `json:"content"`
+	Status   string `json:"status"`   // "pending", "in_progress", "completed", "cancelled"
+	Priority string `json:"priority"` // "high", "medium", "low"
+}
+
 // SessionUpdate is a discriminated union; Kind determines which fields apply.
 type SessionUpdate struct {
 	// Discriminant field
@@ -224,8 +232,8 @@ type SessionUpdate struct {
 	Status    ToolCallStatus `json:"status,omitempty"`
 	RawOutput interface{}    `json:"rawOutput,omitempty"`
 
-	// plan
-	Plan string `json:"plan,omitempty"`
+	// plan – ACP sends entries (structured list), not a plain string.
+	Entries []PlanEntry `json:"entries,omitempty"`
 
 	// session_info_update
 	Title string `json:"title,omitempty"`
@@ -277,7 +285,9 @@ type PermissionOption struct {
 
 // RequestPermissionToolCall contains the tool call details nested in RequestPermissionParams.
 type RequestPermissionToolCall struct {
-	ToolCallId string `json:"toolCallId"`
+	ToolCallId string          `json:"toolCallId"`
+	Kind       string          `json:"kind,omitempty"`     // e.g. "switch_mode" for ExitPlanMode
+	RawInput   json.RawMessage `json:"rawInput,omitempty"` // raw tool input JSON
 }
 
 // RequestPermissionParams is the params for "session/request_permission"

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -42,13 +42,13 @@ type TerminalCapability struct {
 
 // InitializeParams is the params for the "initialize" request (client→agent).
 type InitializeParams struct {
-	ProtocolVersion    string             `json:"protocolVersion"`
+	ProtocolVersion    int                `json:"protocolVersion"`
 	ClientCapabilities ClientCapabilities `json:"clientCapabilities"`
 }
 
 // InitializeResult is the response to "initialize".
 type InitializeResult struct {
-	ProtocolVersion   string            `json:"protocolVersion"`
+	ProtocolVersion   int               `json:"protocolVersion"`
 	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
 }
 

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -1,0 +1,278 @@
+// Package acp provides types and a client for the Agent Client Protocol (ACP).
+// Spec: https://github.com/agentclientprotocol/agent-client-protocol
+package acp
+
+import "time"
+
+// ----------------------------------------------------------------------------
+// Capabilities
+// ----------------------------------------------------------------------------
+
+// ClientCapabilities describes what the client supports.
+type ClientCapabilities struct {
+	// Filesystem access (fs/read_text_file, fs/write_text_file)
+	Filesystem *FilesystemCapability `json:"filesystem,omitempty"`
+	// Terminal management
+	Terminal *TerminalCapability `json:"terminal,omitempty"`
+}
+
+// AgentCapabilities describes what the agent supports.
+type AgentCapabilities struct {
+	// Session restore / load
+	SessionLoad bool `json:"sessionLoad,omitempty"`
+	// Image content blocks in prompts
+	Image bool `json:"image,omitempty"`
+	// Audio content blocks in prompts
+	Audio bool `json:"audio,omitempty"`
+}
+
+// FilesystemCapability indicates the client can handle fs requests.
+type FilesystemCapability struct {
+	Enabled bool `json:"enabled"`
+}
+
+// TerminalCapability indicates the client can handle terminal requests.
+type TerminalCapability struct {
+	Enabled bool `json:"enabled"`
+}
+
+// ----------------------------------------------------------------------------
+// Initialization
+// ----------------------------------------------------------------------------
+
+// InitializeParams is the params for the "initialize" request (client→agent).
+type InitializeParams struct {
+	ProtocolVersion    string             `json:"protocolVersion"`
+	ClientCapabilities ClientCapabilities `json:"clientCapabilities"`
+}
+
+// InitializeResult is the response to "initialize".
+type InitializeResult struct {
+	ProtocolVersion   string            `json:"protocolVersion"`
+	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
+}
+
+// ----------------------------------------------------------------------------
+// Session management
+// ----------------------------------------------------------------------------
+
+// McpServer describes an MCP server to connect to.
+type McpServer struct {
+	Name    string   `json:"name"`
+	Command string   `json:"command"`
+	Args    []string `json:"args,omitempty"`
+}
+
+// SessionNewParams is the params for "session/new" (client→agent).
+type SessionNewParams struct {
+	Cwd        string      `json:"cwd"`
+	McpServers []McpServer `json:"mcpServers,omitempty"`
+}
+
+// Mode is an agent operating mode.
+type Mode struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// ConfigOption is a runtime config option offered by the agent.
+type ConfigOption struct {
+	Key         string      `json:"key"`
+	Description string      `json:"description,omitempty"`
+	Default     interface{} `json:"default,omitempty"`
+}
+
+// SessionNewResult is the response to "session/new".
+type SessionNewResult struct {
+	SessionId     string         `json:"sessionId"`
+	Modes         []Mode         `json:"modes,omitempty"`
+	ConfigOptions []ConfigOption `json:"configOptions,omitempty"`
+}
+
+// SessionInfo describes a session returned by "session/list".
+type SessionInfo struct {
+	SessionId string    `json:"sessionId"`
+	Cwd       string    `json:"cwd"`
+	Title     string    `json:"title,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt,omitempty"`
+}
+
+// SessionListResult is the response to "session/list".
+type SessionListResult struct {
+	Sessions []SessionInfo `json:"sessions"`
+}
+
+// SessionSetModeParams is the params for "session/set_mode".
+type SessionSetModeParams struct {
+	SessionId string `json:"sessionId"`
+	Mode      string `json:"mode"`
+}
+
+// ----------------------------------------------------------------------------
+// Prompt
+// ----------------------------------------------------------------------------
+
+// ContentBlockType distinguishes prompt content blocks.
+type ContentBlockType string
+
+const (
+	ContentBlockTypeText         ContentBlockType = "text"
+	ContentBlockTypeImage        ContentBlockType = "image"
+	ContentBlockTypeAudio        ContentBlockType = "audio"
+	ContentBlockTypeResource     ContentBlockType = "resource"
+	ContentBlockTypeResourceLink ContentBlockType = "resource_link"
+)
+
+// ContentBlock is a single element of a prompt.
+type ContentBlock struct {
+	Type ContentBlockType `json:"type"`
+
+	// type=text
+	Text string `json:"text,omitempty"`
+
+	// type=image
+	MimeType string `json:"mimeType,omitempty"`
+	Data     string `json:"data,omitempty"` // base64
+
+	// type=resource_link
+	URI   string `json:"uri,omitempty"`
+	Title string `json:"title,omitempty"`
+}
+
+// PromptParams is the params for "session/prompt" (client→agent).
+type PromptParams struct {
+	SessionId string         `json:"sessionId"`
+	Prompt    []ContentBlock `json:"prompt"`
+}
+
+// StopReason describes why an agent turn ended.
+type StopReason string
+
+const (
+	StopReasonEndTurn         StopReason = "end_turn"
+	StopReasonMaxTokens       StopReason = "max_tokens"
+	StopReasonRefusal         StopReason = "refusal"
+	StopReasonCancelled       StopReason = "cancelled"
+	StopReasonMaxTurnRequests StopReason = "max_turn_requests"
+)
+
+// PromptResult is the response to "session/prompt".
+type PromptResult struct {
+	StopReason StopReason `json:"stopReason"`
+}
+
+// SessionCancelParams is the params for "session/cancel" notification.
+type SessionCancelParams struct {
+	SessionId string `json:"sessionId"`
+}
+
+// ----------------------------------------------------------------------------
+// Session updates (notifications: session/update)
+// ----------------------------------------------------------------------------
+
+// SessionUpdateKind is the discriminant for SessionUpdate.
+type SessionUpdateKind string
+
+const (
+	SessionUpdateKindUserMessageChunk        SessionUpdateKind = "user_message_chunk"
+	SessionUpdateKindAgentMessageChunk       SessionUpdateKind = "agent_message_chunk"
+	SessionUpdateKindAgentThoughtChunk       SessionUpdateKind = "agent_thought_chunk"
+	SessionUpdateKindToolCall                SessionUpdateKind = "tool_call"
+	SessionUpdateKindToolCallUpdate          SessionUpdateKind = "tool_call_update"
+	SessionUpdateKindPlan                    SessionUpdateKind = "plan"
+	SessionUpdateKindAvailableCommandsUpdate SessionUpdateKind = "available_commands_update"
+	SessionUpdateKindSessionInfoUpdate       SessionUpdateKind = "session_info_update"
+	SessionUpdateKindCurrentModeUpdate       SessionUpdateKind = "current_mode_update"
+)
+
+// ToolCallStatus describes the lifecycle state of a tool call.
+type ToolCallStatus string
+
+const (
+	ToolCallStatusRunning   ToolCallStatus = "running"
+	ToolCallStatusSuccess   ToolCallStatus = "success"
+	ToolCallStatusError     ToolCallStatus = "error"
+	ToolCallStatusCancelled ToolCallStatus = "cancelled"
+)
+
+// SessionUpdate is a discriminated union; Kind determines which fields apply.
+type SessionUpdate struct {
+	// Discriminant field
+	Kind SessionUpdateKind `json:"sessionUpdate"`
+
+	// agent_message_chunk / user_message_chunk / agent_thought_chunk
+	Content string `json:"content,omitempty"`
+
+	// tool_call
+	ToolCallId string      `json:"toolCallId,omitempty"`
+	ToolKind   string      `json:"kind,omitempty"` // e.g. "bash", "edit", ...
+	RawInput   interface{} `json:"rawInput,omitempty"`
+
+	// tool_call_update
+	Status    ToolCallStatus `json:"status,omitempty"`
+	RawOutput interface{}    `json:"rawOutput,omitempty"`
+
+	// plan
+	Plan string `json:"plan,omitempty"`
+
+	// session_info_update
+	Title string `json:"title,omitempty"`
+
+	// current_mode_update
+	Mode string `json:"mode,omitempty"`
+}
+
+// SessionUpdateNotification is the params for the "session/update" notification
+// sent from agent→client.
+type SessionUpdateNotification struct {
+	SessionId string        `json:"sessionId"`
+	Update    SessionUpdate `json:"update"`
+}
+
+// ----------------------------------------------------------------------------
+// Permission request (agent→client bidirectional RPC)
+// ----------------------------------------------------------------------------
+
+// PermissionOption is one choice the user can make.
+type PermissionOption struct {
+	Id          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+// RequestPermissionParams is the params for "session/request_permission"
+// (agent→client request).
+type RequestPermissionParams struct {
+	SessionId   string             `json:"sessionId"`
+	ToolCallId  string             `json:"toolCallId"`
+	Description string             `json:"description"`
+	Options     []PermissionOption `json:"options"`
+}
+
+// RequestPermissionResult is the response to "session/request_permission".
+type RequestPermissionResult struct {
+	OptionId string `json:"optionId"`
+}
+
+// ----------------------------------------------------------------------------
+// Filesystem requests (agent→client bidirectional RPC)
+// ----------------------------------------------------------------------------
+
+// FsReadTextFileParams is the params for "fs/read_text_file".
+type FsReadTextFileParams struct {
+	Path string `json:"path"`
+}
+
+// FsReadTextFileResult is the result of "fs/read_text_file".
+type FsReadTextFileResult struct {
+	Text string `json:"text"`
+}
+
+// FsWriteTextFileParams is the params for "fs/write_text_file".
+type FsWriteTextFileParams struct {
+	Path string `json:"path"`
+	Text string `json:"text"`
+}
+
+// FsWriteTextFileResult is the result of "fs/write_text_file".
+type FsWriteTextFileResult struct{}

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -268,24 +268,36 @@ func ExtractTextContent(raw json.RawMessage) string {
 // ----------------------------------------------------------------------------
 
 // PermissionOption is one choice the user can make.
+// Field names match the ACP spec: optionId (identifier) and name (display label).
 type PermissionOption struct {
-	Id          string `json:"id"`
-	Label       string `json:"label"`
-	Description string `json:"description,omitempty"`
+	Kind     string `json:"kind,omitempty"` // "allow_always", "allow_once", "reject_once"
+	Name     string `json:"name"`           // human-readable display label
+	OptionId string `json:"optionId"`       // machine identifier sent back in the response
+}
+
+// RequestPermissionToolCall contains the tool call details nested in RequestPermissionParams.
+type RequestPermissionToolCall struct {
+	ToolCallId string `json:"toolCallId"`
 }
 
 // RequestPermissionParams is the params for "session/request_permission"
 // (agent→client request).
 type RequestPermissionParams struct {
-	SessionId   string             `json:"sessionId"`
-	ToolCallId  string             `json:"toolCallId"`
-	Description string             `json:"description"`
-	Options     []PermissionOption `json:"options"`
+	SessionId string                    `json:"sessionId"`
+	Options   []PermissionOption        `json:"options"`
+	ToolCall  RequestPermissionToolCall `json:"toolCall"`
+}
+
+// RequestPermissionOutcome is the inner outcome object of RequestPermissionResult.
+type RequestPermissionOutcome struct {
+	Outcome  string `json:"outcome"`            // "selected" or "cancelled"
+	OptionId string `json:"optionId,omitempty"` // set when outcome="selected"
 }
 
 // RequestPermissionResult is the response to "session/request_permission".
+// The ACP spec requires: {outcome: {outcome: "selected", optionId: "<id>"}}
 type RequestPermissionResult struct {
-	OptionId string `json:"optionId"`
+	Outcome RequestPermissionOutcome `json:"outcome"`
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -66,7 +66,7 @@ type McpServer struct {
 // SessionNewParams is the params for "session/new" (client→agent).
 type SessionNewParams struct {
 	Cwd        string      `json:"cwd"`
-	McpServers []McpServer `json:"mcpServers,omitempty"`
+	McpServers []McpServer `json:"mcpServers"`
 }
 
 // Mode is an agent operating mode.

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -69,10 +69,18 @@ type SessionNewParams struct {
 	McpServers []McpServer `json:"mcpServers"`
 }
 
-// Mode is an agent operating mode.
-type Mode struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+// SessionMode is a single mode available in a session.
+type SessionMode struct {
+	Id          string  `json:"id"`
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+}
+
+// SessionModeState is the modes object returned in session/new response.
+// Per spec: modes is an object with currentModeId and availableModes, not a flat array.
+type SessionModeState struct {
+	CurrentModeId  string        `json:"currentModeId"`
+	AvailableModes []SessionMode `json:"availableModes"`
 }
 
 // ConfigOption is a runtime config option offered by the agent.
@@ -84,9 +92,9 @@ type ConfigOption struct {
 
 // SessionNewResult is the response to "session/new".
 type SessionNewResult struct {
-	SessionId     string         `json:"sessionId"`
-	Modes         []Mode         `json:"modes,omitempty"`
-	ConfigOptions []ConfigOption `json:"configOptions,omitempty"`
+	SessionId     string            `json:"sessionId"`
+	Modes         *SessionModeState `json:"modes,omitempty"`
+	ConfigOptions []ConfigOption    `json:"configOptions,omitempty"`
 }
 
 // SessionInfo describes a session returned by "session/list".

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -2,7 +2,10 @@
 // Spec: https://github.com/agentclientprotocol/agent-client-protocol
 package acp
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ----------------------------------------------------------------------------
 // Capabilities
@@ -209,7 +212,8 @@ type SessionUpdate struct {
 	Kind SessionUpdateKind `json:"sessionUpdate"`
 
 	// agent_message_chunk / user_message_chunk / agent_thought_chunk
-	Content string `json:"content,omitempty"`
+	// Content is a ContentBlock object (not a string) per ACP spec.
+	Content json.RawMessage `json:"content,omitempty"`
 
 	// tool_call
 	ToolCallId string      `json:"toolCallId,omitempty"`
@@ -235,6 +239,28 @@ type SessionUpdate struct {
 type SessionUpdateNotification struct {
 	SessionId string        `json:"sessionId"`
 	Update    SessionUpdate `json:"update"`
+}
+
+// ContentBlockText is the text variant of a ContentBlock (type="text").
+type ContentBlockText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ExtractTextContent extracts the text string from a raw ContentBlock JSON value.
+// If the block is not a text block or is invalid, returns an empty string.
+func ExtractTextContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var block ContentBlockText
+	if err := json.Unmarshal(raw, &block); err != nil {
+		return ""
+	}
+	if block.Type != "text" {
+		return ""
+	}
+	return block.Text
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -578,6 +578,18 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	case "codex-agentapi":
 		return "bunx", []string{"@takutakahashi/codex-agentapi"}
 
+	case "claude-acp":
+		// Start the acp-server bridge that wraps claude-agent-acp (ACP agent) via stdio.
+		// The bridge exposes an agentapi-compatible HTTP server on AGENTAPI_PORT.
+		// claude-agent-acp is the official ACP adapter for the Claude Agent SDK:
+		// https://github.com/agentclientprotocol/claude-agent-acp
+		return "agentapi-proxy", []string{
+			"acp-server",
+			"--port", agentapiPort,
+			"--",
+			"bunx", "@agentclientprotocol/claude-agent-acp",
+		}
+
 	default:
 		// Default: agentapi server wrapping claude
 		claudeCmd := "claude"


### PR DESCRIPTION
## Summary

- **新サブコマンド `acp-server`** を追加。ACP (Agent Client Protocol) 準拠のエージェントを stdio で起動し、`takutakahashi/claude-agentapi` / `coder/agentapi` 互換の HTTP API として公開する。
- **新エージェントタイプ `claude-acp`** を追加。`@agentclientprotocol/claude-agent-acp` (Claude Agent SDK の ACP アダプタ) を `acp-server` ブリッジ経由で使用する。

### 追加パッケージ (acp-server)
- `pkg/acp/jsonrpc`: bidirectional JSON-RPC 2.0 クライアント (stdio over `io.Reader`/`io.Writer`)
- `pkg/acp`: ACP プロトコル型 + 高レベルクライアント (`initialize`, `session/new`, `session/prompt`, `session/cancel`, `fs/read_text_file`, `fs/write_text_file`, `session/request_permission`)
- `pkg/acp/bridge`: ACP 通知 → agentapi messages/SSE events 変換ブリッジ + HTTP サーバー

### 公開エンドポイント (acp-server)

| Method | Path | 説明 |
|--------|------|------|
| GET | `/health` | ヘルスチェック |
| GET | `/status` | エージェントステータス (`running`\|`stable`, `transport: "acp"`) |
| GET | `/messages` | 会話履歴 (ページネーション付き) |
| POST | `/message` | ユーザーメッセージ送信 |
| GET | `/events` | SSE ストリーム (`message_update`, `status_change`, `agent_error`) |
| GET | `/action` | ペンディングアクション一覧 (permission requests) |
| POST | `/action` | アクション応答 (`answer_question`, `approve_plan`, `stop_agent`) |

### `claude-acp` エージェントタイプ

セッション作成時に `params.agent_type = "claude-acp"` を指定すると、provisioner が以下を実行する:

```
agentapi-proxy acp-server --port $AGENTAPI_PORT -- bunx @agentclientprotocol/claude-agent-acp
```

これにより、Claude Agent SDK ベースの ACP エージェントがセッションの HTTP バックエンドとして動作する。

変更ファイル:
- `pkg/provisioner/provision.go`: `buildAgentCommand()` に `claude-acp` ケース追加
- `internal/infrastructure/services/kubernetes_session_manager.go`: startup config に `claude-acp` ケース追加
- `cmd/helpers_generate_setting.go`: `buildStartupConfig()` に `claude-acp` ケース追加

### スタンドアロン使用例

```bash
# claude-agent-acp を stdio で起動し HTTP API として公開
agentapi-proxy acp-server --port 3284 -- bunx @agentclientprotocol/claude-agent-acp
```

## Test plan

- [x] `go build ./...` 成功
- [x] `make lint` 0 issues
- [x] `go test ./...` 全パス
- [ ] ACP エージェントとの実結合テスト
- [ ] `claude-acp` エージェントタイプでのセッション作成テスト

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)