### PR TITLE
feat(slackbot): チャンネル名マッチングを前方一致 + 最長マッチに変更

### DIFF
--- a/internal/domain/entities/slackbot.go
+++ b/internal/domain/entities/slackbot.go
@@ -31,7 +31,7 @@ type SlackBot struct {
 	botTokenSecretKey      string                // Key within the Secret; default: "bot-token"
 	appTokenSecretKey      string                // Key within botTokenSecretName Secret for xapp-... token; default: "app-token"
 	allowedEventTypes      []string              // Empty means all event types
-	allowedChannelNames    []string              // Empty means all channels; partial match on resolved channel name
+	allowedChannelNames    []string              // Empty means all channels; prefix match on resolved channel name
 	sessionConfig          *WebhookSessionConfig // Reuse existing type
 	maxSessions            int
 	notifyOnSessionCreated *bool // nil means true (default: notify)
@@ -174,7 +174,7 @@ func (s *SlackBot) SetAllowedEventTypes(types []string) {
 }
 
 // AllowedChannelNames returns the list of allowed Slack channel name patterns.
-// Empty means all channels are allowed. Matching is partial (substring).
+// Empty means all channels are allowed. Matching is prefix (前方一致).
 func (s *SlackBot) AllowedChannelNames() []string { return s.allowedChannelNames }
 
 // SetAllowedChannelNames sets the list of allowed Slack channel name patterns
@@ -276,18 +276,32 @@ func (s *SlackBot) IsEventTypeAllowed(eventType string) bool {
 }
 
 // IsChannelNameAllowed returns true if the given channel name matches any of the allowed patterns.
-// Matching is partial (substring): a pattern is considered matched if the channel name contains it.
+// Matching is prefix (前方一致): a pattern is considered matched if the channel name starts with it.
 // If no patterns are configured, all channels are allowed.
 func (s *SlackBot) IsChannelNameAllowed(channelName string) bool {
 	if len(s.allowedChannelNames) == 0 {
 		return true
 	}
 	for _, pattern := range s.allowedChannelNames {
-		if strings.Contains(channelName, pattern) {
+		if strings.HasPrefix(channelName, pattern) {
 			return true
 		}
 	}
 	return false
+}
+
+// LongestMatchingChannelPatternLength returns the length of the longest channel name pattern
+// that matches channelName by prefix (前方一致). Returns 0 if no pattern matches or if
+// allowedChannelNames is empty. This is used for longest-match bot selection when multiple
+// bots have patterns that match the same channel.
+func (s *SlackBot) LongestMatchingChannelPatternLength(channelName string) int {
+	maxLen := 0
+	for _, pattern := range s.allowedChannelNames {
+		if strings.HasPrefix(channelName, pattern) && len(pattern) > maxLen {
+			maxLen = len(pattern)
+		}
+	}
+	return maxLen
 }
 
 // BotToken returns the transient bot token value (write-only, never returned in API)

--- a/internal/domain/entities/slackbot_test.go
+++ b/internal/domain/entities/slackbot_test.go
@@ -206,22 +206,22 @@ func TestSlackBot_IsChannelNameAllowed(t *testing.T) {
 			want:                true,
 		},
 		{
-			name:                "partial match (prefix)",
+			name:                "prefix match",
 			allowedChannelNames: []string{"dev"},
 			channelName:         "dev-alerts",
 			want:                true,
 		},
 		{
-			name:                "partial match (suffix)",
+			name:                "suffix-only does not match (not prefix)",
 			allowedChannelNames: []string{"alerts"},
 			channelName:         "dev-alerts",
-			want:                true,
+			want:                false,
 		},
 		{
-			name:                "partial match (substring)",
-			allowedChannelNames: []string{"back"},
+			name:                "substring-only does not match (not prefix)",
+			allowedChannelNames: []string{"end"},
 			channelName:         "backend-team",
-			want:                true,
+			want:                false,
 		},
 		{
 			name:                "no match",
@@ -244,6 +244,63 @@ func TestSlackBot_IsChannelNameAllowed(t *testing.T) {
 			got := bot.IsChannelNameAllowed(tt.channelName)
 			if got != tt.want {
 				t.Errorf("IsChannelNameAllowed(%q) = %v, want %v", tt.channelName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlackBot_LongestMatchingChannelPatternLength(t *testing.T) {
+	tests := []struct {
+		name                string
+		allowedChannelNames []string
+		channelName         string
+		want                int
+	}{
+		{
+			name:                "no patterns configured",
+			allowedChannelNames: []string{},
+			channelName:         "dev-alerts",
+			want:                0,
+		},
+		{
+			name:                "no prefix match",
+			allowedChannelNames: []string{"prod", "staging"},
+			channelName:         "dev-alerts",
+			want:                0,
+		},
+		{
+			name:                "single prefix match",
+			allowedChannelNames: []string{"dev"},
+			channelName:         "dev-alerts",
+			want:                3,
+		},
+		{
+			name:                "exact match",
+			allowedChannelNames: []string{"dev-alerts"},
+			channelName:         "dev-alerts",
+			want:                10, // len("dev-alerts") == 10
+		},
+		{
+			name:                "longer pattern wins",
+			allowedChannelNames: []string{"dev", "dev-alerts"},
+			channelName:         "dev-alerts",
+			want:                10, // len("dev-alerts") == 10 > len("dev") == 3
+		},
+		{
+			name:                "suffix-only pattern does not match",
+			allowedChannelNames: []string{"alerts"},
+			channelName:         "dev-alerts",
+			want:                0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bot := NewSlackBot("id-1", "bot", "user-1")
+			bot.SetAllowedChannelNames(tt.allowedChannelNames)
+			got := bot.LongestMatchingChannelPatternLength(tt.channelName)
+			if got != tt.want {
+				t.Errorf("LongestMatchingChannelPatternLength(%q) = %d, want %d", tt.channelName, got, tt.want)
 			}
 		})
 	}

--- a/internal/interfaces/controllers/slackbot_event_handler.go
+++ b/internal/interfaces/controllers/slackbot_event_handler.go
@@ -484,6 +484,8 @@ func (h *SlackBotEventHandler) resolveBotByChannel(ctx context.Context, channelI
 		log.Printf("[SLACKBOT] resolveBotByChannel: failed to list bots: %v", err)
 		return nil
 	}
+	var bestCandidate *entities.SlackBot
+	var bestMatchLen int
 	for _, candidate := range allBots {
 		// Only match bots that rely on the default bot token
 		if candidate.BotTokenSecretName() != "" {
@@ -493,11 +495,16 @@ func (h *SlackBotEventHandler) resolveBotByChannel(ctx context.Context, channelI
 		if len(candidate.AllowedChannelNames()) == 0 {
 			continue
 		}
-		if candidate.IsChannelNameAllowed(channelName) {
-			log.Printf("[SLACKBOT] resolveBotByChannel: matched bot id=%s for channel=%s (name=%s)",
-				candidate.ID(), channelID, channelName)
-			return candidate
+		matchLen := candidate.LongestMatchingChannelPatternLength(channelName)
+		if matchLen > bestMatchLen {
+			bestMatchLen = matchLen
+			bestCandidate = candidate
 		}
+	}
+	if bestCandidate != nil {
+		log.Printf("[SLACKBOT] resolveBotByChannel: matched bot id=%s for channel=%s (name=%s, matchLen=%d)",
+			bestCandidate.ID(), channelID, channelName, bestMatchLen)
+		return bestCandidate
 	}
 	return nil
 }

--- a/internal/interfaces/controllers/slackbot_event_handler_test.go
+++ b/internal/interfaces/controllers/slackbot_event_handler_test.go
@@ -215,7 +215,7 @@ func TestResolveBotByChannel_Success(t *testing.T) {
 	// Bot with matching AllowedChannelNames and no custom bot token
 	repo := newMockSlackBotRepository()
 	bot := entities.NewSlackBot("bot-uuid-1", "Dev Alerts Bot", "user-1")
-	bot.SetAllowedChannelNames([]string{"dev"}) // partial match: "dev" ⊆ "dev-alerts"
+	bot.SetAllowedChannelNames([]string{"dev"}) // prefix match: "dev-alerts" starts with "dev"
 	// BotTokenSecretName = "" → uses default
 	repo.bots["bot-uuid-1"] = bot
 
@@ -335,6 +335,75 @@ func TestResolveBotByChannel_EmptyAllowedChannelNames_Skipped(t *testing.T) {
 
 	resolved := handler.resolveBotByChannel(context.Background(), channelID)
 	assert.Nil(t, resolved, "bot with empty AllowedChannelNames cannot be identified via default endpoint")
+}
+
+func TestResolveBotByChannel_LongestMatch(t *testing.T) {
+	const (
+		namespace  = "test-ns"
+		secretName = "bot-token-secret"
+		channelID  = "C-dev-alerts"
+	)
+
+	fakeClient := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+			Data:       map[string][]byte{"bot-token": []byte("xoxb-test")},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "agentapi-slack-channel-cache", Namespace: namespace},
+			Data:       map[string]string{channelID: "dev-alerts"},
+		},
+	)
+	resolver := services.NewSlackChannelResolver(fakeClient, namespace)
+
+	repo := newMockSlackBotRepository()
+
+	// Bot A: shorter prefix "dev" — matches "dev-alerts" but less specific
+	botA := entities.NewSlackBot("bot-uuid-a", "Dev Bot", "user-1")
+	botA.SetAllowedChannelNames([]string{"dev"})
+	repo.bots["bot-uuid-a"] = botA
+
+	// Bot B: longer prefix "dev-alerts" — more specific, should win
+	botB := entities.NewSlackBot("bot-uuid-b", "Dev Alerts Bot", "user-1")
+	botB.SetAllowedChannelNames([]string{"dev-alerts"})
+	repo.bots["bot-uuid-b"] = botB
+
+	handler := NewSlackBotEventHandler(repo, &mockSessionManager{}, secretName, "bot-token", resolver, "", false, nil)
+
+	resolved := handler.resolveBotByChannel(context.Background(), channelID)
+	require.NotNil(t, resolved, "should resolve a bot by channel name")
+	assert.Equal(t, "bot-uuid-b", resolved.ID(), "longest matching prefix bot should be selected")
+}
+
+func TestResolveBotByChannel_PrefixOnly_NoSuffixMatch(t *testing.T) {
+	const (
+		namespace  = "test-ns"
+		secretName = "bot-token-secret"
+		channelID  = "C-dev-alerts"
+	)
+
+	fakeClient := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+			Data:       map[string][]byte{"bot-token": []byte("xoxb-test")},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "agentapi-slack-channel-cache", Namespace: namespace},
+			Data:       map[string]string{channelID: "dev-alerts"},
+		},
+	)
+	resolver := services.NewSlackChannelResolver(fakeClient, namespace)
+
+	repo := newMockSlackBotRepository()
+	// Bot with suffix-only pattern — must NOT match because matching is prefix only
+	bot := entities.NewSlackBot("bot-uuid-1", "Alerts Bot", "user-1")
+	bot.SetAllowedChannelNames([]string{"alerts"}) // "dev-alerts" does NOT start with "alerts"
+	repo.bots["bot-uuid-1"] = bot
+
+	handler := NewSlackBotEventHandler(repo, &mockSessionManager{}, secretName, "bot-token", resolver, "", false, nil)
+
+	resolved := handler.resolveBotByChannel(context.Background(), channelID)
+	assert.Nil(t, resolved, "suffix-only pattern should not match with prefix matching")
 }
 
 // ---- Tests for ProcessEvent ----


### PR DESCRIPTION
## Summary

- `IsChannelNameAllowed`: `strings.Contains`（部分一致）→ `strings.HasPrefix`（前方一致）に変更
- `LongestMatchingChannelPatternLength` メソッドを新規追加。チャンネル名に前方一致するパターンの中で最長のものの長さを返す
- `resolveBotByChannel`: 複数ボットがマッチする場合に「最初のマッチ」ではなく「最長マッチ（longest match）」を持つボットを選択するよう変更

## 変更の詳細

| 変更箇所 | 変更前 | 変更後 |
|---|---|---|
| `IsChannelNameAllowed` | `strings.Contains`（部分一致） | `strings.HasPrefix`（前方一致） |
| `resolveBotByChannel` | 最初にマッチしたボットを返す | 最長プレフィックスマッチのボットを返す |
| 新規メソッド | — | `LongestMatchingChannelPatternLength` |

## Test plan

- [x] `TestSlackBot_IsChannelNameAllowed`: suffix/substring-only が false になることを検証
- [x] `TestSlackBot_LongestMatchingChannelPatternLength`: 新規メソッドの動作検証
- [x] `TestResolveBotByChannel_LongestMatch`: 短いプレフィックスと長いプレフィックスで長い方が選ばれることを検証
- [x] `TestResolveBotByChannel_PrefixOnly_NoSuffixMatch`: suffix-only パターンがマッチしないことを検証
- [x] `make test` 全通過
- [x] `golangci-lint` 0 issues

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)