### PR TITLE
feat: add user-managed files API (/files)

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -34,6 +34,7 @@ type HandlerRegistry struct {
 	memoryController         *controllers.MemoryController
 	taskController           *controllers.TaskController
 	taskGroupController      *controllers.TaskGroupController
+	fileController           *controllers.FileController
 	customHandlers           []CustomHandler
 }
 
@@ -116,6 +117,13 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] Task group controller initialized")
 	}
 
+	// Create file controller if user file repository is available
+	var fileController *controllers.FileController
+	if server.userFileRepo != nil {
+		fileController = controllers.NewFileController(server.userFileRepo)
+		log.Printf("[ROUTER] File controller initialized")
+	}
+
 	return &Router{
 		echo:   e,
 		server: server,
@@ -131,6 +139,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 			memoryController:         memoryController,
 			taskController:           taskController,
 			taskGroupController:      taskGroupController,
+			fileController:           fileController,
 			customHandlers:           make([]CustomHandler, 0),
 		},
 	}
@@ -324,6 +333,19 @@ func (r *Router) registerConditionalRoutes() error {
 		log.Printf("[ROUTES] Task group endpoints registered")
 	} else {
 		log.Printf("[ROUTES] Task group repository not available, skipping task group routes")
+	}
+
+	// Add file routes if user file repository is available (Kubernetes mode only)
+	if r.server.userFileRepo != nil && r.handlers.fileController != nil {
+		log.Printf("[ROUTES] Registering user file endpoints...")
+		r.echo.POST("/files", r.handlers.fileController.CreateFile, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.GET("/files", r.handlers.fileController.ListFiles, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.GET("/files/:fileId", r.handlers.fileController.GetFile, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.PUT("/files/:fileId", r.handlers.fileController.UpdateFile, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.DELETE("/files/:fileId", r.handlers.fileController.DeleteFile, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		log.Printf("[ROUTES] User file endpoints registered")
+	} else {
+		log.Printf("[ROUTES] User file repository not available, skipping file routes")
 	}
 
 	return nil

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -55,6 +55,7 @@ type Server struct {
 	taskRepo         portrepos.TaskRepository         // Task repository
 	taskGroupRepo    portrepos.TaskGroupRepository    // Task group repository
 	sessionRouteRepo portrepos.SessionRouteRepository // Session route repository for proxy B routing
+	userFileRepo     portrepos.UserFileRepository     // User-managed files repository
 	router           *Router                          // Router for custom handler registration
 }
 
@@ -94,7 +95,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 			// (at least 3 parts, not starting with "start", "search", "sessions", "oauth", "auth", "notification", or "notifications")
 			if len(pathParts) >= 3 && pathParts[1] != "" {
 				firstSegment := pathParts[1]
-				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials"
+				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files"
 			}
 			return false
 		},
@@ -267,6 +268,13 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 	)
 	log.Printf("[SERVER] Session route repository initialized")
 
+	// Initialize user file repository (Kubernetes Secret-backed)
+	userFileRepo := portrepos.UserFileRepository(repositories.NewKubernetesUserFileRepository(
+		k8sSessionManager.GetClient(),
+		k8sSessionManager.GetNamespace(),
+	))
+	log.Printf("[SERVER] User file repository initialized")
+
 	s := &Server{
 		config:           cfg,
 		echo:             e,
@@ -282,6 +290,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 		taskRepo:         taskRepo,
 		taskGroupRepo:    taskGroupRepo,
 		sessionRouteRepo: sessionRouteRepo,
+		userFileRepo:     userFileRepo,
 	}
 
 	// Add logging middleware if verbose

--- a/internal/domain/entities/user_file.go
+++ b/internal/domain/entities/user_file.go
@@ -1,0 +1,87 @@
+package entities
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrUserFilePathRequired is returned when a UserFile has an empty path.
+var ErrUserFilePathRequired = errors.New("user file path is required")
+
+// UserFile represents a user-managed file to be placed inside agent sessions.
+// Files are stored in the agentapi-user-files-{userID} Kubernetes Secret and
+// embedded into SessionSettings.Files at session creation time so that the
+// provisioner writes them to their target paths (mode 0600).
+type UserFile struct {
+	id          string
+	name        string
+	path        string // destination path inside the container
+	content     string // file content (plain text or base64)
+	permissions string // e.g. "0600" (informational; provisioner uses 0600 by default)
+	createdAt   time.Time
+	updatedAt   time.Time
+}
+
+// NewUserFile creates a new UserFile entity.
+func NewUserFile(id, name, path, content, permissions string) *UserFile {
+	now := time.Now()
+	return &UserFile{
+		id:          id,
+		name:        name,
+		path:        path,
+		content:     content,
+		permissions: permissions,
+		createdAt:   now,
+		updatedAt:   now,
+	}
+}
+
+// ID returns the file's unique identifier.
+func (f *UserFile) ID() string { return f.id }
+
+// Name returns the human-readable display name.
+func (f *UserFile) Name() string { return f.name }
+
+// SetName sets the display name.
+func (f *UserFile) SetName(name string) { f.name = name }
+
+// Path returns the destination path inside the container.
+func (f *UserFile) Path() string { return f.path }
+
+// SetPath sets the destination path.
+func (f *UserFile) SetPath(path string) { f.path = path }
+
+// Content returns the file content.
+func (f *UserFile) Content() string { return f.content }
+
+// SetContent replaces the file content and updates UpdatedAt.
+func (f *UserFile) SetContent(content string) {
+	f.content = content
+	f.updatedAt = time.Now()
+}
+
+// Permissions returns the permissions string (e.g. "0600").
+func (f *UserFile) Permissions() string { return f.permissions }
+
+// SetPermissions sets the permissions string.
+func (f *UserFile) SetPermissions(p string) { f.permissions = p }
+
+// CreatedAt returns the creation timestamp.
+func (f *UserFile) CreatedAt() time.Time { return f.createdAt }
+
+// UpdatedAt returns the last update timestamp.
+func (f *UserFile) UpdatedAt() time.Time { return f.updatedAt }
+
+// SetCreatedAt sets the creation timestamp (used when loading from storage).
+func (f *UserFile) SetCreatedAt(t time.Time) { f.createdAt = t }
+
+// SetUpdatedAt sets the update timestamp (used when loading from storage).
+func (f *UserFile) SetUpdatedAt(t time.Time) { f.updatedAt = t }
+
+// Validate returns an error if the entity is invalid.
+func (f *UserFile) Validate() error {
+	if f.path == "" {
+		return ErrUserFilePathRequired
+	}
+	return nil
+}

--- a/internal/infrastructure/repositories/kubernetes_user_file_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_user_file_repository.go
@@ -1,0 +1,320 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
+)
+
+const (
+	// UserFilesSecretPrefix is the prefix for agentapi-user-files-* Secrets.
+	UserFilesSecretPrefix = "agentapi-user-files-"
+
+	// LabelUserFiles is the label key for user-files Secrets.
+	LabelUserFiles = "agentapi.proxy/user-files"
+
+	// Annotation keys for user-files Secrets.
+	AnnotationUserFilesUpdatedAt = "agentapi.proxy/user-files-updated-at"
+)
+
+// KubernetesUserFileRepository implements UserFileRepository using a
+// agentapi-user-files-{userID} Kubernetes Secret with index-based KV format.
+//
+// Each file is stored as:
+//
+//	"{i}.id"          → UUID
+//	"{i}.name"        → display name
+//	"{i}.path"        → destination path inside the container
+//	"{i}.content"     → file content
+//	"{i}.permissions" → permissions string (optional, e.g. "0600")
+type KubernetesUserFileRepository struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewKubernetesUserFileRepository creates a new KubernetesUserFileRepository.
+func NewKubernetesUserFileRepository(client kubernetes.Interface, namespace string) *KubernetesUserFileRepository {
+	return &KubernetesUserFileRepository{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+// Save creates or updates a file entry inside the user's Secret.
+func (r *KubernetesUserFileRepository) Save(ctx context.Context, userID string, file *entities.UserFile) error {
+	if err := file.Validate(); err != nil {
+		return fmt.Errorf("invalid user file: %w", err)
+	}
+
+	secretName := r.secretName(userID)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Load existing files to preserve others.
+	existing, err := r.client.CoreV1().Secrets(r.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	var currentFiles []*entities.UserFile
+	if err == nil {
+		currentFiles = secretDataToUserFiles(existing.Data)
+	}
+
+	// Update existing entry or append a new one.
+	updated := false
+	for i, f := range currentFiles {
+		if f.ID() == file.ID() {
+			currentFiles[i] = file
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		currentFiles = append(currentFiles, file)
+	}
+
+	secretData := userFilesToSecretData(currentFiles)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: r.namespace,
+			Labels: map[string]string{
+				LabelUserFiles: "true",
+			},
+			Annotations: map[string]string{
+				AnnotationUserFilesUpdatedAt: now,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: secretData,
+	}
+
+	_, createErr := r.client.CoreV1().Secrets(r.namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if createErr != nil {
+		if errors.IsAlreadyExists(createErr) {
+			existing.Data = secretData
+			existing.Labels = secret.Labels
+			if existing.Annotations == nil {
+				existing.Annotations = map[string]string{}
+			}
+			existing.Annotations[AnnotationUserFilesUpdatedAt] = now
+			_, updateErr := r.client.CoreV1().Secrets(r.namespace).Update(ctx, existing, metav1.UpdateOptions{})
+			if updateErr != nil {
+				return fmt.Errorf("failed to update user files secret: %w", updateErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to create user files secret: %w", createErr)
+	}
+	return nil
+}
+
+// FindByID retrieves a single file by ID from the user's Secret.
+func (r *KubernetesUserFileRepository) FindByID(ctx context.Context, userID string, fileID string) (*entities.UserFile, error) {
+	files, err := r.List(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range files {
+		if f.ID() == fileID {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("user file not found: %s", fileID)
+}
+
+// List retrieves all files for the given user.
+func (r *KubernetesUserFileRepository) List(ctx context.Context, userID string) ([]*entities.UserFile, error) {
+	secretName := r.secretName(userID)
+	secret, err := r.client.CoreV1().Secrets(r.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return []*entities.UserFile{}, nil
+		}
+		return nil, fmt.Errorf("failed to get user files secret: %w", err)
+	}
+	return secretDataToUserFiles(secret.Data), nil
+}
+
+// Delete removes a file entry from the user's Secret.
+func (r *KubernetesUserFileRepository) Delete(ctx context.Context, userID string, fileID string) error {
+	secretName := r.secretName(userID)
+
+	secret, err := r.client.CoreV1().Secrets(r.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("user file not found: %s", fileID)
+		}
+		return fmt.Errorf("failed to get user files secret: %w", err)
+	}
+
+	current := secretDataToUserFiles(secret.Data)
+	filtered := make([]*entities.UserFile, 0, len(current))
+	found := false
+	for _, f := range current {
+		if f.ID() == fileID {
+			found = true
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+	if !found {
+		return fmt.Errorf("user file not found: %s", fileID)
+	}
+
+	if len(filtered) == 0 {
+		// Delete the secret entirely when no files remain.
+		deleteErr := r.client.CoreV1().Secrets(r.namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
+			return fmt.Errorf("failed to delete user files secret: %w", deleteErr)
+		}
+		return nil
+	}
+
+	secret.Data = userFilesToSecretData(filtered)
+	if _, updateErr := r.client.CoreV1().Secrets(r.namespace).Update(ctx, secret, metav1.UpdateOptions{}); updateErr != nil {
+		return fmt.Errorf("failed to update user files secret after deletion: %w", updateErr)
+	}
+	return nil
+}
+
+// ToManagedFiles converts all user files to the ManagedFile format used by
+// SessionSettings so they can be written to the container by the provisioner.
+func (r *KubernetesUserFileRepository) ToManagedFiles(ctx context.Context, userID string) ([]sessionsettings.ManagedFile, error) {
+	files, err := r.List(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	managed := make([]sessionsettings.ManagedFile, 0, len(files))
+	for _, f := range files {
+		managed = append(managed, sessionsettings.ManagedFile{
+			Path:    f.Path(),
+			Content: f.Content(),
+		})
+	}
+	return managed, nil
+}
+
+// secretName returns the Secret name for the given userID.
+func (r *KubernetesUserFileRepository) secretName(userID string) string {
+	sanitized := sanitizeSecretName(userID)
+	maxLen := 253 - len(UserFilesSecretPrefix)
+	if len(sanitized) > maxLen {
+		sanitized = sanitized[:maxLen]
+	}
+	return UserFilesSecretPrefix + sanitized
+}
+
+// --- serialization helpers ---
+
+// userFilesToSecretData serialises a slice of UserFile into a flat map
+// suitable for storing in a Kubernetes Secret.
+//
+// Format:
+//
+//	"{i}.id"          → file.ID()
+//	"{i}.name"        → file.Name()
+//	"{i}.path"        → file.Path()
+//	"{i}.content"     → file.Content()
+//	"{i}.permissions" → file.Permissions()  (omitted when empty)
+//	"{i}.created_at"  → RFC3339 timestamp
+//	"{i}.updated_at"  → RFC3339 timestamp
+func userFilesToSecretData(files []*entities.UserFile) map[string][]byte {
+	data := make(map[string][]byte, len(files)*7)
+	for i, f := range files {
+		prefix := strconv.Itoa(i)
+		data[prefix+".id"] = []byte(f.ID())
+		data[prefix+".name"] = []byte(f.Name())
+		data[prefix+".path"] = []byte(f.Path())
+		data[prefix+".content"] = []byte(f.Content())
+		if f.Permissions() != "" {
+			data[prefix+".permissions"] = []byte(f.Permissions())
+		}
+		data[prefix+".created_at"] = []byte(f.CreatedAt().UTC().Format(time.RFC3339))
+		data[prefix+".updated_at"] = []byte(f.UpdatedAt().UTC().Format(time.RFC3339))
+	}
+	return data
+}
+
+// secretDataToUserFiles reconstructs a slice of UserFile from the flat map
+// produced by userFilesToSecretData.
+func secretDataToUserFiles(data map[string][]byte) []*entities.UserFile {
+	// Collect unique indices.
+	indexSet := map[int]struct{}{}
+	for k := range data {
+		if idx, ok := parseUserFileSecretKey(k); ok {
+			indexSet[idx] = struct{}{}
+		}
+	}
+
+	indices := make([]int, 0, len(indexSet))
+	for idx := range indexSet {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	files := make([]*entities.UserFile, 0, len(indices))
+	for _, idx := range indices {
+		prefix := strconv.Itoa(idx)
+		id := string(data[prefix+".id"])
+		if id == "" {
+			continue
+		}
+		path := string(data[prefix+".path"])
+		if path == "" {
+			continue
+		}
+		name := string(data[prefix+".name"])
+		content := string(data[prefix+".content"])
+		permissions := string(data[prefix+".permissions"])
+
+		f := entities.NewUserFile(id, name, path, content, permissions)
+		if v, ok := data[prefix+".created_at"]; ok {
+			if t, err := time.Parse(time.RFC3339, string(v)); err == nil {
+				f.SetCreatedAt(t)
+			}
+		}
+		if v, ok := data[prefix+".updated_at"]; ok {
+			if t, err := time.Parse(time.RFC3339, string(v)); err == nil {
+				f.SetUpdatedAt(t)
+			}
+		}
+		files = append(files, f)
+	}
+	return files
+}
+
+// parseUserFileSecretKey parses a key like "0.id", "1.path", etc.
+// and returns the index and true on success.
+var userFileSecretSuffixes = []string{"id", "name", "path", "content", "permissions", "created_at", "updated_at"}
+
+func parseUserFileSecretKey(k string) (int, bool) {
+	dot := strings.LastIndex(k, ".")
+	if dot < 0 {
+		return 0, false
+	}
+	suffix := k[dot+1:]
+	valid := false
+	for _, s := range userFileSecretSuffixes {
+		if suffix == s {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(k[:dot])
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
+}

--- a/internal/infrastructure/repositories/kubernetes_user_file_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_user_file_repository.go
@@ -196,8 +196,9 @@ func (r *KubernetesUserFileRepository) ToManagedFiles(ctx context.Context, userI
 	managed := make([]sessionsettings.ManagedFile, 0, len(files))
 	for _, f := range files {
 		managed = append(managed, sessionsettings.ManagedFile{
-			Path:    f.Path(),
-			Content: f.Content(),
+			Path:        f.Path(),
+			Content:     f.Content(),
+			Permissions: f.Permissions(),
 		})
 	}
 	return managed, nil

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3426,8 +3426,9 @@ func userFilesSecretDataToManagedFiles(data map[string][]byte) []sessionsettings
 			continue
 		}
 		files = append(files, sessionsettings.ManagedFile{
-			Path:    path,
-			Content: content,
+			Path:        path,
+			Content:     content,
+			Permissions: string(data[prefix+".permissions"]),
 		})
 	}
 	return files

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -3166,6 +3167,19 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			}
 		}
 		// Not found or no data is normal (user hasn't logged in yet); skip silently.
+
+		// Also embed user-managed files from the agentapi-user-files-{userID} Secret.
+		userFilesSecretName := fmt.Sprintf("agentapi-user-files-%s", sanitizeLabelValue(req.UserID))
+		userFilesSecret, userFilesErr := m.client.CoreV1().Secrets(m.namespace).Get(ctx, userFilesSecretName, metav1.GetOptions{})
+		if userFilesErr == nil && len(userFilesSecret.Data) > 0 {
+			userManagedFiles := userFilesSecretDataToManagedFiles(userFilesSecret.Data)
+			if len(userManagedFiles) > 0 {
+				settings.Files = append(settings.Files, userManagedFiles...)
+				log.Printf("[K8S_SESSION] Embedded %d user file(s) from Secret %s for session %s",
+					len(userManagedFiles), userFilesSecretName, session.id)
+			}
+		}
+		// Not found or no data is normal (user has no registered files); skip silently.
 	}
 
 	// When CycleMessage is set, write the message into /tmp/check/CYCLE_ENABLED so
@@ -3370,4 +3384,51 @@ func (m *KubernetesSessionManager) BuildRemoteProvisionSettings(
 	}
 	settings := m.buildSessionSettings(ctx, tempSession, req, nil)
 	return settings, nil
+}
+
+// userFilesSecretDataToManagedFiles converts the index-based Secret data from
+// agentapi-user-files-{userID} into a slice of ManagedFile for embedding in
+// SessionSettings.Files.  Only entries that have both a non-empty path and
+// content are included.
+func userFilesSecretDataToManagedFiles(data map[string][]byte) []sessionsettings.ManagedFile {
+	// Collect unique indices.
+	indexSet := map[int]struct{}{}
+	for k := range data {
+		dot := strings.LastIndex(k, ".")
+		if dot < 0 {
+			continue
+		}
+		suffix := k[dot+1:]
+		if suffix != "id" && suffix != "name" && suffix != "path" && suffix != "content" &&
+			suffix != "permissions" && suffix != "created_at" && suffix != "updated_at" {
+			continue
+		}
+		idxStr := k[:dot]
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			continue
+		}
+		indexSet[idx] = struct{}{}
+	}
+
+	indices := make([]int, 0, len(indexSet))
+	for idx := range indexSet {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	files := make([]sessionsettings.ManagedFile, 0, len(indices))
+	for _, idx := range indices {
+		prefix := strconv.Itoa(idx)
+		path := string(data[prefix+".path"])
+		content := string(data[prefix+".content"])
+		if path == "" {
+			continue
+		}
+		files = append(files, sessionsettings.ManagedFile{
+			Path:    path,
+			Content: content,
+		})
+	}
+	return files
 }

--- a/internal/interfaces/controllers/file_controller.go
+++ b/internal/interfaces/controllers/file_controller.go
@@ -1,0 +1,219 @@
+package controllers
+
+import (
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// FileController handles user-managed file endpoints.
+type FileController struct {
+	repo portrepos.UserFileRepository
+}
+
+// NewFileController creates a new FileController.
+func NewFileController(repo portrepos.UserFileRepository) *FileController {
+	return &FileController{repo: repo}
+}
+
+// GetName returns the controller name for logging.
+func (c *FileController) GetName() string { return "FileController" }
+
+// CreateFileRequest is the request body for creating or updating a file.
+type CreateFileRequest struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Content     string `json:"content"`
+	Permissions string `json:"permissions"`
+}
+
+// UpdateFileRequest is the request body for updating an existing file.
+type UpdateFileRequest struct {
+	Name        *string `json:"name"`
+	Path        *string `json:"path"`
+	Content     *string `json:"content"`
+	Permissions *string `json:"permissions"`
+}
+
+// FileResponse is the response body for a single file.
+type FileResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Content     string `json:"content"`
+	Permissions string `json:"permissions"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// ListFilesResponse is the response body for listing files.
+type ListFilesResponse struct {
+	Files []FileResponse `json:"files"`
+}
+
+// CreateFile handles POST /files
+func (c *FileController) CreateFile(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var req CreateFileRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+	if req.Path == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "path is required")
+	}
+
+	fileID := uuid.New().String()
+	file := entities.NewUserFile(fileID, req.Name, req.Path, req.Content, req.Permissions)
+
+	userID := string(user.ID())
+	if err := c.repo.Save(ctx.Request().Context(), userID, file); err != nil {
+		log.Printf("[FILES] Failed to save file for user %s: %v", userID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to save file")
+	}
+
+	return ctx.JSON(http.StatusCreated, toFileResponse(file))
+}
+
+// ListFiles handles GET /files
+func (c *FileController) ListFiles(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	userID := string(user.ID())
+	files, err := c.repo.List(ctx.Request().Context(), userID)
+	if err != nil {
+		log.Printf("[FILES] Failed to list files for user %s: %v", userID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list files")
+	}
+
+	resp := ListFilesResponse{Files: make([]FileResponse, 0, len(files))}
+	for _, f := range files {
+		resp.Files = append(resp.Files, toFileResponse(f))
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// GetFile handles GET /files/:fileId
+func (c *FileController) GetFile(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	fileID := ctx.Param("fileId")
+	if fileID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "fileId is required")
+	}
+
+	userID := string(user.ID())
+	file, err := c.repo.FindByID(ctx.Request().Context(), userID, fileID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "File not found")
+		}
+		log.Printf("[FILES] Failed to get file %s for user %s: %v", fileID, userID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get file")
+	}
+
+	return ctx.JSON(http.StatusOK, toFileResponse(file))
+}
+
+// UpdateFile handles PUT /files/:fileId
+func (c *FileController) UpdateFile(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	fileID := ctx.Param("fileId")
+	if fileID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "fileId is required")
+	}
+
+	var req UpdateFileRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	userID := string(user.ID())
+	file, err := c.repo.FindByID(ctx.Request().Context(), userID, fileID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "File not found")
+		}
+		log.Printf("[FILES] Failed to find file %s for user %s: %v", fileID, userID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find file")
+	}
+
+	if req.Name != nil {
+		file.SetName(*req.Name)
+	}
+	if req.Path != nil {
+		if *req.Path == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "path must not be empty")
+		}
+		file.SetPath(*req.Path)
+	}
+	if req.Content != nil {
+		file.SetContent(*req.Content)
+	}
+	if req.Permissions != nil {
+		file.SetPermissions(*req.Permissions)
+	}
+
+	if err := c.repo.Save(ctx.Request().Context(), userID, file); err != nil {
+		log.Printf("[FILES] Failed to update file %s for user %s: %v", fileID, userID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update file")
+	}
+
+	return ctx.JSON(http.StatusOK, toFileResponse(file))
+}
+
+// DeleteFile handles DELETE /files/:fileId
+func (c *FileController) DeleteFile(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	fileID := ctx.Param("fileId")
+	if fileID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "fileId is required")
+	}
+
+	userID := string(user.ID())
+	if err := c.repo.Delete(ctx.Request().Context(), userID, fileID); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "File not found")
+		}
+		log.Printf("[FILES] Failed to delete file %s for user %s: %v", fileID, userID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete file")
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]bool{"success": true})
+}
+
+// toFileResponse converts a UserFile entity to a FileResponse.
+func toFileResponse(f *entities.UserFile) FileResponse {
+	return FileResponse{
+		ID:          f.ID(),
+		Name:        f.Name(),
+		Path:        f.Path(),
+		Content:     f.Content(),
+		Permissions: f.Permissions(),
+		CreatedAt:   f.CreatedAt().Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:   f.UpdatedAt().Format("2006-01-02T15:04:05Z07:00"),
+	}
+}

--- a/internal/usecases/ports/repositories/user_file_repository.go
+++ b/internal/usecases/ports/repositories/user_file_repository.go
@@ -1,0 +1,23 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+// UserFileRepository defines the interface for user-managed file persistence.
+// Files are stored per-user and embedded into sessions at creation time.
+type UserFileRepository interface {
+	// Save creates or updates a file for the given user.
+	Save(ctx context.Context, userID string, file *entities.UserFile) error
+
+	// FindByID retrieves a single file by its ID for the given user.
+	FindByID(ctx context.Context, userID string, fileID string) (*entities.UserFile, error)
+
+	// List returns all files for the given user.
+	List(ctx context.Context, userID string) ([]*entities.UserFile, error)
+
+	// Delete removes a file by its ID for the given user.
+	Delete(ctx context.Context, userID string, fileID string) error
+}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -255,12 +256,21 @@ var managedFilePaths = []string{
 	"/home/agentapi/.claude/.credentials.json",
 }
 
-// writeFiles writes each ManagedFile to its path (mode 0600), creating parent
-// directories as needed.  It is called once at provision time to restore files
-// delivered via the SessionSettings payload.
+// writeFiles writes each ManagedFile to its path, creating parent directories
+// as needed.  The file mode is taken from ManagedFile.Permissions (octal string,
+// e.g. "0600"); if empty or unparseable, 0600 is used as a safe default.
+// Called once at provision time to restore files delivered via SessionSettings.
 func writeFiles(files []sessionsettings.ManagedFile) error {
 	var firstErr error
 	for _, f := range files {
+		perm := os.FileMode(0600)
+		if f.Permissions != "" {
+			if p, err := strconv.ParseUint(f.Permissions, 8, 32); err == nil {
+				perm = os.FileMode(p)
+			} else {
+				log.Printf("[PROVISIONER] Warning: invalid permissions %q for %s, using 0600", f.Permissions, f.Path)
+			}
+		}
 		if err := os.MkdirAll(filepath.Dir(f.Path), 0755); err != nil {
 			log.Printf("[PROVISIONER] Warning: failed to create dir for %s: %v", f.Path, err)
 			if firstErr == nil {
@@ -268,14 +278,14 @@ func writeFiles(files []sessionsettings.ManagedFile) error {
 			}
 			continue
 		}
-		if err := os.WriteFile(f.Path, []byte(f.Content), 0600); err != nil {
+		if err := os.WriteFile(f.Path, []byte(f.Content), perm); err != nil {
 			log.Printf("[PROVISIONER] Warning: failed to write %s: %v", f.Path, err)
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
-		log.Printf("[PROVISIONER] Restored managed file: %s", f.Path)
+		log.Printf("[PROVISIONER] Restored managed file: %s (mode %s)", f.Path, perm)
 	}
 	return firstErr
 }

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -34,8 +34,9 @@ var ManagedFileTypeOrder = []string{
 // ManagedFile represents a file path and its contents, used to persist arbitrary
 // files across sessions via the agentapi-agent-files-{userID} Kubernetes Secret.
 type ManagedFile struct {
-	Path    string `yaml:"path"    json:"path"`
-	Content string `yaml:"content" json:"content"`
+	Path        string `yaml:"path"                  json:"path"`
+	Content     string `yaml:"content"               json:"content"`
+	Permissions string `yaml:"permissions,omitempty" json:"permissions,omitempty"`
 }
 
 // FilesToSecretData converts a slice of ManagedFile into a flat map suitable for

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1513,7 +1513,10 @@
                     "team_id": "myorg/backend",
                     "bot_token_secret_name": "my-slack-bot-token",
                     "bot_token_secret_key": "bot-token",
-                    "allowed_channel_names": ["dev", "backend"],
+                    "allowed_channel_names": [
+                      "dev",
+                      "backend"
+                    ],
                     "session_config": {
                       "initial_message_template": "{{.event.text}}",
                       "tags": {
@@ -2389,8 +2392,12 @@
           "Notifications"
         ],
         "security": [
-          {"ApiKeyAuth": []},
-          {"BearerAuth": []}
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
         ],
         "requestBody": {
           "required": true,
@@ -2430,13 +2437,24 @@
         "summary": "Create a memory entry",
         "description": "Creates a new memory entry for a user or team. User-scoped memories are private to the owner. Team-scoped memories are accessible to all team members.",
         "operationId": "createMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateMemoryRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateMemoryRequest"
+              }
             }
           }
         },
@@ -2445,49 +2463,78 @@
             "description": "Memory entry created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Memory"}
+                "schema": {
+                  "$ref": "#/components/schemas/Memory"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       },
       "get": {
         "summary": "List memory entries",
         "description": "Lists memory entries accessible to the authenticated user. User-scoped queries return only the user's own entries. Team-scoped queries return entries for teams the user belongs to.",
         "operationId": "listMemories",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "scope",
             "in": "query",
             "description": "Filter by scope: 'user' or 'team'. Omit to return both.",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "team"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "team"
+              ]
+            }
           },
           {
             "name": "team_id",
             "in": "query",
             "description": "Filter by team ID (required when scope=team)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "q",
             "in": "query",
             "description": "Full-text search query applied to title and content (case-insensitive)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "include_tag.{key}",
             "in": "query",
             "description": "Include only memories whose tags contain ALL of the specified key=value pairs. For example, `include_tag.category=news` returns only memories tagged with `category=news`. Multiple include_tag parameters are AND-combined.",
             "required": false,
-            "schema": {"type": "string"},
+            "schema": {
+              "type": "string"
+            },
             "example": "include_tag.category=news"
           },
           {
@@ -2495,7 +2542,9 @@
             "in": "query",
             "description": "Exclude memories whose tags contain ALL of the specified key=value pairs. For example, `exclude_tag.category=news` excludes memories tagged with `category=news`. Multiple exclude_tag parameters are AND-combined.",
             "required": false,
-            "schema": {"type": "string"},
+            "schema": {
+              "type": "string"
+            },
             "example": "exclude_tag.category=news"
           }
         ],
@@ -2504,12 +2553,18 @@
             "description": "List of memory entries",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/MemoryListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryListResponse"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       }
     },
@@ -2518,15 +2573,26 @@
         "summary": "Get a memory entry",
         "description": "Retrieves a specific memory entry by ID. Access is restricted to the owner (user-scoped) or team members (team-scoped). Admin privilege does NOT bypass these restrictions.",
         "operationId": "getMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "memoryId",
             "in": "path",
             "required": true,
             "description": "UUID of the memory entry",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2534,35 +2600,56 @@
             "description": "Memory entry",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Memory"}
+                "schema": {
+                  "$ref": "#/components/schemas/Memory"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Memory entry not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Memory entry not found"
+          }
         }
       },
       "put": {
         "summary": "Update a memory entry",
         "description": "Updates a memory entry. Only the owner (user-scoped) or team members (team-scoped) can update. Omitted fields are not changed.",
         "operationId": "updateMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "memoryId",
             "in": "path",
             "required": true,
             "description": "UUID of the memory entry",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateMemoryRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemoryRequest"
+              }
             }
           }
         },
@@ -2571,29 +2658,50 @@
             "description": "Updated memory entry",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Memory"}
+                "schema": {
+                  "$ref": "#/components/schemas/Memory"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Memory entry not found"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Memory entry not found"
+          }
         }
       },
       "delete": {
         "summary": "Delete a memory entry",
         "description": "Deletes a memory entry. Only the owner (user-scoped) or team members (team-scoped) can delete.",
         "operationId": "deleteMemory",
-        "tags": ["Memory"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Memory"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "memoryId",
             "in": "path",
             "required": true,
             "description": "UUID of the memory entry",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2604,15 +2712,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"}
+                    "success": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Memory entry not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Memory entry not found"
+          }
         }
       }
     },
@@ -2621,13 +2737,24 @@
         "summary": "Create a task",
         "description": "Creates a new task for a user or team. User-scoped tasks are private to the owner. Team-scoped tasks are accessible to all team members.",
         "operationId": "createTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateTaskRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateTaskRequest"
+              }
             }
           }
         },
@@ -2636,56 +2763,95 @@
             "description": "Task created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Task"}
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       },
       "get": {
         "summary": "List tasks",
         "description": "Lists tasks accessible to the authenticated user. Supports filtering by scope, team, group, status, and task type.",
         "operationId": "listTasks",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "scope",
             "in": "query",
             "description": "Filter by scope: 'user' or 'team'. Omit to return both.",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "team"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "team"
+              ]
+            }
           },
           {
             "name": "team_id",
             "in": "query",
             "description": "Filter by team ID (required when scope=team)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "group_id",
             "in": "query",
             "description": "Filter by task group ID",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filter by status: 'todo' or 'done'",
             "required": false,
-            "schema": {"type": "string", "enum": ["todo", "done"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "todo",
+                "done"
+              ]
+            }
           },
           {
             "name": "task_type",
             "in": "query",
             "description": "Filter by task type: 'user' or 'agent'",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "agent"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "agent"
+              ]
+            }
           }
         ],
         "responses": {
@@ -2693,12 +2859,18 @@
             "description": "List of tasks",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskListResponse"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       }
     },
@@ -2707,15 +2879,26 @@
         "summary": "Get a task",
         "description": "Retrieves a specific task by ID.",
         "operationId": "getTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "taskId",
             "in": "path",
             "required": true,
             "description": "UUID of the task",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2723,35 +2906,56 @@
             "description": "Task",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Task"}
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task not found"
+          }
         }
       },
       "put": {
         "summary": "Update a task",
         "description": "Updates a task. Only the owner (user-scoped) or team members (team-scoped) can update. Omitted fields are not changed.",
         "operationId": "updateTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "taskId",
             "in": "path",
             "required": true,
             "description": "UUID of the task",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateTaskRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTaskRequest"
+              }
             }
           }
         },
@@ -2760,29 +2964,50 @@
             "description": "Updated task",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Task"}
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task not found"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task not found"
+          }
         }
       },
       "delete": {
         "summary": "Delete a task",
         "description": "Deletes a task. Only the owner (user-scoped) or team members (team-scoped) can delete.",
         "operationId": "deleteTask",
-        "tags": ["Tasks"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "Tasks"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "taskId",
             "in": "path",
             "required": true,
             "description": "UUID of the task",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2793,15 +3018,23 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"}
+                    "success": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task not found"
+          }
         }
       }
     },
@@ -2810,13 +3043,24 @@
         "summary": "Create a task group",
         "description": "Creates a new task group for organizing tasks. Groups support user and team scopes.",
         "operationId": "createTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateTaskGroupRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateTaskGroupRequest"
+              }
             }
           }
         },
@@ -2825,35 +3069,60 @@
             "description": "Task group created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroup"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroup"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       },
       "get": {
         "summary": "List task groups",
         "description": "Lists task groups accessible to the authenticated user.",
         "operationId": "listTaskGroups",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "scope",
             "in": "query",
             "description": "Filter by scope: 'user' or 'team'. Omit to return both.",
             "required": false,
-            "schema": {"type": "string", "enum": ["user", "team"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "user",
+                "team"
+              ]
+            }
           },
           {
             "name": "team_id",
             "in": "query",
             "description": "Filter by team ID (required when scope=team)",
             "required": false,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2861,12 +3130,18 @@
             "description": "List of task groups",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroupListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroupListResponse"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
         }
       }
     },
@@ -2875,15 +3150,26 @@
         "summary": "Get a task group",
         "description": "Retrieves a specific task group by ID.",
         "operationId": "getTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "groupId",
             "in": "path",
             "required": true,
             "description": "UUID of the task group",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2891,35 +3177,56 @@
             "description": "Task group",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroup"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroup"
+                }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task group not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task group not found"
+          }
         }
       },
       "put": {
         "summary": "Update a task group",
         "description": "Updates a task group. Omitted fields are not changed.",
         "operationId": "updateTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "groupId",
             "in": "path",
             "required": true,
             "description": "UUID of the task group",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateTaskGroupRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTaskGroupRequest"
+              }
             }
           }
         },
@@ -2928,29 +3235,50 @@
             "description": "Updated task group",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TaskGroup"}
+                "schema": {
+                  "$ref": "#/components/schemas/TaskGroup"
+                }
               }
             }
           },
-          "400": {"description": "Invalid request"},
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task group not found"}
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task group not found"
+          }
         }
       },
       "delete": {
         "summary": "Delete a task group",
         "description": "Deletes a task group.",
         "operationId": "deleteTaskGroup",
-        "tags": ["TaskGroups"],
-        "security": [{"ApiKeyAuth": []}, {"BearerAuth": []}],
+        "tags": [
+          "TaskGroups"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "groupId",
             "in": "path",
             "required": true,
             "description": "UUID of the task group",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2961,15 +3289,252 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"}
+                    "success": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
             }
           },
-          "401": {"description": "Unauthorized"},
-          "403": {"description": "Forbidden"},
-          "404": {"description": "Task group not found"}
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Task group not found"
+          }
+        }
+      }
+    },
+    "/files": {
+      "post": {
+        "summary": "Create a user file",
+        "description": "Register an arbitrary file (e.g. SSH key) that will be placed inside agent sessions at startup.",
+        "operationId": "createFile",
+        "tags": [
+          "Files"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserFile"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "get": {
+        "summary": "List user files",
+        "description": "List all files registered for the authenticated user.",
+        "operationId": "listFiles",
+        "tags": [
+          "Files"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/files/{fileId}": {
+      "get": {
+        "summary": "Get a user file",
+        "operationId": "getFile",
+        "tags": [
+          "Files"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserFile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update a user file",
+        "operationId": "updateFile",
+        "tags": [
+          "Files"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserFile"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a user file",
+        "operationId": "deleteFile",
+        "tags": [
+          "Files"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "fileId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         }
       }
     }
@@ -2995,7 +3560,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the memory entry"
           },
           "owner_id": {
@@ -3008,7 +3576,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Key-value tags for filtering"
           },
           "created_at": {
@@ -3022,12 +3592,23 @@
             "description": "Last update timestamp"
           }
         },
-        "required": ["id", "title", "content", "scope", "owner_id", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "title",
+          "content",
+          "scope",
+          "owner_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateMemoryRequest": {
         "type": "object",
         "description": "Request body for creating a memory entry",
-        "required": ["title", "scope"],
+        "required": [
+          "title",
+          "scope"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -3039,7 +3620,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the memory entry"
           },
           "team_id": {
@@ -3048,7 +3632,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "Key-value tags for filtering"
           }
         }
@@ -3067,7 +3653,9 @@
           },
           "tags": {
             "type": "object",
-            "additionalProperties": {"type": "string"},
+            "additionalProperties": {
+              "type": "string"
+            },
             "description": "New tags (when present, replaces ALL existing tags; omit to keep existing)"
           }
         }
@@ -3078,7 +3666,9 @@
         "properties": {
           "memories": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/Memory"},
+            "items": {
+              "$ref": "#/components/schemas/Memory"
+            },
             "description": "List of memory entries"
           },
           "total": {
@@ -3086,7 +3676,10 @@
             "description": "Total number of entries in the response"
           }
         },
-        "required": ["memories", "total"]
+        "required": [
+          "memories",
+          "total"
+        ]
       },
       "TaskLink": {
         "type": "object",
@@ -3107,7 +3700,10 @@
             "description": "Optional label for the link"
           }
         },
-        "required": ["id", "url"]
+        "required": [
+          "id",
+          "url"
+        ]
       },
       "TaskLinkRequest": {
         "type": "object",
@@ -3123,7 +3719,9 @@
             "description": "Optional label for the link"
           }
         },
-        "required": ["url"]
+        "required": [
+          "url"
+        ]
       },
       "Task": {
         "type": "object",
@@ -3144,17 +3742,26 @@
           },
           "status": {
             "type": "string",
-            "enum": ["todo", "done"],
+            "enum": [
+              "todo",
+              "done"
+            ],
             "description": "Current status of the task"
           },
           "task_type": {
             "type": "string",
-            "enum": ["user", "agent"],
+            "enum": [
+              "user",
+              "agent"
+            ],
             "description": "Who manages the task: 'user' for human-managed, 'agent' for AI agent-managed"
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task"
           },
           "owner_id": {
@@ -3176,7 +3783,9 @@
           },
           "links": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskLink"},
+            "items": {
+              "$ref": "#/components/schemas/TaskLink"
+            },
             "description": "List of associated links"
           },
           "created_at": {
@@ -3190,7 +3799,17 @@
             "description": "Last update timestamp (ISO 8601)"
           }
         },
-        "required": ["id", "title", "status", "task_type", "scope", "owner_id", "links", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "title",
+          "status",
+          "task_type",
+          "scope",
+          "owner_id",
+          "links",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateTaskRequest": {
         "type": "object",
@@ -3206,12 +3825,18 @@
           },
           "task_type": {
             "type": "string",
-            "enum": ["user", "agent"],
+            "enum": [
+              "user",
+              "agent"
+            ],
             "description": "Who manages the task"
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task"
           },
           "team_id": {
@@ -3229,11 +3854,17 @@
           },
           "links": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskLinkRequest"},
+            "items": {
+              "$ref": "#/components/schemas/TaskLinkRequest"
+            },
             "description": "Associated links"
           }
         },
-        "required": ["title", "task_type", "scope"]
+        "required": [
+          "title",
+          "task_type",
+          "scope"
+        ]
       },
       "UpdateTaskRequest": {
         "type": "object",
@@ -3249,7 +3880,10 @@
           },
           "status": {
             "type": "string",
-            "enum": ["todo", "done"],
+            "enum": [
+              "todo",
+              "done"
+            ],
             "description": "New status"
           },
           "group_id": {
@@ -3262,7 +3896,9 @@
           },
           "links": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskLinkRequest"},
+            "items": {
+              "$ref": "#/components/schemas/TaskLinkRequest"
+            },
             "description": "Replaces all existing links when present"
           }
         }
@@ -3273,7 +3909,9 @@
         "properties": {
           "tasks": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/Task"},
+            "items": {
+              "$ref": "#/components/schemas/Task"
+            },
             "description": "List of tasks"
           },
           "total": {
@@ -3281,7 +3919,10 @@
             "description": "Total number of tasks in the response"
           }
         },
-        "required": ["tasks", "total"]
+        "required": [
+          "tasks",
+          "total"
+        ]
       },
       "TaskGroup": {
         "type": "object",
@@ -3302,7 +3943,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task group"
           },
           "owner_id": {
@@ -3324,7 +3968,14 @@
             "description": "Last update timestamp (ISO 8601)"
           }
         },
-        "required": ["id", "name", "scope", "owner_id", "created_at", "updated_at"]
+        "required": [
+          "id",
+          "name",
+          "scope",
+          "owner_id",
+          "created_at",
+          "updated_at"
+        ]
       },
       "CreateTaskGroupRequest": {
         "type": "object",
@@ -3340,7 +3991,10 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["user", "team"],
+            "enum": [
+              "user",
+              "team"
+            ],
             "description": "Scope of the task group"
           },
           "team_id": {
@@ -3348,7 +4002,10 @@
             "description": "Team ID (required when scope is 'team')"
           }
         },
-        "required": ["name", "scope"]
+        "required": [
+          "name",
+          "scope"
+        ]
       },
       "UpdateTaskGroupRequest": {
         "type": "object",
@@ -3370,7 +4027,9 @@
         "properties": {
           "task_groups": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/TaskGroup"},
+            "items": {
+              "$ref": "#/components/schemas/TaskGroup"
+            },
             "description": "List of task groups"
           },
           "total": {
@@ -3378,7 +4037,10 @@
             "description": "Total number of task groups in the response"
           }
         },
-        "required": ["task_groups", "total"]
+        "required": [
+          "task_groups",
+          "total"
+        ]
       },
       "StartRequest": {
         "type": "object",
@@ -4631,7 +5293,10 @@
       },
       "SendNotificationRequest": {
         "type": "object",
-        "required": ["title", "body"],
+        "required": [
+          "title",
+          "body"
+        ],
         "properties": {
           "title": {
             "type": "string",
@@ -4814,11 +5479,99 @@
             "type": "string"
           }
         }
+      },
+      "UserFile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique file identifier (UUID)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable display name"
+          },
+          "path": {
+            "type": "string",
+            "description": "Destination path inside the agent container (e.g. /home/agentapi/.ssh/id_rsa)"
+          },
+          "content": {
+            "type": "string",
+            "description": "File content (plain text or base64-encoded)"
+          },
+          "permissions": {
+            "type": "string",
+            "description": "File permissions hint (e.g. \"0600\"). The provisioner writes files with mode 0600 by default."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateFileRequest": {
+        "type": "object",
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable display name"
+          },
+          "path": {
+            "type": "string",
+            "description": "Destination path inside the agent container"
+          },
+          "content": {
+            "type": "string",
+            "description": "File content"
+          },
+          "permissions": {
+            "type": "string",
+            "description": "Permissions hint (informational)"
+          }
+        }
+      },
+      "UpdateFileRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "permissions": {
+            "type": "string"
+          }
+        }
+      },
+      "FileListResponse": {
+        "type": "object",
+        "properties": {
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserFile"
+            }
+          }
+        }
       }
     },
     "SlackBotStatus": {
       "type": "string",
-      "enum": ["active", "paused"],
+      "enum": [
+        "active",
+        "paused"
+      ],
       "description": "SlackBot operational status"
     },
     "SlackBotSessionParams": {
@@ -4871,7 +5624,9 @@
     },
     "CreateSlackBotRequest": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -4902,7 +5657,10 @@
             "type": "string"
           },
           "description": "Slack event types to process. Empty means all event types are allowed.",
-          "example": ["message", "app_mention"]
+          "example": [
+            "message",
+            "app_mention"
+          ]
         },
         "allowed_channel_names": {
           "type": "array",
@@ -4910,7 +5668,10 @@
             "type": "string"
           },
           "description": "Slack channel name patterns to listen to (partial match). Empty means all channels are allowed.",
-          "example": ["dev", "backend"]
+          "example": [
+            "dev",
+            "backend"
+          ]
         },
         "session_config": {
           "$ref": "#/components/schemas/SlackBotSessionConfig"
@@ -5159,6 +5920,10 @@
     {
       "name": "TaskGroups",
       "description": "Task group management for organizing tasks into logical collections. Groups support user and team scopes."
+    },
+    {
+      "name": "Files",
+      "description": "User-managed files to be placed inside agent sessions"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **新エンドポイント `/files`** — SSH鍵・設定ファイルなど任意のファイルを登録・管理できる CRUD API
- **K8s Secret ストレージ** — `agentapi-user-files-{userID}` Secret にインデックスベース形式で保存
- **セッション自動マウント** — セッション起動時にファイルを読み込み、provisioner が `0600` で配置

## 追加ファイル

| ファイル | 役割 |
|---|---|
| `internal/domain/entities/user_file.go` | `UserFile` エンティティ |
| `internal/usecases/ports/repositories/user_file_repository.go` | リポジトリインターフェース |
| `internal/infrastructure/repositories/kubernetes_user_file_repository.go` | K8s 実装 |
| `internal/interfaces/controllers/file_controller.go` | HTTP コントローラー |

## 変更ファイル

- `internal/app/router.go` — `/files` ルート追加
- `internal/app/server.go` — `userFileRepo` 追加・初期化
- `internal/infrastructure/services/kubernetes_session_manager.go` — セッション作成時にユーザーファイル読み込み追加
- `spec/openapi.json` — `/files`, `/files/{fileId}` エンドポイント追加

## API 概要

```
POST   /files           ファイル作成（path, content, name, permissions）
GET    /files           ファイル一覧
GET    /files/{fileId}  ファイル取得（コンテンツ含む）
PUT    /files/{fileId}  ファイル更新
DELETE /files/{fileId}  ファイル削除
```

## SSH鍵の使い方イメージ

```bash
# SSH鍵を登録
curl -X POST /files \
  -d '{"name":"GitHub SSH Key","path":"/home/agentapi/.ssh/id_ed25519","content":"-----BEGIN OPENSSH PRIVATE KEY-----\n..."}'

# 以後、セッション起動時に /home/agentapi/.ssh/id_ed25519 が自動配置される（mode 0600）
```

## Test plan

- [ ] `POST /files` で SSH 鍵を登録し、セッション起動後にファイルが配置されることを確認
- [ ] `GET /files` で一覧が返ることを確認
- [ ] `DELETE /files/{fileId}` で削除後、次のセッションには含まれないことを確認
- [ ] 既存の credentials API に影響がないことを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)