### PR TITLE
fix: update next execution time even when session launch fails

### DIFF
--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -178,6 +178,8 @@ func (w *Worker) executeSchedule(ctx context.Context, schedule *Schedule) {
 			Status:     "failed",
 			Error:      err.Error(),
 		})
+		// Update next execution time even on failure to prevent retrying every check interval
+		w.updateNextExecution(ctx, schedule)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- セッション起動失敗時に `updateNextExecution` が呼ばれていなかったバグを修正
- `NextExecutionAt` が更新されないまま残ることで、ワーカーの次回チェック（30秒後）でも「due」と判定され、毎30秒リトライされていた
- 失敗時にも `updateNextExecution` を呼ぶことで、次の cron スロットまで待機するよう修正

## 修正前の挙動

`0 * * * *` のスケジュールで起動失敗が続いた場合：
- 13:00:00 → 失敗、NextExecutionAt = 13:00:00 のまま
- 13:00:30 → また due → また失敗（毎30秒繰り返し → 1時間に120回）

## 修正後の挙動

- 13:00:00 → 失敗、updateNextExecution → NextExecutionAt = 14:00:00
- 13:00:30 〜 13:59:30 → due にならない
- 14:00:00 → 次の実行

## Test plan

- [ ] `go test ./pkg/schedule/...` がすべて PASS することを確認（済み）
- [ ] 失敗ケースで NextExecutionAt が正しく次のスロットに更新されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)