### PR TITLE
feat(sessions): add long-polling endpoint for session message updates

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -191,7 +191,9 @@ func (r *Router) registerCoreRoutes() error {
 	// Proxy-wide session status push endpoints (registered before /:sessionId/* catch-all)
 	r.echo.GET("/sessions/status/stream", r.handlers.sessionController.StreamSessionsStatus)
 	r.echo.GET("/sessions/status/wait", r.handlers.sessionController.WaitSessionsStatus)
-	log.Printf("[ROUTES] Session status push endpoints registered (SSE + long-poll)")
+	// Per-session message update long-poll endpoint (must be before /:sessionId/* catch-all)
+	r.echo.GET("/sessions/:sessionId/messages/wait", r.handlers.sessionController.WaitSessionMessages)
+	log.Printf("[ROUTES] Session status/message push endpoints registered (SSE + long-poll)")
 
 	// Session sharing routes
 	if r.handlers.shareController != nil {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -63,6 +63,14 @@ type SessionStatusEvent struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// SessionMessageEvent represents a message_update event for a specific session.
+// It is emitted by KubernetesSessionManager whenever the agentapi backend for a session
+// sends a message_update SSE event, and is delivered to per-session long-poll subscribers.
+type SessionMessageEvent struct {
+	SessionID string    `json:"session_id"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // SessionDeletedHandler is a callback invoked just before a session's Kubernetes resources
 // are removed. At this point the session's Service endpoint is still reachable, so handlers
 // can safely call GetMessages or other in-session APIs.
@@ -94,6 +102,13 @@ type KubernetesSessionManager struct {
 	globalSubsMu    sync.Mutex
 	globalSubs      map[uint64]chan SessionStatusEvent
 	nextGlobalSubID uint64
+
+	// Per-session message update pub/sub.
+	// messageSubs[sessionID][subscriberID] = buffered channel of SessionMessageEvent.
+	// Protected by messageSubsMu.
+	messageSubsMu    sync.Mutex
+	messageSubs      map[string]map[uint64]chan SessionMessageEvent
+	nextMessageSubID uint64
 }
 
 // NewKubernetesSessionManager creates a new KubernetesSessionManager
@@ -136,14 +151,15 @@ func NewKubernetesSessionManagerWithClient(
 	log.Printf("[K8S_SESSION] Initialized KubernetesSessionManager in namespace: %s", namespace)
 
 	manager := &KubernetesSessionManager{
-		config:     cfg,
-		k8sConfig:  k8sConfig,
-		client:     client,
-		verbose:    verbose,
-		logger:     lgr,
-		sessions:   make(map[string]*KubernetesSession),
-		namespace:  namespace,
-		globalSubs: make(map[uint64]chan SessionStatusEvent),
+		config:      cfg,
+		k8sConfig:   k8sConfig,
+		client:      client,
+		verbose:     verbose,
+		logger:      lgr,
+		sessions:    make(map[string]*KubernetesSession),
+		namespace:   namespace,
+		globalSubs:  make(map[uint64]chan SessionStatusEvent),
+		messageSubs: make(map[string]map[uint64]chan SessionMessageEvent),
 	}
 
 	// Ensure OpenTelemetry Collector ConfigMap exists
@@ -1975,11 +1991,14 @@ func (m *KubernetesSessionManager) deletePVC(ctx context.Context, session *Kuber
 	return m.client.CoreV1().PersistentVolumeClaims(m.namespace).Delete(ctx, session.PVCName(), metav1.DeleteOptions{})
 }
 
-// cleanupSession removes a session from the internal map
+// cleanupSession removes a session from the internal map and releases its message subscribers.
 func (m *KubernetesSessionManager) cleanupSession(id string) {
 	m.mutex.Lock()
-	defer m.mutex.Unlock()
 	delete(m.sessions, id)
+	m.mutex.Unlock()
+	// Close all per-session message subscribers to unblock any waiting long-poll handlers.
+	// Called after releasing m.mutex to avoid holding two locks simultaneously.
+	m.cleanupMessageSubs(id)
 }
 
 // buildLabelSelector builds a Kubernetes label selector string from entities.SessionFilter
@@ -2256,6 +2275,70 @@ func (m *KubernetesSessionManager) broadcastStatusChange(sessionID, status strin
 	}
 }
 
+// broadcastMessageUpdate notifies all active per-session subscribers that a message_update
+// event was received from the agentapi backend for the given session.
+// Non-blocking: slow subscribers are skipped to avoid stalling the SSE reader goroutine.
+func (m *KubernetesSessionManager) broadcastMessageUpdate(sessionID string) {
+	evt := SessionMessageEvent{SessionID: sessionID, Timestamp: time.Now()}
+	m.messageSubsMu.Lock()
+	defer m.messageSubsMu.Unlock()
+	subs, ok := m.messageSubs[sessionID]
+	if !ok {
+		return
+	}
+	log.Printf("[MSG_BROADCAST] session=%s subscribers=%d", sessionID, len(subs))
+	for _, ch := range subs {
+		select {
+		case ch <- evt:
+		default:
+			// subscriber channel is full; drop to avoid blocking the caller
+		}
+	}
+}
+
+// SubscribeMessageEvents registers a new per-session subscriber for message_update events.
+// Returns a channel that receives SessionMessageEvent values whenever the agentapi backend
+// for the given session emits a message_update event, and a cancel func that must be called
+// to unsubscribe (closes the channel).
+func (m *KubernetesSessionManager) SubscribeMessageEvents(sessionID string) (<-chan SessionMessageEvent, func()) {
+	m.messageSubsMu.Lock()
+	defer m.messageSubsMu.Unlock()
+	if _, ok := m.messageSubs[sessionID]; !ok {
+		m.messageSubs[sessionID] = make(map[uint64]chan SessionMessageEvent)
+	}
+	id := m.nextMessageSubID
+	m.nextMessageSubID++
+	ch := make(chan SessionMessageEvent, 32)
+	m.messageSubs[sessionID][id] = ch
+	cancel := func() {
+		m.messageSubsMu.Lock()
+		defer m.messageSubsMu.Unlock()
+		if subs, ok := m.messageSubs[sessionID]; ok {
+			if c, ok := subs[id]; ok {
+				close(c)
+				delete(subs, id)
+			}
+			if len(subs) == 0 {
+				delete(m.messageSubs, sessionID)
+			}
+		}
+	}
+	return ch, cancel
+}
+
+// cleanupMessageSubs closes all active message subscribers for a session and removes them.
+// Called during session deletion to prevent goroutine leaks.
+func (m *KubernetesSessionManager) cleanupMessageSubs(sessionID string) {
+	m.messageSubsMu.Lock()
+	defer m.messageSubsMu.Unlock()
+	if subs, ok := m.messageSubs[sessionID]; ok {
+		for _, ch := range subs {
+			close(ch)
+		}
+		delete(m.messageSubs, sessionID)
+	}
+}
+
 // SubscribeStatusEvents registers a new proxy-wide subscriber for session status changes.
 // Returns a channel that receives SessionStatusEvent values whenever any session's status
 // changes, and a cancel func that must be called to unsubscribe (closes the channel).
@@ -2352,21 +2435,27 @@ func (m *KubernetesSessionManager) streamAgentAPIEvents(ctx context.Context, ses
 			eventType = strings.TrimPrefix(line, "event: ")
 			continue
 		}
-		if strings.HasPrefix(line, "data: ") && eventType == "status_change" {
+		if strings.HasPrefix(line, "data: ") {
 			data := strings.TrimPrefix(line, "data: ")
-			var body struct {
-				Status string `json:"status"`
-			}
-			if jsonErr := json.Unmarshal([]byte(data), &body); jsonErr != nil {
-				continue
-			}
-			switch body.Status {
-			case "running":
-				session.SetStatus("running")
-				log.Printf("[AGENT_STATUS] Session %s is now running", session.id)
-			case "stable":
-				session.SetStatus("active")
-				log.Printf("[AGENT_STATUS] Session %s is now stable (active)", session.id)
+			switch eventType {
+			case "status_change":
+				var body struct {
+					Status string `json:"status"`
+				}
+				if jsonErr := json.Unmarshal([]byte(data), &body); jsonErr != nil {
+					continue
+				}
+				switch body.Status {
+				case "running":
+					session.SetStatus("running")
+					log.Printf("[AGENT_STATUS] Session %s is now running", session.id)
+				case "stable":
+					session.SetStatus("active")
+					log.Printf("[AGENT_STATUS] Session %s is now stable (active)", session.id)
+				}
+			case "message_update":
+				log.Printf("[AGENT_MSG] Session %s: message_update received", session.id)
+				m.broadcastMessageUpdate(session.id)
 			}
 		}
 	}

--- a/internal/interfaces/controllers/session_message_controller.go
+++ b/internal/interfaces/controllers/session_message_controller.go
@@ -1,0 +1,83 @@
+package controllers
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// ProxyMessageWatcher is implemented by session managers that support per-session
+// real-time message update notifications via long polling.
+// KubernetesSessionManager implements this interface.
+type ProxyMessageWatcher interface {
+	SubscribeMessageEvents(sessionID string) (<-chan services.SessionMessageEvent, func())
+}
+
+// WaitSessionMessages handles GET /sessions/:sessionId/messages/wait.
+// It blocks until a message_update event is received from the agentapi backend for the
+// specified session, then returns {"updated": true, "session_id": "...", "timestamp": "..."}.
+// If the timeout elapses before any message update, it returns {"updated": false}.
+//
+// Query parameters:
+//   - timeout: max wait time in seconds (default 30, max 60)
+func (c *SessionController) WaitSessionMessages(ctx echo.Context) error {
+	sessionID := ctx.Param("sessionId")
+	authzCtx := auth.GetAuthorizationContext(ctx)
+
+	manager := c.getSessionManager()
+	session := manager.GetSession(sessionID)
+	if session == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "session not found")
+	}
+	if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	timeoutSec := 30
+	if t := ctx.QueryParam("timeout"); t != "" {
+		if v, err := strconv.Atoi(t); err == nil {
+			timeoutSec = clampStatusTimeout(v) // reuse from session_status_controller.go
+		}
+	}
+
+	watcher, ok := manager.(ProxyMessageWatcher)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotImplemented,
+			"message waiting not supported by this session manager")
+	}
+
+	eventCh, cancel := watcher.SubscribeMessageEvents(sessionID)
+	defer cancel()
+
+	timer := time.NewTimer(time.Duration(timeoutSec) * time.Second)
+	defer timer.Stop()
+
+	reqCtx := ctx.Request().Context()
+
+	for {
+		select {
+		case <-reqCtx.Done():
+			return nil
+
+		case evt, open := <-eventCh:
+			if !open {
+				// Session deleted or manager shutting down
+				return ctx.JSON(http.StatusOK, map[string]interface{}{"updated": false})
+			}
+			log.Printf("[MSG_WAIT] Session %s: message update received at %s", sessionID, evt.Timestamp)
+			return ctx.JSON(http.StatusOK, map[string]interface{}{
+				"updated":    true,
+				"session_id": evt.SessionID,
+				"timestamp":  evt.Timestamp,
+			})
+
+		case <-timer.C:
+			return ctx.JSON(http.StatusOK, map[string]interface{}{"updated": false})
+		}
+	}
+}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -344,6 +344,100 @@
         }
       }
     },
+    "/sessions/{sessionId}/messages/wait": {
+      "get": {
+        "summary": "Long-poll for message updates in a session",
+        "description": "Blocks until a `message_update` event is received from the agentapi backend for the specified session, or until the timeout expires. Returns `{\"updated\": true, \"session_id\": \"...\", \"timestamp\": \"...\"}` on update, or `{\"updated\": false}` on timeout. Clients should immediately re-issue the request after each response to maintain continuous notification.",
+        "operationId": "waitSessionMessages",
+        "tags": [
+          "Sessions"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "description": "Session ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "Maximum wait time in seconds (default: 30, max: 60).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60,
+              "default": 30
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A message update occurred or the timeout elapsed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "description": "Message update received",
+                      "properties": {
+                        "updated": {
+                          "type": "boolean",
+                          "enum": [true]
+                        },
+                        "session_id": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      },
+                      "required": ["updated", "session_id", "timestamp"]
+                    },
+                    {
+                      "type": "object",
+                      "description": "Timeout elapsed with no update",
+                      "properties": {
+                        "updated": {
+                          "type": "boolean",
+                          "enum": [false]
+                        }
+                      },
+                      "required": ["updated"]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "501": {
+            "description": "Not implemented for this session manager type"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
     "/sessions/{sessionId}/share": {
       "post": {
         "summary": "Create a share URL",


### PR DESCRIPTION
## Summary

- agentapi バックエンドの SSE `message_update` イベントを agentapi-proxy で受信・処理するよう拡張
- 新しいロングポーリングエンドポイント `GET /sessions/:sessionId/messages/wait` を追加
- チャット画面が1秒ポーリングではなくロングポーリングで効率的にメッセージ更新を受け取れるようになる

## Changes

### `kubernetes_session_manager.go`
- `SessionMessageEvent` 型を追加
- per-session メッセージ update pub/sub フィールド (`messageSubs`) を追加
- `broadcastMessageUpdate()` / `SubscribeMessageEvents()` / `cleanupMessageSubs()` メソッドを追加
- `streamAgentAPIEvents()` を拡張して `message_update` イベントを処理（従来は `status_change` のみ処理）
- セッション削除時にサブスクライバをクリーンアップ

### `session_message_controller.go` (新規)
- `ProxyMessageWatcher` インターフェース定義
- `WaitSessionMessages` ハンドラ: `GET /sessions/:sessionId/messages/wait`
  - `message_update` 受信時: `{"updated": true, "session_id": "...", "timestamp": "..."}`
  - タイムアウト時: `{"updated": false}`
  - タイムアウト: 1〜60秒（デフォルト30秒）

### `router.go`
- `/:sessionId/*` catch-all より前に新ルートを登録

### `spec/openapi.json`
- 新エンドポイントの OpenAPI 定義を追加

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (all tests green)
- [ ] curl で実際のセッションにリクエストを送り、メッセージ更新時に `{"updated": true}` が返ることを確認
- [ ] agentapi-ui 側の変更 (別PR: takutakahashi/agentapi-ui) と合わせてエンドツーエンドで確認

## Related

- agentapi-ui 対応 PR: takutakahashi/agentapi-ui (別途作成予定)

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)