### PR TITLE
acp/bridge: buffer agent message chunks, emit only complete messages

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -171,10 +171,11 @@ type Bridge struct {
 	// so they survive beyond the HTTP request that triggered them.
 	serverCtx context.Context
 
-	mu       sync.RWMutex
-	status   AgentStatus
-	messages []Message
-	nextID   int64
+	mu               sync.RWMutex
+	status           AgentStatus
+	messages         []Message
+	nextID           int64
+	pendingAgentText strings.Builder // buffers agent_message_chunk until message boundary
 
 	subsMu sync.Mutex
 	subs   []*subscriber
@@ -239,13 +240,19 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 
 	switch update.Kind {
 	case acp.SessionUpdateKindAgentMessageChunk:
+		// Buffer chunks; the complete message is emitted when a boundary event
+		// (tool_call, plan, or turn-end via setStatus) is reached.
 		text := acp.ExtractTextContent(update.Content)
-		b.appendOrCreateMessage(MessageRoleAgent, text, MessageTypeNormal, "", "")
+		b.mu.Lock()
+		b.pendingAgentText.WriteString(text)
+		b.mu.Unlock()
 
 	case acp.SessionUpdateKindAgentThoughtChunk:
 		// Thinking/reasoning content – intentionally not surfaced to the frontend.
 
 	case acp.SessionUpdateKindToolCall:
+		// Flush any buffered agent text before recording the tool call.
+		b.flushPendingAgentText()
 		// New tool invocation – serialize as JSON string matching claude-agentapi format.
 		// Frontend expects: {"type":"tool_use","name":"<kind>","id":"<toolCallId>","input":{...}}
 		toolObj := map[string]interface{}{
@@ -304,6 +311,8 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 		}
 
 	case acp.SessionUpdateKindPlan:
+		// Flush any buffered agent text before recording the plan.
+		b.flushPendingAgentText()
 		// ACP sends plan as a structured entries list (from TodoWrite), not a plain string.
 		// Convert to a markdown task list for display in the frontend plan modal.
 		if len(update.Entries) > 0 {
@@ -786,6 +795,9 @@ func (b *Bridge) SubmitAction(ctx context.Context, req ActionRequest) error {
 // ----------------------------------------------------------------------------
 
 func (b *Bridge) setStatus(s AgentStatus) {
+	// Flush any remaining buffered agent text before changing status so that
+	// a complete message is visible before the "stable" status is broadcast.
+	b.flushPendingAgentText()
 	b.mu.Lock()
 	b.status = s
 	b.mu.Unlock()
@@ -793,6 +805,31 @@ func (b *Bridge) setStatus(s AgentStatus) {
 		Type: EventTypeStatusChange,
 		Data: StatusChangeData{Status: s, AgentType: "acp"},
 	})
+}
+
+// flushPendingAgentText commits any buffered agent_message_chunk text as a
+// single complete Message and broadcasts it to SSE subscribers.
+// It is a no-op when the buffer is empty.
+// Must NOT be called while b.mu is held (it acquires b.mu internally).
+func (b *Bridge) flushPendingAgentText() {
+	b.mu.Lock()
+	text := b.pendingAgentText.String()
+	if text == "" {
+		b.mu.Unlock()
+		return
+	}
+	b.pendingAgentText.Reset()
+	b.nextID++
+	msg := Message{
+		ID:      b.nextID,
+		Role:    MessageRoleAgent,
+		Content: text,
+		Time:    time.Now(),
+		Type:    MessageTypeNormal,
+	}
+	b.messages = append(b.messages, msg)
+	b.broadcastMessageUpdateLocked(msg)
+	b.mu.Unlock()
 }
 
 func (b *Bridge) broadcastError(msg string) {

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -322,35 +322,6 @@ func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
 	}
 }
 
-// appendOrCreateMessage appends content to the last agent/assistant message if
-// it has the same role and is not a tool message; otherwise creates a new one.
-func (b *Bridge) appendOrCreateMessage(role MessageRole, content string, msgType MessageType, toolUseId, parentToolUseId string) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if len(b.messages) > 0 {
-		last := &b.messages[len(b.messages)-1]
-		if last.Role == role && last.ToolUseId == "" && last.Type == msgType {
-			last.Content += content
-			last.Time = time.Now()
-			b.broadcastMessageUpdateLocked(*last)
-			return
-		}
-	}
-	b.nextID++
-	msg := Message{
-		ID:              b.nextID,
-		Role:            role,
-		Content:         content,
-		Time:            time.Now(),
-		Type:            msgType,
-		ToolUseId:       toolUseId,
-		ParentToolUseId: parentToolUseId,
-	}
-	b.messages = append(b.messages, msg)
-	b.broadcastMessageUpdateLocked(msg)
-}
-
 func (b *Bridge) addNewMessage(role MessageRole, content string, msgType MessageType, toolUseId, parentToolUseId string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()


### PR DESCRIPTION
## Summary

- `agent_message_chunk` を受け取るたびに `b.messages` へ追記して SSE ブロードキャストしていた挙動を廃止
- チャンクは `Bridge.pendingAgentText`（`strings.Builder`）に蓄積し、メッセージが完結するタイミングで一度だけ `b.messages` に追加・ブロードキャストするよう変更
- フラッシュタイミング:
  - `tool_call` イベント受信前
  - `plan` イベント受信前
  - `setStatus()` 呼び出し時（ターン終了 / エラー / 接続切断）

## 変更の背景

以前の実装ではストリーミング中に `GET /messages` を呼ぶと途中のメッセージが見えてしまい、SSE クライアントにも大量の中間イベントが届いていた。本変更により、`/messages` は完成したメッセージのみを返し、SSE も完成したメッセージのみを配信する。

## Test plan

- [ ] `go build ./...` が通ること ✅
- [ ] `go test ./...` が全て PASS すること ✅
- [ ] ACP agent を実際に動かしてメッセージが完成後にのみ `/messages` に現れることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)