### PR TITLE
fix: ステータス変更時にセッション一覧キャッシュを無効化する

### DIFF
--- a/internal/infrastructure/repositories/redis_status_repository.go
+++ b/internal/infrastructure/repositories/redis_status_repository.go
@@ -23,10 +23,6 @@ const (
 	// redisSessionListCachePrefix is the prefix for session-list cache keys.
 	// Key format: agentapi:sessions:list:{namespace}:{labelSelectorHash}
 	redisSessionListCachePrefix = "agentapi:sessions:list:"
-	// redisSessionListCacheTTL is how long a session-list cache entry is kept.
-	// Short enough that mutations (create/delete) are visible quickly even on
-	// cache invalidation failure, but long enough to absorb burst list requests.
-	redisSessionListCacheTTL = 15 * time.Second
 )
 
 // redisStatusFields are the hash field names used within a status key.
@@ -172,10 +168,6 @@ func (r *RedisStatusRepository) DeleteStatus(ctx context.Context, sessionID stri
 // --------------------------------------------------------------------------
 // SessionListCacheRepository implementation
 // --------------------------------------------------------------------------
-
-func sessionListCacheKey(namespace, labelSelectorHash string) string {
-	return redisSessionListCachePrefix + namespace + ":" + labelSelectorHash
-}
 
 func sessionListCachePattern(namespace string) string {
 	return redisSessionListCachePrefix + namespace + ":*"

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2581,6 +2581,14 @@ func (m *KubernetesSessionManager) broadcastStatusChangeLocal(sessionID, status 
 		}
 	}
 	m.globalSubsMu.Unlock()
+
+	// Invalidate session-list cache so the updated status is reflected immediately
+	// on this pod as well (the originating pod already invalidated its own cache).
+	if m.sessionListCacheRepo != nil {
+		if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache on cross-pod status change session=%s: %v", sessionID, err)
+		}
+	}
 }
 
 // broadcastStatusChange broadcasts a SessionStatusEvent to all active proxy-wide subscribers.
@@ -2620,6 +2628,13 @@ func (m *KubernetesSessionManager) broadcastStatusChange(sessionID, status strin
 		}
 		if err := m.statusEventRepo.PublishStatusChange(ctx, crossEvt); err != nil {
 			log.Printf("[K8S_SESSION] Warning: failed to publish status to Redis session=%s: %v", sessionID, err)
+		}
+	}
+
+	// Invalidate session-list cache so the updated status is reflected immediately.
+	if m.sessionListCacheRepo != nil {
+		if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache on status change session=%s: %v", sessionID, err)
 		}
 	}
 }

--- a/internal/interfaces/controllers/session_message_controller_test.go
+++ b/internal/interfaces/controllers/session_message_controller_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 )
 
@@ -26,25 +26,25 @@ type mockWaitSession struct {
 	lastMessageAt time.Time
 }
 
-func (s *mockWaitSession) ID() string                        { return s.id }
-func (s *mockWaitSession) Addr() string                      { return "localhost:9000" }
-func (s *mockWaitSession) UserID() string                    { return s.userID }
-func (s *mockWaitSession) Scope() entities.ResourceScope     { return entities.ScopeUser }
-func (s *mockWaitSession) TeamID() string                    { return "" }
-func (s *mockWaitSession) Tags() map[string]string           { return nil }
-func (s *mockWaitSession) Status() string                    { return "active" }
-func (s *mockWaitSession) StartedAt() time.Time              { return time.Time{} }
-func (s *mockWaitSession) UpdatedAt() time.Time              { return time.Time{} }
-func (s *mockWaitSession) LastMessageAt() time.Time          { return s.lastMessageAt }
-func (s *mockWaitSession) Description() string               { return "" }
-func (s *mockWaitSession) Cancel()                           {}
+func (s *mockWaitSession) ID() string                    { return s.id }
+func (s *mockWaitSession) Addr() string                  { return "localhost:9000" }
+func (s *mockWaitSession) UserID() string                { return s.userID }
+func (s *mockWaitSession) Scope() entities.ResourceScope { return entities.ScopeUser }
+func (s *mockWaitSession) TeamID() string                { return "" }
+func (s *mockWaitSession) Tags() map[string]string       { return nil }
+func (s *mockWaitSession) Status() string                { return "active" }
+func (s *mockWaitSession) StartedAt() time.Time          { return time.Time{} }
+func (s *mockWaitSession) UpdatedAt() time.Time          { return time.Time{} }
+func (s *mockWaitSession) LastMessageAt() time.Time      { return s.lastMessageAt }
+func (s *mockWaitSession) Description() string           { return "" }
+func (s *mockWaitSession) Cancel()                       {}
 
 // --- mock session manager that also implements ProxyMessageWatcher ---
 
 type mockWaitSessionManager struct {
-	session   entities.Session
-	eventCh   chan services.SessionMessageEvent
-	cancelFn  func()
+	session  entities.Session
+	eventCh  chan services.SessionMessageEvent
+	cancelFn func()
 }
 
 func newMockWaitSessionManager(session entities.Session) *mockWaitSessionManager {


### PR DESCRIPTION
## Summary

- セッションのステータスが変更された際にセッション一覧のRedisキャッシュが無効化されず、一覧に古いステータスが表示される問題を修正
- キャッシュの無効化はセッション作成・削除時にのみ行われていたが、ステータス変更時にも無効化するよう対応
- 同一ポッド内の変更（`broadcastStatusChange`）とクロスポッドからの変更（`broadcastStatusChangeLocal`）両方に対応

## Changes

- `broadcastStatusChange`: Redisへのステータス永続化・配信後にセッション一覧キャッシュを無効化
- `broadcastStatusChangeLocal`: クロスポッドのステータスイベント受信後にも同様にキャッシュを無効化
- `redis_status_repository.go`: 既存の未使用定数 `redisSessionListCacheTTL` と関数 `sessionListCacheKey` を削除（TTLは `kubernetes_session_manager.go` に定義済みのため重複していた）

## Test plan

- [ ] `make lint` が通ること
- [ ] `make test` が通ること
- [ ] セッション起動後、一覧のステータスが `starting` → `active` に即時反映されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)