### PR TITLE
fix: resolve Asia/Tokyo timezone failure causing infinite schedule execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex && \
 FROM ubuntu:24.04
 
 # Install essential packages: ca-certificates, curl, bash, git, make, sudo, jq, procps, and GitHub CLI
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	_ "time/tzdata" // embed IANA timezone database so time.LoadLocation works in containers without tzdata installed
 
 	"github.com/spf13/cobra"
 	"github.com/takutakahashi/agentapi-proxy/cmd"

--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -331,6 +331,17 @@ func (w *Worker) updateNextExecution(ctx context.Context, schedule *Schedule) {
 	if err != nil {
 		log.Printf("[SCHEDULE_WORKER] Failed to calculate next execution for schedule %s: %v",
 			schedule.ID, err)
+		// Push the next execution time into the future to prevent infinite retry loops.
+		// Without this, the schedule would remain perpetually "due" and be re-executed
+		// every check interval (e.g. every 30 seconds) due to the calculation failure.
+		fallback := time.Now().Add(time.Hour)
+		if updateErr := w.manager.UpdateNextExecution(ctx, schedule.ID, fallback); updateErr != nil {
+			log.Printf("[SCHEDULE_WORKER] Failed to set fallback next execution for schedule %s: %v",
+				schedule.ID, updateErr)
+		} else {
+			log.Printf("[SCHEDULE_WORKER] Set fallback next execution for schedule %s to %v (1h delay due to calculation error)",
+				schedule.ID, fallback)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary

- `Asia/Tokyo` タイムゾーンを使ったスケジュールが30秒ごとに無限に実行される問題を修正
- 根本原因: コンテナ（Ubuntu 24.04）に `tzdata` パッケージが未インストールのため `time.LoadLocation("Asia/Tokyo")` が失敗する
- 失敗後 `updateNextExecution()` が `NextExecutionAt` を更新せずに `return` するため、スケジュールが永遠に「期限切れ」状態になり無限ループが発生

## 修正内容

1. **`main.go`**: `import _ "time/tzdata"` を追加し、IANAタイムゾーンデータをバイナリに埋め込む（OSの `tzdata` インストール状況に依存しなくなる）
2. **`Dockerfile`**: `tzdata` パッケージを `apt-get install` に追加（多重防御）
3. **`pkg/schedule/worker.go`**: `updateNextExecution()` でエラー時に `NextExecutionAt` を1時間後に設定し、無限リトライループを防止

## Test plan

- [x] `make lint` パス
- [x] `make test` パス（全テスト通過）
- [ ] タイムゾーンを含むスケジュールが正しく次回実行時刻を計算できることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)