### PR TITLE
feat: message_update long-poll に since パラメータを追加してキャッチアップを実現

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2277,9 +2277,18 @@ func (m *KubernetesSessionManager) broadcastStatusChange(sessionID, status strin
 
 // broadcastMessageUpdate notifies all active per-session subscribers that a message_update
 // event was received from the agentapi backend for the given session.
+// Also updates the session's lastMessageAt so late-arriving pollers can detect the update.
 // Non-blocking: slow subscribers are skipped to avoid stalling the SSE reader goroutine.
 func (m *KubernetesSessionManager) broadcastMessageUpdate(sessionID string) {
-	evt := SessionMessageEvent{SessionID: sessionID, Timestamp: time.Now()}
+	now := time.Now()
+	m.mutex.RLock()
+	session, exists := m.sessions[sessionID]
+	m.mutex.RUnlock()
+	if exists {
+		session.SetLastMessageAt(now)
+	}
+
+	evt := SessionMessageEvent{SessionID: sessionID, Timestamp: now}
 	m.messageSubsMu.Lock()
 	defer m.messageSubsMu.Unlock()
 	subs, ok := m.messageSubs[sessionID]

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+// TestBroadcastMessageUpdate_UpdatesLastMessageAt verifies that broadcastMessageUpdate
+// updates the session's lastMessageAt field so late-arriving pollers can detect missed events.
+func TestBroadcastMessageUpdate_UpdatesLastMessageAt(t *testing.T) {
+	m := newTestManagerForCycle(t)
+
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "user1"},
+		"test-deploy", "test-svc", "test-pvc", "test-ns",
+		9000, nil, nil,
+	)
+	before := time.Now()
+	// Set lastMessageAt to a known past time.
+	session.SetLastMessageAt(before.Add(-1 * time.Hour))
+
+	m.mutex.Lock()
+	m.sessions["test-session"] = session
+	m.mutex.Unlock()
+
+	m.broadcastMessageUpdate("test-session")
+
+	if !session.LastMessageAt().After(before.Add(-1 * time.Hour)) {
+		t.Errorf("lastMessageAt was not updated: got %v, want after %v",
+			session.LastMessageAt(), before.Add(-1*time.Hour))
+	}
+	if session.LastMessageAt().Before(before) {
+		t.Errorf("lastMessageAt %v should be >= broadcast time %v", session.LastMessageAt(), before)
+	}
+}
+
+// TestSubscribeMessageEvents_ReceivesBroadcast verifies that a subscriber
+// registered before broadcastMessageUpdate is called receives the event.
+func TestSubscribeMessageEvents_ReceivesBroadcast(t *testing.T) {
+	m := newTestManagerForCycle(t)
+
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "user1"},
+		"test-deploy", "test-svc", "test-pvc", "test-ns",
+		9000, nil, nil,
+	)
+	m.mutex.Lock()
+	m.sessions["test-session"] = session
+	m.mutex.Unlock()
+
+	ch, cancel := m.SubscribeMessageEvents("test-session")
+	defer cancel()
+
+	m.broadcastMessageUpdate("test-session")
+
+	select {
+	case evt := <-ch:
+		if evt.SessionID != "test-session" {
+			t.Errorf("unexpected session ID: %s", evt.SessionID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for message event")
+	}
+}

--- a/internal/interfaces/controllers/session_message_controller.go
+++ b/internal/interfaces/controllers/session_message_controller.go
@@ -25,6 +25,10 @@ type ProxyMessageWatcher interface {
 //
 // Query parameters:
 //   - timeout: max wait time in seconds (default 30, max 60)
+//   - since: Unix timestamp in milliseconds (or RFC3339 string) of the last known update.
+//     If the session has received a message_update after this timestamp, the response is
+//     returned immediately without waiting. This allows clients that were inactive to
+//     catch up to the latest state on their next poll.
 func (c *SessionController) WaitSessionMessages(ctx echo.Context) error {
 	sessionID := ctx.Param("sessionId")
 	authzCtx := auth.GetAuthorizationContext(ctx)
@@ -45,14 +49,42 @@ func (c *SessionController) WaitSessionMessages(ctx echo.Context) error {
 		}
 	}
 
+	// Parse the optional since parameter (Unix ms or RFC3339).
+	var since time.Time
+	if s := ctx.QueryParam("since"); s != "" {
+		if ms, err := strconv.ParseInt(s, 10, 64); err == nil {
+			since = time.UnixMilli(ms)
+		} else if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			since = t
+		}
+	}
+
 	watcher, ok := manager.(ProxyMessageWatcher)
 	if !ok {
 		return echo.NewHTTPError(http.StatusNotImplemented,
 			"message waiting not supported by this session manager")
 	}
 
+	// Subscribe before reading lastMessageAt to avoid a TOCTOU race: if a
+	// broadcast arrives between the check and the subscribe, the channel will
+	// already have the event and we return on the first select iteration.
 	eventCh, cancel := watcher.SubscribeMessageEvents(sessionID)
 	defer cancel()
+
+	// If the caller provided a since timestamp and the session already has a
+	// newer message update, return immediately so that clients resuming after
+	// inactivity catch up without waiting for the next event.
+	if !since.IsZero() {
+		if lastMsgAt := session.LastMessageAt(); lastMsgAt.After(since) {
+			log.Printf("[MSG_WAIT] Session %s: already updated at %s (since=%s), returning immediately",
+				sessionID, lastMsgAt, since)
+			return ctx.JSON(http.StatusOK, map[string]interface{}{
+				"updated":    true,
+				"session_id": sessionID,
+				"timestamp":  lastMsgAt,
+			})
+		}
+	}
 
 	timer := time.NewTimer(time.Duration(timeoutSec) * time.Second)
 	defer timer.Stop()

--- a/internal/interfaces/controllers/session_message_controller_test.go
+++ b/internal/interfaces/controllers/session_message_controller_test.go
@@ -1,0 +1,215 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// --- minimal mock session ---
+
+type mockWaitSession struct {
+	id            string
+	userID        string
+	lastMessageAt time.Time
+}
+
+func (s *mockWaitSession) ID() string                        { return s.id }
+func (s *mockWaitSession) Addr() string                      { return "localhost:9000" }
+func (s *mockWaitSession) UserID() string                    { return s.userID }
+func (s *mockWaitSession) Scope() entities.ResourceScope     { return entities.ScopeUser }
+func (s *mockWaitSession) TeamID() string                    { return "" }
+func (s *mockWaitSession) Tags() map[string]string           { return nil }
+func (s *mockWaitSession) Status() string                    { return "active" }
+func (s *mockWaitSession) StartedAt() time.Time              { return time.Time{} }
+func (s *mockWaitSession) UpdatedAt() time.Time              { return time.Time{} }
+func (s *mockWaitSession) LastMessageAt() time.Time          { return s.lastMessageAt }
+func (s *mockWaitSession) Description() string               { return "" }
+func (s *mockWaitSession) Cancel()                           {}
+
+// --- mock session manager that also implements ProxyMessageWatcher ---
+
+type mockWaitSessionManager struct {
+	session   entities.Session
+	eventCh   chan services.SessionMessageEvent
+	cancelFn  func()
+}
+
+func newMockWaitSessionManager(session entities.Session) *mockWaitSessionManager {
+	ch := make(chan services.SessionMessageEvent, 1)
+	return &mockWaitSessionManager{
+		session:  session,
+		eventCh:  ch,
+		cancelFn: func() {},
+	}
+}
+
+func (m *mockWaitSessionManager) CreateSession(_ context.Context, _ string, _ *entities.RunServerRequest, _ []byte) (entities.Session, error) {
+	return nil, nil
+}
+func (m *mockWaitSessionManager) GetSession(id string) entities.Session {
+	if m.session != nil && m.session.ID() == id {
+		return m.session
+	}
+	return nil
+}
+func (m *mockWaitSessionManager) ListSessions(_ entities.SessionFilter) []entities.Session {
+	return nil
+}
+func (m *mockWaitSessionManager) DeleteSession(_ string) error { return nil }
+func (m *mockWaitSessionManager) SendMessage(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (m *mockWaitSessionManager) StopAgent(_ context.Context, _ string) error { return nil }
+func (m *mockWaitSessionManager) GetMessages(_ context.Context, _ string) ([]portrepos.Message, error) {
+	return nil, nil
+}
+func (m *mockWaitSessionManager) Shutdown(_ time.Duration) error { return nil }
+
+// ProxyMessageWatcher
+func (m *mockWaitSessionManager) SubscribeMessageEvents(_ string) (<-chan services.SessionMessageEvent, func()) {
+	return m.eventCh, m.cancelFn
+}
+
+// --- mock SessionManagerProvider ---
+
+type mockWaitProvider struct {
+	manager portrepos.SessionManager
+}
+
+func (p *mockWaitProvider) GetSessionManager() portrepos.SessionManager { return p.manager }
+
+// --- helpers ---
+
+func makeWaitEchoContext(t *testing.T, sessionID string, queryParams map[string]string, userID string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	url := fmt.Sprintf("/sessions/%s/messages/wait", sessionID)
+	if len(queryParams) > 0 {
+		url += "?"
+		first := true
+		for k, v := range queryParams {
+			if !first {
+				url += "&"
+			}
+			url += k + "=" + v
+			first = false
+		}
+	}
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("sessionId")
+	c.SetParamValues(sessionID)
+	for k, v := range queryParams {
+		c.QueryParams().Set(k, v)
+	}
+
+	// Set authz context so the handler can authorize the request.
+	authzCtx := &auth.AuthorizationContext{
+		PersonalScope: auth.PersonalScopeAuth{
+			UserID:  userID,
+			CanRead: true,
+		},
+		TeamScope: auth.TeamScopeAuth{
+			TeamPermissions: make(map[string]auth.TeamPermissions),
+		},
+	}
+	c.Set("authz_context", authzCtx)
+	return c, rec
+}
+
+// --- tests ---
+
+// TestWaitSessionMessages_Since_ImmediateReturn verifies that when `since` is before
+// the session's lastMessageAt, the handler returns immediately with updated=true
+// without waiting for a new event.
+func TestWaitSessionMessages_Since_ImmediateReturn(t *testing.T) {
+	lastMsg := time.Now().Add(-5 * time.Minute)
+	session := &mockWaitSession{
+		id:            "sess-1",
+		userID:        "user-1",
+		lastMessageAt: lastMsg,
+	}
+	mgr := newMockWaitSessionManager(session)
+	provider := &mockWaitProvider{manager: mgr}
+	controller := NewSessionController(provider, nil)
+
+	// since is 10 minutes ago, session was updated 5 minutes ago → should return immediately
+	sinceMs := fmt.Sprintf("%d", time.Now().Add(-10*time.Minute).UnixMilli())
+	c, rec := makeWaitEchoContext(t, "sess-1", map[string]string{"since": sinceMs, "timeout": "1"}, "user-1")
+
+	err := controller.WaitSessionMessages(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["updated"])
+	assert.Equal(t, "sess-1", resp["session_id"])
+}
+
+// TestWaitSessionMessages_Since_NoUpdate verifies that when `since` is after
+// the session's lastMessageAt, the handler waits and returns updated=false on timeout.
+func TestWaitSessionMessages_Since_NoUpdate(t *testing.T) {
+	lastMsg := time.Now().Add(-10 * time.Minute)
+	session := &mockWaitSession{
+		id:            "sess-2",
+		userID:        "user-1",
+		lastMessageAt: lastMsg,
+	}
+	mgr := newMockWaitSessionManager(session)
+	provider := &mockWaitProvider{manager: mgr}
+	controller := NewSessionController(provider, nil)
+
+	// since is 5 minutes ago, session was last updated 10 minutes ago → no catch-up
+	sinceMs := fmt.Sprintf("%d", time.Now().Add(-5*time.Minute).UnixMilli())
+	c, rec := makeWaitEchoContext(t, "sess-2", map[string]string{"since": sinceMs, "timeout": "1"}, "user-1")
+
+	err := controller.WaitSessionMessages(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["updated"])
+}
+
+// TestWaitSessionMessages_NoSince_ReceivesEvent verifies that without a since parameter
+// the handler blocks and returns updated=true when an event arrives.
+func TestWaitSessionMessages_NoSince_ReceivesEvent(t *testing.T) {
+	session := &mockWaitSession{
+		id:            "sess-3",
+		userID:        "user-1",
+		lastMessageAt: time.Now().Add(-1 * time.Hour),
+	}
+	mgr := newMockWaitSessionManager(session)
+	provider := &mockWaitProvider{manager: mgr}
+	controller := NewSessionController(provider, nil)
+
+	// Send an event before the handler runs (buffered channel).
+	now := time.Now()
+	mgr.eventCh <- services.SessionMessageEvent{SessionID: "sess-3", Timestamp: now}
+
+	c, rec := makeWaitEchoContext(t, "sess-3", map[string]string{"timeout": "5"}, "user-1")
+
+	err := controller.WaitSessionMessages(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["updated"])
+}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -372,11 +372,19 @@
               "maximum": 60,
               "default": 30
             }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Timestamp of the last known message update. If the session has received a message_update after this time, the response is returned immediately without waiting. Accepts Unix timestamp in milliseconds (integer) or RFC3339 string. Use the `timestamp` value from the previous response.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "A message update occurred or the timeout elapsed.",
+            "description": "A message update occurred, a catch-up update was detected via `since`, or the timeout elapsed.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

- `GET /sessions/:sessionId/messages/wait` に `since` クエリパラメータを追加
  - Unix タイムスタンプ（ミリ秒整数）または RFC3339 文字列を受け付ける
  - セッションの `lastMessageAt` が `since` より新しい場合は即座に `updated: true` を返す（待機なし）
  - これにより、非アクティブ中に見逃した更新をクライアントが復帰時にキャッチアップできる
- `broadcastMessageUpdate` が `session.SetLastMessageAt(now)` を更新するよう修正
  - 従来は `SendMessage` 呼び出し時のみ更新していたが、agentapi からの `message_update` イベント受信時にも更新するようにした
- サブスクライブ後に `since` チェックすることで TOCTOU レースを回避

## 背景

SSE/long-poll でポーリング中でない（非アクティブ）期間に `message_update` が発生すると、チャンネルに受信者がおらずイベントがドロップされる。
再度アクティブになってもその更新は伝わらず、次のイベントまで古いままに見える問題があった。

## クライアント側の使い方

```
// 前回レスポンスの timestamp を保持しておく
GET /sessions/{id}/messages/wait?since=<前回 timestamp の Unix ms>&timeout=30
```

レスポンスの `timestamp` フィールド（RFC3339）を `Date.parse()` などで Unix ms に変換して次のリクエストに渡す。

## Test plan

- [ ] `TestBroadcastMessageUpdate_UpdatesLastMessageAt` — `broadcastMessageUpdate` が `lastMessageAt` を更新することを確認
- [ ] `TestSubscribeMessageEvents_ReceivesBroadcast` — サブスクライバーがイベントを受信できることを確認
- [ ] `TestWaitSessionMessages_Since_ImmediateReturn` — `since` < `lastMessageAt` のとき即座に返ることを確認
- [ ] `TestWaitSessionMessages_Since_NoUpdate` — `since` > `lastMessageAt` のとき待機してタイムアウトすることを確認
- [ ] `TestWaitSessionMessages_NoSince_ReceivesEvent` — `since` なしで通常のイベント受信が動作することを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)