### PR TITLE
feat(schedule): add --env KEY=VALUE flag to schedule create and apply

### DIFF
--- a/cmd/client_schedule.go
+++ b/cmd/client_schedule.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -15,6 +16,7 @@ var (
 	scheduleFilterScope  string
 	scheduleFilterTeamID string
 	scheduleFile         string
+	scheduleEnvVars      []string
 )
 
 var scheduleCmd = &cobra.Command{
@@ -83,18 +85,27 @@ var scheduleCreateCmd = &cobra.Command{
 Reads JSON from a file (--file) or from stdin when --file is omitted or set to "-".
 The server assigns a unique ID and returns the created resource as JSON.
 
+Use --env KEY=VALUE (repeatable) to inject environment variables into the session.
+These are merged into session_config.environment, overriding any same-key values
+already present in the JSON body.
+
 Example JSON for a one-time schedule:
   {
     "name": "daily-report",
     "scheduled_at": "2026-03-25T09:00:00Z",
-    "prompt": "Generate the daily report"
+    "session_config": {
+      "params": {"message": "Generate the daily report"}
+    }
   }
 
 Example JSON for a recurring schedule (cron):
   {
     "name": "weekday-standup",
     "cron_expr": "0 9 * * 1-5",
-    "prompt": "Post standup summary"
+    "session_config": {
+      "params": {"message": "Post standup summary"},
+      "environment": {"MY_VAR": "value"}
+    }
   }
 
 Examples:
@@ -105,8 +116,12 @@ Examples:
   cat schedule.json | agentapi-proxy client schedule create
 
   # Inline one-time schedule
-  echo '{"name":"daily-report","scheduled_at":"2026-03-25T09:00:00Z"}' \
-    | agentapi-proxy client schedule create`,
+  echo '{"name":"daily-report","scheduled_at":"2026-03-25T09:00:00Z","session_config":{"params":{"message":"hello"}}}' \
+    | agentapi-proxy client schedule create
+
+  # With environment variables via --env flags
+  echo '{"name":"daily-report","cron_expr":"0 9 * * 1-5","session_config":{"params":{"message":"hello"}}}' \
+    | agentapi-proxy client schedule create --env MY_VAR=value --env DEBUG=true`,
 	Run: runScheduleCreate,
 }
 
@@ -118,6 +133,10 @@ var scheduleApplyCmd = &cobra.Command{
 Only the fields present in the JSON body are updated (merge-patch semantics).
 Omitted fields are left unchanged on the server.
 Reads JSON from a file (--file) or from stdin when --file is omitted or set to "-".
+
+Use --env KEY=VALUE (repeatable) to set or update environment variables in
+session_config.environment. These are merged into the patch body, overriding any
+same-key values already present in the JSON body.
 
 Typical workflow:
   1. agentapi-proxy client schedule get <id> > schedule.json
@@ -132,7 +151,13 @@ Examples:
   echo '{"cron_expr":"0 10 * * 1-5"}' | agentapi-proxy client schedule apply abc123
 
   # Apply a full JSON file (unchanged fields are preserved on the server)
-  agentapi-proxy client schedule apply abc123 --file schedule.json`,
+  agentapi-proxy client schedule apply abc123 --file schedule.json
+
+  # Update environment variables only
+  echo '{}' | agentapi-proxy client schedule apply abc123 --env MY_VAR=new_value --env DEBUG=false
+
+  # Combine JSON patch with --env flags (flags take precedence for overlapping keys)
+  echo '{"status":"active"}' | agentapi-proxy client schedule apply abc123 --env MY_VAR=value`,
 	Args: cobra.ExactArgs(1),
 	Run:  runScheduleApply,
 }
@@ -159,7 +184,9 @@ func init() {
 
 	// create / apply flags
 	scheduleCreateCmd.Flags().StringVarP(&scheduleFile, "file", "f", "", `Path to JSON file, or "-" for stdin (default: stdin)`)
+	scheduleCreateCmd.Flags().StringArrayVar(&scheduleEnvVars, "env", nil, `Environment variable in KEY=VALUE format (can be specified multiple times)`)
 	scheduleApplyCmd.Flags().StringVarP(&scheduleFile, "file", "f", "", `Path to JSON file, or "-" for stdin (default: stdin)`)
+	scheduleApplyCmd.Flags().StringArrayVar(&scheduleEnvVars, "env", nil, `Environment variable in KEY=VALUE format (can be specified multiple times)`)
 
 	scheduleCmd.AddCommand(scheduleListCmd)
 	scheduleCmd.AddCommand(scheduleGetCmd)
@@ -213,6 +240,46 @@ func runScheduleGet(cmd *cobra.Command, args []string) {
 	fmt.Println(prettyJSONOutput(result))
 }
 
+// mergeEnvIntoScheduleJSON merges the given environment variable map into the
+// session_config.environment field of the provided JSON object.  If envMap is
+// empty the original data is returned unchanged.  CLI --env flags take
+// precedence over values already present in the JSON body.
+func mergeEnvIntoScheduleJSON(data []byte, envMap map[string]string) ([]byte, error) {
+	if len(envMap) == 0 {
+		return data, nil
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	// Ensure session_config exists
+	sessionConfig, _ := obj["session_config"].(map[string]interface{})
+	if sessionConfig == nil {
+		sessionConfig = make(map[string]interface{})
+		obj["session_config"] = sessionConfig
+	}
+
+	// Ensure environment exists inside session_config
+	env, _ := sessionConfig["environment"].(map[string]interface{})
+	if env == nil {
+		env = make(map[string]interface{})
+		sessionConfig["environment"] = env
+	}
+
+	// Merge: CLI flags override JSON body values
+	for k, v := range envMap {
+		env[k] = v
+	}
+
+	merged, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	return merged, nil
+}
+
 func runScheduleCreate(cmd *cobra.Command, args []string) {
 	data, err := readJSONInput(scheduleFile)
 	if err != nil {
@@ -220,6 +287,20 @@ func runScheduleCreate(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Hint: provide JSON via stdin or use --file path/to/schedule.json\n")
 		fmt.Fprintf(os.Stderr, "Example: echo '{\"name\":\"my-schedule\",\"cron_expr\":\"0 9 * * 1-5\"}' | agentapi-proxy client schedule create\n")
 		os.Exit(1)
+	}
+
+	if len(scheduleEnvVars) > 0 {
+		envMap, err := parseKeyValueFlags(scheduleEnvVars)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing --env flags: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Hint: use KEY=VALUE format, e.g. --env MY_VAR=value\n")
+			os.Exit(1)
+		}
+		data, err = mergeEnvIntoScheduleJSON(data, envMap)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error merging environment variables: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	c, err := resolveBaseClient()
@@ -247,6 +328,20 @@ func runScheduleApply(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Hint: provide the patch as JSON via stdin or use --file path/to/patch.json\n")
 		fmt.Fprintf(os.Stderr, "Example: echo '{\"status\":\"paused\"}' | agentapi-proxy client schedule apply %s\n", args[0])
 		os.Exit(1)
+	}
+
+	if len(scheduleEnvVars) > 0 {
+		envMap, err := parseKeyValueFlags(scheduleEnvVars)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing --env flags: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Hint: use KEY=VALUE format, e.g. --env MY_VAR=value\n")
+			os.Exit(1)
+		}
+		data, err = mergeEnvIntoScheduleJSON(data, envMap)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error merging environment variables: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	c, err := resolveBaseClient()

--- a/cmd/client_schedule_test.go
+++ b/cmd/client_schedule_test.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeEnvIntoScheduleJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		envMap  map[string]string
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name:   "empty envMap returns unchanged data",
+			input:  `{"name":"test"}`,
+			envMap: map[string]string{},
+			want: map[string]interface{}{
+				"name": "test",
+			},
+		},
+		{
+			name:  "nil envMap returns unchanged data",
+			input: `{"name":"test"}`,
+			want: map[string]interface{}{
+				"name": "test",
+			},
+		},
+		{
+			name:  "adds session_config.environment when absent",
+			input: `{"name":"test","cron_expr":"0 9 * * 1-5"}`,
+			envMap: map[string]string{
+				"MY_VAR": "hello",
+				"DEBUG":  "true",
+			},
+			want: map[string]interface{}{
+				"name":      "test",
+				"cron_expr": "0 9 * * 1-5",
+				"session_config": map[string]interface{}{
+					"environment": map[string]interface{}{
+						"MY_VAR": "hello",
+						"DEBUG":  "true",
+					},
+				},
+			},
+		},
+		{
+			name: "merges into existing session_config.environment",
+			input: `{
+				"name": "test",
+				"session_config": {
+					"environment": {"EXISTING": "val", "MY_VAR": "old"}
+				}
+			}`,
+			envMap: map[string]string{
+				"MY_VAR": "new",
+				"ADDED":  "yes",
+			},
+			want: map[string]interface{}{
+				"name": "test",
+				"session_config": map[string]interface{}{
+					"environment": map[string]interface{}{
+						"EXISTING": "val",
+						"MY_VAR":   "new", // overridden by CLI flag
+						"ADDED":    "yes",
+					},
+				},
+			},
+		},
+		{
+			name: "creates environment when session_config exists but environment does not",
+			input: `{
+				"name": "test",
+				"session_config": {
+					"tags": {"repo": "org/repo"}
+				}
+			}`,
+			envMap: map[string]string{
+				"FOO": "bar",
+			},
+			want: map[string]interface{}{
+				"name": "test",
+				"session_config": map[string]interface{}{
+					"tags": map[string]interface{}{"repo": "org/repo"},
+					"environment": map[string]interface{}{
+						"FOO": "bar",
+					},
+				},
+			},
+		},
+		{
+			name:    "invalid JSON returns error",
+			input:   `{invalid json}`,
+			envMap:  map[string]string{"KEY": "val"},
+			wantErr: true,
+		},
+		{
+			name:  "value with equals sign is preserved",
+			input: `{"name":"test"}`,
+			envMap: map[string]string{
+				"BASE64": "abc=def=",
+			},
+			want: map[string]interface{}{
+				"name": "test",
+				"session_config": map[string]interface{}{
+					"environment": map[string]interface{}{
+						"BASE64": "abc=def=",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeEnvIntoScheduleJSON([]byte(tt.input), tt.envMap)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.want == nil {
+				// No structural check needed for unchanged-data cases
+				return
+			}
+
+			var gotMap map[string]interface{}
+			require.NoError(t, json.Unmarshal(got, &gotMap))
+			assert.Equal(t, tt.want, gotMap)
+		})
+	}
+}
+
+func TestScheduleCreateCmdFlags(t *testing.T) {
+	// --file flag
+	fileFlag := scheduleCreateCmd.Flags().Lookup("file")
+	assert.NotNil(t, fileFlag, "--file flag should be registered on schedule create")
+	assert.Equal(t, "f", fileFlag.Shorthand)
+
+	// --env flag
+	envFlag := scheduleCreateCmd.Flags().Lookup("env")
+	assert.NotNil(t, envFlag, "--env flag should be registered on schedule create")
+}
+
+func TestScheduleApplyCmdFlags(t *testing.T) {
+	// --file flag
+	fileFlag := scheduleApplyCmd.Flags().Lookup("file")
+	assert.NotNil(t, fileFlag, "--file flag should be registered on schedule apply")
+	assert.Equal(t, "f", fileFlag.Shorthand)
+
+	// --env flag
+	envFlag := scheduleApplyCmd.Flags().Lookup("env")
+	assert.NotNil(t, envFlag, "--env flag should be registered on schedule apply")
+}


### PR DESCRIPTION
## Summary

- `schedule create` と `schedule apply` コマンドに `--env KEY=VALUE` フラグを追加
- `--env` は複数回指定可能（例: `--env MY_VAR=value --env DEBUG=true`）
- 指定した環境変数は `session_config.environment` にマージされ、JSON ボディに同じキーが存在する場合は CLI フラグの値が優先される
- `session_config` や `environment` が JSON に存在しない場合は自動的に生成される

## 使用例

```bash
# schedule create で環境変数を設定
echo '{"name":"daily","cron_expr":"0 9 * * 1-5","session_config":{"params":{"message":"hello"}}}' \
  | agentapi-proxy client schedule create --env MY_VAR=value --env DEBUG=true

# schedule apply で環境変数のみを更新
echo '{}' | agentapi-proxy client schedule apply abc123 --env MY_VAR=new_value

# JSON と --env フラグの組み合わせ（フラグが優先）
echo '{"status":"active"}' | agentapi-proxy client schedule apply abc123 --env KEY=val
```

## Test plan

- [x] `TestMergeEnvIntoScheduleJSON` - 7ケースのユニットテスト（環境変数のマージ、上書き、新規作成、不正JSON等）
- [x] `TestScheduleCreateCmdFlags` - `--env` フラグ登録確認
- [x] `TestScheduleApplyCmdFlags` - `--env` フラグ登録確認
- [x] `make lint` - 0 issues
- [x] `CGO_ENABLED=0 go build ./...` - ビルド成功

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)