### PR TITLE
feat(acp): ACP sessions を ACP ネイティブ HTTP トランスポートに刷新

### DIFF
--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -15,10 +17,11 @@ import (
 )
 
 var (
-	acpPort      string
-	acpCwd       string
-	acpSessionID string
-	acpVerbose   bool
+	acpPort        string
+	acpCwd         string
+	acpSessionID   string
+	acpSessionFile string
+	acpVerbose     bool
 )
 
 // AcpServerCmd starts an ACP agent over stdio and exposes it as an
@@ -50,6 +53,7 @@ func init() {
 	AcpServerCmd.Flags().StringVarP(&acpPort, "port", "p", "3284", "HTTP port to listen on")
 	AcpServerCmd.Flags().StringVar(&acpCwd, "cwd", "", "Working directory for the ACP session (defaults to current directory)")
 	AcpServerCmd.Flags().StringVar(&acpSessionID, "session-id", "", "Session ID to use (defaults to auto-generated)")
+	AcpServerCmd.Flags().StringVar(&acpSessionFile, "session-file", "", "File to persist ACP session ID for reuse across restarts (defaults to {cwd}/.acp-session-id)")
 	AcpServerCmd.Flags().BoolVarP(&acpVerbose, "verbose", "v", false, "Enable verbose logging")
 }
 
@@ -114,10 +118,41 @@ func runAcpServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("ACP initialization failed: %w", err)
 	}
 
-	// Create the ACP session.
-	if err := acpClient.NewSession(ctx, cwd, nil); err != nil {
-		return fmt.Errorf("ACP session creation failed: %w", err)
+	// Resolve session file path (used to persist the session ID across restarts).
+	sessionFile := acpSessionFile
+	if sessionFile == "" {
+		sessionFile = filepath.Join(cwd, ".acp-session-id")
 	}
+
+	// Try to restore a previous session if the agent supports session/load.
+	restored := false
+	if acpClient.AgentCaps().SessionLoad {
+		if data, err := os.ReadFile(sessionFile); err == nil {
+			savedID := strings.TrimSpace(string(data))
+			if savedID != "" {
+				if err := acpClient.LoadSession(ctx, savedID); err != nil {
+					log.Printf("[acp-server] session/load failed (%v), creating new session", err)
+				} else {
+					log.Printf("[acp-server] restored previous session (session=%s)", acpClient.SessionID())
+					restored = true
+				}
+			}
+		}
+	}
+
+	if !restored {
+		// Create a fresh ACP session.
+		if err := acpClient.NewSession(ctx, cwd, nil); err != nil {
+			return fmt.Errorf("ACP session creation failed: %w", err)
+		}
+		// Persist the new session ID so future restarts can attempt to restore it.
+		if err := os.WriteFile(sessionFile, []byte(acpClient.SessionID()), 0600); err != nil {
+			log.Printf("[acp-server] warning: failed to save session ID to %s: %v", sessionFile, err)
+		} else {
+			log.Printf("[acp-server] session ID saved to %s", sessionFile)
+		}
+	}
+
 	log.Printf("[acp-server] ACP session ready (session=%s)", acpClient.SessionID())
 
 	// Create the bridge and start its event loop.

--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -121,7 +121,7 @@ func runAcpServer(cmd *cobra.Command, args []string) error {
 	log.Printf("[acp-server] ACP session ready (session=%s)", acpClient.SessionID())
 
 	// Create the bridge and start its event loop.
-	b := bridge.New(acpClient, acpVerbose)
+	b := bridge.New(acpClient, acpClient.SessionID(), acpVerbose)
 	go b.Run(ctx)
 
 	// Start the HTTP server.

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -183,10 +183,13 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 		promptCtx = context.Background()
 	}
 
+	log.Printf("[bridge] SendPrompt (session=%s, clientID=%s, textLen=%d)", b.sessionId, clientID, len(text))
+
 	go func() {
 		stopReason, err := b.acp.Prompt(promptCtx, text)
 
 		if err != nil {
+			log.Printf("[bridge] Prompt error (session=%s): %v", b.sessionId, err)
 			b.broadcast(jsonRPCMsg{
 				JSONRPC: "2.0",
 				ID:      &clientID,
@@ -194,6 +197,7 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 			})
 			return
 		}
+		log.Printf("[bridge] Prompt done (session=%s, stopReason=%s)", b.sessionId, stopReason)
 		b.broadcast(jsonRPCMsg{
 			JSONRPC: "2.0",
 			ID:      &clientID,
@@ -234,18 +238,23 @@ func (b *Bridge) Subscribe() (<-chan json.RawMessage, func()) {
 
 	b.subsMu.Lock()
 	b.subs = append(b.subs, sub)
+	count := len(b.subs)
 	b.subsMu.Unlock()
+
+	log.Printf("[bridge] SSE subscriber connected (session=%s, total=%d)", b.sessionId, count)
 
 	cancel := func() {
 		b.subsMu.Lock()
-		defer b.subsMu.Unlock()
 		for i, s := range b.subs {
 			if s == sub {
 				b.subs = append(b.subs[:i], b.subs[i+1:]...)
 				break
 			}
 		}
+		remaining := len(b.subs)
+		b.subsMu.Unlock()
 		close(sub.ch)
+		log.Printf("[bridge] SSE subscriber disconnected (session=%s, remaining=%d)", b.sessionId, remaining)
 	}
 	return sub.ch, cancel
 }

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -1,5 +1,6 @@
-// Package bridge translates between the ACP client and an agentapi-compatible
-// HTTP interface (compatible with takutakahashi/claude-agentapi).
+// Package bridge provides a minimal HTTP transport layer for the Agent Client Protocol (ACP).
+// Instead of translating ACP messages to a proprietary format, it relays JSON-RPC 2.0 messages
+// directly over HTTP: POST /rpc (client→agent) and GET /sse (agent→client).
 package bridge
 
 import (
@@ -7,200 +8,88 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strconv"
-	"strings"
 	"sync"
-	"time"
+	"sync/atomic"
 
 	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
 )
 
 // ----------------------------------------------------------------------------
-// agentapi-compatible types
+// Wire types
 // ----------------------------------------------------------------------------
 
-// AgentStatus mirrors coder/agentapi status values.
-type AgentStatus string
-
-const (
-	AgentStatusRunning AgentStatus = "running"
-	AgentStatusStable  AgentStatus = "stable"
-)
-
-// MessageRole mirrors takutakahashi/claude-agentapi message roles.
-type MessageRole string
-
-const (
-	MessageRoleUser       MessageRole = "user"
-	MessageRoleAssistant  MessageRole = "assistant"
-	MessageRoleAgent      MessageRole = "agent"
-	MessageRoleToolResult MessageRole = "tool_result"
-)
-
-// MessageType mirrors takutakahashi/claude-agentapi message types.
-type MessageType string
-
-const (
-	MessageTypeNormal   MessageType = "normal"
-	MessageTypeQuestion MessageType = "question"
-	MessageTypePlan     MessageType = "plan"
-)
-
-// Message is an agentapi-compatible message entry.
-type Message struct {
-	ID              int64       `json:"id"`
-	Role            MessageRole `json:"role"`
-	Content         string      `json:"content"`
-	Time            time.Time   `json:"time"`
-	Type            MessageType `json:"type"`
-	ToolUseId       string      `json:"toolUseId,omitempty"`
-	ParentToolUseId string      `json:"parentToolUseId,omitempty"`
-	Status          string      `json:"status,omitempty"` // "success"|"error"
-	Error           string      `json:"error,omitempty"`  // present when status=="error"
+// jsonRPCMsg is a JSON-RPC 2.0 message emitted to SSE subscribers.
+type jsonRPCMsg struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method,omitempty"`
+	Params  interface{}      `json:"params,omitempty"`
+	Result  interface{}      `json:"result,omitempty"`
+	Error   *rpcError        `json:"error,omitempty"`
 }
 
-// StatusResponse mirrors coder/agentapi /status response.
-type StatusResponse struct {
-	AgentType string      `json:"agent_type"`
-	Status    AgentStatus `json:"status"`
-	Transport string      `json:"transport"`
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// sessionUpdateParams is the params envelope for a session/update notification.
+type sessionUpdateParams struct {
+	SessionId string            `json:"sessionId"`
+	Update    acp.SessionUpdate `json:"update"`
 }
 
 // ----------------------------------------------------------------------------
-// SSE events
-// ----------------------------------------------------------------------------
-
-// EventType names the SSE event.
-type EventType string
-
-const (
-	EventTypeMessageUpdate EventType = "message_update"
-	EventTypeStatusChange  EventType = "status_change"
-	EventTypeAgentError    EventType = "agent_error"
-)
-
-// Event is a single SSE event.
-type Event struct {
-	Type EventType
-	Data interface{}
-}
-
-// MessageUpdateData is the data for message_update events.
-// It sends the full Message object (matching takutakahashi/claude-agentapi format).
-// The content key is "content" (not "message") as expected by the frontend.
-type MessageUpdateData = Message
-
-// StatusChangeData is the data for status_change events.
-type StatusChangeData struct {
-	Status    AgentStatus `json:"status"`
-	AgentType string      `json:"agent_type"`
-}
-
-// AgentErrorData is the data for agent_error events.
-type AgentErrorData struct {
-	Level   string    `json:"level"`
-	Message string    `json:"message"`
-	Time    time.Time `json:"time"`
-}
-
-// ----------------------------------------------------------------------------
-// Actions (takutakahashi/claude-agentapi extension)
-// ----------------------------------------------------------------------------
-
-// ActionType names a pending action.
-type ActionType string
-
-const (
-	ActionTypeAnswerQuestion ActionType = "answer_question"
-	ActionTypeApprovePlan    ActionType = "approve_plan"
-	ActionTypeStopAgent      ActionType = "stop_agent"
-)
-
-// PendingAction is an action waiting for the HTTP client to respond.
-type PendingAction struct {
-	Type      ActionType  `json:"type"`
-	ToolUseId string      `json:"tool_use_id,omitempty"`
-	Content   interface{} `json:"content,omitempty"`
-}
-
-// frontendQuestionOption matches the QuestionOption interface in the frontend.
-type frontendQuestionOption struct {
-	Label       string `json:"label"`
-	Description string `json:"description"`
-}
-
-// frontendQuestion matches the Question interface in the frontend
-// (src/types/agentapi.ts: { question, header, options, multiSelect }).
-type frontendQuestion struct {
-	Question    string                   `json:"question"`
-	Header      string                   `json:"header"`
-	Options     []frontendQuestionOption `json:"options"`
-	MultiSelect bool                     `json:"multiSelect"`
-}
-
-// PendingActionsResponse is the body for GET /action.
-type PendingActionsResponse struct {
-	PendingActions []PendingAction `json:"pending_actions"`
-}
-
-// ActionRequest is the body for POST /action.
-type ActionRequest struct {
-	Type     ActionType        `json:"type"`
-	Answers  map[string]string `json:"answers,omitempty"`  // answer_question
-	Approved *bool             `json:"approved,omitempty"` // approve_plan
-}
-
-// ----------------------------------------------------------------------------
-// subscriber
+// Subscriber
 // ----------------------------------------------------------------------------
 
 type subscriber struct {
-	ch chan Event
+	ch chan json.RawMessage
 }
 
 // ----------------------------------------------------------------------------
 // Bridge
 // ----------------------------------------------------------------------------
 
-// Bridge holds all state for bridging an ACP client to the agentapi HTTP interface.
+// Bridge connects an ACP client to HTTP SSE subscribers via raw JSON-RPC 2.0 messages.
+// It does not translate ACP semantics – it reconstructs JSON-RPC envelopes from
+// the parsed events that acp.Client exposes and broadcasts them to subscribers.
 type Bridge struct {
-	acp     *acp.Client
-	verbose bool
-
-	// serverCtx is the long-lived context from Run(); used for ACP Prompt calls
-	// so they survive beyond the HTTP request that triggered them.
+	acp       *acp.Client
+	sessionId string
+	verbose   bool
 	serverCtx context.Context
-
-	mu               sync.RWMutex
-	status           AgentStatus
-	messages         []Message
-	nextID           int64
-	pendingAgentText strings.Builder // buffers agent_message_chunk until message boundary
 
 	subsMu sync.Mutex
 	subs   []*subscriber
 
-	actionsMu      sync.Mutex
-	pendingActions []PendingAction
-	actionReplyCh  map[string]chan string            // toolUseId → selected optionId
-	permOptionMaps map[string][]acp.PermissionOption // toolUseId → original ACP options (for label→id mapping)
+	// Agent-initiated RPCs (e.g. session/request_permission):
+	// We assign local sequential ids, emit them via SSE, and await replies on POST /rpc.
+	agentReqSeq    atomic.Int64
+	pendingReplyMu sync.Mutex
+	pendingReplies map[int64]chan json.RawMessage // local agentReqId → reply channel
 }
 
 // New creates a Bridge backed by the given ACP client.
-func New(client *acp.Client, verbose bool) *Bridge {
+// sessionId must be the id returned by acp.Client.SessionID() after session/new.
+func New(client *acp.Client, sessionId string, verbose bool) *Bridge {
 	return &Bridge{
 		acp:            client,
+		sessionId:      sessionId,
 		verbose:        verbose,
-		status:         AgentStatusStable,
-		actionReplyCh:  make(map[string]chan string),
-		permOptionMaps: make(map[string][]acp.PermissionOption),
+		pendingReplies: make(map[int64]chan json.RawMessage),
 	}
 }
 
-// Run starts the background goroutines that consume ACP notifications and
-// feed the bridge state. Call this in a goroutine; it blocks until ctx is done.
-// The ctx is stored as the server context for use in background operations
-// (e.g., ACP Prompt calls that outlive the HTTP request that triggered them).
+// SessionID returns the ACP session ID.
+func (b *Bridge) SessionID() string { return b.sessionId }
+
+// ----------------------------------------------------------------------------
+// Event loop
+// ----------------------------------------------------------------------------
+
+// Run starts the event loop. It blocks until ctx is cancelled.
+// Call this in a goroutine before starting the HTTP server.
 func (b *Bridge) Run(ctx context.Context) {
 	b.serverCtx = ctx
 	updates := b.acp.Updates()
@@ -213,12 +102,9 @@ func (b *Bridge) Run(ctx context.Context) {
 
 		case update, ok := <-updates:
 			if !ok {
-				// ACP client closed – mark error
-				b.setStatus(AgentStatusStable)
-				b.broadcastError("agent connection closed")
 				return
 			}
-			b.handleUpdate(update)
+			b.emitUpdate(update)
 
 		case req, ok := <-perms:
 			if !ok {
@@ -229,412 +115,126 @@ func (b *Bridge) Run(ctx context.Context) {
 	}
 }
 
-// ----------------------------------------------------------------------------
-// Update handling
-// ----------------------------------------------------------------------------
-
-func (b *Bridge) handleUpdate(update acp.SessionUpdate) {
-	if b.verbose {
-		log.Printf("[bridge] update kind=%s content=%s", update.Kind, update.Content)
-	}
-
-	switch update.Kind {
-	case acp.SessionUpdateKindAgentMessageChunk:
-		// Buffer chunks; the complete message is emitted when a boundary event
-		// (tool_call, plan, or turn-end via setStatus) is reached.
-		text := acp.ExtractTextContent(update.Content)
-		b.mu.Lock()
-		b.pendingAgentText.WriteString(text)
-		b.mu.Unlock()
-
-	case acp.SessionUpdateKindAgentThoughtChunk:
-		// Thinking/reasoning content – intentionally not surfaced to the frontend.
-
-	case acp.SessionUpdateKindToolCall:
-		// Flush any buffered agent text before recording the tool call.
-		b.flushPendingAgentText()
-		// New tool invocation – serialize as JSON string matching claude-agentapi format.
-		// Frontend expects: {"type":"tool_use","name":"<kind>","id":"<toolCallId>","input":{...}}
-		toolObj := map[string]interface{}{
-			"type":  "tool_use",
-			"name":  update.ToolKind,
-			"id":    update.ToolCallId,
-			"input": update.RawInput,
-		}
-		toolJSON, err := json.Marshal(toolObj)
-		if err != nil {
-			toolJSON = []byte(fmt.Sprintf(`{"type":"tool_use","name":%q,"id":%q}`, update.ToolKind, update.ToolCallId))
-		}
-		b.addNewMessage(MessageRoleAgent, string(toolJSON), MessageTypeNormal, update.ToolCallId, "")
-
-	case acp.SessionUpdateKindToolCallUpdate:
-		// If rawInput is provided, refine the existing tool_use message.
-		// claude-agent-acp sends an initial tool_call with empty input (streaming start),
-		// then a tool_call_update with the actual input once the full params are known.
-		if update.RawInput != nil {
-			b.updateToolUseInput(update.ToolCallId, update.RawInput)
-		}
-
-		// Map status: ACP spec uses "success"/"error", claude-agent-acp uses "completed"/"failed".
-		statusStr := string(update.Status)
-		isSuccess := update.Status == acp.ToolCallStatusSuccess || statusStr == "completed"
-		isError := update.Status == acp.ToolCallStatusError || statusStr == "failed"
-
-		if isSuccess || isError {
-			resolvedStatus := "success"
-			if isError {
-				resolvedStatus = "error"
-			}
-			// Serialize raw output as string content.
-			var content string
-			if update.RawOutput != nil {
-				if b, err := json.Marshal(update.RawOutput); err == nil {
-					content = string(b)
-				} else {
-					content = fmt.Sprintf("%v", update.RawOutput)
-				}
-			}
-			b.mu.Lock()
-			b.nextID++
-			msg := Message{
-				ID:              b.nextID,
-				Role:            MessageRoleToolResult,
-				Content:         content,
-				Time:            time.Now(),
-				Type:            MessageTypeNormal,
-				ParentToolUseId: update.ToolCallId,
-				Status:          resolvedStatus,
-			}
-			b.messages = append(b.messages, msg)
-			b.broadcastMessageUpdateLocked(msg)
-			b.mu.Unlock()
-		}
-
-	case acp.SessionUpdateKindPlan:
-		// Flush any buffered agent text before recording the plan.
-		b.flushPendingAgentText()
-		// ACP sends plan as a structured entries list (from TodoWrite), not a plain string.
-		// Convert to a markdown task list for display in the frontend plan modal.
-		if len(update.Entries) > 0 {
-			planMD := planEntriesToMarkdown(update.Entries)
-			b.addNewMessage(MessageRoleAgent, planMD, MessageTypePlan, "", "")
-		}
-	}
-}
-
-func (b *Bridge) addNewMessage(role MessageRole, content string, msgType MessageType, toolUseId, parentToolUseId string) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	b.nextID++
-	msg := Message{
-		ID:              b.nextID,
-		Role:            role,
-		Content:         content,
-		Time:            time.Now(),
-		Type:            msgType,
-		ToolUseId:       toolUseId,
-		ParentToolUseId: parentToolUseId,
-	}
-	b.messages = append(b.messages, msg)
-	b.broadcastMessageUpdateLocked(msg)
-}
-
-// ----------------------------------------------------------------------------
-// Permission request handling
-// ----------------------------------------------------------------------------
-
-func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
-	p := req.Params
-	toolCallId := p.ToolCall.ToolCallId
-
-	// ExitPlanMode sends kind="switch_mode" with rawInput.plan containing the plan markdown.
-	// Show it as a type="plan" message with an approve_plan action so the user can review
-	// and approve/reject from the PlanApprovalModal.
-	if p.ToolCall.Kind == "switch_mode" {
-		b.handleExitPlanModePermission(req, toolCallId)
-		return
-	}
-
-	// ── Generic permission request ──────────────────────────────────────────────
-
-	// Build frontend-compatible options (QuestionOption[]).
-	// The frontend expects { label, description } per option.
-	// ACP options have: { kind, name, optionId }.
-	//
-	// Check whether the ACP agent provided any meaningful option content.
-	hasMeaningfulOptions := false
-	for _, opt := range p.Options {
-		if opt.Name != "" || opt.OptionId != "" {
-			hasMeaningfulOptions = true
-			break
-		}
-	}
-
-	opts := make([]frontendQuestionOption, 0, len(p.Options))
-	if hasMeaningfulOptions {
-		for _, opt := range p.Options {
-			label := opt.Name
-			if label == "" {
-				label = opt.OptionId // Fall back to optionId when name is empty.
-			}
-			opts = append(opts, frontendQuestionOption{
-				Label:       label,
-				Description: "",
-			})
-		}
-	}
-
-	// Provide sensible defaults when the ACP agent sends no options or empty options.
-	originalOptions := p.Options
-	if !hasMeaningfulOptions {
-		opts = []frontendQuestionOption{
-			{Label: "Yes", Description: "Allow this action"},
-			{Label: "No, and don't ask again", Description: "Deny and remember"},
-			{Label: "No", Description: "Deny this action"},
-		}
-		originalOptions = []acp.PermissionOption{
-			{OptionId: "yes", Name: "Yes"},
-			{OptionId: "no_dont_ask", Name: "No, and don't ask again"},
-			{OptionId: "no", Name: "No"},
-		}
-	}
-
-	// Build a human-readable description or use a default.
-	desc := "Permission required"
-
-	// Build one Question object (frontend type).
-	question := frontendQuestion{
-		Question:    desc,
-		Header:      "Permission Required",
-		Options:     opts,
-		MultiSelect: false,
-	}
-
-	b.mu.Lock()
-	b.nextID++
-	qMsg := Message{
-		ID:        b.nextID,
-		Role:      MessageRoleAgent,
-		Content:   desc,
-		Time:      time.Now(),
-		Type:      MessageTypeQuestion,
-		ToolUseId: toolCallId,
-	}
-	b.messages = append(b.messages, qMsg)
-	b.broadcastMessageUpdateLocked(qMsg)
-	b.mu.Unlock()
-
-	// Register a pending action.
-	replyCh := make(chan string, 1)
-	b.actionsMu.Lock()
-	b.pendingActions = append(b.pendingActions, PendingAction{
-		Type:      ActionTypeAnswerQuestion,
-		ToolUseId: toolCallId,
-		Content: map[string]interface{}{
-			"questions": []frontendQuestion{question},
+// emitUpdate broadcasts a session/update notification as a JSON-RPC 2.0 message.
+func (b *Bridge) emitUpdate(update acp.SessionUpdate) {
+	msg := jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: b.sessionId,
+			Update:    update,
 		},
-	})
-	b.actionReplyCh[toolCallId] = replyCh
-	// Store the original options so we can map label → optionId when the user answers.
-	b.permOptionMaps[toolCallId] = originalOptions
-	b.actionsMu.Unlock()
-
-	// Wait for the HTTP client to POST /action and provide an answer.
-	go func() {
-		optionId := <-replyCh
-		_ = req.Reply(optionId)
-	}()
+	}
+	b.broadcast(msg)
 }
 
-// handleExitPlanModePermission handles ExitPlanMode permission requests (kind="switch_mode").
-// It extracts the plan markdown from rawInput, emits a type="plan" message, and waits for
-// an approve_plan action from the user. Approve maps to the first allow option; reject maps
-// to "plan" (stay in plan mode).
-func (b *Bridge) handleExitPlanModePermission(req acp.PermissionRequest, toolCallId string) {
-	p := req.Params
+// handlePermissionRequest emits a session/request_permission request via SSE
+// and waits for the HTTP client to reply via POST /rpc.
+func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
+	id := b.agentReqSeq.Add(1)
+	idRaw, _ := json.Marshal(id)
+	idRawMsg := json.RawMessage(idRaw)
 
-	// Extract plan text from rawInput.
-	planText := ""
-	if len(p.ToolCall.RawInput) > 0 {
-		var rawInput map[string]interface{}
-		if err := json.Unmarshal(p.ToolCall.RawInput, &rawInput); err == nil {
-			if v, ok := rawInput["plan"]; ok {
-				if s, ok := v.(string); ok {
-					planText = s
-				}
-			}
-		}
-	}
-	if planText == "" {
-		planText = "Plan ready for review."
-	}
+	replyCh := make(chan json.RawMessage, 1)
 
-	// Emit the plan message (type="plan") so the frontend shows PlanApprovalModal.
-	b.mu.Lock()
-	b.nextID++
-	planMsg := Message{
-		ID:        b.nextID,
-		Role:      MessageRoleAgent,
-		Content:   planText,
-		Time:      time.Now(),
-		Type:      MessageTypePlan,
-		ToolUseId: toolCallId,
-	}
-	b.messages = append(b.messages, planMsg)
-	b.broadcastMessageUpdateLocked(planMsg)
-	b.mu.Unlock()
+	b.pendingReplyMu.Lock()
+	b.pendingReplies[id] = replyCh
+	b.pendingReplyMu.Unlock()
 
-	// Determine the "allow" and "reject" optionIds from the ACP options.
-	allowOptionId := ""
-	rejectOptionId := "plan"
-	for _, opt := range p.Options {
-		if opt.Kind == "allow_always" || opt.Kind == "allow_once" {
-			if allowOptionId == "" {
-				allowOptionId = opt.OptionId
-			}
-		}
-		if opt.OptionId == "plan" {
-			rejectOptionId = "plan"
-		}
+	msg := jsonRPCMsg{
+		JSONRPC: "2.0",
+		ID:      &idRawMsg,
+		Method:  "session/request_permission",
+		Params:  req.Params,
 	}
-	if allowOptionId == "" && len(p.Options) > 0 {
-		allowOptionId = p.Options[0].OptionId
-	}
-
-	// Register an approve_plan pending action.
-	replyCh := make(chan string, 1)
-	b.actionsMu.Lock()
-	b.pendingActions = append(b.pendingActions, PendingAction{
-		Type:      ActionTypeApprovePlan,
-		ToolUseId: toolCallId,
-	})
-	b.actionReplyCh[toolCallId] = replyCh
-	b.actionsMu.Unlock()
-
-	capturedAllow := allowOptionId
-	capturedReject := rejectOptionId
+	b.broadcast(msg)
 
 	go func() {
-		answer := <-replyCh
-		optionId := capturedReject
-		if answer == "approve" {
-			optionId = capturedAllow
+		defer func() {
+			b.pendingReplyMu.Lock()
+			delete(b.pendingReplies, id)
+			b.pendingReplyMu.Unlock()
+		}()
+
+		select {
+		case <-b.serverCtx.Done():
+			_ = req.Reply("")
+		case raw := <-replyCh:
+			var result acp.RequestPermissionResult
+			if err := json.Unmarshal(raw, &result); err == nil {
+				_ = req.Reply(result.Outcome.OptionId)
+			} else {
+				_ = req.Reply("")
+			}
 		}
-		_ = req.Reply(optionId)
 	}()
 }
 
 // ----------------------------------------------------------------------------
-// Public API (called by HTTP handlers)
+// Public API (called by the HTTP server)
 // ----------------------------------------------------------------------------
 
-// SendMessage posts a user message to the ACP agent. It sets status to
-// "running" immediately and returns; the status reverts to "stable" when
-// the agent finishes (via a goroutine watching the Prompt call).
-func (b *Bridge) SendMessage(ctx context.Context, content string) error {
-	b.mu.Lock()
-	if b.status == AgentStatusRunning {
-		b.mu.Unlock()
-		return fmt.Errorf("agent is busy")
-	}
-	// Add the user message to history.
-	b.nextID++
-	userMsg := Message{
-		ID:      b.nextID,
-		Role:    MessageRoleUser,
-		Content: content,
-		Time:    time.Now(),
-		Type:    MessageTypeNormal,
-	}
-	b.messages = append(b.messages, userMsg)
-	b.broadcastMessageUpdateLocked(userMsg)
-	b.status = AgentStatusRunning
-	b.mu.Unlock()
-
-	b.broadcast(Event{
-		Type: EventTypeStatusChange,
-		Data: StatusChangeData{Status: AgentStatusRunning, AgentType: "acp"},
-	})
-
-	// Run the prompt in the background using the long-lived server context,
-	// NOT the HTTP request context (which is cancelled when the response returns).
+// SendPrompt sends a session/prompt request to the ACP agent.
+// clientID is the raw JSON-RPC id from the HTTP client; the result (or error)
+// is emitted via SSE with that same id so the client can correlate the response.
+func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 	promptCtx := b.serverCtx
 	if promptCtx == nil {
-		promptCtx = ctx
+		promptCtx = context.Background()
 	}
+
 	go func() {
-		stopReason, err := b.acp.Prompt(promptCtx, content)
+		stopReason, err := b.acp.Prompt(promptCtx, text)
+
 		if err != nil {
-			log.Printf("[bridge] prompt error: %v", err)
-			b.broadcastError(err.Error())
+			b.broadcast(jsonRPCMsg{
+				JSONRPC: "2.0",
+				ID:      &clientID,
+				Error:   &rpcError{Code: -32000, Message: err.Error()},
+			})
+			return
 		}
-		if b.verbose {
-			log.Printf("[bridge] prompt done: stopReason=%s", stopReason)
-		}
-		b.setStatus(AgentStatusStable)
+		b.broadcast(jsonRPCMsg{
+			JSONRPC: "2.0",
+			ID:      &clientID,
+			Result:  acp.PromptResult{StopReason: stopReason},
+		})
 	}()
 
 	return nil
 }
 
-// StopAgent cancels the current agent turn.
-func (b *Bridge) StopAgent(ctx context.Context) error {
+// HandleReply routes a JSON-RPC result from the HTTP client to a pending
+// agent-initiated request (e.g. session/request_permission).
+// id is the integer id the bridge assigned when it emitted the agent request.
+func (b *Bridge) HandleReply(id int64, result json.RawMessage) error {
+	b.pendingReplyMu.Lock()
+	ch, ok := b.pendingReplies[id]
+	b.pendingReplyMu.Unlock()
+
+	if !ok {
+		return fmt.Errorf("no pending agent request for id %d", id)
+	}
+	select {
+	case ch <- result:
+	default:
+	}
+	return nil
+}
+
+// Cancel cancels the current agent turn.
+func (b *Bridge) Cancel(ctx context.Context) error {
 	return b.acp.Cancel(ctx)
 }
 
-// GetMessages returns the current conversation history.
-func (b *Bridge) GetMessages() []Message {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	result := make([]Message, len(b.messages))
-	copy(result, b.messages)
-	return result
-}
-
-// GetStatus returns the current agent status.
-// AgentType is reported as "claude" so the frontend routes stop_agent via
-// the /action endpoint (which the ACP bridge supports) rather than sending
-// a raw Ctrl-C character (which the ACP bridge does not support).
-func (b *Bridge) GetStatus() StatusResponse {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	return StatusResponse{
-		AgentType: "claude",
-		Status:    b.status,
-		Transport: "acp",
-	}
-}
-
-// Subscribe returns a channel that receives SSE events and a cancel function.
-// On subscription, the subscriber immediately receives replayed events to
-// reconstruct the current state.
-func (b *Bridge) Subscribe() (<-chan Event, func()) {
-	sub := &subscriber{ch: make(chan Event, 128)}
+// Subscribe returns a channel of raw JSON-RPC messages and a cancel function.
+// The cancel function must be called when the subscriber disconnects.
+func (b *Bridge) Subscribe() (<-chan json.RawMessage, func()) {
+	sub := &subscriber{ch: make(chan json.RawMessage, 128)}
 
 	b.subsMu.Lock()
 	b.subs = append(b.subs, sub)
 	b.subsMu.Unlock()
-
-	// Replay all existing messages.
-	b.mu.RLock()
-	msgs := make([]Message, len(b.messages))
-	copy(msgs, b.messages)
-	status := b.status
-	b.mu.RUnlock()
-
-	go func() {
-		for _, msg := range msgs {
-			sub.ch <- Event{
-				Type: EventTypeMessageUpdate,
-				Data: msg, // Full Message object
-			}
-		}
-		sub.ch <- Event{
-			Type: EventTypeStatusChange,
-			Data: StatusChangeData{Status: status, AgentType: "acp"},
-		}
-	}()
 
 	cancel := func() {
 		b.subsMu.Lock()
@@ -650,264 +250,29 @@ func (b *Bridge) Subscribe() (<-chan Event, func()) {
 	return sub.ch, cancel
 }
 
-// GetPendingActions returns the list of actions waiting for a user response.
-func (b *Bridge) GetPendingActions() PendingActionsResponse {
-	b.actionsMu.Lock()
-	defer b.actionsMu.Unlock()
-	result := make([]PendingAction, len(b.pendingActions))
-	copy(result, b.pendingActions)
-	return PendingActionsResponse{PendingActions: result}
-}
-
-// SubmitAction processes a user response to a pending action.
-func (b *Bridge) SubmitAction(ctx context.Context, req ActionRequest) error {
-	switch req.Type {
-	case ActionTypeStopAgent:
-		return b.StopAgent(ctx)
-
-	case ActionTypeAnswerQuestion:
-		b.actionsMu.Lock()
-		defer b.actionsMu.Unlock()
-
-		// The frontend sends answers as {"0": "optionLabel"} (question index → label).
-		// The legacy format is {toolUseId: optionId}.
-		// Detect format by checking whether all keys are numeric.
-		allNumeric := len(req.Answers) > 0
-		for k := range req.Answers {
-			if _, err := strconv.Atoi(k); err != nil {
-				allNumeric = false
-				break
-			}
-		}
-
-		if allNumeric {
-			// New format from frontend: question index → selected option label.
-			// Collect pending answer_question actions in insertion order.
-			pendingQToolUseIds := make([]string, 0)
-			for _, pa := range b.pendingActions {
-				if pa.Type == ActionTypeAnswerQuestion {
-					pendingQToolUseIds = append(pendingQToolUseIds, pa.ToolUseId)
-				}
-			}
-
-			for idxStr, selectedLabel := range req.Answers {
-				idx, _ := strconv.Atoi(idxStr)
-				if idx >= len(pendingQToolUseIds) {
-					return fmt.Errorf("no pending action at question index %d", idx)
-				}
-				toolUseId := pendingQToolUseIds[idx]
-
-				// Map the selected label back to the original ACP option ID.
-				// ACP options have Name (display) and OptionId (machine id).
-				optionId := selectedLabel // Default: use label as ID.
-				if opts, ok := b.permOptionMaps[toolUseId]; ok {
-					for _, opt := range opts {
-						if opt.Name == selectedLabel {
-							if opt.OptionId != "" {
-								optionId = opt.OptionId
-							}
-							break
-						}
-					}
-					delete(b.permOptionMaps, toolUseId)
-				}
-
-				ch, ok := b.actionReplyCh[toolUseId]
-				if !ok {
-					return fmt.Errorf("no pending action for question index %d", idx)
-				}
-				ch <- optionId
-				delete(b.actionReplyCh, toolUseId)
-				b.removePendingActionLocked(toolUseId)
-			}
-		} else {
-			// Legacy format: toolUseId → optionId.
-			for toolUseId, optionId := range req.Answers {
-				ch, ok := b.actionReplyCh[toolUseId]
-				if !ok {
-					return fmt.Errorf("no pending action for tool_use_id %q", toolUseId)
-				}
-				ch <- optionId
-				delete(b.actionReplyCh, toolUseId)
-				delete(b.permOptionMaps, toolUseId)
-				b.removePendingActionLocked(toolUseId)
-			}
-		}
-		return nil
-
-	case ActionTypeApprovePlan:
-		// Find the plan action (no specific toolUseId – pick first plan).
-		b.actionsMu.Lock()
-		defer b.actionsMu.Unlock()
-		for i, pa := range b.pendingActions {
-			if pa.Type == ActionTypeApprovePlan {
-				ch, ok := b.actionReplyCh[pa.ToolUseId]
-				if ok {
-					if req.Approved != nil && *req.Approved {
-						ch <- "approve"
-					} else {
-						ch <- "reject"
-					}
-					delete(b.actionReplyCh, pa.ToolUseId)
-					b.pendingActions = append(b.pendingActions[:i], b.pendingActions[i+1:]...)
-				}
-				return nil
-			}
-		}
-		return fmt.Errorf("no pending approve_plan action")
-
-	default:
-		return fmt.Errorf("unknown action type: %s", req.Type)
-	}
-}
-
 // ----------------------------------------------------------------------------
 // Internal helpers
 // ----------------------------------------------------------------------------
 
-func (b *Bridge) setStatus(s AgentStatus) {
-	// Flush any remaining buffered agent text before changing status so that
-	// a complete message is visible before the "stable" status is broadcast.
-	b.flushPendingAgentText()
-	b.mu.Lock()
-	b.status = s
-	b.mu.Unlock()
-	b.broadcast(Event{
-		Type: EventTypeStatusChange,
-		Data: StatusChangeData{Status: s, AgentType: "acp"},
-	})
-}
-
-// flushPendingAgentText commits any buffered agent_message_chunk text as a
-// single complete Message and broadcasts it to SSE subscribers.
-// It is a no-op when the buffer is empty.
-// Must NOT be called while b.mu is held (it acquires b.mu internally).
-func (b *Bridge) flushPendingAgentText() {
-	b.mu.Lock()
-	text := b.pendingAgentText.String()
-	if text == "" {
-		b.mu.Unlock()
+func (b *Bridge) broadcast(msg jsonRPCMsg) {
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		if b.verbose {
+			log.Printf("[bridge] marshal error: %v", err)
+		}
 		return
 	}
-	b.pendingAgentText.Reset()
-	b.nextID++
-	msg := Message{
-		ID:      b.nextID,
-		Role:    MessageRoleAgent,
-		Content: text,
-		Time:    time.Now(),
-		Type:    MessageTypeNormal,
+	if b.verbose {
+		log.Printf("[bridge] broadcast: %s", raw)
 	}
-	b.messages = append(b.messages, msg)
-	b.broadcastMessageUpdateLocked(msg)
-	b.mu.Unlock()
-}
 
-func (b *Bridge) broadcastError(msg string) {
-	b.broadcast(Event{
-		Type: EventTypeAgentError,
-		Data: AgentErrorData{Level: "error", Message: msg, Time: time.Now()},
-	})
-}
-
-func (b *Bridge) broadcast(e Event) {
 	b.subsMu.Lock()
 	defer b.subsMu.Unlock()
 	for _, sub := range b.subs {
 		select {
-		case sub.ch <- e:
+		case sub.ch <- raw:
 		default:
+			// Slow subscriber – drop the message rather than blocking.
 		}
 	}
-}
-
-// broadcastMessageUpdateLocked must be called with b.mu held (at least read).
-func (b *Bridge) broadcastMessageUpdateLocked(msg Message) {
-	e := Event{
-		Type: EventTypeMessageUpdate,
-		Data: msg, // Send full Message object (matches takutakahashi/claude-agentapi format)
-	}
-	b.subsMu.Lock()
-	defer b.subsMu.Unlock()
-	for _, sub := range b.subs {
-		select {
-		case sub.ch <- e:
-		default:
-		}
-	}
-}
-
-func (b *Bridge) removePendingActionLocked(toolUseId string) {
-	for i, pa := range b.pendingActions {
-		if pa.ToolUseId == toolUseId {
-			b.pendingActions = append(b.pendingActions[:i], b.pendingActions[i+1:]...)
-			return
-		}
-	}
-}
-
-// updateToolUseInput refines the input of an existing tool_use message.
-// claude-agent-acp emits an initial tool_call with empty input during streaming,
-// then sends a tool_call_update with the full rawInput once the block is complete.
-func (b *Bridge) updateToolUseInput(toolCallId string, rawInput interface{}) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	for i := len(b.messages) - 1; i >= 0; i-- {
-		msg := &b.messages[i]
-		if msg.ToolUseId != toolCallId {
-			continue
-		}
-		// Parse the existing content JSON.
-		var toolObj map[string]interface{}
-		if err := json.Unmarshal([]byte(msg.Content), &toolObj); err != nil {
-			return
-		}
-		// Only update if the current input is nil/empty.
-		if existing, ok := toolObj["input"]; ok {
-			if m, ok := existing.(map[string]interface{}); ok && len(m) > 0 {
-				return // already has input, don't overwrite
-			}
-		}
-		toolObj["input"] = rawInput
-		updated, err := json.Marshal(toolObj)
-		if err != nil {
-			return
-		}
-		msg.Content = string(updated)
-		b.broadcastMessageUpdateLocked(*msg)
-		return
-	}
-}
-
-// planEntriesToMarkdown converts ACP plan entries (from TodoWrite) into a markdown
-// task list suitable for display in the frontend's PlanApprovalModal.
-func planEntriesToMarkdown(entries []acp.PlanEntry) string {
-	if len(entries) == 0 {
-		return ""
-	}
-	var sb strings.Builder
-	sb.WriteString("## Plan\n\n")
-	for _, e := range entries {
-		var marker string
-		switch e.Status {
-		case "completed":
-			marker = "- [x]"
-		case "in_progress":
-			marker = "- [~]"
-		case "cancelled":
-			marker = "- [!]"
-		default: // "pending"
-			marker = "- [ ]"
-		}
-		priority := ""
-		switch e.Priority {
-		case "high":
-			priority = " 🔴"
-		case "low":
-			priority = " 🔵"
-		}
-		fmt.Fprintf(&sb, "%s %s%s\n", marker, e.Content, priority)
-	}
-	return sb.String()
 }

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -200,6 +200,21 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 
 	log.Printf("[bridge] SendPrompt (session=%s, clientID=%s, textLen=%d)", b.sessionId, clientID, len(text))
 
+	// Record the user's prompt as a synthetic session/update notification so
+	// it appears in GET /messages history alongside the agent's replies.
+	userContentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
+	b.broadcast(jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: b.sessionId,
+			Update: acp.SessionUpdate{
+				Kind:    acp.SessionUpdateKindUserMessageChunk,
+				Content: json.RawMessage(userContentRaw),
+			},
+		},
+	})
+
 	go func() {
 		stopReason, err := b.acp.Prompt(promptCtx, text)
 

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -63,6 +63,11 @@ type Bridge struct {
 	subsMu sync.Mutex
 	subs   []*subscriber
 
+	// Message history: every broadcast message is appended so that reconnecting
+	// SSE clients can replay missed events via GET /messages.
+	histMu  sync.RWMutex
+	history []json.RawMessage
+
 	// Agent-initiated RPCs (e.g. session/request_permission):
 	// We assign local sequential ids, emit them via SSE, and await replies on POST /rpc.
 	agentReqSeq    atomic.Int64
@@ -79,6 +84,16 @@ func New(client *acp.Client, sessionId string, verbose bool) *Bridge {
 		verbose:        verbose,
 		pendingReplies: make(map[int64]chan json.RawMessage),
 	}
+}
+
+// Messages returns a snapshot of all broadcasted JSON-RPC messages since the
+// bridge started.  Callers can use this to replay history for reconnecting clients.
+func (b *Bridge) Messages() []json.RawMessage {
+	b.histMu.RLock()
+	defer b.histMu.RUnlock()
+	out := make([]json.RawMessage, len(b.history))
+	copy(out, b.history)
+	return out
 }
 
 // SessionID returns the ACP session ID.
@@ -274,6 +289,11 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 	if b.verbose {
 		log.Printf("[bridge] broadcast: %s", raw)
 	}
+
+	// Persist to history so reconnecting clients can replay.
+	b.histMu.Lock()
+	b.history = append(b.history, raw)
+	b.histMu.Unlock()
 
 	b.subsMu.Lock()
 	defer b.subsMu.Unlock()

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -52,6 +52,10 @@ func NewServer(b *Bridge, verbose bool) *Server {
 
 func (s *Server) registerRoutes() {
 	s.echo.GET("/health", s.handleHealth)
+	// /status is polled by the provisioner to detect when the agent is ready.
+	// It must return HTTP 200; the body mirrors the agentapi status shape so
+	// that existing tooling can parse it without changes.
+	s.echo.GET("/status", s.handleStatus)
 	s.echo.GET("/session", s.handleGetSession)
 	s.echo.POST("/rpc", s.handleRPC)
 	s.echo.GET("/sse", s.handleSSE)
@@ -84,6 +88,12 @@ func (s *Server) Start(ctx context.Context, addr string) error {
 // GET /health
 func (s *Server) handleHealth(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// GET /status
+// Returns agentapi-compatible status so the provisioner's health check passes.
+func (s *Server) handleStatus(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{"status": "stable"})
 }
 
 // GET /session

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -6,29 +6,26 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
 )
 
-// Server is an agentapi-compatible HTTP server backed by a Bridge.
-// It exposes the following endpoints (compatible with takutakahashi/claude-agentapi):
+// Server is a minimal HTTP transport for ACP.
+// It exposes three endpoints that mirror the ACP JSON-RPC 2.0 protocol over HTTP:
 //
-//	GET  /health
-//	GET  /status
-//	GET  /messages
-//	POST /message
-//	GET  /events   (SSE)
-//	GET  /action
-//	POST /action
+//	GET  /session  – session info (sessionId, status)
+//	POST /rpc      – JSON-RPC 2.0 messages from HTTP client to ACP agent
+//	GET  /sse      – SSE stream of JSON-RPC 2.0 messages from ACP agent to HTTP client
+//	GET  /health   – health check (for compatibility)
 type Server struct {
 	bridge  *Bridge
 	echo    *echo.Echo
 	verbose bool
 }
 
-// NewServer creates a new HTTP server wrapping the given Bridge.
+// NewServer creates a new HTTP transport server backed by the given Bridge.
 func NewServer(b *Bridge, verbose bool) *Server {
 	e := echo.New()
 	e.HideBanner = true
@@ -55,12 +52,9 @@ func NewServer(b *Bridge, verbose bool) *Server {
 
 func (s *Server) registerRoutes() {
 	s.echo.GET("/health", s.handleHealth)
-	s.echo.GET("/status", s.handleStatus)
-	s.echo.GET("/messages", s.handleGetMessages)
-	s.echo.POST("/message", s.handlePostMessage)
-	s.echo.GET("/events", s.handleEvents)
-	s.echo.GET("/action", s.handleGetAction)
-	s.echo.POST("/action", s.handlePostAction)
+	s.echo.GET("/session", s.handleGetSession)
+	s.echo.POST("/rpc", s.handleRPC)
+	s.echo.GET("/sse", s.handleSSE)
 }
 
 // Start starts the HTTP server on the given address (e.g. ":3284").
@@ -92,140 +86,120 @@ func (s *Server) handleHealth(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 
-// GET /status
-func (s *Server) handleStatus(c echo.Context) error {
-	return c.JSON(http.StatusOK, s.bridge.GetStatus())
-}
-
-// GET /messages
-//
-// Query parameters (takutakahashi/claude-agentapi compatible):
-//
-//	limit     int    – max messages to return (default 50)
-//	direction string – "head" | "tail" (default "tail")
-//	around    int    – message ID to centre the window on
-//	context   int    – number of messages before/after `around` (default 10)
-//	after     int    – cursor: messages with ID > after
-//	before    int    – cursor: messages with ID < before
-func (s *Server) handleGetMessages(c echo.Context) error {
-	all := s.bridge.GetMessages()
-
-	limit := 50
-	if v := c.QueryParam("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
-		}
-	}
-	direction := c.QueryParam("direction")
-	if direction == "" {
-		direction = "tail"
-	}
-
-	// Cursor filters
-	if after := c.QueryParam("after"); after != "" {
-		if id, err := strconv.ParseInt(after, 10, 64); err == nil {
-			filtered := all[:0]
-			for _, m := range all {
-				if m.ID > id {
-					filtered = append(filtered, m)
-				}
-			}
-			all = filtered
-		}
-	}
-	if before := c.QueryParam("before"); before != "" {
-		if id, err := strconv.ParseInt(before, 10, 64); err == nil {
-			filtered := all[:0]
-			for _, m := range all {
-				if m.ID < id {
-					filtered = append(filtered, m)
-				}
-			}
-			all = filtered
-		}
-	}
-
-	// around / context window
-	if aroundStr := c.QueryParam("around"); aroundStr != "" {
-		if aroundID, err := strconv.ParseInt(aroundStr, 10, 64); err == nil {
-			ctx := 10
-			if v := c.QueryParam("context"); v != "" {
-				if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-					ctx = n
-				}
-			}
-			centerIdx := -1
-			for i, m := range all {
-				if m.ID == aroundID {
-					centerIdx = i
-					break
-				}
-			}
-			if centerIdx >= 0 {
-				start := centerIdx - ctx
-				if start < 0 {
-					start = 0
-				}
-				end := centerIdx + ctx + 1
-				if end > len(all) {
-					end = len(all)
-				}
-				all = all[start:end]
-			}
-		}
-	}
-
-	total := len(all)
-	hasMore := false
-
-	if direction == "tail" {
-		if len(all) > limit {
-			all = all[len(all)-limit:]
-			hasMore = true
-		}
-	} else {
-		if len(all) > limit {
-			all = all[:limit]
-			hasMore = true
-		}
-	}
-
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"messages": all,
-		"total":    total,
-		"hasMore":  hasMore,
+// GET /session
+// Returns the session ID and current status so clients know what ID to use in RPC calls.
+func (s *Server) handleGetSession(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{
+		"sessionId": s.bridge.SessionID(),
+		"status":    "ready",
 	})
 }
 
-// postMessageRequest is the body for POST /message.
-type postMessageRequest struct {
-	Content string `json:"content"`
-	Type    string `json:"type"` // "user" | "raw"
+// rpcEnvelope is the JSON-RPC 2.0 message envelope received on POST /rpc.
+// Covers all three message kinds: request, notification, and response.
+type rpcEnvelope struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method,omitempty"`
+	Params  json.RawMessage  `json:"params,omitempty"`
+	Result  json.RawMessage  `json:"result,omitempty"`
+	Error   json.RawMessage  `json:"error,omitempty"`
 }
 
-// POST /message
-func (s *Server) handlePostMessage(c echo.Context) error {
-	var req postMessageRequest
-	if err := c.Bind(&req); err != nil {
-		return problemJSON(c, http.StatusBadRequest, "invalid request body", err.Error())
-	}
-	if req.Content == "" {
-		return problemJSON(c, http.StatusBadRequest, "content is required", "")
+// POST /rpc
+//
+// Accepts three kinds of JSON-RPC 2.0 messages:
+//
+//  1. Client-initiated requests (id + method):
+//     - "session/prompt"  → forwards text to ACP agent; result comes via SSE
+//     - "session/cancel"  → cancels the current agent turn
+//
+//  2. Client-initiated notifications (no id, method set):
+//     - "session/cancel"  → same as above, no response expected
+//
+//  3. Client responses to agent-initiated requests (id set, no method):
+//     - Response to "session/request_permission" emitted via SSE
+func (s *Server) handleRPC(c echo.Context) error {
+	var env rpcEnvelope
+	if err := c.Bind(&env); err != nil {
+		return c.JSON(http.StatusBadRequest, rpcErrorResp(nil, -32700, "Parse error"))
 	}
 
-	// "raw" type is not applicable for ACP (no PTY) – treat same as user.
-	if err := s.bridge.SendMessage(c.Request().Context(), req.Content); err != nil {
-		if err.Error() == "agent is busy" {
-			return problemJSON(c, http.StatusConflict, "agent is busy", "wait for status to become stable")
+	// ── Case 1: Response to an agent-initiated request ───────────────────────
+	// Identified by: id is set, method is absent.
+	if env.ID != nil && env.Method == "" {
+		if env.Result == nil {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32600, "result is required for response messages"))
 		}
-		return problemJSON(c, http.StatusInternalServerError, "failed to send message", err.Error())
+		var id int64
+		if err := json.Unmarshal(*env.ID, &id); err != nil {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32600, "id must be an integer for agent-initiated requests"))
+		}
+		if err := s.bridge.HandleReply(id, env.Result); err != nil {
+			return c.JSON(http.StatusBadRequest, rpcErrorResp(env.ID, -32600, err.Error()))
+		}
+		return c.JSON(http.StatusOK, map[string]bool{"ok": true})
 	}
 
-	return c.JSON(http.StatusOK, map[string]bool{"ok": true})
+	// ── Case 2: Client-initiated request or notification ─────────────────────
+	switch env.Method {
+	case "session/prompt":
+		// Require an id so we can correlate the async result via SSE.
+		if env.ID == nil {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(nil, -32600, "id is required for session/prompt"))
+		}
+		var params acp.PromptParams
+		if err := json.Unmarshal(env.Params, &params); err != nil {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32602, "invalid params: "+err.Error()))
+		}
+		// Extract the first text content block.
+		text := ""
+		for _, block := range params.Prompt {
+			if block.Type == acp.ContentBlockTypeText {
+				text = block.Text
+				break
+			}
+		}
+		if text == "" {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32602, "prompt must contain at least one text content block"))
+		}
+		if err := s.bridge.SendPrompt(*env.ID, text); err != nil {
+			return c.JSON(http.StatusInternalServerError,
+				rpcErrorResp(env.ID, -32000, err.Error()))
+		}
+		// 202: the agent is working asynchronously; the result arrives via SSE.
+		return c.JSON(http.StatusAccepted, map[string]bool{"ok": true})
+
+	case "session/cancel":
+		_ = s.bridge.Cancel(c.Request().Context())
+		// Notifications don't require a response; requests get a simple ack.
+		return c.JSON(http.StatusOK, map[string]bool{"ok": true})
+
+	default:
+		return c.JSON(http.StatusBadRequest,
+			rpcErrorResp(env.ID, -32601, "method not supported: "+env.Method))
+	}
 }
 
-// GET /events – Server-Sent Events
-func (s *Server) handleEvents(c echo.Context) error {
+// GET /sse
+//
+// Server-Sent Events stream of JSON-RPC 2.0 messages from the ACP agent.
+// Each SSE event has type "message" and carries a raw JSON-RPC object:
+//
+//	event: message
+//	data: {"jsonrpc":"2.0","method":"session/update","params":{...}}
+//
+//	event: message
+//	data: {"jsonrpc":"2.0","id":1,"method":"session/request_permission","params":{...}}
+//
+//	event: message
+//	data: {"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}
+func (s *Server) handleSSE(c echo.Context) error {
 	w := c.Response()
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -236,60 +210,37 @@ func (s *Server) handleEvents(c echo.Context) error {
 	ch, cancel := s.bridge.Subscribe()
 	defer cancel()
 
-	flusher, ok := w.Writer.(http.Flusher)
+	flusher, hasFlusher := w.Writer.(http.Flusher)
 
 	ctx := c.Request().Context()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case event, open := <-ch:
+		case raw, open := <-ch:
 			if !open {
 				return nil
 			}
-			data, err := json.Marshal(event.Data)
-			if err != nil {
-				continue
-			}
-			_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.Type, data)
-			if ok {
+			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", raw)
+			if hasFlusher {
 				flusher.Flush()
 			}
 		}
 	}
 }
 
-// GET /action
-func (s *Server) handleGetAction(c echo.Context) error {
-	return c.JSON(http.StatusOK, s.bridge.GetPendingActions())
-}
-
-// POST /action
-func (s *Server) handlePostAction(c echo.Context) error {
-	var req ActionRequest
-	if err := c.Bind(&req); err != nil {
-		return problemJSON(c, http.StatusBadRequest, "invalid request body", err.Error())
-	}
-
-	if err := s.bridge.SubmitAction(c.Request().Context(), req); err != nil {
-		return problemJSON(c, http.StatusBadRequest, "action failed", err.Error())
-	}
-	return c.JSON(http.StatusOK, map[string]bool{"ok": true})
-}
-
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
 
-// problemJSON returns an RFC 9457 problem detail response.
-func problemJSON(c echo.Context, status int, title, detail string) error {
-	body := map[string]interface{}{
-		"type":   fmt.Sprintf("https://httpstatuses.io/%d", status),
-		"title":  title,
-		"status": status,
+// rpcErrorResp builds a JSON-RPC 2.0 error response object.
+func rpcErrorResp(id *json.RawMessage, code int, message string) map[string]interface{} {
+	return map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]interface{}{
+			"code":    code,
+			"message": message,
+		},
 	}
-	if detail != "" {
-		body["detail"] = detail
-	}
-	return c.JSON(status, body)
 }

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -89,8 +89,10 @@ func (s *Server) handleHealth(c echo.Context) error {
 // GET /session
 // Returns the session ID and current status so clients know what ID to use in RPC calls.
 func (s *Server) handleGetSession(c echo.Context) error {
+	sessionId := s.bridge.SessionID()
+	log.Printf("[acp-server] GET /session -> sessionId=%s (remoteAddr=%s)", sessionId, c.RealIP())
 	return c.JSON(http.StatusOK, map[string]string{
-		"sessionId": s.bridge.SessionID(),
+		"sessionId": sessionId,
 		"status":    "ready",
 	})
 }
@@ -122,8 +124,10 @@ type rpcEnvelope struct {
 func (s *Server) handleRPC(c echo.Context) error {
 	var env rpcEnvelope
 	if err := c.Bind(&env); err != nil {
+		log.Printf("[acp-server] POST /rpc parse error (remoteAddr=%s): %v", c.RealIP(), err)
 		return c.JSON(http.StatusBadRequest, rpcErrorResp(nil, -32700, "Parse error"))
 	}
+	log.Printf("[acp-server] POST /rpc method=%q id=%v (remoteAddr=%s)", env.Method, env.ID, c.RealIP())
 
 	// ── Case 1: Response to an agent-initiated request ───────────────────────
 	// Identified by: id is set, method is absent.
@@ -207,8 +211,13 @@ func (s *Server) handleSSE(c echo.Context) error {
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
+	log.Printf("[acp-server] GET /sse connected (remoteAddr=%s, lastEventID=%q)", c.RealIP(), c.Request().Header.Get("Last-Event-ID"))
+
 	ch, cancel := s.bridge.Subscribe()
-	defer cancel()
+	defer func() {
+		cancel()
+		log.Printf("[acp-server] GET /sse disconnected (remoteAddr=%s)", c.RealIP())
+	}()
 
 	flusher, hasFlusher := w.Writer.(http.Flusher)
 

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -57,6 +57,10 @@ func (s *Server) registerRoutes() {
 	// that existing tooling can parse it without changes.
 	s.echo.GET("/status", s.handleStatus)
 	s.echo.GET("/session", s.handleGetSession)
+	// /messages returns the full in-memory message history as a JSON array of
+	// raw JSON-RPC 2.0 objects.  Reconnecting clients use this to replay events
+	// they missed while disconnected from the SSE stream.
+	s.echo.GET("/messages", s.handleGetMessages)
 	s.echo.POST("/rpc", s.handleRPC)
 	s.echo.GET("/sse", s.handleSSE)
 }
@@ -94,6 +98,18 @@ func (s *Server) handleHealth(c echo.Context) error {
 // Returns agentapi-compatible status so the provisioner's health check passes.
 func (s *Server) handleStatus(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "stable"})
+}
+
+// GET /messages
+// Returns all JSON-RPC 2.0 messages that have been broadcast since the bridge started.
+// The response is a JSON object with a "messages" array so the client can distinguish
+// an empty history ({"messages":[]}) from an error.
+func (s *Server) handleGetMessages(c echo.Context) error {
+	msgs := s.bridge.Messages()
+	if msgs == nil {
+		msgs = []json.RawMessage{}
+	}
+	return c.JSON(http.StatusOK, map[string]interface{}{"messages": msgs})
 }
 
 // GET /session

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -96,8 +97,15 @@ func (s *Server) handleHealth(c echo.Context) error {
 
 // GET /status
 // Returns agentapi-compatible status so the provisioner's health check passes.
+// Includes agent_type from the AGENTAPI_AGENT_TYPE environment variable (if set)
+// so that the UI can detect the ACP session type and enable appropriate features
+// such as Markdown rendering.
 func (s *Server) handleStatus(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]string{"status": "stable"})
+	resp := map[string]string{"status": "stable"}
+	if agentType := os.Getenv("AGENTAPI_AGENT_TYPE"); agentType != "" {
+		resp["agent_type"] = agentType
+	}
+	return c.JSON(http.StatusOK, resp)
 }
 
 // GET /messages

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	verbose bool
 
 	sessionId string
+	agentCaps AgentCapabilities
 
 	// updateCh is closed when the client is stopped.
 	updateCh chan SessionUpdate
@@ -163,10 +164,16 @@ func (c *Client) Initialize(ctx context.Context) error {
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return fmt.Errorf("acp initialize: parse result: %w", err)
 	}
+	c.agentCaps = result.AgentCapabilities
 	if c.verbose {
 		log.Printf("[acp] initialized: protocol=%d agentCaps=%+v", result.ProtocolVersion, result.AgentCapabilities)
 	}
 	return nil
+}
+
+// AgentCaps returns the capabilities reported by the agent during Initialize.
+func (c *Client) AgentCaps() AgentCapabilities {
+	return c.agentCaps
 }
 
 // NewSession creates a new ACP session and stores the session ID.
@@ -196,6 +203,27 @@ func (c *Client) NewSession(ctx context.Context, cwd string, mcpServers []McpSer
 // SessionID returns the current session ID (set after NewSession).
 func (c *Client) SessionID() string {
 	return c.sessionId
+}
+
+// LoadSession restores a previously created ACP session by its ID.
+// Only call this when AgentCaps().SessionLoad is true; otherwise fall back to NewSession.
+// On success the session ID is updated; on failure (session not found, etc.) the caller
+// should call NewSession to start fresh.
+func (c *Client) LoadSession(ctx context.Context, sessionId string) error {
+	params := SessionLoadParams{SessionId: sessionId}
+	raw, err := c.rpc.Call(ctx, "session/load", params)
+	if err != nil {
+		return fmt.Errorf("acp session/load: %w", err)
+	}
+	var result SessionLoadResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return fmt.Errorf("acp session/load: parse result: %w", err)
+	}
+	c.sessionId = result.SessionId
+	if c.verbose {
+		log.Printf("[acp] session loaded: id=%s", result.SessionId)
+	}
+	return nil
 }
 
 // Prompt sends a user message and returns when the agent has finished the turn.

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -113,6 +113,19 @@ type SessionListResult struct {
 	Sessions []SessionInfo `json:"sessions"`
 }
 
+// SessionLoadParams is the params for "session/load" (client→agent).
+// Only valid when AgentCapabilities.SessionLoad is true.
+type SessionLoadParams struct {
+	SessionId string `json:"sessionId"`
+}
+
+// SessionLoadResult is the response to "session/load".
+type SessionLoadResult struct {
+	SessionId     string            `json:"sessionId"`
+	Modes         *SessionModeState `json:"modes,omitempty"`
+	ConfigOptions []ConfigOption    `json:"configOptions,omitempty"`
+}
+
 // SessionSetModeParams is the params for "session/set_mode".
 type SessionSetModeParams struct {
 	SessionId string `json:"sessionId"`

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -656,9 +656,28 @@ type agentMessagesResponse struct {
 	} `json:"messages"`
 }
 
+// acpSessionResponse is the shape of the ACP bridge's GET /session response.
+type acpSessionResponse struct {
+	SessionId string `json:"sessionId"`
+	Status    string `json:"status"`
+}
+
+// acpMessagesResponse is the shape of the ACP bridge's GET /messages response.
+// Each message is a raw JSON-RPC 2.0 envelope; we only need to inspect
+// the method and the sessionUpdate discriminant inside params.update.
+type acpMessagesResponse struct {
+	Messages []json.RawMessage `json:"messages"`
+}
+
 // sendInitialMessage sends an initial message to agentapi after it has
 // started, replicating the logic of initialMessageSenderScript.
 func sendInitialMessage(ctx context.Context, agentapiURL, message, agentType string, waitSec int) {
+	// ACP sessions use a different transport (JSON-RPC 2.0 over POST /rpc).
+	if agentType == "claude-acp" {
+		sendACPInitialMessage(ctx, agentapiURL, message, waitSec)
+		return
+	}
+
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	// Check for existing user messages (idempotency / Pod restart).
@@ -721,6 +740,153 @@ func sendInitialMessage(ctx context.Context, agentapiURL, message, agentType str
 		}
 	}
 	log.Printf("[PROVISIONER] ERROR: Failed to send initial message after 5 attempts")
+}
+
+// sendACPInitialMessage sends an initial message to an ACP bridge session
+// via POST /rpc (JSON-RPC 2.0 session/prompt).
+func sendACPInitialMessage(ctx context.Context, agentapiURL, message string, waitSec int) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	// Idempotency: check whether user messages already exist in ACP format.
+	if count := countACPUserMessages(client, agentapiURL); count > 0 {
+		log.Printf("[PROVISIONER] ACP user messages already exist (%d), skipping initial message", count)
+		return
+	}
+
+	// Wait for the ACP bridge /status to report "stable".
+	waitForStable(ctx, client, agentapiURL, 60)
+
+	// Configured delay before sending.
+	log.Printf("[PROVISIONER] Waiting %d second(s) before sending ACP initial message", waitSec)
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(time.Duration(waitSec) * time.Second):
+	}
+
+	// Double-check idempotency after wait.
+	if count := countACPUserMessages(client, agentapiURL); count > 0 {
+		log.Printf("[PROVISIONER] ACP user messages appeared during wait (%d), skipping", count)
+		return
+	}
+
+	// Fetch the ACP session ID from GET /session.
+	acpSessionId, err := getACPSessionId(client, agentapiURL)
+	if err != nil {
+		log.Printf("[PROVISIONER] ERROR: failed to get ACP session ID: %v", err)
+		return
+	}
+	log.Printf("[PROVISIONER] ACP session ID: %s", acpSessionId)
+
+	// Build JSON-RPC 2.0 session/prompt payload.
+	type contentBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type promptParams struct {
+		SessionId string         `json:"sessionId"`
+		Prompt    []contentBlock `json:"prompt"`
+	}
+	type rpcRequest struct {
+		JSONRPC string       `json:"jsonrpc"`
+		ID      int          `json:"id"`
+		Method  string       `json:"method"`
+		Params  promptParams `json:"params"`
+	}
+	payload := rpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "session/prompt",
+		Params: promptParams{
+			SessionId: acpSessionId,
+			Prompt:    []contentBlock{{Type: "text", Text: message}},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	for attempt := 1; attempt <= 5; attempt++ {
+		log.Printf("[PROVISIONER] ACP initial message send attempt %d/5", attempt)
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, agentapiURL+"/rpc", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			// Bridge returns 202 Accepted for session/prompt (async).
+			if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusOK {
+				log.Printf("[PROVISIONER] ACP initial message sent successfully (HTTP %d)", resp.StatusCode)
+				return
+			}
+			log.Printf("[PROVISIONER] ACP send failed (HTTP %d), attempt %d/5", resp.StatusCode, attempt)
+		} else {
+			log.Printf("[PROVISIONER] ACP send error: %v, attempt %d/5", err, attempt)
+		}
+
+		if attempt < 5 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(3 * time.Second):
+			}
+		}
+	}
+	log.Printf("[PROVISIONER] ERROR: Failed to send ACP initial message after 5 attempts")
+}
+
+// getACPSessionId fetches the ACP session ID from GET /session.
+func getACPSessionId(client *http.Client, agentapiURL string) (string, error) {
+	resp, err := client.Get(agentapiURL + "/session")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var sr acpSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return "", err
+	}
+	if sr.SessionId == "" {
+		return "", fmt.Errorf("empty sessionId in /session response")
+	}
+	return sr.SessionId, nil
+}
+
+// countACPUserMessages returns the number of user_message_chunk events in the
+// ACP bridge's GET /messages history. Used for idempotency on Pod restarts.
+func countACPUserMessages(client *http.Client, agentapiURL string) int {
+	resp, err := client.Get(agentapiURL + "/messages")
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var mr acpMessagesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&mr); err != nil {
+		return 0
+	}
+
+	// Each element is a raw JSON-RPC 2.0 message. We look for:
+	//   { "method": "session/update", "params": { "update": { "sessionUpdate": "user_message_chunk" } } }
+	type acpUpdateParams struct {
+		Update struct {
+			SessionUpdate string `json:"sessionUpdate"`
+		} `json:"update"`
+	}
+	type acpMsg struct {
+		Method string          `json:"method"`
+		Params acpUpdateParams `json:"params"`
+	}
+	count := 0
+	for _, raw := range mr.Messages {
+		var m acpMsg
+		if err := json.Unmarshal(raw, &m); err != nil {
+			continue
+		}
+		if m.Method == "session/update" && m.Params.Update.SessionUpdate == "user_message_chunk" {
+			count++
+		}
+	}
+	return count
 }
 
 // waitForDefaultAgentReady uses the two-phase strategy from the original shell


### PR DESCRIPTION
## Summary

- ACP セッションのレスポンス形式を agentapi 互換形式から **ACP ネイティブ JSON-RPC 2.0** に全面置換
- `bridge.go` / `server.go` を書き換え、変換層を完全に排除
- エンドポイントを最小化（旧: 7 エンドポイント → 新: 4 エンドポイント）

## 変更内容

### Before（agentapi 互換形式）

旧 7 エンドポイントは agentapi 独自形式（Message, action API 等）を返していた。
tool_call は JSON 文字列として content フィールドに埋め込まれ、意味情報が失われていた。

### After（ACP HTTP トランスポート）

```
GET  /health   → {"status":"ok"}
GET  /session  → {"sessionId":"...", "status":"ready"}
POST /rpc      → JSON-RPC 2.0 メッセージ（client → agent）
GET  /sse      → SSE: event: message, data: {raw JSON-RPC 2.0}
```

SSE で流れるのは ACP プロトコルそのままの JSON-RPC 2.0 メッセージ:
- `session/update` 通知（agentMessageChunk, toolCall, toolCallUpdate, plan 等）
- `session/request_permission` リクエスト（エージェント → クライアント RPC）
- `session/prompt` 結果（stopReason）

## Test plan

- [ ] `acp-server` 起動後 `GET /session` で sessionId が取得できること
- [ ] `POST /rpc` で session/prompt を送り、`GET /sse` で session/update と result が流れること
- [ ] CI が通ること

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)