### PR TITLE
feat(sessions): add proxy-wide session status SSE and long-polling endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,37 +1,99 @@
-## 前提条件
+# CLAUDE.md
 
-作業を開始する前に、以下の前提条件を必ず確認してください：
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## コマンド
+
+```bash
+make build          # バイナリのビルド (bin/agentapi-proxy)
+make test           # テスト実行 (CGO_ENABLED=1, race detector 有効)
+make test-verbose PKG=./internal/app  # 特定パッケージを詳細出力でテスト
+make lint           # golangci-lint 実行 (gofmt も含む)
+make gofmt          # コードフォーマット
+make install-deps   # Go モジュールと golangci-lint のインストール
+make ci             # lint + test + build をまとめて実行
+make devbuild       # GitHub Actions でdev用 Docker image + Helm chart をビルド
+```
+
+テスト実行には `CGO_ENABLED=1` が必要（race detector のため）。
+
+## アーキテクチャ概要
+
+### 全体像
+
+agentapi-proxy は [coder/agentapi](https://github.com/coder/agentapi) のプロセスマネージャ兼リバースプロキシ。各セッションで独立した agentapi サーバプロセスを起動し、`/:sessionId/*` へのリクエストをそのセッションのバックエンドに転送する。
+
+### レイヤー構成 (Clean Architecture)
+
+```
+internal/
+  domain/         # エンティティ・インターフェース定義 (外部依存なし)
+    entities/     # Session, Task, Memory, Schedule など
+    services/     # EncryptionService インターフェース
+  usecases/       # ビジネスロジック
+    ports/        # repositories/ (SessionManager, SettingsRepository など Port インターフェース)
+    session/      # セッション検証 UseCase
+    auth/         # 認証 UseCase
+    notification/ # 通知 UseCase
+  infrastructure/ # 実装詳細
+    repositories/ # Kubernetes CRD/Secret/ConfigMap を使った実装、S3/メモリ実装
+    services/     # KubernetesSessionManager, SimpleAuthService など
+  interfaces/
+    controllers/  # Echo ハンドラ (各エンドポイントのビジネスロジック呼び出し)
+    presenters/   # レスポンス整形
+  app/            # Server と Router の組み立て (DI)
+  di/             # DI コンテナ
+pkg/              # 外部パッケージから使われる共通ライブラリ
+  auth/           # 認証・認可 (API Key, GitHub OAuth, JWT, Team mapping)
+  config/         # 設定読み込み (YAML + 環境変数)
+  client/         # agentapi-proxy Go クライアント
+  notification/   # WebPush 通知サービス
+  sessionsettings # セッション設定ユーティリティ
+cmd/              # cobra CLI コマンド定義
+spec/             # OpenAPI 仕様 (spec/openapi.json) + 静的ファイル埋め込み
+```
+
+### セッション管理フロー
+
+1. `POST /start` → `SessionController.StartSession` → `Server.CreateSession` → `KubernetesSessionManager.CreateSession`
+2. Kubernetes Deployment + Service + PVC を作成して agentapi プロセスを起動
+3. `GET /search` でセッション一覧を取得
+4. `ANY /:sessionId/*` → `SessionController.RouteToSession` → バックエンドへプロキシ転送（SSE ストリームも pass-through）
+5. `DELETE /sessions/:sessionId` でセッション削除
+
+### 実行モード
+
+| モード | SessionManager 実装 | 説明 |
+|--------|-------------------|------|
+| Kubernetes | `KubernetesSessionManager` | 本番。K8s Deployment でセッションを管理 |
+| Local (acp_server) | `LocalSessionManager` | ローカル開発。プロセス直接起動 |
+| External Session Manager | Proxy A → Proxy B | `ManagerID` 指定時に別の agentapi-proxy インスタンスに転送 |
+
+### 認証・認可
+
+- `pkg/auth/` にて API Key / GitHub OAuth / Personal API Key (K8s Secret) / Service Account の4種類をサポート
+- `entities.Permission` で `session:read` / `session:create` / `admin` を定義
+- 各ルートに `auth.RequirePermission(...)` ミドルウェアを付与
+
+### ルーティング登録
+
+`internal/app/router.go` の `Router.RegisterRoutes()` が起点。リポジトリ/コントローラが nil の場合（K8s 外での起動時など）はそのルートを登録しない条件分岐がある。カスタムハンドラは `CustomHandler` インターフェースを実装して `Router.AddCustomHandler()` で追加。
+
+### OpenAPI 仕様
+
+`spec/openapi.json` が正規の API ドキュメント。API を変更した際はこのファイルも必ず更新する。`spec/static.go` で `//go:embed` により実行バイナリに埋め込まれ `/public/*` として配信される。
+
+## 前提条件・開発ワークフロー
 
 ### API 仕様の参照
 
 - **作業開始前に [agentapi の OpenAPI 仕様](https://github.com/coder/agentapi/blob/main/openapi.json) を必ず参照する**
-  - API エンドポイント、リクエスト/レスポンス形式、認証方法などを確認
-  - UI 実装時に正確な API 仕様に基づいて開発を行う
-
-### 参考資料
-
-- **必要に応じて [agentapi のコード](https://github.com/coder/agentapi) を参考にする**
-  - バックエンドの実装詳細を理解する際に参照
-  - API の動作を理解するためのリファレンスとして活用
+- 必要に応じて [agentapi のコード](https://github.com/coder/agentapi) を参照する
 
 ### 開発ワークフロー
 
-- **絶対に main ブランチに直接プッシュしてはいけない**
-  - 必ず feature ブランチを作成して作業を行う
-  - 変更は feature ブランチにコミット・プッシュする
-  - プルリクエストを作成してレビューを受ける
-  - main ブランチへの直接プッシュは禁止
-
-- **変更を行った際は忘れずにブランチにプッシュする**
-  - コードの変更、新機能の追加、バグ修正などを行った場合は必ずコミットしてブランチにプッシュする
-  - プルリクエストを作成して変更内容をレビューしてもらう
-  - チーム内での作業状況を共有し、進捗を可視化する
-
-- **API の変更時は必ず OpenAPI 仕様を更新する**
-  - 新しいエンドポイントを追加した場合は `spec/openapi.json` に追加する
-  - 既存エンドポイントのリクエスト/レスポンス形式を変更した場合も更新する
-  - スキーマ（components/schemas）の追加・変更も忘れずに行う
-  - タグ（tags）の追加が必要な場合は追加する
+- **絶対に main ブランチに直接プッシュしてはいけない** — 必ず feature ブランチを切って作業し、PR を作成する
+- **API の変更時は必ず `spec/openapi.json` を更新する**（エンドポイント・スキーマ・タグ）
 
 ### 📋 タスクリストの更新ルール
 

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -188,6 +188,11 @@ func (r *Router) registerCoreRoutes() error {
 	r.echo.GET("/search", r.handlers.sessionController.SearchSessions)
 	r.echo.DELETE("/sessions/:sessionId", r.handlers.sessionController.DeleteSession)
 
+	// Proxy-wide session status push endpoints (registered before /:sessionId/* catch-all)
+	r.echo.GET("/sessions/status/stream", r.handlers.sessionController.StreamSessionsStatus)
+	r.echo.GET("/sessions/status/wait", r.handlers.sessionController.WaitSessionsStatus)
+	log.Printf("[ROUTES] Session status push endpoints registered (SSE + long-poll)")
+
 	// Session sharing routes
 	if r.handlers.shareController != nil {
 		log.Printf("[ROUTES] Registering session sharing endpoints...")

--- a/internal/infrastructure/services/kubernetes_session.go
+++ b/internal/infrastructure/services/kubernetes_session.go
@@ -31,6 +31,10 @@ type KubernetesSession struct {
 	provisionPayload  []byte                           // JSON body for POST /provision to agent-provisioner
 	provisionSettings *sessionsettings.SessionSettings // Settings used for provisioning (stored after successful provisioning)
 	isStock           bool                             // Whether this is a pre-warmed stock session
+
+	// statusChangeCallback is called by SetStatus when the status changes.
+	// Set by KubernetesSessionManager at session creation to enable proxy-wide pub/sub.
+	statusChangeCallback func(sessionID, newStatus string)
 }
 
 // NewKubernetesSession creates a new KubernetesSession
@@ -155,11 +159,19 @@ func (s *KubernetesSession) Cancel() {
 	}
 }
 
-// SetStatus updates the session status
+// SetStatus updates the session status.
+// If the status changed, the statusChangeCallback (if set) is called outside
+// the mutex to notify proxy-wide subscribers without risk of deadlock.
 func (s *KubernetesSession) SetStatus(status string) {
 	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	changed := s.status != status
 	s.status = status
+	cb := s.statusChangeCallback
+	s.mutex.Unlock()
+
+	if changed && cb != nil {
+		cb(s.id, status)
+	}
 }
 
 // SetStartedAt sets the session start time (used for restored sessions)

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -53,6 +53,15 @@ type ServiceAccountEnsurer interface {
 	EnsureServiceAccount(ctx context.Context, teamID string) error
 }
 
+// SessionStatusEvent represents a proxy-level status change event for any session.
+// It is emitted by KubernetesSessionManager whenever a session's status changes,
+// and is delivered to all active SSE/long-poll subscribers.
+type SessionStatusEvent struct {
+	SessionID string    `json:"session_id"`
+	Status    string    `json:"status"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // SessionDeletedHandler is a callback invoked just before a session's Kubernetes resources
 // are removed. At this point the session's Service endpoint is still reachable, so handlers
 // can safely call GetMessages or other in-session APIs.
@@ -77,6 +86,13 @@ type KubernetesSessionManager struct {
 	// Protected by handlersMutex.
 	onSessionDeletedHandlers []SessionDeletedHandler
 	handlersMutex            sync.RWMutex
+
+	// Proxy-wide status change pub/sub.
+	// globalSubs maps subscriber ID → buffered channel of SessionStatusEvent.
+	// Protected by globalSubsMu.
+	globalSubsMu    sync.Mutex
+	globalSubs      map[uint64]chan SessionStatusEvent
+	nextGlobalSubID uint64
 }
 
 // NewKubernetesSessionManager creates a new KubernetesSessionManager
@@ -119,13 +135,14 @@ func NewKubernetesSessionManagerWithClient(
 	log.Printf("[K8S_SESSION] Initialized KubernetesSessionManager in namespace: %s", namespace)
 
 	manager := &KubernetesSessionManager{
-		config:    cfg,
-		k8sConfig: k8sConfig,
-		client:    client,
-		verbose:   verbose,
-		logger:    lgr,
-		sessions:  make(map[string]*KubernetesSession),
-		namespace: namespace,
+		config:     cfg,
+		k8sConfig:  k8sConfig,
+		client:     client,
+		verbose:    verbose,
+		logger:     lgr,
+		sessions:   make(map[string]*KubernetesSession),
+		namespace:  namespace,
+		globalSubs: make(map[uint64]chan SessionStatusEvent),
 	}
 
 	// Ensure OpenTelemetry Collector ConfigMap exists
@@ -176,6 +193,8 @@ func (m *KubernetesSessionManager) CreateSession(ctx context.Context, id string,
 		cancel,
 		webhookPayload,
 	)
+	// Register proxy-wide status change broadcaster
+	session.statusChangeCallback = m.broadcastStatusChange
 
 	// Store session
 	m.mutex.Lock()
@@ -495,6 +514,9 @@ func (m *KubernetesSessionManager) adoptStockSession(
 	if req.InitialMessage != "" {
 		session.SetDescription(req.InitialMessage)
 	}
+
+	// Register proxy-wide status change broadcaster
+	session.statusChangeCallback = m.broadcastStatusChange
 
 	// Register session in memory.
 	m.mutex.Lock()
@@ -2205,6 +2227,47 @@ func (m *KubernetesSessionManager) AddSessionDeletedHandler(handler SessionDelet
 	m.onSessionDeletedHandlers = append(m.onSessionDeletedHandlers, handler)
 }
 
+// broadcastStatusChange broadcasts a SessionStatusEvent to all active proxy-wide subscribers.
+// It is registered as the statusChangeCallback on each KubernetesSession.
+// Non-blocking: slow subscribers are skipped to avoid stalling SetStatus.
+func (m *KubernetesSessionManager) broadcastStatusChange(sessionID, status string) {
+	evt := SessionStatusEvent{
+		SessionID: sessionID,
+		Status:    status,
+		Timestamp: time.Now(),
+	}
+	m.globalSubsMu.Lock()
+	defer m.globalSubsMu.Unlock()
+	for _, ch := range m.globalSubs {
+		select {
+		case ch <- evt:
+		default:
+			// subscriber channel is full; drop to avoid blocking the caller
+		}
+	}
+}
+
+// SubscribeStatusEvents registers a new proxy-wide subscriber for session status changes.
+// Returns a channel that receives SessionStatusEvent values whenever any session's status
+// changes, and a cancel func that must be called to unsubscribe (closes the channel).
+func (m *KubernetesSessionManager) SubscribeStatusEvents() (<-chan SessionStatusEvent, func()) {
+	m.globalSubsMu.Lock()
+	defer m.globalSubsMu.Unlock()
+	id := m.nextGlobalSubID
+	m.nextGlobalSubID++
+	ch := make(chan SessionStatusEvent, 32)
+	m.globalSubs[id] = ch
+	cancel := func() {
+		m.globalSubsMu.Lock()
+		defer m.globalSubsMu.Unlock()
+		if ch, ok := m.globalSubs[id]; ok {
+			close(ch)
+			delete(m.globalSubs, id)
+		}
+	}
+	return ch, cancel
+}
+
 // SetPersonalAPIKeyRepository sets the personal API key repository
 func (m *KubernetesSessionManager) SetPersonalAPIKeyRepository(repo portrepos.PersonalAPIKeyRepository) {
 	m.personalAPIKeyRepo = repo
@@ -2387,6 +2450,9 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 	session.SetStatus(m.getSessionStatusFromDeployment(sessionID))
 	session.SetDescription(initialMessage) // Cache initial message as description
 
+	// Register proxy-wide status change broadcaster
+	session.statusChangeCallback = m.broadcastStatusChange
+
 	// Add to memory map
 	m.mutex.Lock()
 	m.sessions[sessionID] = session
@@ -2503,6 +2569,9 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 	session.SetLastMessageAt(lastMessageAt)
 	session.SetStatus(m.getStatusFromDeploymentObject(deployment))
 	session.SetDescription(initialMessage) // Cache initial message as description
+
+	// Register proxy-wide status change broadcaster
+	session.statusChangeCallback = m.broadcastStatusChange
 
 	// Add to memory map
 	m.mutex.Lock()

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/rand"
@@ -695,7 +696,8 @@ func (m *KubernetesSessionManager) watchStockSession(ctx context.Context, sessio
 	session.SetStatus("active")
 	log.Printf("[K8S_SESSION] Stock session %s is now active", session.id)
 
-	// Continue watching deployment status for the lifetime of the session.
+	// Continue watching deployment health and agentapi runtime status.
+	go m.watchAgentAPIStatus(ctx, session)
 	m.watchDeploymentStatus(ctx, session)
 }
 
@@ -1776,7 +1778,8 @@ func (m *KubernetesSessionManager) watchSession(ctx context.Context, session *Ku
 				session.SetStatus("active")
 				log.Printf("[K8S_SESSION] Session %s is now active", session.id)
 
-				// Continue watching for changes.
+				// Continue watching deployment health and agentapi runtime status.
+				go m.watchAgentAPIStatus(ctx, session)
 				m.watchDeploymentStatus(ctx, session)
 				return
 			}
@@ -1900,7 +1903,12 @@ func (m *KubernetesSessionManager) watchDeploymentStatus(ctx context.Context, se
 			if deployment.Status.ReadyReplicas == 0 {
 				session.SetStatus("unhealthy")
 			} else {
-				session.SetStatus("active")
+				// Only recover to "active" from a bad state.
+				// Do not overwrite "running" (agentapi is processing a message).
+				current := session.Status()
+				if current == "unhealthy" || current == "stopped" || current == "error" || current == "timeout" {
+					session.SetStatus("active")
+				}
 			}
 		}
 	}
@@ -2269,6 +2277,102 @@ func (m *KubernetesSessionManager) SubscribeStatusEvents() (<-chan SessionStatus
 	return ch, cancel
 }
 
+// watchAgentAPIStatus subscribes to the agentapi backend's /events SSE stream for the
+// given session. Whenever the runtime status changes (stable ↔ running), SetStatus is
+// called so the change propagates to proxy-wide SSE subscribers.
+// The goroutine exits when ctx is cancelled.
+func (m *KubernetesSessionManager) watchAgentAPIStatus(ctx context.Context, session *KubernetesSession) {
+	backoff := 2 * time.Second
+	const maxBackoff = 30 * time.Second
+	url := fmt.Sprintf("http://%s/events", session.Addr())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		if err := m.streamAgentAPIEvents(ctx, session, url); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("[AGENT_STATUS] Session %s: /events stream error: %v; retrying in %s", session.id, err, backoff)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+// streamAgentAPIEvents connects to the agentapi backend's /events SSE endpoint and
+// maps status_change events to proxy-level session status changes.
+// Returns when the stream ends or the context is cancelled.
+func (m *KubernetesSessionManager) streamAgentAPIEvents(ctx context.Context, session *KubernetesSession, url string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d from /events", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var eventType string
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		line := scanner.Text()
+		if line == "" {
+			eventType = ""
+			continue
+		}
+		if strings.HasPrefix(line, "event: ") {
+			eventType = strings.TrimPrefix(line, "event: ")
+			continue
+		}
+		if strings.HasPrefix(line, "data: ") && eventType == "status_change" {
+			data := strings.TrimPrefix(line, "data: ")
+			var body struct {
+				Status string `json:"status"`
+			}
+			if jsonErr := json.Unmarshal([]byte(data), &body); jsonErr != nil {
+				continue
+			}
+			switch body.Status {
+			case "running":
+				session.SetStatus("running")
+				log.Printf("[AGENT_STATUS] Session %s is now running", session.id)
+			case "stable":
+				session.SetStatus("active")
+				log.Printf("[AGENT_STATUS] Session %s is now stable (active)", session.id)
+			}
+		}
+	}
+	return scanner.Err()
+}
+
 // SetPersonalAPIKeyRepository sets the personal API key repository
 func (m *KubernetesSessionManager) SetPersonalAPIKeyRepository(repo portrepos.PersonalAPIKeyRepository) {
 	m.personalAPIKeyRepo = repo
@@ -2459,8 +2563,9 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 	m.sessions[sessionID] = session
 	m.mutex.Unlock()
 
-	// Start watching deployment status
+	// Start watching deployment health and agentapi runtime status.
 	go m.watchDeploymentStatus(ctx, session)
+	go m.watchAgentAPIStatus(ctx, session)
 
 	log.Printf("[K8S_SESSION] Restored session %s from Service", sessionID)
 
@@ -2579,8 +2684,9 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 	m.sessions[sessionID] = session
 	m.mutex.Unlock()
 
-	// Start watching deployment status
+	// Start watching deployment health and agentapi runtime status.
 	go m.watchDeploymentStatus(ctx, session)
+	go m.watchAgentAPIStatus(ctx, session)
 
 	log.Printf("[K8S_SESSION] Restored session %s from Service (with pre-fetched deployment)", sessionID)
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2238,6 +2238,7 @@ func (m *KubernetesSessionManager) broadcastStatusChange(sessionID, status strin
 	}
 	m.globalSubsMu.Lock()
 	defer m.globalSubsMu.Unlock()
+	log.Printf("[SSE_BROADCAST] session=%s status=%s subscribers=%d", sessionID, status, len(m.globalSubs))
 	for _, ch := range m.globalSubs {
 		select {
 		case ch <- evt:

--- a/internal/interfaces/controllers/session_status_controller.go
+++ b/internal/interfaces/controllers/session_status_controller.go
@@ -1,0 +1,166 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// ProxyStatusWatcher is implemented by session managers that support proxy-wide
+// real-time status change notifications. KubernetesSessionManager implements this.
+// The session controller uses a type-assertion to obtain this capability, keeping
+// the core SessionManager interface unchanged.
+type ProxyStatusWatcher interface {
+	SubscribeStatusEvents() (<-chan services.SessionStatusEvent, func())
+}
+
+// StreamSessionsStatus handles GET /sessions/status/stream.
+// It opens a Server-Sent Events stream that pushes a SessionStatusEvent whenever
+// any session accessible to the authenticated user changes its status.
+// A heartbeat comment is sent every 30 seconds to keep the connection alive.
+func (c *SessionController) StreamSessionsStatus(ctx echo.Context) error {
+	authzCtx := auth.GetAuthorizationContext(ctx)
+
+	manager := c.getSessionManager()
+	watcher, ok := manager.(ProxyStatusWatcher)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotImplemented, "status streaming not supported by this session manager")
+	}
+
+	// Set SSE response headers
+	r := ctx.Response()
+	r.Header().Set("Content-Type", "text/event-stream")
+	r.Header().Set("Cache-Control", "no-cache")
+	r.Header().Set("Connection", "keep-alive")
+	r.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
+	r.WriteHeader(http.StatusOK)
+
+	eventCh, cancel := watcher.SubscribeStatusEvents()
+	defer cancel()
+
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
+	reqCtx := ctx.Request().Context()
+	flusher, hasFlusher := r.Writer.(http.Flusher)
+
+	for {
+		select {
+		case <-reqCtx.Done():
+			return nil
+
+		case evt, open := <-eventCh:
+			if !open {
+				return nil
+			}
+			// Authorization filter: only forward events for sessions this user can access.
+			session := manager.GetSession(evt.SessionID)
+			if session == nil {
+				continue
+			}
+			if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+				continue
+			}
+			if err := writeSessionStatusSSEEvent(r, evt); err != nil {
+				return nil
+			}
+			if hasFlusher {
+				flusher.Flush()
+			}
+
+		case <-heartbeat.C:
+			if _, err := fmt.Fprintf(r, ": heartbeat\n\n"); err != nil {
+				return nil
+			}
+			if hasFlusher {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// WaitSessionsStatus handles GET /sessions/status/wait.
+// It blocks until any session accessible to the authenticated user changes status,
+// then returns the event as JSON. If the timeout elapses before any change,
+// it returns `{"events": []}`.
+//
+// Query parameters:
+//   - timeout: max wait time in seconds (default 30, max 60)
+func (c *SessionController) WaitSessionsStatus(ctx echo.Context) error {
+	authzCtx := auth.GetAuthorizationContext(ctx)
+
+	timeoutSec := 30
+	if t := ctx.QueryParam("timeout"); t != "" {
+		if v, err := strconv.Atoi(t); err == nil {
+			timeoutSec = clampStatusTimeout(v)
+		}
+	}
+
+	manager := c.getSessionManager()
+	watcher, ok := manager.(ProxyStatusWatcher)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotImplemented, "status streaming not supported by this session manager")
+	}
+
+	eventCh, cancel := watcher.SubscribeStatusEvents()
+	defer cancel()
+
+	timer := time.NewTimer(time.Duration(timeoutSec) * time.Second)
+	defer timer.Stop()
+
+	reqCtx := ctx.Request().Context()
+
+	for {
+		select {
+		case <-reqCtx.Done():
+			return nil
+
+		case evt, open := <-eventCh:
+			if !open {
+				// Manager shutting down
+				return ctx.JSON(http.StatusOK, map[string]interface{}{"events": []interface{}{}})
+			}
+			// Authorization filter
+			session := manager.GetSession(evt.SessionID)
+			if session == nil {
+				continue
+			}
+			if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+				continue
+			}
+			return ctx.JSON(http.StatusOK, evt)
+
+		case <-timer.C:
+			// Timeout reached: return empty event list so callers can distinguish
+			// a real change from a timeout without relying on HTTP status codes.
+			return ctx.JSON(http.StatusOK, map[string]interface{}{"events": []interface{}{}})
+		}
+	}
+}
+
+// writeSessionStatusSSEEvent marshals evt and writes a data event to the SSE response.
+func writeSessionStatusSSEEvent(w *echo.Response, evt services.SessionStatusEvent) error {
+	payload, err := json.Marshal(evt)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "data: %s\n\n", payload)
+	return err
+}
+
+// clampStatusTimeout returns v clamped to [1, 60].
+func clampStatusTimeout(v int) int {
+	if v < 1 {
+		return 1
+	}
+	if v > 60 {
+		return 60
+	}
+	return v
+}

--- a/internal/interfaces/controllers/session_status_controller.go
+++ b/internal/interfaces/controllers/session_status_controller.go
@@ -41,6 +41,13 @@ func (c *SessionController) StreamSessionsStatus(ctx echo.Context) error {
 	r.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
 	r.WriteHeader(http.StatusOK)
 
+	// Flush the response headers immediately so the client knows the stream is open.
+	// Without this, headers stay in the buffer until the first event/heartbeat.
+	flusher, hasFlusher := r.Writer.(http.Flusher)
+	if hasFlusher {
+		flusher.Flush()
+	}
+
 	eventCh, cancel := watcher.SubscribeStatusEvents()
 	defer cancel()
 
@@ -48,7 +55,6 @@ func (c *SessionController) StreamSessionsStatus(ctx echo.Context) error {
 	defer heartbeat.Stop()
 
 	reqCtx := ctx.Request().Context()
-	flusher, hasFlusher := r.Writer.(http.Flusher)
 
 	for {
 		select {

--- a/internal/interfaces/controllers/session_status_controller.go
+++ b/internal/interfaces/controllers/session_status_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -33,6 +34,9 @@ func (c *SessionController) StreamSessionsStatus(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotImplemented, "status streaming not supported by this session manager")
 	}
 
+	clientIP := ctx.RealIP()
+	log.Printf("[SSE] Client connected to /sessions/status/stream from %s (user: %s)", clientIP, authzCtx.PersonalScope.UserID)
+
 	// Set SSE response headers
 	r := ctx.Response()
 	r.Header().Set("Content-Type", "text/event-stream")
@@ -49,7 +53,10 @@ func (c *SessionController) StreamSessionsStatus(ctx echo.Context) error {
 	}
 
 	eventCh, cancel := watcher.SubscribeStatusEvents()
-	defer cancel()
+	defer func() {
+		cancel()
+		log.Printf("[SSE] Client disconnected from /sessions/status/stream (user: %s)", authzCtx.PersonalScope.UserID)
+	}()
 
 	heartbeat := time.NewTicker(30 * time.Second)
 	defer heartbeat.Stop()

--- a/internal/interfaces/controllers/slackbot_controller.go
+++ b/internal/interfaces/controllers/slackbot_controller.go
@@ -32,16 +32,16 @@ type CreateSlackBotRequest struct {
 	// (MCP servers, env vars, Bedrock config, etc.) will be merged into sessions
 	// created by this bot. When omitted, the server falls back to the authenticated
 	// user's team memberships at creation time.
-	Teams               []string               `json:"teams,omitempty"`
-	BotTokenSecretName  string                 `json:"bot_token_secret_name,omitempty"`
-	BotTokenSecretKey   string                 `json:"bot_token_secret_key,omitempty"`
-	AllowedEventTypes   []string               `json:"allowed_event_types,omitempty"`
-	AllowedChannelNames []string               `json:"allowed_channel_names,omitempty"`
+	Teams               []string `json:"teams,omitempty"`
+	BotTokenSecretName  string   `json:"bot_token_secret_name,omitempty"`
+	BotTokenSecretKey   string   `json:"bot_token_secret_key,omitempty"`
+	AllowedEventTypes   []string `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames []string `json:"allowed_channel_names,omitempty"`
 	// AllowedUserIDs is the list of Slack user IDs allowed to trigger the bot.
 	// Empty means all users are allowed. Matching is exact (e.g., "U012AB3CD").
-	AllowedUserIDs      []string               `json:"allowed_user_ids,omitempty"`
-	SessionConfig       *SlackBotSessionConfig `json:"session_config,omitempty"`
-	MaxSessions         int                    `json:"max_sessions,omitempty"`
+	AllowedUserIDs []string               `json:"allowed_user_ids,omitempty"`
+	SessionConfig  *SlackBotSessionConfig `json:"session_config,omitempty"`
+	MaxSessions    int                    `json:"max_sessions,omitempty"`
 	// NotifyOnSessionCreated controls whether the bot posts a Slack message with
 	// the session URL when a new session is created. Defaults to true.
 	NotifyOnSessionCreated *bool `json:"notify_on_session_created,omitempty"`
@@ -64,15 +64,15 @@ type UpdateSlackBotRequest struct {
 	Teams []string `json:"teams,omitempty"`
 	// BotTokenSecretName is a pointer to allow clearing the value by passing an empty string "".
 	// nil means "not provided / do not change"; "" means "clear (revert to global default)".
-	BotTokenSecretName  *string                `json:"bot_token_secret_name"`
-	BotTokenSecretKey   *string                `json:"bot_token_secret_key"`
-	AllowedEventTypes   []string               `json:"allowed_event_types,omitempty"`
-	AllowedChannelNames []string               `json:"allowed_channel_names,omitempty"`
+	BotTokenSecretName  *string  `json:"bot_token_secret_name"`
+	BotTokenSecretKey   *string  `json:"bot_token_secret_key"`
+	AllowedEventTypes   []string `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames []string `json:"allowed_channel_names,omitempty"`
 	// AllowedUserIDs is the list of Slack user IDs allowed to trigger the bot.
 	// Empty means all users are allowed. Matching is exact (e.g., "U012AB3CD").
-	AllowedUserIDs      []string               `json:"allowed_user_ids,omitempty"`
-	SessionConfig       *SlackBotSessionConfig `json:"session_config,omitempty"`
-	MaxSessions         int                    `json:"max_sessions,omitempty"`
+	AllowedUserIDs []string               `json:"allowed_user_ids,omitempty"`
+	SessionConfig  *SlackBotSessionConfig `json:"session_config,omitempty"`
+	MaxSessions    int                    `json:"max_sessions,omitempty"`
 	// NotifyOnSessionCreated controls whether the bot posts a Slack message with
 	// the session URL when a new session is created. Defaults to true.
 	NotifyOnSessionCreated *bool `json:"notify_on_session_created,omitempty"`

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/takutakahashi/agentapi-proxy/pkg/utils"
@@ -1159,4 +1160,122 @@ func (c *Client) StreamEvents(ctx context.Context, sessionID string) (<-chan str
 	}()
 
 	return eventChan, errorChan
+}
+
+// ProxySessionStatusEvent is a proxy-level event emitted whenever any session's status changes.
+type ProxySessionStatusEvent struct {
+	SessionID string    `json:"session_id"`
+	Status    string    `json:"status"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// WatchSessionsStatus subscribes to proxy-wide session status changes via SSE.
+// The returned channel receives a ProxySessionStatusEvent whenever any accessible session
+// changes status. The caller must cancel ctx to stop the stream; both channels are closed
+// when the stream ends.
+func (c *Client) WatchSessionsStatus(ctx context.Context) (<-chan ProxySessionStatusEvent, <-chan error) {
+	eventChan := make(chan ProxySessionStatusEvent, 32)
+	errorChan := make(chan error, 1)
+
+	go func() {
+		defer close(eventChan)
+		defer close(errorChan)
+
+		reqURL := fmt.Sprintf("%s/sessions/status/stream", c.baseURL)
+		httpReq, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to create request: %w", err)
+			return
+		}
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("Cache-Control", "no-cache")
+
+		if err := c.applyMiddlewares(httpReq); err != nil {
+			errorChan <- err
+			return
+		}
+
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			errorChan <- fmt.Errorf("failed to send request: %w", err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			errorChan <- fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue // skip heartbeat comments and blank lines
+			}
+			var evt ProxySessionStatusEvent
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &evt); err != nil {
+				continue // skip malformed events
+			}
+			select {
+			case eventChan <- evt:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			errorChan <- fmt.Errorf("error reading stream: %w", err)
+		}
+	}()
+
+	return eventChan, errorChan
+}
+
+// WaitSessionsStatus long-polls for the next proxy-wide session status change.
+// It blocks until any accessible session changes status or until the timeout elapses.
+// Returns the event on change, or (nil, nil) on timeout.
+// timeoutSec=0 uses the server default (30 s). Valid range: 1–60.
+func (c *Client) WaitSessionsStatus(ctx context.Context, timeoutSec int) (*ProxySessionStatusEvent, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/sessions/status/wait", c.baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	if timeoutSec > 0 {
+		q := u.Query()
+		q.Set("timeout", fmt.Sprintf("%d", timeoutSec))
+		u.RawQuery = q.Encode()
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if err := c.applyMiddlewares(httpReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Timeout response: {"events": []}
+	var evt ProxySessionStatusEvent
+	if err := json.Unmarshal(body, &evt); err != nil || evt.SessionID == "" {
+		return nil, nil
+	}
+	return &evt, nil
 }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -259,6 +259,91 @@
         }
       }
     },
+    "/sessions/status/stream": {
+      "get": {
+        "summary": "Stream all session status changes (SSE)",
+        "description": "Opens a Server-Sent Events stream that pushes a `SessionStatusEvent` whenever any session accessible to the authenticated user changes status. A heartbeat comment (`: heartbeat`) is sent every 30 seconds to keep the connection alive. The stream stays open until the client disconnects.",
+        "operationId": "streamSessionsStatus",
+        "tags": [
+          "Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE stream of SessionStatusEvent objects. Each event line: `data: {\"session_id\":\"...\",\"status\":\"...\",\"timestamp\":\"...\"}`",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "data: {\"session_id\":\"abc123\",\"status\":\"active\",\"timestamp\":\"2026-05-02T12:00:00Z\"}\n\n"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "501": {
+            "description": "Not implemented for this session manager type"
+          }
+        }
+      }
+    },
+    "/sessions/status/wait": {
+      "get": {
+        "summary": "Long-poll next session status change",
+        "description": "Blocks until any session accessible to the authenticated user changes status, or until the timeout expires. Returns a `SessionStatusEvent` on change, or `{\"events\": []}` on timeout.",
+        "operationId": "waitSessionsStatus",
+        "tags": [
+          "Sessions"
+        ],
+        "parameters": [
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Maximum wait time in seconds (default: 30, max: 60).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A `SessionStatusEvent` if a status change occurred before the timeout, or `{\"events\": []}` if the timeout elapsed with no change.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SessionStatusEvent"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "events": {
+                          "type": "array",
+                          "items": {},
+                          "maxItems": 0
+                        }
+                      },
+                      "required": ["events"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "501": {
+            "description": "Not implemented for this session manager type"
+          }
+        }
+      }
+    },
     "/sessions/{sessionId}/share": {
       "post": {
         "summary": "Create a share URL",
@@ -4213,6 +4298,25 @@
           "unknown"
         ],
         "description": "Session status"
+      },
+      "SessionStatusEvent": {
+        "type": "object",
+        "description": "A proxy-level event emitted whenever a session's status changes.",
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "description": "The session whose status changed"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SessionStatus"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the status change was detected by the proxy"
+          }
+        },
+        "required": ["session_id", "status", "timestamp"]
       },
       "CreateScheduleRequest": {
         "type": "object",

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4292,12 +4292,13 @@
         "enum": [
           "creating",
           "starting",
+          "running",
           "active",
           "unhealthy",
           "stopped",
           "unknown"
         ],
-        "description": "Session status"
+        "description": "Session status. 'running' means the agentapi backend is actively processing a message."
       },
       "SessionStatusEvent": {
         "type": "object",


### PR DESCRIPTION
## Summary

- `GET /sessions/status/stream` — SSE ストリームでプロキシ全体の全セッションのステータス変化を push
- `GET /sessions/status/wait` — ロングポーリング：次のステータス変化まで待って返す（`?timeout=N`、最大60秒）
- どちらも認可フィルタ付き（自分のセッションまたは所属チームのセッションのみ）

## 実装の詳細

### `internal/infrastructure/services/kubernetes_session.go`
- `statusChangeCallback func(sessionID, newStatus string)` フィールドを追加
- `SetStatus` を改修：ステータスが実際に変化した場合のみコールバックを呼ぶ（mutex 解放後）

### `internal/infrastructure/services/kubernetes_session_manager.go`
- `SessionStatusEvent` 型を追加
- グローバル pub/sub マップ（`globalSubs`）を追加
- `broadcastStatusChange` / `SubscribeStatusEvents` メソッドを追加
- セッション作成・stock 引き継ぎ・再起動後の復元の全パスでコールバックを登録

### `internal/interfaces/controllers/session_status_controller.go`（新規）
- `ProxyStatusWatcher` インターフェース定義（SessionManager インターフェースを変更しない）
- `StreamSessionsStatus` ハンドラ（SSE）
- `WaitSessionsStatus` ハンドラ（ロングポーリング）

### `internal/app/router.go`
- 2 つのルートを catch-all `/:sessionId/*` より前に登録

### `pkg/client/client.go`
- `WatchSessionsStatus` (SSE)、`WaitSessionsStatus` (long-poll) クライアントメソッドを追加

### `spec/openapi.json`
- `SessionStatusEvent` スキーマを追加
- `/sessions/status/stream` と `/sessions/status/wait` パスを追加

## Test plan

- [x] `make lint` — 通過済み（0 issues）
- [x] `mise exec -- go test ./...` — 全テスト通過済み
- [ ] SSE 手動確認: `curl -H "Accept: text/event-stream" http://localhost:8080/sessions/status/stream`
- [ ] ロングポーリング手動確認: `curl "http://localhost:8080/sessions/status/wait?timeout=30"`

🤖🐮 Generated with [Claude Code](https://claude.ai/claude-code)