### PR TITLE
feat: Dockerfile に CLAUDE_CODE_EXECUTABLE_PATH を自動設定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,8 +156,14 @@ RUN bun install -g @takutakahashi/claude-agentapi
 # Install codex CLI
 RUN bun install -g @openai/codex
 
+# Install claude-agent-sdk CLI
+RUN bun install -g @anthropic-ai/claude-agent-sdk
+
 # Set default CLAUDE_MD_PATH for Docker environment
 ENV CLAUDE_MD_PATH=/tmp/config/CLAUDE.md
+
+# Set CLAUDE_CODE_EXECUTABLE_PATH to use claude-agent-sdk CLI
+ENV CLAUDE_CODE_EXECUTABLE_PATH=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/cli.js
 
 # Copy CLAUDE.md to temporary location for entrypoint script
 COPY config/CLAUDE.md /tmp/config/CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,14 +156,22 @@ RUN bun install -g @takutakahashi/claude-agentapi
 # Install codex CLI
 RUN bun install -g @openai/codex
 
-# Install claude-agent-sdk CLI
-RUN bun install -g @anthropic-ai/claude-agent-sdk
+# Install claude-agent-sdk CLI and create arch-agnostic symlink
+RUN bun install -g @anthropic-ai/claude-agent-sdk && \
+    ARCH=$(dpkg --print-architecture) && \
+    case "$ARCH" in \
+      amd64) SDK_ARCH="linux-x64" ;; \
+      arm64) SDK_ARCH="linux-arm64" ;; \
+      *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    ln -sf "/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk-${SDK_ARCH}/claude" \
+           /home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
 
 # Set default CLAUDE_MD_PATH for Docker environment
 ENV CLAUDE_MD_PATH=/tmp/config/CLAUDE.md
 
-# Set CLAUDE_CODE_EXECUTABLE_PATH to use claude-agent-sdk CLI
-ENV CLAUDE_CODE_EXECUTABLE_PATH=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/cli.js
+# Set CLAUDE_CODE_EXECUTABLE_PATH to use claude-agent-sdk native binary (via arch-agnostic symlink)
+ENV CLAUDE_CODE_EXECUTABLE_PATH=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
 
 # Copy CLAUDE.md to temporary location for entrypoint script
 COPY config/CLAUDE.md /tmp/config/CLAUDE.md


### PR DESCRIPTION
## Summary

- `@anthropic-ai/claude-agent-sdk` を bun でグローバルインストールする RUN 命令を追加
- `CLAUDE_CODE_EXECUTABLE_PATH` 環境変数を `/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/cli.js` に設定する `ENV` 命令を追加

これにより、コンテナ起動時に自動的に `CLAUDE_CODE_EXECUTABLE_PATH` が設定され、claude-agent-sdk の CLI が使われるようになります。

## Test plan

- [ ] Docker イメージをビルドして `CLAUDE_CODE_EXECUTABLE_PATH` が正しく設定されていることを確認
- [ ] `@anthropic-ai/claude-agent-sdk` が `/home/agentapi/.bun/install/global/node_modules/` にインストールされていることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)