### PR TITLE
feat(slackbot): add allowed_user_ids filter to restrict triggering users

### DIFF
--- a/internal/domain/entities/slackbot.go
+++ b/internal/domain/entities/slackbot.go
@@ -32,6 +32,7 @@ type SlackBot struct {
 	appTokenSecretKey      string                // Key within botTokenSecretName Secret for xapp-... token; default: "app-token"
 	allowedEventTypes      []string              // Empty means all event types
 	allowedChannelNames    []string              // Empty means all channels; partial match on resolved channel name
+	allowedUserIDs         []string              // Empty means all users; exact match on Slack user ID
 	sessionConfig          *WebhookSessionConfig // Reuse existing type
 	maxSessions            int
 	notifyOnSessionCreated *bool // nil means true (default: notify)
@@ -183,6 +184,16 @@ func (s *SlackBot) SetAllowedChannelNames(names []string) {
 	s.updatedAt = time.Now()
 }
 
+// AllowedUserIDs returns the list of allowed Slack user IDs.
+// Empty means all users are allowed. Matching is exact (e.g., "U012AB3CD").
+func (s *SlackBot) AllowedUserIDs() []string { return s.allowedUserIDs }
+
+// SetAllowedUserIDs sets the list of allowed Slack user IDs
+func (s *SlackBot) SetAllowedUserIDs(userIDs []string) {
+	s.allowedUserIDs = userIDs
+	s.updatedAt = time.Now()
+}
+
 // SessionConfig returns the session configuration
 func (s *SlackBot) SessionConfig() *WebhookSessionConfig { return s.sessionConfig }
 
@@ -284,6 +295,20 @@ func (s *SlackBot) IsChannelNameAllowed(channelName string) bool {
 	}
 	for _, pattern := range s.allowedChannelNames {
 		if strings.Contains(channelName, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsUserIDAllowed returns true if the given Slack user ID is allowed.
+// Matching is exact. If no user IDs are configured, all users are allowed.
+func (s *SlackBot) IsUserIDAllowed(userID string) bool {
+	if len(s.allowedUserIDs) == 0 {
+		return true
+	}
+	for _, id := range s.allowedUserIDs {
+		if id == userID {
 			return true
 		}
 	}

--- a/internal/domain/entities/slackbot_test.go
+++ b/internal/domain/entities/slackbot_test.go
@@ -249,6 +249,69 @@ func TestSlackBot_IsChannelNameAllowed(t *testing.T) {
 	}
 }
 
+func TestSlackBot_IsUserIDAllowed(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedUserIDs []string
+		userID         string
+		want           bool
+	}{
+		{
+			name:           "all users allowed (empty list)",
+			allowedUserIDs: []string{},
+			userID:         "U012AB3CD",
+			want:           true,
+		},
+		{
+			name:           "nil allowed list (all users allowed)",
+			allowedUserIDs: nil,
+			userID:         "U012AB3CD",
+			want:           true,
+		},
+		{
+			name:           "user in allowed list",
+			allowedUserIDs: []string{"U012AB3CD", "U987XY654"},
+			userID:         "U012AB3CD",
+			want:           true,
+		},
+		{
+			name:           "second user in allowed list",
+			allowedUserIDs: []string{"U012AB3CD", "U987XY654"},
+			userID:         "U987XY654",
+			want:           true,
+		},
+		{
+			name:           "user not in allowed list",
+			allowedUserIDs: []string{"U012AB3CD"},
+			userID:         "UNOTALLOWED",
+			want:           false,
+		},
+		{
+			name:           "partial match does not count (exact match required)",
+			allowedUserIDs: []string{"U012AB"},
+			userID:         "U012AB3CD",
+			want:           false,
+		},
+		{
+			name:           "empty user ID not in non-empty list",
+			allowedUserIDs: []string{"U012AB3CD"},
+			userID:         "",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bot := NewSlackBot("id-1", "bot", "user-1")
+			bot.SetAllowedUserIDs(tt.allowedUserIDs)
+			got := bot.IsUserIDAllowed(tt.userID)
+			if got != tt.want {
+				t.Errorf("IsUserIDAllowed(%q) = %v, want %v", tt.userID, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSlackBot_BotTokenSecretKey_Default(t *testing.T) {
 	bot := NewSlackBot("id-1", "bot", "user-1")
 	// When not set, should return default "bot-token"

--- a/internal/infrastructure/repositories/kubernetes_slackbot_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_slackbot_repository.go
@@ -50,6 +50,7 @@ type slackBotJSON struct {
 	AppTokenSecretKey      string                    `json:"app_token_secret_key,omitempty"`
 	AllowedEventTypes      []string                  `json:"allowed_event_types,omitempty"`
 	AllowedChannelNames    []string                  `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                  `json:"allowed_user_ids,omitempty"`
 	SessionConfig          *webhookSessionConfigJSON `json:"session_config,omitempty"`
 	MaxSessions            int                       `json:"max_sessions,omitempty"`
 	NotifyOnSessionCreated *bool                     `json:"notify_on_session_created,omitempty"`
@@ -387,6 +388,9 @@ func (r *KubernetesSlackBotRepository) jsonToEntity(sbj *slackBotJSON) *entities
 	if len(sbj.AllowedChannelNames) > 0 {
 		slackBot.SetAllowedChannelNames(sbj.AllowedChannelNames)
 	}
+	if len(sbj.AllowedUserIDs) > 0 {
+		slackBot.SetAllowedUserIDs(sbj.AllowedUserIDs)
+	}
 	if sbj.MaxSessions > 0 {
 		slackBot.SetMaxSessions(sbj.MaxSessions)
 	}
@@ -415,6 +419,7 @@ func (r *KubernetesSlackBotRepository) entityToJSON(sb *entities.SlackBot) *slac
 		AppTokenSecretKey:   sb.AppTokenSecretKey(),
 		AllowedEventTypes:   sb.AllowedEventTypes(),
 		AllowedChannelNames: sb.AllowedChannelNames(),
+		AllowedUserIDs:      sb.AllowedUserIDs(),
 		MaxSessions:         sb.MaxSessions(),
 		CreatedAt:           sb.CreatedAt(),
 		UpdatedAt:           sb.UpdatedAt(),

--- a/internal/interfaces/controllers/slackbot_controller.go
+++ b/internal/interfaces/controllers/slackbot_controller.go
@@ -37,6 +37,9 @@ type CreateSlackBotRequest struct {
 	BotTokenSecretKey   string                 `json:"bot_token_secret_key,omitempty"`
 	AllowedEventTypes   []string               `json:"allowed_event_types,omitempty"`
 	AllowedChannelNames []string               `json:"allowed_channel_names,omitempty"`
+	// AllowedUserIDs is the list of Slack user IDs allowed to trigger the bot.
+	// Empty means all users are allowed. Matching is exact (e.g., "U012AB3CD").
+	AllowedUserIDs      []string               `json:"allowed_user_ids,omitempty"`
 	SessionConfig       *SlackBotSessionConfig `json:"session_config,omitempty"`
 	MaxSessions         int                    `json:"max_sessions,omitempty"`
 	// NotifyOnSessionCreated controls whether the bot posts a Slack message with
@@ -65,6 +68,9 @@ type UpdateSlackBotRequest struct {
 	BotTokenSecretKey   *string                `json:"bot_token_secret_key"`
 	AllowedEventTypes   []string               `json:"allowed_event_types,omitempty"`
 	AllowedChannelNames []string               `json:"allowed_channel_names,omitempty"`
+	// AllowedUserIDs is the list of Slack user IDs allowed to trigger the bot.
+	// Empty means all users are allowed. Matching is exact (e.g., "U012AB3CD").
+	AllowedUserIDs      []string               `json:"allowed_user_ids,omitempty"`
 	SessionConfig       *SlackBotSessionConfig `json:"session_config,omitempty"`
 	MaxSessions         int                    `json:"max_sessions,omitempty"`
 	// NotifyOnSessionCreated controls whether the bot posts a Slack message with
@@ -112,6 +118,7 @@ type SlackBotResponse struct {
 	BotTokenSecretKey      string                  `json:"bot_token_secret_key,omitempty"`
 	AllowedEventTypes      []string                `json:"allowed_event_types,omitempty"`
 	AllowedChannelNames    []string                `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                `json:"allowed_user_ids,omitempty"`
 	SessionConfig          *SlackBotSessionConfig  `json:"session_config,omitempty"`
 	MaxSessions            int                     `json:"max_sessions"`
 	NotifyOnSessionCreated bool                    `json:"notify_on_session_created"`
@@ -175,6 +182,9 @@ func (c *SlackBotController) CreateSlackBot(ctx echo.Context) error {
 	}
 	if len(req.AllowedChannelNames) > 0 {
 		bot.SetAllowedChannelNames(req.AllowedChannelNames)
+	}
+	if len(req.AllowedUserIDs) > 0 {
+		bot.SetAllowedUserIDs(req.AllowedUserIDs)
 	}
 	if req.MaxSessions > 0 {
 		bot.SetMaxSessions(req.MaxSessions)
@@ -324,6 +334,9 @@ func (c *SlackBotController) UpdateSlackBot(ctx echo.Context) error {
 	if req.AllowedChannelNames != nil {
 		bot.SetAllowedChannelNames(req.AllowedChannelNames)
 	}
+	if req.AllowedUserIDs != nil {
+		bot.SetAllowedUserIDs(req.AllowedUserIDs)
+	}
 	if req.MaxSessions > 0 {
 		bot.SetMaxSessions(req.MaxSessions)
 	}
@@ -403,6 +416,7 @@ func (c *SlackBotController) toResponse(bot *entities.SlackBot) *SlackBotRespons
 		BotTokenSecretKey:      bot.BotTokenSecretKey(),
 		AllowedEventTypes:      bot.AllowedEventTypes(),
 		AllowedChannelNames:    bot.AllowedChannelNames(),
+		AllowedUserIDs:         bot.AllowedUserIDs(),
 		MaxSessions:            bot.MaxSessions(),
 		NotifyOnSessionCreated: bot.NotifyOnSessionCreated(),
 		AllowBotMessages:       bot.AllowBotMessages(),

--- a/internal/interfaces/controllers/slackbot_event_handler.go
+++ b/internal/interfaces/controllers/slackbot_event_handler.go
@@ -159,6 +159,11 @@ func (h *SlackBotEventHandler) ProcessEvent(ctx context.Context, botID string, p
 			log.Printf("[SLACKBOT] Event type not allowed: id=%s, type=%s", botID, event.Type)
 			return nil
 		}
+		// User ID filter: check if the sender's Slack user ID is allowed
+		if !bot.IsUserIDAllowed(event.User) {
+			log.Printf("[SLACKBOT] User ID not allowed: id=%s, user=%s", botID, event.User)
+			return nil
+		}
 		// Channel name filter: resolve channel ID → name, then apply partial-match filter
 		if len(bot.AllowedChannelNames()) > 0 && h.channelResolver != nil {
 			secretName := bot.BotTokenSecretName()

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5678,6 +5678,17 @@
             "backend"
           ]
         },
+        "allowed_user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Slack user IDs allowed to trigger this bot (exact match, e.g. \"U012AB3CD\"). Empty means all users are allowed.",
+          "example": [
+            "U012AB3CD",
+            "U987XY654"
+          ]
+        },
         "session_config": {
           "$ref": "#/components/schemas/SlackBotSessionConfig"
         },
@@ -5740,6 +5751,13 @@
             "type": "string"
           },
           "description": "Slack channel name patterns to listen to (partial match). Empty means all channels are allowed."
+        },
+        "allowed_user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Slack user IDs allowed to trigger this bot (exact match, e.g. \"U012AB3CD\"). Empty means all users are allowed."
         },
         "session_config": {
           "$ref": "#/components/schemas/SlackBotSessionConfig"
@@ -5825,6 +5843,13 @@
             "type": "string"
           },
           "description": "Slack channel name patterns monitored by this bot (partial match)"
+        },
+        "allowed_user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Slack user IDs allowed to trigger this bot (exact match). Empty means all users are allowed."
         },
         "session_config": {
           "$ref": "#/components/schemas/SlackBotSessionConfig"


### PR DESCRIPTION
## Summary

- SlackBot に `allowed_user_ids` フィールドを追加し、発話できるユーザーを Slack ユーザー ID で絞り込めるようにした
- 指定したユーザー ID に含まれないユーザーのメッセージは無視される（完全一致）
- 空リストの場合は全ユーザーを許可（既存動作と互換性あり）

## 変更内容

- **`internal/domain/entities/slackbot.go`**: `allowedUserIDs` フィールド、getter/setter、`IsUserIDAllowed()` メソッドを追加
- **`internal/infrastructure/repositories/kubernetes_slackbot_repository.go`**: シリアライズ/デシリアライズに `allowed_user_ids` を追加
- **`internal/interfaces/controllers/slackbot_controller.go`**: Create/Update DTO と Response に `allowed_user_ids` を追加
- **`internal/interfaces/controllers/slackbot_event_handler.go`**: `ProcessEvent` でユーザー ID フィルタを適用
- **`internal/domain/entities/slackbot_test.go`**: `IsUserIDAllowed` のテストケースを追加
- **`spec/openapi.json`**: 3つのスキーマ（CreateSlackBotRequest / UpdateSlackBotRequest / SlackBotResponse）を更新

## Test plan

- [ ] `go test ./internal/...` がすべて通ることを確認
- [ ] UI PR と合わせて動作確認: https://github.com/takutakahashi/agentapi-ui/pull/new/feature/slackbot-allowed-user-ids

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)