### PR TITLE
feat(slackbot): session params に repo_full_name を追加してリポジトリのクローン設定を可能に

### DIFF
--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -57,6 +57,11 @@ type SessionParams struct {
 	// CycleMaxCount is the maximum number of cycles to run. 0 means unlimited.
 	// Requires CycleMessage to be set. The cycle count is tracked in /tmp/check/CYCLE_COUNT.
 	CycleMaxCount int `json:"cycle_max_count,omitempty"`
+	// RepoFullName is the full name of the GitHub repository to clone (e.g. "org/repo").
+	// When set, AGENTAPI_REPO_FULLNAME and AGENTAPI_CLONE_DIR are injected into the session
+	// environment so the repository is cloned at session startup.
+	// For SlackBot sessions, this takes priority over any repository auto-detected from the message text.
+	RepoFullName string `json:"repo_full_name,omitempty"`
 }
 
 // StartRequest represents the request body for starting a new agentapi server

--- a/internal/interfaces/controllers/slackbot_controller.go
+++ b/internal/interfaces/controllers/slackbot_controller.go
@@ -93,6 +93,10 @@ type SlackBotSessionConfig struct {
 type SlackBotSessionParams struct {
 	AgentType string `json:"agent_type,omitempty"`
 	Oneshot   bool   `json:"oneshot,omitempty"`
+	// RepoFullName is the full name of the GitHub repository to clone (e.g. "org/repo").
+	// When set, this repository is always used for sessions created by this SlackBot,
+	// taking priority over any repository auto-detected from the Slack message text.
+	RepoFullName string `json:"repo_full_name,omitempty"`
 }
 
 // SlackBotResponse is the API response for a SlackBot
@@ -437,8 +441,9 @@ func toEntitySessionConfig(cfg *SlackBotSessionConfig) *entities.WebhookSessionC
 	}
 	if cfg.Params != nil {
 		params := &entities.SessionParams{
-			AgentType: cfg.Params.AgentType,
-			Oneshot:   cfg.Params.Oneshot,
+			AgentType:    cfg.Params.AgentType,
+			Oneshot:      cfg.Params.Oneshot,
+			RepoFullName: cfg.Params.RepoFullName,
 		}
 		sc.SetParams(params)
 	}
@@ -458,8 +463,9 @@ func fromEntitySessionConfig(sc *entities.WebhookSessionConfig) *SlackBotSession
 	}
 	if sc.Params() != nil {
 		cfg.Params = &SlackBotSessionParams{
-			AgentType: sc.Params().AgentType,
-			Oneshot:   sc.Params().Oneshot,
+			AgentType:    sc.Params().AgentType,
+			Oneshot:      sc.Params().Oneshot,
+			RepoFullName: sc.Params().RepoFullName,
 		}
 	}
 	return cfg

--- a/internal/interfaces/controllers/slackbot_event_handler.go
+++ b/internal/interfaces/controllers/slackbot_event_handler.go
@@ -243,8 +243,21 @@ func (h *SlackBotEventHandler) ProcessEvent(ctx context.Context, botID string, p
 	// The result is used directly to populate RepoInfo in the LaunchRequest;
 	// the tag is set only as informational metadata.
 	detectedRepo := parseRepository(event.Text)
-	if detectedRepo != "" {
-		tags["repository"] = detectedRepo
+
+	// Determine the effective repository for this session.
+	// Priority: session_config.params.repo_full_name (static bot config) > message auto-detection.
+	// A statically configured repo means the bot always operates on that repository,
+	// regardless of what is mentioned in the Slack message.
+	configuredRepo := ""
+	if bot != nil && bot.SessionConfig() != nil && bot.SessionConfig().Params() != nil {
+		configuredRepo = bot.SessionConfig().Params().RepoFullName
+	}
+	effectiveRepoForTag := configuredRepo
+	if effectiveRepoForTag == "" {
+		effectiveRepoForTag = detectedRepo
+	}
+	if effectiveRepoForTag != "" {
+		tags["repository"] = effectiveRepoForTag
 	}
 
 	// Apply session config tags if present
@@ -378,13 +391,16 @@ func (h *SlackBotEventHandler) ProcessEvent(ctx context.Context, botID string, p
 			}
 		}
 
-		// Build RepoInfo directly from the detected repository identifier.
-		// This drives AGENTAPI_CLONE_DIR and AGENTAPI_REPO_FULLNAME in the session;
-		// the tag is separate metadata and must not be used as a trigger for behavior.
+		// Build RepoInfo for the session.
+		// Use the already-computed effective repo (configuredRepo takes priority, then detectedRepo).
 		var repoInfo *entities.RepositoryInfo
-		if detectedRepo != "" {
+		effectiveRepo := configuredRepo
+		if effectiveRepo == "" {
+			effectiveRepo = detectedRepo
+		}
+		if effectiveRepo != "" {
 			repoInfo = &entities.RepositoryInfo{
-				FullName: detectedRepo,
+				FullName: effectiveRepo,
 				CloneDir: "/home/agentapi/workdir/repo",
 			}
 		}

--- a/internal/interfaces/controllers/slackbot_event_handler_test.go
+++ b/internal/interfaces/controllers/slackbot_event_handler_test.go
@@ -1572,3 +1572,123 @@ func TestParseRepository(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessEvent_ConfiguredRepo_UsedWhenNoMessageRepo verifies that when session_config.params.repo_full_name
+// is set on the SlackBot and the message does not contain an org/repo identifier,
+// the configured repository is used.
+func TestProcessEvent_ConfiguredRepo_UsedWhenNoMessageRepo(t *testing.T) {
+	const (
+		botID     = "config-repo-bot"
+		channelID = "C-configRepo"
+	)
+
+	repo := newMockSlackBotRepository()
+	bot := entities.NewSlackBot(botID, "Config Repo Bot", "user-1")
+
+	// Configure a static repository in session params.
+	sc := entities.NewWebhookSessionConfig()
+	sc.SetParams(&entities.SessionParams{
+		RepoFullName: "myorg/configured-repo",
+	})
+	bot.SetSessionConfig(sc)
+	repo.bots[botID] = bot
+
+	sessionMgr := &mockSessionManager{}
+	handler := NewSlackBotEventHandler(repo, sessionMgr, "", "", nil, "", false, nil)
+
+	// Message does NOT contain an org/repo identifier.
+	payload := buildEventPayload(channelID, "バグを修正してください")
+	err := handler.ProcessEvent(context.Background(), botID, payload)
+	require.NoError(t, err)
+
+	ok := waitForCondition(2*time.Second, 10*time.Millisecond, func() bool {
+		return sessionMgr.createdCount() == 1
+	})
+	require.True(t, ok, "session should be created")
+
+	sess := sessionMgr.getCreatedSession(0)
+	assert.Equal(t, "myorg/configured-repo", sess.tags["repository"],
+		"repository tag should be set from bot session_config.params.repo_full_name")
+	require.NotNil(t, sess.repoInfo, "RepoInfo should be set from configured repo")
+	assert.Equal(t, "myorg/configured-repo", sess.repoInfo.FullName)
+	assert.Equal(t, "/home/agentapi/workdir/repo", sess.repoInfo.CloneDir)
+}
+
+// TestProcessEvent_ConfiguredRepo_TakesPriorityOverMessageRepo verifies that when
+// session_config.params.repo_full_name is set and the message also contains an org/repo
+// identifier, the static bot config takes priority.
+func TestProcessEvent_ConfiguredRepo_TakesPriorityOverMessageRepo(t *testing.T) {
+	const (
+		botID     = "config-repo-priority-bot"
+		channelID = "C-priority"
+	)
+
+	repo := newMockSlackBotRepository()
+	bot := entities.NewSlackBot(botID, "Config Repo Priority Bot", "user-1")
+
+	// Configure a static repository in session params.
+	sc := entities.NewWebhookSessionConfig()
+	sc.SetParams(&entities.SessionParams{
+		RepoFullName: "myorg/configured-repo",
+	})
+	bot.SetSessionConfig(sc)
+	repo.bots[botID] = bot
+
+	sessionMgr := &mockSessionManager{}
+	handler := NewSlackBotEventHandler(repo, sessionMgr, "", "", nil, "", false, nil)
+
+	// Message contains a DIFFERENT org/repo identifier.
+	payload := buildEventPayload(channelID, "other-org/other-repo\nPlease fix this.")
+	err := handler.ProcessEvent(context.Background(), botID, payload)
+	require.NoError(t, err)
+
+	ok := waitForCondition(2*time.Second, 10*time.Millisecond, func() bool {
+		return sessionMgr.createdCount() == 1
+	})
+	require.True(t, ok, "session should be created")
+
+	sess := sessionMgr.getCreatedSession(0)
+	assert.Equal(t, "myorg/configured-repo", sess.tags["repository"],
+		"configured repo_full_name should take priority over message-detected repository")
+	require.NotNil(t, sess.repoInfo, "RepoInfo should be set from configured repo")
+	assert.Equal(t, "myorg/configured-repo", sess.repoInfo.FullName)
+}
+
+// TestProcessEvent_NoConfiguredRepo_FallsBackToMessageDetection verifies that when
+// repo_full_name is NOT configured in session params, the message auto-detection still works.
+func TestProcessEvent_NoConfiguredRepo_FallsBackToMessageDetection(t *testing.T) {
+	const (
+		botID     = "no-config-repo-bot"
+		channelID = "C-noConfigRepo"
+	)
+
+	repo := newMockSlackBotRepository()
+	bot := entities.NewSlackBot(botID, "No Config Repo Bot", "user-1")
+
+	// Configure session params WITHOUT repo_full_name.
+	sc := entities.NewWebhookSessionConfig()
+	sc.SetParams(&entities.SessionParams{
+		AgentType: "claude-agentapi",
+	})
+	bot.SetSessionConfig(sc)
+	repo.bots[botID] = bot
+
+	sessionMgr := &mockSessionManager{}
+	handler := NewSlackBotEventHandler(repo, sessionMgr, "", "", nil, "", false, nil)
+
+	// Message contains an org/repo identifier.
+	payload := buildEventPayload(channelID, "myorg/detected-repo\nPlease fix this.")
+	err := handler.ProcessEvent(context.Background(), botID, payload)
+	require.NoError(t, err)
+
+	ok := waitForCondition(2*time.Second, 10*time.Millisecond, func() bool {
+		return sessionMgr.createdCount() == 1
+	})
+	require.True(t, ok, "session should be created")
+
+	sess := sessionMgr.getCreatedSession(0)
+	assert.Equal(t, "myorg/detected-repo", sess.tags["repository"],
+		"message-detected repository should be used when repo_full_name is not configured")
+	require.NotNil(t, sess.repoInfo, "RepoInfo should be set from message-detected repo")
+	assert.Equal(t, "myorg/detected-repo", sess.repoInfo.FullName)
+}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5586,6 +5586,11 @@
           "type": "boolean",
           "description": "If true, session exits after one response",
           "default": false
+        },
+        "repo_full_name": {
+          "type": "string",
+          "description": "Full name of the GitHub repository to clone (e.g. 'org/repo'). When set, AGENTAPI_REPO_FULLNAME and AGENTAPI_CLONE_DIR are injected into the session environment so the repository is cloned at session startup. Takes priority over any repository auto-detected from the Slack message text.",
+          "example": "myorg/myrepo"
         }
       }
     },


### PR DESCRIPTION
## Summary

- `session_config.params.repo_full_name` フィールドを SlackBot に追加
- SlackBot が常に特定のリポジトリで動作するよう静的に設定できる
- 設定されたリポジトリは Slack メッセージからの自動検出より優先される

## 変更内容

- `SessionParams` エンティティ（`internal/domain/entities/session.go`）に `RepoFullName` フィールドを追加
- `SlackBotSessionParams` DTO（コントローラー）に `repo_full_name` を追加
- イベントハンドラーにて優先度ロジックを実装: `session_config.params.repo_full_name` > メッセージからの自動検出
- `spec/openapi.json` を更新
- 3件のテストを追加

## 使用方法

\`\`\`json
{
  "name": "my-slackbot",
  "session_config": {
    "params": {
      "repo_full_name": "myorg/myrepo"
    }
  }
}
\`\`\`

このように設定すると、Slack メッセージの内容に関わらず、常に `myorg/myrepo` がクローンされる。

## 優先度

| 設定 | メッセージ内 org/repo | 使用されるリポジトリ |
|------|----------------------|---------------------|
| `repo_full_name` あり | なし | 設定値 |
| `repo_full_name` あり | あり | **設定値**（優先） |
| `repo_full_name` なし | あり | メッセージ検出値 |
| `repo_full_name` なし | なし | なし |

## Test plan

- [x] `TestProcessEvent_ConfiguredRepo_UsedWhenNoMessageRepo` - メッセージにリポジトリなし、設定あり → 設定値を使用
- [x] `TestProcessEvent_ConfiguredRepo_TakesPriorityOverMessageRepo` - 両方あり → 設定値が優先
- [x] `TestProcessEvent_NoConfiguredRepo_FallsBackToMessageDetection` - 設定なし → メッセージ検出値を使用
- [x] 全既存テストがパス

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)