### PR TITLE
feat: MCP OAuth 2.1 PKCE flow with DCR for remote MCP server auth

### DIFF
--- a/internal/app/mcp_oauth.go
+++ b/internal/app/mcp_oauth.go
@@ -86,7 +86,7 @@ func (s *Server) handleMCPOAuthConnect(c echo.Context) error {
 	})
 	if err != nil {
 		log.Printf("[MCP-OAUTH] connect error for user=%s server=%s: %v", user.ID(), req.ServerName, err)
-		return echo.NewHTTPError(http.StatusBadGateway, friendlyOAuthError(err))
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, friendlyOAuthError(err))
 	}
 
 	return c.JSON(http.StatusOK, MCPOAuthConnectResponse{

--- a/internal/app/mcp_oauth.go
+++ b/internal/app/mcp_oauth.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"bytes"
+	"html/template"
+	"log"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/mcpoauth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/mcpoauth/callbackui"
+)
+
+// MCPOAuthConnectRequest is the body for POST /mcp-oauth/connect.
+type MCPOAuthConnectRequest struct {
+	// ServerName is the key in the user's mcp_servers settings map.
+	ServerName string `json:"server_name"`
+	// MCPServerURL is the remote MCP server URL (required).
+	MCPServerURL string `json:"mcp_server_url"`
+	// ClientID overrides DCR (optional).
+	ClientID string `json:"client_id,omitempty"`
+	// ClientSecret is used for confidential clients (optional).
+	ClientSecret string `json:"client_secret,omitempty"`
+	// Scopes is the list of OAuth scopes to request (optional).
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// MCPOAuthConnectResponse is returned by POST /mcp-oauth/connect.
+type MCPOAuthConnectResponse struct {
+	AuthorizationURL string `json:"authorization_url"`
+	State            string `json:"state"`
+}
+
+// MCPOAuthStatusResponse is returned by GET /mcp-oauth/status/:serverName.
+type MCPOAuthStatusResponse struct {
+	ServerName      string `json:"server_name"`
+	Connected       bool   `json:"connected"`
+	ExpiresAt       string `json:"expires_at,omitempty"`
+	HasRefreshToken bool   `json:"has_refresh_token"`
+}
+
+// setupMCPOAuthRoutes registers all MCP OAuth endpoints.
+func (s *Server) setupMCPOAuthRoutes() {
+	// Authenticated endpoints.
+	s.echo.POST("/mcp-oauth/connect", s.handleMCPOAuthConnect,
+		auth.RequirePermission(entities.PermissionSessionRead, s.container.AuthService))
+	s.echo.GET("/mcp-oauth/status/:serverName", s.handleMCPOAuthStatus,
+		auth.RequirePermission(entities.PermissionSessionRead, s.container.AuthService))
+	s.echo.DELETE("/mcp-oauth/disconnect/:serverName", s.handleMCPOAuthDisconnect,
+		auth.RequirePermission(entities.PermissionSessionRead, s.container.AuthService))
+
+	// Callback is unauthenticated (browser redirect from OAuth provider).
+	s.echo.GET("/mcp-oauth/callback", s.handleMCPOAuthCallback)
+
+	log.Println("[MCP-OAUTH] Routes registered: /mcp-oauth/connect, /mcp-oauth/callback, /mcp-oauth/status/:serverName, /mcp-oauth/disconnect/:serverName")
+}
+
+// handleMCPOAuthConnect begins the OAuth flow and returns the authorization URL.
+func (s *Server) handleMCPOAuthConnect(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.ErrUnauthorized
+	}
+
+	var req MCPOAuthConnectRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if req.ServerName == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "server_name is required")
+	}
+	if req.MCPServerURL == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "mcp_server_url is required")
+	}
+
+	result, err := s.mcpOAuthManager.Connect(c.Request().Context(), mcpoauth.ConnectRequest{
+		UserID:       string(user.ID()),
+		ServerName:   req.ServerName,
+		MCPServerURL: req.MCPServerURL,
+		ClientID:     req.ClientID,
+		ClientSecret: req.ClientSecret,
+		Scopes:       req.Scopes,
+	})
+	if err != nil {
+		log.Printf("[MCP-OAUTH] connect error for user=%s server=%s: %v", user.ID(), req.ServerName, err)
+		return echo.NewHTTPError(http.StatusBadGateway, "OAuth discovery failed: "+err.Error())
+	}
+
+	return c.JSON(http.StatusOK, MCPOAuthConnectResponse{
+		AuthorizationURL: result.AuthorizationURL,
+		State:            result.State,
+	})
+}
+
+// handleMCPOAuthCallback receives the authorization code redirect and exchanges it for tokens.
+func (s *Server) handleMCPOAuthCallback(c echo.Context) error {
+	code := c.QueryParam("code")
+	state := c.QueryParam("state")
+	errParam := c.QueryParam("error")
+
+	if errParam != "" {
+		desc := c.QueryParam("error_description")
+		if desc == "" {
+			desc = errParam
+		}
+		return c.HTML(http.StatusOK, renderCallbackHTML("", desc))
+	}
+	if code == "" || state == "" {
+		return c.HTML(http.StatusBadRequest, renderCallbackHTML("", "missing code or state parameter"))
+	}
+
+	token, err := s.mcpOAuthManager.HandleCallback(c.Request().Context(), code, state)
+	if err != nil {
+		log.Printf("[MCP-OAUTH] callback error: %v", err)
+		return c.HTML(http.StatusOK, renderCallbackHTML("", err.Error()))
+	}
+
+	return c.HTML(http.StatusOK, renderCallbackHTML(token.ServerName(), ""))
+}
+
+// handleMCPOAuthStatus returns the connection status for a specific MCP server.
+func (s *Server) handleMCPOAuthStatus(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.ErrUnauthorized
+	}
+	serverName := c.Param("serverName")
+
+	token, err := s.mcpOAuthTokenRepo.FindByUserAndServer(c.Request().Context(), string(user.ID()), serverName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resp := MCPOAuthStatusResponse{ServerName: serverName}
+	if token != nil && !token.IsEmpty() {
+		resp.Connected = true
+		resp.HasRefreshToken = token.RefreshToken() != ""
+		if !token.ExpiresAt().IsZero() {
+			resp.ExpiresAt = token.ExpiresAt().UTC().Format("2006-01-02T15:04:05Z")
+		}
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+// handleMCPOAuthDisconnect removes the stored token for a specific MCP server.
+func (s *Server) handleMCPOAuthDisconnect(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.ErrUnauthorized
+	}
+	serverName := c.Param("serverName")
+
+	if err := s.mcpOAuthTokenRepo.Delete(c.Request().Context(), string(user.ID()), serverName); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// ---- helpers ----
+
+type callbackTemplateData struct {
+	ServerName string
+	Error      string
+}
+
+var callbackTmpl = template.Must(template.New("callback").Parse(callbackui.CallbackHTML))
+
+func renderCallbackHTML(serverName, errMsg string) string {
+	var buf bytes.Buffer
+	_ = callbackTmpl.Execute(&buf, callbackTemplateData{
+		ServerName: serverName,
+		Error:      errMsg,
+	})
+	return buf.String()
+}

--- a/internal/app/mcp_oauth.go
+++ b/internal/app/mcp_oauth.go
@@ -76,13 +76,39 @@ func (s *Server) handleMCPOAuthConnect(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "mcp_server_url is required")
 	}
 
+	// Fill in ClientID / ClientSecret / Scopes from saved oauth_config when
+	// the request did not supply them, so users only need to save the
+	// credentials once in Settings → MCP Servers.
+	clientID := req.ClientID
+	clientSecret := req.ClientSecret
+	scopes := req.Scopes
+	if (clientID == "" || clientSecret == "") && s.settingsRepo != nil {
+		if userSettings, sErr := s.settingsRepo.FindByName(c.Request().Context(), string(user.ID())); sErr == nil && userSettings != nil {
+			if mcpServers := userSettings.MCPServers(); mcpServers != nil {
+				if srv := mcpServers.GetServer(req.ServerName); srv != nil {
+					if cfg := srv.OAuthConfig(); cfg != nil {
+						if clientID == "" {
+							clientID = cfg.ClientID
+						}
+						if clientSecret == "" {
+							clientSecret = cfg.ClientSecret
+						}
+						if len(scopes) == 0 && len(cfg.Scopes) > 0 {
+							scopes = cfg.Scopes
+						}
+					}
+				}
+			}
+		}
+	}
+
 	result, err := s.mcpOAuthManager.Connect(c.Request().Context(), mcpoauth.ConnectRequest{
 		UserID:       string(user.ID()),
 		ServerName:   req.ServerName,
 		MCPServerURL: req.MCPServerURL,
-		ClientID:     req.ClientID,
-		ClientSecret: req.ClientSecret,
-		Scopes:       req.Scopes,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       scopes,
 	})
 	if err != nil {
 		log.Printf("[MCP-OAUTH] connect error for user=%s server=%s: %v", user.ID(), req.ServerName, err)

--- a/internal/app/mcp_oauth.go
+++ b/internal/app/mcp_oauth.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
@@ -85,7 +86,7 @@ func (s *Server) handleMCPOAuthConnect(c echo.Context) error {
 	})
 	if err != nil {
 		log.Printf("[MCP-OAUTH] connect error for user=%s server=%s: %v", user.ID(), req.ServerName, err)
-		return echo.NewHTTPError(http.StatusBadGateway, "OAuth discovery failed: "+err.Error())
+		return echo.NewHTTPError(http.StatusBadGateway, friendlyOAuthError(err))
 	}
 
 	return c.JSON(http.StatusOK, MCPOAuthConnectResponse{
@@ -159,6 +160,21 @@ func (s *Server) handleMCPOAuthDisconnect(c echo.Context) error {
 }
 
 // ---- helpers ----
+
+// friendlyOAuthError converts internal OAuth errors into user-readable messages.
+func friendlyOAuthError(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "discovery") || strings.Contains(msg, "fetch protected resource") || strings.Contains(msg, "fetch authorization server"):
+		return "OAuth 2.0 エンドポイントが見つかりませんでした。このサーバーは OAuth 2.0 に対応していないか、URL が正しくない可能性があります。"
+	case strings.Contains(msg, "DCR") || strings.Contains(msg, "registration"):
+		return "OAuth クライアントの自動登録 (DCR) に失敗しました。OAuth 設定に Client ID と Client Secret を手動で入力してください。"
+	case strings.Contains(msg, "no client_id"):
+		return "Client ID が取得できませんでした。OAuth 設定で Client ID を指定するか、DCR に対応したサーバーの URL を使用してください。"
+	default:
+		return "OAuth 接続に失敗しました: " + msg
+	}
+}
 
 type callbackTemplateData struct {
 	ServerName string

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/hmacutil"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+	"github.com/takutakahashi/agentapi-proxy/pkg/mcpoauth"
 	"github.com/takutakahashi/agentapi-proxy/pkg/notification"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 	"k8s.io/client-go/kubernetes/fake"
@@ -38,24 +39,26 @@ import (
 
 // Server represents the HTTP server
 type Server struct {
-	config           *config.Config
-	echo             *echo.Echo
-	verbose          bool
-	logger           *logger.Logger
-	oauthProvider    *auth.GitHubOAuthProvider
-	oauthSessions    sync.Map // sessionID -> OAuthSession
-	notificationSvc  *notification.Service
-	container        *di.Container                    // Internal DI container
-	sessionManager   portrepos.SessionManager         // Session lifecycle manager
-	settingsRepo     portrepos.SettingsRepository     // Settings repository
-	credentialsRepo  portrepos.CredentialsRepository  // Credentials repository
-	shareRepo        portrepos.ShareRepository        // Share repository for session sharing
-	teamConfigRepo   portrepos.TeamConfigRepository   // Team configuration repository
-	memoryRepo       portrepos.MemoryRepository       // Memory repository
-	taskRepo         portrepos.TaskRepository         // Task repository
-	taskGroupRepo    portrepos.TaskGroupRepository    // Task group repository
-	sessionRouteRepo portrepos.SessionRouteRepository // Session route repository for proxy B routing
-	router           *Router                          // Router for custom handler registration
+	config            *config.Config
+	echo              *echo.Echo
+	verbose           bool
+	logger            *logger.Logger
+	oauthProvider     *auth.GitHubOAuthProvider
+	oauthSessions     sync.Map // sessionID -> OAuthSession
+	notificationSvc   *notification.Service
+	container         *di.Container                     // Internal DI container
+	sessionManager    portrepos.SessionManager          // Session lifecycle manager
+	settingsRepo      portrepos.SettingsRepository      // Settings repository
+	credentialsRepo   portrepos.CredentialsRepository   // Credentials repository
+	shareRepo         portrepos.ShareRepository         // Share repository for session sharing
+	teamConfigRepo    portrepos.TeamConfigRepository    // Team configuration repository
+	memoryRepo        portrepos.MemoryRepository        // Memory repository
+	taskRepo          portrepos.TaskRepository          // Task repository
+	taskGroupRepo     portrepos.TaskGroupRepository     // Task group repository
+	sessionRouteRepo  portrepos.SessionRouteRepository  // Session route repository for proxy B routing
+	mcpOAuthManager   *mcpoauth.Manager                 // MCP OAuth flow manager (nil if not configured)
+	mcpOAuthTokenRepo portrepos.MCPOAuthTokenRepository // MCP OAuth token storage
+	router            *Router                           // Router for custom handler registration
 }
 
 // NewServer creates a new server instance
@@ -267,21 +270,37 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 	)
 	log.Printf("[SERVER] Session route repository initialized")
 
+	// Initialize MCP OAuth token repository and manager.
+	mcpOAuthTokenRepo := repositories.NewKubernetesMCPOAuthTokenRepository(
+		k8sSessionManager.GetClient(),
+		k8sSessionManager.GetNamespace(),
+	)
+	externalURL := os.Getenv("AGENTAPI_EXTERNAL_URL")
+	if externalURL == "" {
+		// Best-effort default; OAuth callbacks will fail unless overridden.
+		externalURL = "http://localhost:8080"
+	}
+	mcpOAuthMgr := mcpoauth.NewManager(mcpOAuthTokenRepo, externalURL)
+	k8sSessionManager.SetMCPOAuthManager(mcpOAuthMgr)
+	log.Printf("[SERVER] MCP OAuth manager initialized (external URL: %s)", externalURL)
+
 	s := &Server{
-		config:           cfg,
-		echo:             e,
-		verbose:          verbose,
-		logger:           lgr,
-		container:        container,
-		sessionManager:   sessionManager,
-		settingsRepo:     settingsRepo,
-		credentialsRepo:  credentialsRepo,
-		shareRepo:        shareRepo,
-		teamConfigRepo:   teamConfigRepo,
-		memoryRepo:       memoryRepo,
-		taskRepo:         taskRepo,
-		taskGroupRepo:    taskGroupRepo,
-		sessionRouteRepo: sessionRouteRepo,
+		config:            cfg,
+		echo:              e,
+		verbose:           verbose,
+		logger:            lgr,
+		container:         container,
+		sessionManager:    sessionManager,
+		settingsRepo:      settingsRepo,
+		credentialsRepo:   credentialsRepo,
+		shareRepo:         shareRepo,
+		teamConfigRepo:    teamConfigRepo,
+		memoryRepo:        memoryRepo,
+		taskRepo:          taskRepo,
+		taskGroupRepo:     taskGroupRepo,
+		sessionRouteRepo:  sessionRouteRepo,
+		mcpOAuthManager:   mcpOAuthMgr,
+		mcpOAuthTokenRepo: mcpOAuthTokenRepo,
 	}
 
 	// Add logging middleware if verbose
@@ -453,6 +472,11 @@ func (s *Server) setupRoutes() {
 
 	// Register auth-related routes directly
 	s.setupAuthRoutes()
+
+	// Register MCP OAuth routes when the manager is configured.
+	if s.mcpOAuthManager != nil {
+		s.setupMCPOAuthRoutes()
+	}
 }
 
 // AddCustomHandler adds a custom handler to the router
@@ -1026,6 +1050,11 @@ func (s *Server) GetTaskRepository() portrepos.TaskRepository {
 // GetTaskGroupRepository returns the task group repository
 func (s *Server) GetTaskGroupRepository() portrepos.TaskGroupRepository {
 	return s.taskGroupRepo
+}
+
+// GetMCPOAuthTokenRepository returns the MCP OAuth token repository.
+func (s *Server) GetMCPOAuthTokenRepository() portrepos.MCPOAuthTokenRepository {
+	return s.mcpOAuthTokenRepo
 }
 
 // ExtractRepositoryInfo extracts repository information from tags.

--- a/internal/domain/entities/mcp_oauth_token.go
+++ b/internal/domain/entities/mcp_oauth_token.go
@@ -1,0 +1,66 @@
+package entities
+
+import "time"
+
+// MCPOAuthToken stores an OAuth access/refresh token pair for a specific
+// user × MCP server combination.
+type MCPOAuthToken struct {
+	userID       string
+	serverName   string
+	clientID     string
+	clientSecret string
+	accessToken  string
+	refreshToken string
+	expiresAt    time.Time
+	tokenType    string
+	tokenURL     string
+}
+
+// NewMCPOAuthToken creates a new empty token for the given user and server.
+func NewMCPOAuthToken(userID, serverName string) *MCPOAuthToken {
+	return &MCPOAuthToken{
+		userID:     userID,
+		serverName: serverName,
+		tokenType:  "Bearer",
+	}
+}
+
+func (t *MCPOAuthToken) UserID() string       { return t.userID }
+func (t *MCPOAuthToken) ServerName() string   { return t.serverName }
+func (t *MCPOAuthToken) ClientID() string     { return t.clientID }
+func (t *MCPOAuthToken) ClientSecret() string { return t.clientSecret }
+func (t *MCPOAuthToken) AccessToken() string  { return t.accessToken }
+func (t *MCPOAuthToken) RefreshToken() string { return t.refreshToken }
+func (t *MCPOAuthToken) ExpiresAt() time.Time { return t.expiresAt }
+func (t *MCPOAuthToken) TokenType() string    { return t.tokenType }
+func (t *MCPOAuthToken) TokenURL() string     { return t.tokenURL }
+
+func (t *MCPOAuthToken) SetClientID(id string)      { t.clientID = id }
+func (t *MCPOAuthToken) SetClientSecret(s string)   { t.clientSecret = s }
+func (t *MCPOAuthToken) SetAccessToken(tok string)  { t.accessToken = tok }
+func (t *MCPOAuthToken) SetRefreshToken(tok string) { t.refreshToken = tok }
+func (t *MCPOAuthToken) SetExpiresAt(t2 time.Time)  { t.expiresAt = t2 }
+func (t *MCPOAuthToken) SetTokenType(tt string)     { t.tokenType = tt }
+func (t *MCPOAuthToken) SetTokenURL(u string)       { t.tokenURL = u }
+
+// IsExpired returns true when the token expires within the next 60 seconds.
+func (t *MCPOAuthToken) IsExpired() bool {
+	if t.expiresAt.IsZero() {
+		return false
+	}
+	return t.expiresAt.Before(time.Now().Add(60 * time.Second))
+}
+
+// IsEmpty returns true when no access token has been set.
+func (t *MCPOAuthToken) IsEmpty() bool {
+	return t.accessToken == ""
+}
+
+// BearerHeader returns the value suitable for an Authorization header.
+func (t *MCPOAuthToken) BearerHeader() string {
+	tt := t.tokenType
+	if tt == "" {
+		tt = "Bearer"
+	}
+	return tt + " " + t.accessToken
+}

--- a/internal/domain/entities/mcp_server.go
+++ b/internal/domain/entities/mcp_server.go
@@ -5,15 +5,32 @@ import (
 	"sort"
 )
 
+// MCPServerOAuthConfig holds the OAuth client configuration for a remote MCP server.
+// When set, agentapi-proxy will manage the OAuth flow on behalf of the user and
+// inject the resulting Bearer token into the session headers at startup.
+type MCPServerOAuthConfig struct {
+	// ClientID is the OAuth client_id. Leave empty to use DCR.
+	ClientID string
+	// ClientSecret is the OAuth client_secret (confidential clients only).
+	ClientSecret string
+	// Scopes is the list of OAuth scopes to request.
+	Scopes []string
+	// AuthURL overrides the authorization endpoint discovered via .well-known.
+	AuthURL string
+	// TokenURL overrides the token endpoint discovered via .well-known.
+	TokenURL string
+}
+
 // MCPServer represents a single MCP server configuration
 type MCPServer struct {
-	name    string
-	type_   string            // "stdio", "http", "sse"
-	url     string            // for http/sse
-	command string            // for stdio
-	args    []string          // for stdio
-	env     map[string]string // environment variables (may contain secrets)
-	headers map[string]string // for http/sse (may contain secrets)
+	name        string
+	type_       string            // "stdio", "http", "sse"
+	url         string            // for http/sse
+	command     string            // for stdio
+	args        []string          // for stdio
+	env         map[string]string // environment variables (may contain secrets)
+	headers     map[string]string // for http/sse (may contain secrets)
+	oauthConfig *MCPServerOAuthConfig
 }
 
 // NewMCPServer creates a new MCPServer
@@ -97,6 +114,21 @@ func (s *MCPServer) SetHeaders(headers map[string]string) {
 	} else {
 		s.headers = headers
 	}
+}
+
+// OAuthConfig returns the OAuth configuration, or nil if not set.
+func (s *MCPServer) OAuthConfig() *MCPServerOAuthConfig {
+	return s.oauthConfig
+}
+
+// SetOAuthConfig sets the OAuth configuration.
+func (s *MCPServer) SetOAuthConfig(cfg *MCPServerOAuthConfig) {
+	s.oauthConfig = cfg
+}
+
+// HasOAuth returns true when an OAuth configuration is present.
+func (s *MCPServer) HasOAuth() bool {
+	return s.oauthConfig != nil
 }
 
 // Validate validates the MCPServer configuration

--- a/internal/infrastructure/repositories/kubernetes_mcp_oauth_token_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_mcp_oauth_token_repository.go
@@ -1,0 +1,213 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+const (
+	// MCPOAuthSecretPrefix is the Secret name prefix for MCP OAuth tokens.
+	MCPOAuthSecretPrefix = "agentapi-mcp-oauth-"
+	// LabelMCPOAuth is the label applied to all MCP OAuth Secrets.
+	LabelMCPOAuth = "agentapi.proxy/mcp-oauth"
+	// SecretKeyMCPOAuth is the data key inside the Secret.
+	SecretKeyMCPOAuth = "tokens.json"
+)
+
+// mcpOAuthTokensJSON is the on-disk representation stored in the Kubernetes Secret.
+// It is a map of serverName → token record.
+type mcpOAuthTokensJSON map[string]*mcpOAuthTokenRecord
+
+type mcpOAuthTokenRecord struct {
+	ClientID     string    `json:"client_id,omitempty"`
+	ClientSecret string    `json:"client_secret,omitempty"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	ExpiresAt    time.Time `json:"expires_at,omitempty"`
+	TokenType    string    `json:"token_type,omitempty"`
+	TokenURL     string    `json:"token_url,omitempty"`
+}
+
+// KubernetesMCPOAuthTokenRepository implements MCPOAuthTokenRepository using
+// one Kubernetes Secret per user (agentapi-mcp-oauth-{sanitizedUserID}).
+type KubernetesMCPOAuthTokenRepository struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewKubernetesMCPOAuthTokenRepository creates a new repository.
+func NewKubernetesMCPOAuthTokenRepository(client kubernetes.Interface, namespace string) *KubernetesMCPOAuthTokenRepository {
+	return &KubernetesMCPOAuthTokenRepository{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// Save persists the token for the given user × server, creating the Secret if necessary.
+func (r *KubernetesMCPOAuthTokenRepository) Save(ctx context.Context, token *entities.MCPOAuthToken) error {
+	secretName := r.secretName(token.UserID())
+
+	tokens, secret, err := r.loadSecret(ctx, secretName)
+	if err != nil {
+		return err
+	}
+
+	tokens[token.ServerName()] = &mcpOAuthTokenRecord{
+		ClientID:     token.ClientID(),
+		ClientSecret: token.ClientSecret(),
+		AccessToken:  token.AccessToken(),
+		RefreshToken: token.RefreshToken(),
+		ExpiresAt:    token.ExpiresAt(),
+		TokenType:    token.TokenType(),
+		TokenURL:     token.TokenURL(),
+	}
+
+	data, err := json.Marshal(tokens)
+	if err != nil {
+		return fmt.Errorf("mcp oauth repo: marshal: %w", err)
+	}
+
+	if secret == nil {
+		// Create new Secret.
+		newSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: r.namespace,
+				Labels: map[string]string{
+					LabelMCPOAuth: "true",
+				},
+			},
+			Data: map[string][]byte{
+				SecretKeyMCPOAuth: data,
+			},
+		}
+		_, err = r.client.CoreV1().Secrets(r.namespace).Create(ctx, newSecret, metav1.CreateOptions{})
+		return err
+	}
+
+	// Update existing Secret.
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[SecretKeyMCPOAuth] = data
+	_, err = r.client.CoreV1().Secrets(r.namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	return err
+}
+
+// FindByUserAndServer returns the stored token or nil when not found.
+func (r *KubernetesMCPOAuthTokenRepository) FindByUserAndServer(ctx context.Context, userID, serverName string) (*entities.MCPOAuthToken, error) {
+	tokens, _, err := r.loadSecret(ctx, r.secretName(userID))
+	if err != nil {
+		return nil, err
+	}
+	rec, ok := tokens[serverName]
+	if !ok {
+		return nil, nil
+	}
+	return r.recordToEntity(userID, serverName, rec), nil
+}
+
+// Delete removes a single server's token from the Secret.
+func (r *KubernetesMCPOAuthTokenRepository) Delete(ctx context.Context, userID, serverName string) error {
+	secretName := r.secretName(userID)
+	tokens, secret, err := r.loadSecret(ctx, secretName)
+	if err != nil {
+		return err
+	}
+	if secret == nil {
+		return nil
+	}
+	delete(tokens, serverName)
+
+	data, err := json.Marshal(tokens)
+	if err != nil {
+		return err
+	}
+	secret.Data[SecretKeyMCPOAuth] = data
+	_, err = r.client.CoreV1().Secrets(r.namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	return err
+}
+
+// ListByUser returns all tokens for a user.
+func (r *KubernetesMCPOAuthTokenRepository) ListByUser(ctx context.Context, userID string) ([]*entities.MCPOAuthToken, error) {
+	tokens, _, err := r.loadSecret(ctx, r.secretName(userID))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*entities.MCPOAuthToken, 0, len(tokens))
+	for serverName, rec := range tokens {
+		result = append(result, r.recordToEntity(userID, serverName, rec))
+	}
+	return result, nil
+}
+
+// ---- helpers ----
+
+func (r *KubernetesMCPOAuthTokenRepository) secretName(userID string) string {
+	return MCPOAuthSecretPrefix + sanitizeName(userID)
+}
+
+// loadSecret fetches the Secret and deserialises the token map.
+// Returns an empty map and nil secret when the Secret does not exist yet.
+func (r *KubernetesMCPOAuthTokenRepository) loadSecret(ctx context.Context, secretName string) (mcpOAuthTokensJSON, *corev1.Secret, error) {
+	secret, err := r.client.CoreV1().Secrets(r.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return make(mcpOAuthTokensJSON), nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("mcp oauth repo: get secret %s: %w", secretName, err)
+	}
+
+	var tokens mcpOAuthTokensJSON
+	if raw, ok := secret.Data[SecretKeyMCPOAuth]; ok && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &tokens); err != nil {
+			return nil, nil, fmt.Errorf("mcp oauth repo: unmarshal: %w", err)
+		}
+	}
+	if tokens == nil {
+		tokens = make(mcpOAuthTokensJSON)
+	}
+	return tokens, secret, nil
+}
+
+func (r *KubernetesMCPOAuthTokenRepository) recordToEntity(userID, serverName string, rec *mcpOAuthTokenRecord) *entities.MCPOAuthToken {
+	t := entities.NewMCPOAuthToken(userID, serverName)
+	t.SetClientID(rec.ClientID)
+	t.SetClientSecret(rec.ClientSecret)
+	t.SetAccessToken(rec.AccessToken)
+	t.SetRefreshToken(rec.RefreshToken)
+	t.SetExpiresAt(rec.ExpiresAt)
+	t.SetTokenType(rec.TokenType)
+	t.SetTokenURL(rec.TokenURL)
+	return t
+}
+
+// sanitizeName converts a name to a valid Kubernetes label/resource suffix.
+func sanitizeName(name string) string {
+	name = strings.ToLower(name)
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	s := b.String()
+	// Trim leading/trailing dashes.
+	s = strings.Trim(s, "-")
+	if len(s) > 63 {
+		s = s[:63]
+	}
+	return s
+}

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -55,14 +55,24 @@ type bedrockJSON struct {
 	Profile         string `json:"profile,omitempty"`
 }
 
+// mcpServerOAuthConfigJSON is the JSON representation of OAuth client config.
+type mcpServerOAuthConfigJSON struct {
+	ClientID     string   `json:"client_id,omitempty"`
+	ClientSecret string   `json:"client_secret,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	AuthURL      string   `json:"auth_url,omitempty"`
+	TokenURL     string   `json:"token_url,omitempty"`
+}
+
 // mcpServerJSON is the JSON representation of a single MCP server
 type mcpServerJSON struct {
-	Type    string            `json:"type"`
-	URL     string            `json:"url,omitempty"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
+	Type        string                    `json:"type"`
+	URL         string                    `json:"url,omitempty"`
+	Command     string                    `json:"command,omitempty"`
+	Args        []string                  `json:"args,omitempty"`
+	Env         map[string]string         `json:"env,omitempty"`
+	Headers     map[string]string         `json:"headers,omitempty"`
+	OAuthConfig *mcpServerOAuthConfigJSON `json:"oauth_config,omitempty"`
 }
 
 // marketplaceJSON is the JSON representation of a single marketplace
@@ -238,7 +248,7 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 	if mcpServers := settings.MCPServers(); mcpServers != nil && !mcpServers.IsEmpty() {
 		sj.MCPServers = make(map[string]*mcpServerJSON)
 		for name, server := range mcpServers.Servers() {
-			sj.MCPServers[name] = &mcpServerJSON{
+			serverJSON := &mcpServerJSON{
 				Type:    server.Type(),
 				URL:     server.URL(),
 				Command: server.Command(),
@@ -246,6 +256,16 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 				Env:     server.Env(),
 				Headers: server.Headers(),
 			}
+			if cfg := server.OAuthConfig(); cfg != nil {
+				serverJSON.OAuthConfig = &mcpServerOAuthConfigJSON{
+					ClientID:     cfg.ClientID,
+					ClientSecret: cfg.ClientSecret,
+					Scopes:       cfg.Scopes,
+					AuthURL:      cfg.AuthURL,
+					TokenURL:     cfg.TokenURL,
+				}
+			}
+			sj.MCPServers[name] = serverJSON
 		}
 	}
 
@@ -328,6 +348,15 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 			server.SetArgs(serverJSON.Args)
 			server.SetEnv(serverJSON.Env)
 			server.SetHeaders(serverJSON.Headers)
+			if serverJSON.OAuthConfig != nil {
+				server.SetOAuthConfig(&entities.MCPServerOAuthConfig{
+					ClientID:     serverJSON.OAuthConfig.ClientID,
+					ClientSecret: serverJSON.OAuthConfig.ClientSecret,
+					Scopes:       serverJSON.OAuthConfig.Scopes,
+					AuthURL:      serverJSON.OAuthConfig.AuthURL,
+					TokenURL:     serverJSON.OAuthConfig.TokenURL,
+				})
+			}
 
 			mcpServers.SetServer(name, server)
 		}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -76,6 +76,15 @@ type KubernetesSessionManager struct {
 	// Protected by handlersMutex.
 	onSessionDeletedHandlers []SessionDeletedHandler
 	handlersMutex            sync.RWMutex
+	// mcpOAuthManager handles OAuth token retrieval/refresh for MCP servers.
+	// nil when the feature is not configured.
+	mcpOAuthManager mcpOAuthManagerIface
+}
+
+// mcpOAuthManagerIface is a minimal interface for the MCP OAuth manager,
+// allowing the session manager to be tested without a real k8s cluster.
+type mcpOAuthManagerIface interface {
+	GetValidToken(ctx context.Context, userID, serverName string) (*entities.MCPOAuthToken, error)
 }
 
 // NewKubernetesSessionManager creates a new KubernetesSessionManager
@@ -2982,13 +2991,16 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		log.Printf("[K8S_SESSION] Injected cycle Stop hook for session %s (max-count=%d)", session.id, req.CycleMaxCount)
 	}
 
+	// Inject MCP OAuth tokens into the MCP server headers.
+	mcpServers := m.injectMCPOAuthTokens(ctx, req.UserID, materialized.MCPServers)
+
 	settings.Claude = sessionsettings.ClaudeConfig{
 		ClaudeJSON: map[string]interface{}{
 			"hasCompletedOnboarding":        true,
 			"bypassPermissionsModeAccepted": true,
 		},
 		SettingsJSON: settingsJSON,
-		MCPServers:   materialized.MCPServers,
+		MCPServers:   mcpServers,
 	}
 
 	// Repository info
@@ -3370,4 +3382,70 @@ func (m *KubernetesSessionManager) BuildRemoteProvisionSettings(
 	}
 	settings := m.buildSessionSettings(ctx, tempSession, req, nil)
 	return settings, nil
+}
+
+// SetMCPOAuthManager injects the MCP OAuth manager into the session manager.
+// Must be called before the first session is created.
+func (m *KubernetesSessionManager) SetMCPOAuthManager(mgr mcpOAuthManagerIface) {
+	m.mcpOAuthManager = mgr
+}
+
+// injectMCPOAuthTokens iterates the MCP server map and, for any server that has
+// an oauth_config entry, retrieves (and if necessary refreshes) the stored token
+// and injects it as "Authorization: Bearer …" into the server's headers map.
+// The oauth_config key is removed from the output so it is not forwarded to the
+// Claude Code container.
+func (m *KubernetesSessionManager) injectMCPOAuthTokens(ctx context.Context, userID string, mcpServers map[string]interface{}) map[string]interface{} {
+	if m.mcpOAuthManager == nil || len(mcpServers) == 0 {
+		return mcpServers
+	}
+
+	result := make(map[string]interface{}, len(mcpServers))
+	for name, raw := range mcpServers {
+		serverMap, ok := raw.(map[string]interface{})
+		if !ok {
+			result[name] = raw
+			continue
+		}
+
+		// Copy the server map so we don't mutate the original.
+		out := make(map[string]interface{}, len(serverMap))
+		for k, v := range serverMap {
+			out[k] = v
+		}
+
+		// Only process servers that have an oauth_config.
+		if _, hasOAuth := out["oauth_config"]; !hasOAuth {
+			result[name] = out
+			continue
+		}
+
+		// Remove oauth_config from the output (never forwarded to container).
+		delete(out, "oauth_config")
+
+		// Retrieve (and optionally refresh) the stored token.
+		token, err := m.mcpOAuthManager.GetValidToken(ctx, userID, name)
+		if err != nil {
+			log.Printf("[MCP-OAUTH] failed to get token for user=%s server=%s: %v", userID, name, err)
+			result[name] = out
+			continue
+		}
+		if token == nil || token.IsEmpty() {
+			log.Printf("[MCP-OAUTH] no token for user=%s server=%s, skipping injection", userID, name)
+			result[name] = out
+			continue
+		}
+
+		// Inject the Bearer token into headers.
+		headers, _ := out["headers"].(map[string]interface{})
+		if headers == nil {
+			headers = make(map[string]interface{})
+		}
+		headers["Authorization"] = token.BearerHeader()
+		out["headers"] = headers
+
+		log.Printf("[MCP-OAUTH] injected token for user=%s server=%s", userID, name)
+		result[name] = out
+	}
+	return result
 }

--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -48,14 +48,29 @@ type BedrockSettingsRequest struct {
 	Profile         string `json:"profile,omitempty"`
 }
 
+// MCPServerOAuthConfigRequest is the OAuth client config for a remote MCP server.
+type MCPServerOAuthConfigRequest struct {
+	// ClientID overrides DCR. Leave empty to use Dynamic Client Registration.
+	ClientID string `json:"client_id,omitempty"`
+	// ClientSecret is for confidential clients only.
+	ClientSecret string `json:"client_secret,omitempty"`
+	// Scopes is the list of OAuth scopes to request.
+	Scopes []string `json:"scopes,omitempty"`
+	// AuthURL overrides the authorization endpoint (optional).
+	AuthURL string `json:"auth_url,omitempty"`
+	// TokenURL overrides the token endpoint (optional).
+	TokenURL string `json:"token_url,omitempty"`
+}
+
 // MCPServerRequest is the request body for a single MCP server
 type MCPServerRequest struct {
-	Type    string            `json:"type"`              // "stdio", "http", "sse"
-	URL     string            `json:"url,omitempty"`     // for http/sse
-	Command string            `json:"command,omitempty"` // for stdio
-	Args    []string          `json:"args,omitempty"`    // for stdio
-	Env     map[string]string `json:"env,omitempty"`     // environment variables
-	Headers map[string]string `json:"headers,omitempty"` // for http/sse
+	Type        string                       `json:"type"`                   // "stdio", "http", "sse"
+	URL         string                       `json:"url,omitempty"`          // for http/sse
+	Command     string                       `json:"command,omitempty"`      // for stdio
+	Args        []string                     `json:"args,omitempty"`         // for stdio
+	Env         map[string]string            `json:"env,omitempty"`          // environment variables
+	Headers     map[string]string            `json:"headers,omitempty"`      // for http/sse
+	OAuthConfig *MCPServerOAuthConfigRequest `json:"oauth_config,omitempty"` // optional OAuth config
 }
 
 // MarketplaceRequest is the request body for a single marketplace
@@ -99,12 +114,14 @@ type BedrockSettingsResponse struct {
 
 // MCPServerResponse is the response body for a single MCP server
 type MCPServerResponse struct {
-	Type       string   `json:"type"`
-	URL        string   `json:"url,omitempty"`
-	Command    string   `json:"command,omitempty"`
-	Args       []string `json:"args,omitempty"`
-	EnvKeys    []string `json:"env_keys,omitempty"`    // only keys, not values
-	HeaderKeys []string `json:"header_keys,omitempty"` // only keys, not values
+	Type           string   `json:"type"`
+	URL            string   `json:"url,omitempty"`
+	Command        string   `json:"command,omitempty"`
+	Args           []string `json:"args,omitempty"`
+	EnvKeys        []string `json:"env_keys,omitempty"`         // only keys, not values
+	HeaderKeys     []string `json:"header_keys,omitempty"`      // only keys, not values
+	HasOAuthConfig bool     `json:"has_oauth_config,omitempty"` // true when an OAuth config is stored
+	OAuthScopes    []string `json:"oauth_scopes,omitempty"`     // requested scopes (no secrets)
 }
 
 // MarketplaceResponse is the response body for a single marketplace
@@ -325,6 +342,26 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 				}
 			}
 			server.SetHeaders(headers)
+
+			// Handle OAuth config
+			if serverReq.OAuthConfig != nil {
+				oauthCfg := &entities.MCPServerOAuthConfig{
+					ClientID:     serverReq.OAuthConfig.ClientID,
+					ClientSecret: serverReq.OAuthConfig.ClientSecret,
+					Scopes:       serverReq.OAuthConfig.Scopes,
+					AuthURL:      serverReq.OAuthConfig.AuthURL,
+					TokenURL:     serverReq.OAuthConfig.TokenURL,
+				}
+				// Preserve existing client_secret when not provided
+				if oauthCfg.ClientSecret == "" && existingMCPServers != nil {
+					if existingServer := existingMCPServers.GetServer(serverName); existingServer != nil {
+						if existingCfg := existingServer.OAuthConfig(); existingCfg != nil {
+							oauthCfg.ClientSecret = existingCfg.ClientSecret
+						}
+					}
+				}
+				server.SetOAuthConfig(oauthCfg)
+			}
 
 			mcpServers.SetServer(serverName, server)
 		}
@@ -686,7 +723,7 @@ func (c *SettingsController) toResponse(settings *entities.Settings) *SettingsRe
 	if mcpServers := settings.MCPServers(); mcpServers != nil && !mcpServers.IsEmpty() {
 		resp.MCPServers = make(map[string]*MCPServerResponse)
 		for name, server := range mcpServers.Servers() {
-			resp.MCPServers[name] = &MCPServerResponse{
+			mcpResp := &MCPServerResponse{
 				Type:       server.Type(),
 				URL:        server.URL(),
 				Command:    server.Command(),
@@ -694,6 +731,11 @@ func (c *SettingsController) toResponse(settings *entities.Settings) *SettingsRe
 				EnvKeys:    server.EnvKeys(),
 				HeaderKeys: server.HeaderKeys(),
 			}
+			if cfg := server.OAuthConfig(); cfg != nil {
+				mcpResp.HasOAuthConfig = true
+				mcpResp.OAuthScopes = cfg.Scopes
+			}
+			resp.MCPServers[name] = mcpResp
 		}
 	}
 

--- a/internal/usecases/ports/repositories/mcp_oauth_token_repository.go
+++ b/internal/usecases/ports/repositories/mcp_oauth_token_repository.go
@@ -1,0 +1,22 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+// MCPOAuthTokenRepository persists OAuth tokens for user × MCP server pairs.
+type MCPOAuthTokenRepository interface {
+	// Save creates or replaces the token for the given user × server.
+	Save(ctx context.Context, token *entities.MCPOAuthToken) error
+
+	// FindByUserAndServer returns the stored token, or nil when not found.
+	FindByUserAndServer(ctx context.Context, userID, serverName string) (*entities.MCPOAuthToken, error)
+
+	// Delete removes the token (called when the user disconnects a server).
+	Delete(ctx context.Context, userID, serverName string) error
+
+	// ListByUser returns all tokens stored for a user.
+	ListByUser(ctx context.Context, userID string) ([]*entities.MCPOAuthToken, error)
+}

--- a/pkg/mcpoauth/callbackui/callback.html
+++ b/pkg/mcpoauth/callbackui/callback.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MCP OAuth</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; background: #f5f5f5; color: #333;
+    }
+    .card {
+      background: #fff; border-radius: 12px; padding: 40px 48px;
+      max-width: 420px; width: 100%; text-align: center;
+      box-shadow: 0 4px 24px rgba(0,0,0,.08);
+    }
+    .icon { font-size: 48px; margin-bottom: 16px; }
+    h1 { font-size: 22px; font-weight: 600; margin-bottom: 8px; }
+    p  { font-size: 15px; color: #666; line-height: 1.5; }
+    .server { font-weight: 600; color: #333; }
+    .error  { color: #d32f2f; }
+    .hint   { margin-top: 24px; font-size: 13px; color: #999; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    {{if .Error}}
+      <div class="icon">❌</div>
+      <h1>接続に失敗しました</h1>
+      <p class="error">{{.Error}}</p>
+      <p class="hint">このタブを閉じて再度お試しください。</p>
+    {{else}}
+      <div class="icon">✅</div>
+      <h1>接続しました</h1>
+      <p><span class="server">{{.ServerName}}</span> の MCP サーバーに接続しました。</p>
+      <p class="hint">このタブを閉じてください。次回のセッションから自動的に使用されます。</p>
+    {{end}}
+  </div>
+  <script>
+    // Notify the opener window if it exists.
+    if (window.opener) {
+      window.opener.postMessage(
+        { type: "mcp-oauth-callback", {{if .Error}}error: "{{.Error}}"{{else}}serverName: "{{.ServerName}}"{{end}} },
+        "*"
+      );
+    }
+  </script>
+</body>
+</html>

--- a/pkg/mcpoauth/callbackui/embed.go
+++ b/pkg/mcpoauth/callbackui/embed.go
@@ -1,0 +1,8 @@
+package callbackui
+
+import _ "embed"
+
+// CallbackHTML is the HTML template for the OAuth callback result page.
+//
+//go:embed callback.html
+var CallbackHTML string

--- a/pkg/mcpoauth/dcr.go
+++ b/pkg/mcpoauth/dcr.go
@@ -1,0 +1,63 @@
+package mcpoauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// DCRRequest is the RFC 7591 client registration request body.
+type DCRRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	Scope                   string   `json:"scope,omitempty"`
+}
+
+// DCRResponse is the RFC 7591 client registration response.
+type DCRResponse struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret,omitempty"`
+}
+
+// Register performs Dynamic Client Registration against the given endpoint.
+func Register(ctx context.Context, client *http.Client, registrationEndpoint string, req DCRRequest) (*DCRResponse, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("dcr: marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("dcr: POST %s: %w", registrationEndpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("dcr: POST %s returned %d", registrationEndpoint, resp.StatusCode)
+	}
+
+	var res DCRResponse
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return nil, fmt.Errorf("dcr: decode response: %w", err)
+	}
+	if res.ClientID == "" {
+		return nil, fmt.Errorf("dcr: response missing client_id")
+	}
+	return &res, nil
+}

--- a/pkg/mcpoauth/discovery.go
+++ b/pkg/mcpoauth/discovery.go
@@ -1,0 +1,188 @@
+package mcpoauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ProtectedResourceMetadata is the RFC 9728 oauth-protected-resource metadata.
+type ProtectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+}
+
+// AuthorizationServerMetadata is the RFC 8414 oauth-authorization-server metadata.
+type AuthorizationServerMetadata struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	RegistrationEndpoint          string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported               []string `json:"scopes_supported,omitempty"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+	ResponseTypesSupported        []string `json:"response_types_supported,omitempty"`
+	GrantTypesSupported           []string `json:"grant_types_supported,omitempty"`
+}
+
+// SupportsDCR returns true when the metadata includes a registration endpoint.
+func (m *AuthorizationServerMetadata) SupportsDCR() bool {
+	return m.RegistrationEndpoint != ""
+}
+
+// Discover resolves the OAuth authorization server metadata for a given MCP server URL.
+//
+// Discovery order:
+//  1. GET {mcpURL} → expect 401 with WWW-Authenticate header containing resource_metadata URL
+//  2. GET {resourceMetadataURL} → ProtectedResourceMetadata → auth server base URL
+//  3. GET {authServerBase}/.well-known/oauth-authorization-server → AuthorizationServerMetadata
+//
+// Falls back to well-known paths on the MCP server origin when step 1 does not
+// provide a resource_metadata URL.
+func Discover(ctx context.Context, client *http.Client, mcpServerURL string) (*AuthorizationServerMetadata, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// Step 1: probe the MCP server to find the resource_metadata URL.
+	resourceMetadataURL, err := probeResourceMetadataURL(ctx, client, mcpServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth: probe failed: %w", err)
+	}
+
+	// Step 2: fetch ProtectedResourceMetadata.
+	prm, err := fetchProtectedResourceMetadata(ctx, client, resourceMetadataURL)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth: fetch protected resource metadata: %w", err)
+	}
+	if len(prm.AuthorizationServers) == 0 {
+		return nil, fmt.Errorf("mcpoauth: protected resource metadata has no authorization_servers")
+	}
+	authServerBase := strings.TrimSuffix(prm.AuthorizationServers[0], "/")
+
+	// Step 3: fetch AuthorizationServerMetadata.
+	asmd, err := fetchAuthorizationServerMetadata(ctx, client, authServerBase)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth: fetch authorization server metadata: %w", err)
+	}
+	return asmd, nil
+}
+
+// probeResourceMetadataURL sends a GET to mcpURL and extracts the resource_metadata
+// URL from the WWW-Authenticate header of the expected 401 response.
+// When the header is absent or the URL cannot be parsed, it falls back to
+// {origin}/.well-known/oauth-protected-resource.
+func probeResourceMetadataURL(ctx context.Context, client *http.Client, mcpURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mcpURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	// Try to extract resource_metadata from WWW-Authenticate.
+	if wwwAuth := resp.Header.Get("WWW-Authenticate"); wwwAuth != "" {
+		if u := extractParam(wwwAuth, "resource_metadata"); u != "" {
+			return u, nil
+		}
+	}
+
+	// Fall back to well-known path on the MCP server origin.
+	origin, err := originOf(mcpURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot determine origin of %q: %w", mcpURL, err)
+	}
+	return origin + "/.well-known/oauth-protected-resource", nil
+}
+
+// fetchProtectedResourceMetadata GETs the given URL and decodes the JSON response.
+func fetchProtectedResourceMetadata(ctx context.Context, client *http.Client, metadataURL string) (*ProtectedResourceMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s returned %d", metadataURL, resp.StatusCode)
+	}
+
+	var prm ProtectedResourceMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&prm); err != nil {
+		return nil, fmt.Errorf("decode protected resource metadata: %w", err)
+	}
+	return &prm, nil
+}
+
+// fetchAuthorizationServerMetadata GETs {base}/.well-known/oauth-authorization-server.
+func fetchAuthorizationServerMetadata(ctx context.Context, client *http.Client, authServerBase string) (*AuthorizationServerMetadata, error) {
+	metaURL := authServerBase + "/.well-known/oauth-authorization-server"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metaURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s returned %d", metaURL, resp.StatusCode)
+	}
+
+	var md AuthorizationServerMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&md); err != nil {
+		return nil, fmt.Errorf("decode authorization server metadata: %w", err)
+	}
+	return &md, nil
+}
+
+// extractParam parses a simple Bearer challenge and returns the value of the
+// named parameter (e.g. resource_metadata="https://...").
+func extractParam(header, name string) string {
+	// e.g.: Bearer realm="MCP", resource_metadata="https://..."
+	target := name + "="
+	idx := strings.Index(header, target)
+	if idx < 0 {
+		return ""
+	}
+	rest := header[idx+len(target):]
+	if strings.HasPrefix(rest, `"`) {
+		rest = rest[1:]
+		end := strings.Index(rest, `"`)
+		if end < 0 {
+			return rest
+		}
+		return rest[:end]
+	}
+	// unquoted value
+	end := strings.IndexAny(rest, " ,\t")
+	if end < 0 {
+		return rest
+	}
+	return rest[:end]
+}
+
+// originOf returns the scheme+host portion of rawURL.
+func originOf(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s://%s", u.Scheme, u.Host), nil
+}

--- a/pkg/mcpoauth/flow.go
+++ b/pkg/mcpoauth/flow.go
@@ -1,0 +1,219 @@
+package mcpoauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+const (
+	callbackPath = "/mcp-oauth/callback"
+	clientName   = "agentapi-proxy"
+)
+
+// ConnectRequest is the input for beginning an OAuth flow for a specific
+// MCP server / user combination.
+type ConnectRequest struct {
+	UserID       string
+	ServerName   string
+	MCPServerURL string
+	// Optional overrides (used when DCR is not supported).
+	ClientID     string
+	ClientSecret string
+	Scopes       []string
+}
+
+// ConnectResult carries the authorization URL that the user must visit.
+type ConnectResult struct {
+	AuthorizationURL string `json:"authorization_url"`
+	State            string `json:"state"`
+}
+
+// Manager orchestrates the full MCP OAuth flow.
+type Manager struct {
+	httpClient      *http.Client
+	tokenRepo       portrepos.MCPOAuthTokenRepository
+	stateStore      *StateStore
+	callbackBaseURL string // e.g. "https://proxy.example.com"
+}
+
+// NewManager creates a Manager. callbackBaseURL must be the externally reachable
+// base URL of agentapi-proxy (scheme + host, no trailing slash).
+func NewManager(tokenRepo portrepos.MCPOAuthTokenRepository, callbackBaseURL string) *Manager {
+	return &Manager{
+		httpClient:      &http.Client{Timeout: 15 * time.Second},
+		tokenRepo:       tokenRepo,
+		stateStore:      NewStateStore(),
+		callbackBaseURL: strings.TrimSuffix(callbackBaseURL, "/"),
+	}
+}
+
+// Connect runs Discovery + optional DCR and returns the authorization URL.
+func (m *Manager) Connect(ctx context.Context, req ConnectRequest) (*ConnectResult, error) {
+	// 1. Discover OAuth endpoints.
+	metadata, err := Discover(ctx, m.httpClient, req.MCPServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth connect: discovery: %w", err)
+	}
+
+	clientID := req.ClientID
+	clientSecret := req.ClientSecret
+	redirectURI := m.callbackBaseURL + callbackPath
+
+	// 2. DCR when no client_id was supplied and the server supports it.
+	if clientID == "" && metadata.SupportsDCR() {
+		scope := strings.Join(req.Scopes, " ")
+		dcrResp, err := Register(ctx, m.httpClient, metadata.RegistrationEndpoint, DCRRequest{
+			ClientName:              clientName,
+			RedirectURIs:            []string{redirectURI},
+			GrantTypes:              []string{"authorization_code", "refresh_token"},
+			ResponseTypes:           []string{"code"},
+			TokenEndpointAuthMethod: "none",
+			Scope:                   scope,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("mcpoauth connect: DCR: %w", err)
+		}
+		clientID = dcrResp.ClientID
+		clientSecret = dcrResp.ClientSecret
+	}
+
+	if clientID == "" {
+		return nil, fmt.Errorf("mcpoauth connect: no client_id available (DCR not supported and none provided)")
+	}
+
+	// 3. Generate PKCE + state.
+	codeVerifier, err := GenerateCodeVerifier()
+	if err != nil {
+		return nil, err
+	}
+	state, err := generateState()
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. Store pending state.
+	m.stateStore.Store(state, &PendingState{
+		State:        state,
+		CodeVerifier: codeVerifier,
+		UserID:       req.UserID,
+		ServerName:   req.ServerName,
+		MCPServerURL: req.MCPServerURL,
+		RedirectURI:  redirectURI,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     metadata.TokenEndpoint,
+		CreatedAt:    time.Now(),
+	})
+
+	// 5. Build authorization URL.
+	scope := strings.Join(req.Scopes, " ")
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"state":                 {state},
+		"code_challenge":        {CodeChallenge(codeVerifier)},
+		"code_challenge_method": {"S256"},
+	}
+	if scope != "" {
+		params.Set("scope", scope)
+	}
+	authURL := metadata.AuthorizationEndpoint + "?" + params.Encode()
+
+	return &ConnectResult{
+		AuthorizationURL: authURL,
+		State:            state,
+	}, nil
+}
+
+// HandleCallback receives the authorization code, exchanges it for tokens,
+// and persists the result.
+func (m *Manager) HandleCallback(ctx context.Context, code, state string) (*entities.MCPOAuthToken, error) {
+	pending, ok := m.stateStore.Load(state)
+	if !ok {
+		return nil, fmt.Errorf("mcpoauth callback: unknown or expired state")
+	}
+
+	tr, err := ExchangeCode(ctx, m.httpClient,
+		pending.TokenURL,
+		pending.ClientID,
+		pending.ClientSecret,
+		code,
+		pending.CodeVerifier,
+		pending.RedirectURI,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth callback: exchange code: %w", err)
+	}
+
+	token := entities.NewMCPOAuthToken(pending.UserID, pending.ServerName)
+	token.SetClientID(pending.ClientID)
+	token.SetClientSecret(pending.ClientSecret)
+	token.SetAccessToken(tr.AccessToken)
+	token.SetRefreshToken(tr.RefreshToken)
+	token.SetExpiresAt(ExpiresAt(tr))
+	token.SetTokenType(tr.TokenType)
+	token.SetTokenURL(pending.TokenURL)
+
+	if err := m.tokenRepo.Save(ctx, token); err != nil {
+		return nil, fmt.Errorf("mcpoauth callback: save token: %w", err)
+	}
+	return token, nil
+}
+
+// GetValidToken retrieves a token for the given user+server and refreshes it
+// when it is about to expire. Returns nil (no error) when no token exists.
+func (m *Manager) GetValidToken(ctx context.Context, userID, serverName string) (*entities.MCPOAuthToken, error) {
+	token, err := m.tokenRepo.FindByUserAndServer(ctx, userID, serverName)
+	if err != nil {
+		return nil, fmt.Errorf("mcpoauth: load token: %w", err)
+	}
+	if token == nil {
+		return nil, nil
+	}
+	if !token.IsExpired() {
+		return token, nil
+	}
+
+	// Try to refresh.
+	if token.RefreshToken() == "" {
+		return nil, nil // no refresh token, user must re-authenticate
+	}
+	tr, err := RefreshToken(ctx, m.httpClient,
+		token.TokenURL(),
+		token.ClientID(),
+		token.ClientSecret(),
+		token.RefreshToken(),
+	)
+	if err != nil {
+		return nil, nil // soft fail: user must re-authenticate
+	}
+
+	token.SetAccessToken(tr.AccessToken)
+	token.SetExpiresAt(ExpiresAt(tr))
+	if tr.RefreshToken != "" {
+		token.SetRefreshToken(tr.RefreshToken)
+	}
+	if err := m.tokenRepo.Save(ctx, token); err != nil {
+		return nil, fmt.Errorf("mcpoauth: save refreshed token: %w", err)
+	}
+	return token, nil
+}
+
+// generateState creates a cryptographically random state string.
+func generateState() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/pkg/mcpoauth/pkce.go
+++ b/pkg/mcpoauth/pkce.go
@@ -1,0 +1,23 @@
+package mcpoauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+// GenerateCodeVerifier generates a cryptographically random PKCE code_verifier
+// per RFC 7636 (43–128 characters from the unreserved set).
+func GenerateCodeVerifier() (string, error) {
+	b := make([]byte, 32) // 32 bytes → 43-char base64url
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// CodeChallenge derives the S256 code_challenge from a code_verifier.
+func CodeChallenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}

--- a/pkg/mcpoauth/state_store.go
+++ b/pkg/mcpoauth/state_store.go
@@ -1,0 +1,67 @@
+package mcpoauth
+
+import (
+	"sync"
+	"time"
+)
+
+const stateTTL = 15 * time.Minute
+
+// PendingState holds the transient data needed between the authorization
+// redirect and the callback.
+type PendingState struct {
+	State        string
+	CodeVerifier string
+	UserID       string
+	ServerName   string
+	MCPServerURL string
+	RedirectURI  string
+	ClientID     string
+	ClientSecret string // only for confidential clients
+	TokenURL     string
+	CreatedAt    time.Time
+}
+
+// StateStore is a thread-safe in-memory store for pending OAuth states.
+type StateStore struct {
+	mu    sync.Mutex
+	items map[string]*PendingState
+}
+
+// NewStateStore creates a new StateStore.
+func NewStateStore() *StateStore {
+	return &StateStore{items: make(map[string]*PendingState)}
+}
+
+// Store saves a pending state.
+func (s *StateStore) Store(state string, p *PendingState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanup()
+	s.items[state] = p
+}
+
+// Load retrieves and removes a pending state. Returns nil when not found or expired.
+func (s *StateStore) Load(state string) (*PendingState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.items[state]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(p.CreatedAt) > stateTTL {
+		delete(s.items, state)
+		return nil, false
+	}
+	delete(s.items, state)
+	return p, true
+}
+
+// cleanup removes expired entries. Must be called with s.mu held.
+func (s *StateStore) cleanup() {
+	for k, v := range s.items {
+		if time.Since(v.CreatedAt) > stateTTL {
+			delete(s.items, k)
+		}
+	}
+}

--- a/pkg/mcpoauth/token_refresh.go
+++ b/pkg/mcpoauth/token_refresh.go
@@ -1,0 +1,86 @@
+package mcpoauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// TokenResponse is the OAuth 2.x token endpoint response.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// ExchangeCode exchanges an authorization code for tokens using PKCE.
+func ExchangeCode(ctx context.Context, client *http.Client, tokenURL, clientID, clientSecret, code, codeVerifier, redirectURI string) (*TokenResponse, error) {
+	return callTokenEndpoint(ctx, client, tokenURL, clientID, clientSecret, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"code_verifier": {codeVerifier},
+	})
+}
+
+// RefreshToken uses a refresh_token to obtain a new access_token.
+func RefreshToken(ctx context.Context, client *http.Client, tokenURL, clientID, clientSecret, refreshToken string) (*TokenResponse, error) {
+	return callTokenEndpoint(ctx, client, tokenURL, clientID, clientSecret, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	})
+}
+
+func callTokenEndpoint(ctx context.Context, client *http.Client, tokenURL, clientID, clientSecret string, params url.Values) (*TokenResponse, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	params.Set("client_id", clientID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	// Confidential client: send Basic auth.
+	if clientSecret != "" {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token endpoint %s: %w", tokenURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token endpoint %s returned %d", tokenURL, resp.StatusCode)
+	}
+
+	var tr TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("decode token response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return nil, fmt.Errorf("token response missing access_token")
+	}
+	return &tr, nil
+}
+
+// ExpiresAt computes the expiry time from a token response.
+// Falls back to 1 hour when ExpiresIn is not set.
+func ExpiresAt(tr *TokenResponse) time.Time {
+	if tr.ExpiresIn > 0 {
+		return time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	return time.Now().Add(time.Hour)
+}

--- a/pkg/settingspatch/patch.go
+++ b/pkg/settingspatch/patch.go
@@ -76,15 +76,26 @@ type BedrockPatch struct {
 	Profile         string `json:"profile,omitempty"`
 }
 
+// MCPServerOAuthConfigPatch holds OAuth client configuration for a remote MCP server.
+// When present, agentapi-proxy will attempt to inject a Bearer token at session creation.
+type MCPServerOAuthConfigPatch struct {
+	ClientID     string   `json:"client_id,omitempty"`
+	ClientSecret string   `json:"client_secret,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	AuthURL      string   `json:"auth_url,omitempty"`
+	TokenURL     string   `json:"token_url,omitempty"`
+}
+
 // MCPServerPatch represents a single MCP server configuration.
 // All fields are replaced as a whole when the server key is present.
 type MCPServerPatch struct {
-	Type    string            `json:"type,omitempty"`
-	URL     string            `json:"url,omitempty"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
+	Type        string                     `json:"type,omitempty"`
+	URL         string                     `json:"url,omitempty"`
+	Command     string                     `json:"command,omitempty"`
+	Args        []string                   `json:"args,omitempty"`
+	Env         map[string]string          `json:"env,omitempty"`
+	Headers     map[string]string          `json:"headers,omitempty"`
+	OAuthConfig *MCPServerOAuthConfigPatch `json:"oauth_config,omitempty"`
 }
 
 // MarketplacePatch represents a single plugin marketplace configuration.

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1513,7 +1513,10 @@
                     "team_id": "myorg/backend",
                     "bot_token_secret_name": "my-slack-bot-token",
                     "bot_token_secret_key": "bot-token",
-                    "allowed_channel_names": ["dev", "backend"],
+                    "allowed_channel_names": [
+                      "dev",
+                      "backend"
+                    ],
                     "session_config": {
                       "initial_message_template": "{{.event.text}}",
                       "tags": {
@@ -2389,8 +2392,12 @@
           "Notifications"
         ],
         "security": [
-          {"ApiKeyAuth": []},
-          {"BearerAuth": []}
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
         ],
         "requestBody": {
           "required": true,
@@ -2430,13 +2437,24 @@
         "summary": "Create a memory entry",
         "description": "Creates a new memory entry for a user or team. User-scoped memories are private to the owner. Team-scoped memories are accessible to all team members.",
         "operationId": "createMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateMemoryRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateMemoryRequest"
+              }
             }
           }
         },
@@ -2445,49 +2463,78 @@
             "description": "Memory entry created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Memory"}
+                "schema": {
+                  "$ref": "#/components/schemas/Memory"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       },
       "get": {
         "summary": "List memory entries",
         "description": "Lists memory entries accessible to the authenticated user. User-scoped queries return only the user's own entries. Team-scoped queries return entries for teams the user belongs to.",
         "operationId": "listMemories",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "scope",
             "in": "query",
             "description": "Filter by scope: 'user' or 'team'. Omit to return both.",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "team"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "team"
+              ]
+            }
           },
           {
             "name": "team_id",
             "in": "query",
             "description": "Filter by team ID (required when scope=team)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "q",
             "in": "query",
             "description": "Full-text search query applied to title and content (case-insensitive)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "include_tag.{key}",
             "in": "query",
             "description": "Include only memories whose tags contain ALL of the specified key=value pairs. For example, `include_tag.category=news` returns only memories tagged with `category=news`. Multiple include_tag parameters are AND-combined.",
             "required": false,
-            "schema": {"type": "string"},
+            "schema": {
+              "type": "string"
+            },
             "example": "include_tag.category=news"
           },
           {
@@ -2495,7 +2542,9 @@
             "in": "query",
             "description": "Exclude memories whose tags contain ALL of the specified key=value pairs. For example, `exclude_tag.category=news` excludes memories tagged with `category=news`. Multiple exclude_tag parameters are AND-combined.",
             "required": false,
-            "schema": {"type": "string"},
+            "schema": {
+              "type": "string"
+            },
             "example": "exclude_tag.category=news"
           }
         ],
@@ -2504,12 +2553,18 @@
             "description": "List of memory entries",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/MemoryListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryListResponse"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       }
     },
@@ -2518,15 +2573,26 @@
         "summary": "Get a memory entry",
         "description": "Retrieves a specific memory entry by ID. Access is restricted to the owner (user-scoped) or team members (team-scoped). Admin privilege does NOT bypass these restrictions.",
         "operationId": "getMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "memoryId",
             "in": "path",
             "required": true,
             "description": "UUID of the memory entry",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2534,35 +2600,56 @@
             "description": "Memory entry",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Memory"}
+                "schema": {
+                  "$ref": "#/components/schemas/Memory"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Memory entry not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Memory entry not found"
+          }
         }
       },
       "put": {
         "summary": "Update a memory entry",
         "description": "Updates a memory entry. Only the owner (user-scoped) or team members (team-scoped) can update. Omitted fields are not changed.",
         "operationId": "updateMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "memoryId",
             "in": "path",
             "required": true,
             "description": "UUID of the memory entry",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateMemoryRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemoryRequest"
+              }
             }
           }
         },
@@ -2571,29 +2658,50 @@
             "description": "Updated memory entry",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Memory"}
+                "schema": {
+                  "$ref": "#/components/schemas/Memory"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Memory entry not found"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Memory entry not found"
+          }
         }
       },
       "delete": {
         "summary": "Delete a memory entry",
         "description": "Deletes a memory entry. Only the owner (user-scoped) or team members (team-scoped) can delete.",
         "operationId": "deleteMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "memoryId",
             "in": "path",
             "required": true,
             "description": "UUID of the memory entry",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2604,15 +2712,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"}
+                    "success": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Memory entry not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Memory entry not found"
+          }
         }
       }
     },
@@ -2621,13 +2737,24 @@
         "summary": "Create a task",
         "description": "Creates a new task for a user or team. User-scoped tasks are private to the owner. Team-scoped tasks are accessible to all team members.",
         "operationId": "createTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateTaskRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateTaskRequest"
+              }
             }
           }
         },
@@ -2636,56 +2763,95 @@
             "description": "Task created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Task"}
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       },
       "get": {
         "summary": "List tasks",
         "description": "Lists tasks accessible to the authenticated user. Supports filtering by scope, team, group, status, and task type.",
         "operationId": "listTasks",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "scope",
             "in": "query",
             "description": "Filter by scope: 'user' or 'team'. Omit to return both.",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "team"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "team"
+              ]
+            }
           },
           {
             "name": "team_id",
             "in": "query",
             "description": "Filter by team ID (required when scope=team)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "group_id",
             "in": "query",
             "description": "Filter by task group ID",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filter by status: 'todo' or 'done'",
             "required": false,
-            "schema": {"type": "string", "enum": ["todo", "done"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "todo",
+                "done"
+              ]
+            }
           },
           {
             "name": "task_type",
             "in": "query",
             "description": "Filter by task type: 'user' or 'agent'",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "agent"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "agent"
+              ]
+            }
           }
         ],
         "responses": {
@@ -2693,12 +2859,18 @@
             "description": "List of tasks",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskListResponse"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       }
     },
@@ -2707,15 +2879,26 @@
         "summary": "Get a task",
         "description": "Retrieves a specific task by ID.",
         "operationId": "getTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "taskId",
             "in": "path",
             "required": true,
             "description": "UUID of the task",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2723,35 +2906,56 @@
             "description": "Task",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Task"}
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task not found"
+          }
         }
       },
       "put": {
         "summary": "Update a task",
         "description": "Updates a task. Only the owner (user-scoped) or team members (team-scoped) can update. Omitted fields are not changed.",
         "operationId": "updateTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "taskId",
             "in": "path",
             "required": true,
             "description": "UUID of the task",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateTaskRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTaskRequest"
+              }
             }
           }
         },
@@ -2760,29 +2964,50 @@
             "description": "Updated task",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Task"}
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task not found"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task not found"
+          }
         }
       },
       "delete": {
         "summary": "Delete a task",
         "description": "Deletes a task. Only the owner (user-scoped) or team members (team-scoped) can delete.",
         "operationId": "deleteTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "taskId",
             "in": "path",
             "required": true,
             "description": "UUID of the task",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2793,15 +3018,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"}
+                    "success": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task not found"
+          }
         }
       }
     },
@@ -2810,13 +3043,24 @@
         "summary": "Create a task group",
         "description": "Creates a new task group for organizing tasks. Groups support user and team scopes.",
         "operationId": "createTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateTaskGroupRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateTaskGroupRequest"
+              }
             }
           }
         },
@@ -2825,35 +3069,60 @@
             "description": "Task group created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroup"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroup"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       },
       "get": {
         "summary": "List task groups",
         "description": "Lists task groups accessible to the authenticated user.",
         "operationId": "listTaskGroups",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "scope",
             "in": "query",
             "description": "Filter by scope: 'user' or 'team'. Omit to return both.",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "team"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "team"
+              ]
+            }
           },
           {
             "name": "team_id",
             "in": "query",
             "description": "Filter by team ID (required when scope=team)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2861,12 +3130,18 @@
             "description": "List of task groups",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroupListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroupListResponse"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       }
     },
@@ -2875,15 +3150,26 @@
         "summary": "Get a task group",
         "description": "Retrieves a specific task group by ID.",
         "operationId": "getTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "groupId",
             "in": "path",
             "required": true,
             "description": "UUID of the task group",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2891,35 +3177,56 @@
             "description": "Task group",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroup"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroup"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task group not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task group not found"
+          }
         }
       },
       "put": {
         "summary": "Update a task group",
         "description": "Updates a task group. Omitted fields are not changed.",
         "operationId": "updateTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "groupId",
             "in": "path",
             "required": true,
             "description": "UUID of the task group",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateTaskGroupRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTaskGroupRequest"
+              }
             }
           }
         },
@@ -2928,29 +3235,50 @@
             "description": "Updated task group",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroup"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroup"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task group not found"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task group not found"
+          }
         }
       },
       "delete": {
         "summary": "Delete a task group",
         "description": "Deletes a task group.",
         "operationId": "deleteTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "groupId",
             "in": "path",
             "required": true,
             "description": "UUID of the task group",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2961,16 +3289,176 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"}
+                    "success": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task group not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task group not found"
+          }
         }
+      }
+    },
+    "/mcp-oauth/connect": {
+      "post": {
+        "tags": [
+          "MCP OAuth"
+        ],
+        "summary": "Start OAuth flow for a remote MCP server",
+        "operationId": "connectMCPOAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MCPOAuthConnectRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authorization URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MCPOAuthConnectResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "502": {
+            "description": "OAuth discovery failed"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/mcp-oauth/callback": {
+      "get": {
+        "tags": [
+          "MCP OAuth"
+        ],
+        "summary": "OAuth callback",
+        "operationId": "mcpOAuthCallback",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "error",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML completion page",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": []
+      }
+    },
+    "/mcp-oauth/status/{serverName}": {
+      "get": {
+        "tags": [
+          "MCP OAuth"
+        ],
+        "summary": "Get OAuth status",
+        "operationId": "getMCPOAuthStatus",
+        "parameters": [
+          {
+            "name": "serverName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MCPOAuthStatusResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/mcp-oauth/disconnect/{serverName}": {
+      "delete": {
+        "tags": [
+          "MCP OAuth"
+        ],
+        "summary": "Disconnect OAuth",
+        "operationId": "disconnectMCPOAuth",
+        "parameters": [
+          {
+            "name": "serverName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
       }
     }
   },
@@ -2995,7 +3483,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the memory entry"
           },
           "owner_id": {
@@ -3008,7 +3499,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Key-value tags for filtering"
           },
           "created_at": {
@@ -3022,12 +3515,23 @@
             "description": "Last update timestamp"
           }
         },
-        "required": ["id", "title", "content", "scope", "owner_id", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "title",
+          "content",
+          "scope",
+          "owner_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateMemoryRequest": {
         "type": "object",
         "description": "Request body for creating a memory entry",
-        "required": ["title", "scope"],
+        "required": [
+          "title",
+          "scope"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -3039,7 +3543,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the memory entry"
           },
           "team_id": {
@@ -3048,7 +3555,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Key-value tags for filtering"
           }
         }
@@ -3067,7 +3576,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "New tags (when present, replaces ALL existing tags; omit to keep existing)"
           }
         }
@@ -3078,7 +3589,9 @@
         "properties": {
           "memories": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/Memory"},
+            "items": {
+              "$ref": "#/components/schemas/Memory"
+            },
             "description": "List of memory entries"
           },
           "total": {
@@ -3086,7 +3599,10 @@
             "description": "Total number of entries in the response"
           }
         },
-        "required": ["memories", "total"]
+        "required": [
+          "memories",
+          "total"
+        ]
       },
       "TaskLink": {
         "type": "object",
@@ -3107,7 +3623,10 @@
             "description": "Optional label for the link"
           }
         },
-        "required": ["id", "url"]
+        "required": [
+          "id",
+          "url"
+        ]
       },
       "TaskLinkRequest": {
         "type": "object",
@@ -3123,7 +3642,9 @@
             "description": "Optional label for the link"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "Task": {
         "type": "object",
@@ -3144,17 +3665,26 @@
           },
           "status": {
             "type": "string",
-            "enum": ["todo", "done"],
+            "enum": [
+              "todo",
+              "done"
+            ],
             "description": "Current status of the task"
           },
           "task_type": {
             "type": "string",
-            "enum": ["user", "agent"],
+            "enum": [
+              "user",
+              "agent"
+            ],
             "description": "Who manages the task: 'user' for human-managed, 'agent' for AI agent-managed"
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task"
           },
           "owner_id": {
@@ -3176,7 +3706,9 @@
           },
           "links": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskLink"},
+            "items": {
+              "$ref": "#/components/schemas/TaskLink"
+            },
             "description": "List of associated links"
           },
           "created_at": {
@@ -3190,7 +3722,17 @@
             "description": "Last update timestamp (ISO 8601)"
           }
         },
-        "required": ["id", "title", "status", "task_type", "scope", "owner_id", "links", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "title",
+          "status",
+          "task_type",
+          "scope",
+          "owner_id",
+          "links",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateTaskRequest": {
         "type": "object",
@@ -3206,12 +3748,18 @@
           },
           "task_type": {
             "type": "string",
-            "enum": ["user", "agent"],
+            "enum": [
+              "user",
+              "agent"
+            ],
             "description": "Who manages the task"
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task"
           },
           "team_id": {
@@ -3229,11 +3777,17 @@
           },
           "links": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskLinkRequest"},
+            "items": {
+              "$ref": "#/components/schemas/TaskLinkRequest"
+            },
             "description": "Associated links"
           }
         },
-        "required": ["title", "task_type", "scope"]
+        "required": [
+          "title",
+          "task_type",
+          "scope"
+        ]
       },
       "UpdateTaskRequest": {
         "type": "object",
@@ -3249,7 +3803,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["todo", "done"],
+            "enum": [
+              "todo",
+              "done"
+            ],
             "description": "New status"
           },
           "group_id": {
@@ -3262,7 +3819,9 @@
           },
           "links": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskLinkRequest"},
+            "items": {
+              "$ref": "#/components/schemas/TaskLinkRequest"
+            },
             "description": "Replaces all existing links when present"
           }
         }
@@ -3273,7 +3832,9 @@
         "properties": {
           "tasks": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/Task"},
+            "items": {
+              "$ref": "#/components/schemas/Task"
+            },
             "description": "List of tasks"
           },
           "total": {
@@ -3281,7 +3842,10 @@
             "description": "Total number of tasks in the response"
           }
         },
-        "required": ["tasks", "total"]
+        "required": [
+          "tasks",
+          "total"
+        ]
       },
       "TaskGroup": {
         "type": "object",
@@ -3302,7 +3866,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task group"
           },
           "owner_id": {
@@ -3324,7 +3891,14 @@
             "description": "Last update timestamp (ISO 8601)"
           }
         },
-        "required": ["id", "name", "scope", "owner_id", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "name",
+          "scope",
+          "owner_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateTaskGroupRequest": {
         "type": "object",
@@ -3340,7 +3914,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task group"
           },
           "team_id": {
@@ -3348,7 +3925,10 @@
             "description": "Team ID (required when scope is 'team')"
           }
         },
-        "required": ["name", "scope"]
+        "required": [
+          "name",
+          "scope"
+        ]
       },
       "UpdateTaskGroupRequest": {
         "type": "object",
@@ -3370,7 +3950,9 @@
         "properties": {
           "task_groups": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskGroup"},
+            "items": {
+              "$ref": "#/components/schemas/TaskGroup"
+            },
             "description": "List of task groups"
           },
           "total": {
@@ -3378,7 +3960,10 @@
             "description": "Total number of task groups in the response"
           }
         },
-        "required": ["task_groups", "total"]
+        "required": [
+          "task_groups",
+          "total"
+        ]
       },
       "StartRequest": {
         "type": "object",
@@ -4350,6 +4935,9 @@
               "type": "string"
             },
             "description": "Headers for http/sse servers. Empty string values are ignored (existing values are preserved). Keys not included in the request are automatically preserved."
+          },
+          "oauth_config": {
+            "$ref": "#/components/schemas/MCPServerOAuthConfig"
           }
         }
       },
@@ -4511,6 +5099,15 @@
               "type": "string"
             },
             "description": "List of header keys (values are not returned)"
+          },
+          "has_oauth_config": {
+            "type": "boolean"
+          },
+          "oauth_scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -4631,7 +5228,10 @@
       },
       "SendNotificationRequest": {
         "type": "object",
-        "required": ["title", "body"],
+        "required": [
+          "title",
+          "body"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -4814,11 +5414,99 @@
             "type": "string"
           }
         }
+      },
+      "MCPServerOAuthConfig": {
+        "type": "object",
+        "description": "OAuth client configuration for a remote MCP server",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "OAuth client_id. Leave empty to use DCR"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "OAuth client_secret for confidential clients"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "OAuth scopes to request"
+          },
+          "auth_url": {
+            "type": "string",
+            "description": "Override authorization endpoint"
+          },
+          "token_url": {
+            "type": "string",
+            "description": "Override token endpoint"
+          }
+        }
+      },
+      "MCPOAuthConnectRequest": {
+        "type": "object",
+        "required": [
+          "server_name",
+          "mcp_server_url"
+        ],
+        "properties": {
+          "server_name": {
+            "type": "string"
+          },
+          "mcp_server_url": {
+            "type": "string"
+          },
+          "client_id": {
+            "type": "string"
+          },
+          "client_secret": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "MCPOAuthConnectResponse": {
+        "type": "object",
+        "properties": {
+          "authorization_url": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        }
+      },
+      "MCPOAuthStatusResponse": {
+        "type": "object",
+        "properties": {
+          "server_name": {
+            "type": "string"
+          },
+          "connected": {
+            "type": "boolean"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "has_refresh_token": {
+            "type": "boolean"
+          }
+        }
       }
     },
     "SlackBotStatus": {
       "type": "string",
-      "enum": ["active", "paused"],
+      "enum": [
+        "active",
+        "paused"
+      ],
       "description": "SlackBot operational status"
     },
     "SlackBotSessionParams": {
@@ -4871,7 +5559,9 @@
     },
     "CreateSlackBotRequest": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -4902,7 +5592,10 @@
             "type": "string"
           },
           "description": "Slack event types to process. Empty means all event types are allowed.",
-          "example": ["message", "app_mention"]
+          "example": [
+            "message",
+            "app_mention"
+          ]
         },
         "allowed_channel_names": {
           "type": "array",
@@ -4910,7 +5603,10 @@
             "type": "string"
           },
           "description": "Slack channel name patterns to listen to (partial match). Empty means all channels are allowed.",
-          "example": ["dev", "backend"]
+          "example": [
+            "dev",
+            "backend"
+          ]
         },
         "session_config": {
           "$ref": "#/components/schemas/SlackBotSessionConfig"
@@ -5159,6 +5855,10 @@
     {
       "name": "TaskGroups",
       "description": "Task group management for organizing tasks into logical collections. Groups support user and team scopes."
+    },
+    {
+      "name": "MCP OAuth",
+      "description": "MCP server OAuth authentication management"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **pkg/mcpoauth**: Implements the full OAuth 2.1 PKCE authorization code flow for remote MCP servers that require OAuth (Figma, Notion, Linear, Stripe, etc.)
  - Discovery via RFC 9728 (Protected Resource Metadata) + RFC 8414 (Authorization Server Metadata)
  - Dynamic Client Registration (RFC 7591) — auto-registers a client when the server supports it; falls back to pre-registered `client_id`
  - PKCE (RFC 7636, S256 method) — mandatory per MCP OAuth 2.1 spec
  - State store with 15-min TTL, token exchange + refresh, and an embedded callback HTML page
- **Domain / repository layer**: New `MCPOAuthToken` entity, `MCPOAuthTokenRepository` interface, and `KubernetesMCPOAuthTokenRepository` (stores tokens as `tokens.json` in a per-user Kubernetes Secret)
- **HTTP handlers** (`internal/app/mcp_oauth.go`): Four new routes:
  - `POST /mcp-oauth/connect` — starts the flow, returns `authorization_url`
  - `GET /mcp-oauth/callback` — exchanges code, saves token, renders callback UI via `go:embed`
  - `GET /mcp-oauth/status/:serverName` — returns connected/expired state
  - `DELETE /mcp-oauth/disconnect/:serverName` — revokes stored token
- **Settings layer**: `MCPServer` entity and `APIMCPServerConfig` extended with optional `oauth_config` (client_id, client_secret, scopes); `KubernetesSessionManager` strips `oauth_config` from the container's MCP server config and injects `headers.Authorization: Bearer <token>` when a valid token exists
- **OpenAPI spec** (`spec/openapi.json`): New `MCP OAuth` tag + schemas + all four paths

## How it works for the user

1. User adds a remote MCP server (e.g. `https://api.figma.com/v1/mcp`) in Settings → MCP Servers
2. In the agentapi-ui they click **Connect OAuth** next to the server
3. A popup opens with the provider's authorization page
4. After granting access the popup closes; agentapi-proxy stores the token in Kubernetes
5. On the next session start, agentapi-proxy injects `Authorization: Bearer <token>` into the MCP server headers — Claude Code never needs to do anything

## Test plan

- [ ] `make lint` passes (verified locally)
- [ ] `make test` passes (verified locally — all packages green)
- [ ] Manual test: add Notion/Linear MCP server URL, click Connect OAuth, verify token stored in Kubernetes Secret, verify new session has `Authorization` header injected

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)