### PR TITLE
fix(acp): dispatch JSON-RPC notifications synchronously to preserve chunk ordering

### DIFF
--- a/pkg/acp/jsonrpc/client.go
+++ b/pkg/acp/jsonrpc/client.go
@@ -245,9 +245,12 @@ func (c *Client) dispatch(ctx context.Context, msg *Message) {
 		}()
 
 	// Notification (no id)
+	// NOTE: handlers are called synchronously (no goroutine) to preserve the
+	// order in which notifications arrive.  Notification handlers must not
+	// block; use a non-blocking channel send or similar.
 	case msg.ID == nil && msg.Method != "":
 		if h, ok := c.notifHandlers[msg.Method]; ok {
-			go h(msg.Params)
+			h(msg.Params)
 		}
 	}
 }


### PR DESCRIPTION
## 問題

`pkg/acp/jsonrpc/client.go` の `dispatch` 関数が、受信した JSON-RPC notification を **goroutine で非同期** に処理していた：

```go
// 修正前
case msg.ID == nil && msg.Method != "":
    if h, ok := c.notifHandlers[msg.Method]; ok {
        go h(msg.Params)  // ← ここが原因
    }
```

`Listen` ループはメッセージを **逐次読み取る** が、goroutine をスポーンすることで複数の `session/update` chunk ハンドラが並列実行され、`updateCh` への書き込み順序が Go スケジューラ次第になる。

結果として、連続して届いた chunk 1 → chunk 2 が `updateCh` には chunk 2 → chunk 1 の順で入ることがあり、SSE クライアントがテキストを逆順・混在順で受信するバグが発生していた。

## 修正

notification ハンドラを同期呼び出しに変更：

```go
// 修正後
case msg.ID == nil && msg.Method != "":
    if h, ok := c.notifHandlers[msg.Method]; ok {
        h(msg.Params)  // 同期呼び出しで順序を保証
    }
```

`session/update` ハンドラは non-blocking な channel send のみ行うため、同期呼び出しでも `Listen` ループをブロックしない。

## 影響

- `acp-server` で長いレスポンスのテキストチャンクが稀に逆順になる問題を修正
- `notification handler は non-blocking であること` というコントラクトをコメントで明記

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)