### PR TITLE
fix: claude-acp 起動失敗を修正 (CLAUDE_CODE_EXECUTABLE 環境変数を追加)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,6 +172,8 @@ ENV CLAUDE_MD_PATH=/tmp/config/CLAUDE.md
 
 # Set CLAUDE_CODE_EXECUTABLE_PATH to use claude-agent-sdk native binary (via arch-agnostic symlink)
 ENV CLAUDE_CODE_EXECUTABLE_PATH=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
+# Set CLAUDE_CODE_EXECUTABLE for @agentclientprotocol/claude-agent-acp (reads this env var, not CLAUDE_CODE_EXECUTABLE_PATH)
+ENV CLAUDE_CODE_EXECUTABLE=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
 
 # Copy CLAUDE.md to temporary location for entrypoint script
 COPY config/CLAUDE.md /tmp/config/CLAUDE.md


### PR DESCRIPTION
## Summary

- `@agentclientprotocol/claude-agent-acp` は `CLAUDE_CODE_EXECUTABLE` 環境変数を読み込むが、Dockerfile には `CLAUDE_CODE_EXECUTABLE_PATH`（末尾に `_PATH`）しか設定されていなかった
- `CLAUDE_CODE_EXECUTABLE` が未設定だと、パッケージが musl バイナリ（`claude-agent-sdk-linux-x64-musl/claude`）を先に解決する
- glibc 環境では musl バイナリが実行できず "Claude Code native binary not found" エラーが発生し claude-acp セッションが起動しなかった
- `CLAUDE_CODE_EXECUTABLE` をアーキテクチャ非依存のシムリンクに設定することで修正

## Root Cause

`acp-agent.js` の該当コード:
\`\`\`javascript
pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_EXECUTABLE,
\`\`\`

`CLAUDE_CODE_EXECUTABLE_PATH` ではなく `CLAUDE_CODE_EXECUTABLE` を参照している。

## Test plan

- [x] `CLAUDE_CODE_EXECUTABLE` を設定してローカルで `agentapi-proxy acp-server` を起動し `/health` と `/status` エンドポイントが正常に応答することを確認
- [ ] Dockerfile を再ビルドして claude-acp セッションが正常に起動することを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)