### PR TITLE
feat(acp/bridge): add /events SSE endpoint for agentapi-compatible status tracking

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -859,8 +859,14 @@ func (m *KubernetesSessionManager) watchStockSession(ctx context.Context, sessio
 		}
 	}
 
-	session.SetStatus("active")
-	log.Printf("[K8S_SESSION] Stock session %s is now active", session.id)
+	// Don't downgrade to "active" if watchAgentAPIStatus already detected the
+	// agent is running (e.g. provisioner's initial message is still in flight).
+	if session.Status() != "running" {
+		session.SetStatus("active")
+		log.Printf("[K8S_SESSION] Stock session %s is now active", session.id)
+	} else {
+		log.Printf("[K8S_SESSION] Stock session %s skipped SetStatus(active): agent already running", session.id)
+	}
 
 	// Continue watching deployment health and agentapi runtime status.
 	go m.watchAgentAPIStatus(ctx, session)

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -82,6 +82,17 @@ type Bridge struct {
 	chunkMu   sync.Mutex
 	chunkKind acp.SessionUpdateKind
 	chunkText strings.Builder
+
+	// Status tracking: "running" while a prompt is being processed, "stable" otherwise.
+	// Mirrors the agentapi status convention so the proxy can watch GET /events.
+	statusMu      sync.RWMutex
+	currentStatus string
+	statusSubsMu  sync.Mutex
+	statusSubs    []*statusSubscriber
+}
+
+type statusSubscriber struct {
+	ch chan string
 }
 
 // New creates a Bridge backed by the given ACP client.
@@ -92,6 +103,7 @@ func New(client *acp.Client, sessionId string, verbose bool) *Bridge {
 		sessionId:      sessionId,
 		verbose:        verbose,
 		pendingReplies: make(map[int64]chan json.RawMessage),
+		currentStatus:  "stable",
 	}
 }
 
@@ -107,6 +119,59 @@ func (b *Bridge) Messages() []json.RawMessage {
 
 // SessionID returns the ACP session ID.
 func (b *Bridge) SessionID() string { return b.sessionId }
+
+// Status returns the current agent status ("running" or "stable").
+func (b *Bridge) Status() string {
+	b.statusMu.RLock()
+	defer b.statusMu.RUnlock()
+	return b.currentStatus
+}
+
+// SubscribeStatus returns a channel that receives status strings whenever the
+// agent status changes, and a cancel function that must be called on disconnect.
+func (b *Bridge) SubscribeStatus() (<-chan string, func()) {
+	sub := &statusSubscriber{ch: make(chan string, 4)}
+	b.statusSubsMu.Lock()
+	b.statusSubs = append(b.statusSubs, sub)
+	b.statusSubsMu.Unlock()
+
+	cancel := func() {
+		b.statusSubsMu.Lock()
+		for i, s := range b.statusSubs {
+			if s == sub {
+				b.statusSubs = append(b.statusSubs[:i], b.statusSubs[i+1:]...)
+				break
+			}
+		}
+		b.statusSubsMu.Unlock()
+		close(sub.ch)
+	}
+	return sub.ch, cancel
+}
+
+// setStatus updates the current status and notifies all subscribers.
+func (b *Bridge) setStatus(status string) {
+	b.statusMu.Lock()
+	prev := b.currentStatus
+	b.currentStatus = status
+	b.statusMu.Unlock()
+
+	if prev == status {
+		return
+	}
+	if b.verbose {
+		log.Printf("[bridge] status: %s → %s (session=%s)", prev, status, b.sessionId)
+	}
+
+	b.statusSubsMu.Lock()
+	defer b.statusSubsMu.Unlock()
+	for _, sub := range b.statusSubs {
+		select {
+		case sub.ch <- status:
+		default:
+		}
+	}
+}
 
 // ----------------------------------------------------------------------------
 // Event loop
@@ -285,11 +350,14 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 		},
 	})
 
+	b.setStatus("running")
+
 	go func() {
 		stopReason, err := b.acp.Prompt(promptCtx, text)
 
 		// Flush any chunk that was still buffered when the agent turn ended.
 		b.flushChunkBuffer()
+		b.setStatus("stable")
 
 		if err != nil {
 			log.Printf("[bridge] Prompt error (session=%s): %v", b.sessionId, err)

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -64,6 +64,10 @@ func (s *Server) registerRoutes() {
 	s.echo.GET("/messages", s.handleGetMessages)
 	s.echo.POST("/rpc", s.handleRPC)
 	s.echo.GET("/sse", s.handleSSE)
+	// /events is the agentapi-compatible SSE endpoint consumed by the proxy's
+	// watchAgentAPIStatus goroutine.  It emits status_change events whenever
+	// the agent transitions between "running" and "stable".
+	s.echo.GET("/events", s.handleEvents)
 }
 
 // Start starts the HTTP server on the given address (e.g. ":3284").
@@ -265,6 +269,49 @@ func (s *Server) handleSSE(c echo.Context) error {
 				return nil
 			}
 			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", raw)
+			if hasFlusher {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// GET /events
+//
+// agentapi-compatible SSE stream consumed by the proxy's watchAgentAPIStatus goroutine.
+// On connect it immediately emits a status_change event with the current status so
+// reconnecting consumers always get a consistent starting point, then streams every
+// subsequent status transition.
+func (s *Server) handleEvents(c echo.Context) error {
+	w := c.Response()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, hasFlusher := w.Writer.(http.Flusher)
+
+	// Emit the current status immediately so the consumer doesn't have to wait
+	// for the next transition.
+	_, _ = fmt.Fprintf(w, "event: status_change\ndata: {\"status\":%q}\n\n", s.bridge.Status())
+	if hasFlusher {
+		flusher.Flush()
+	}
+
+	ch, cancel := s.bridge.SubscribeStatus()
+	defer cancel()
+
+	ctx := c.Request().Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case status, open := <-ch:
+			if !open {
+				return nil
+			}
+			_, _ = fmt.Fprintf(w, "event: status_change\ndata: {\"status\":%q}\n\n", status)
 			if hasFlusher {
 				flusher.Flush()
 			}

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -101,11 +101,13 @@ func (s *Server) handleHealth(c echo.Context) error {
 
 // GET /status
 // Returns agentapi-compatible status so the provisioner's health check passes.
+// Returns the actual agent status ("running" while processing a prompt, "stable" otherwise)
+// so that the UI can disable input and show a stop button while the agent is busy.
 // Includes agent_type from the AGENTAPI_AGENT_TYPE environment variable (if set)
 // so that the UI can detect the ACP session type and enable appropriate features
 // such as Markdown rendering.
 func (s *Server) handleStatus(c echo.Context) error {
-	resp := map[string]string{"status": "stable"}
+	resp := map[string]string{"status": s.bridge.Status()}
 	if agentType := os.Getenv("AGENTAPI_AGENT_TYPE"); agentType != "" {
 		resp["agent_type"] = agentType
 	}


### PR DESCRIPTION
## Summary

- ACP セッションで `status` が `running` にならない問題を修正
- プロキシの `watchAgentAPIStatus()` は `GET /events` で `status_change` イベントを待つが、ACP ブリッジには `/events` が存在しなかった
- ACP プロトコルには専用のステータス通知がなく、`session/prompt` の送受信タイミングで running/stable を判断する

## 変更内容

**`pkg/acp/bridge/bridge.go`**
- `Bridge` に `currentStatus`（`"running"` or `"stable"`）とサブスクライバー機構を追加
- `SendPrompt()` の開始時に `"running"`、`b.acp.Prompt()` 完了後に `"stable"` を設定

**`pkg/acp/bridge/server.go`**
- `GET /events` エンドポイントを追加
  - 初回接続時に現在のステータスを即座に `status_change` SSE で配信（再接続時も即座に現在状態を取得可能）
  - 以降はステータス遷移をストリームで配信

## Test plan

- [ ] CI が通ること
- [ ] ACP セッション起動後、status が `active` になること
- [ ] プロンプト送信中に status が `running` になること
- [ ] プロンプト完了後に status が `active`（stable）に戻ること

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)