### PR TITLE
feat(acp): add server-side timestamp to session/update notifications

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
 )
@@ -38,6 +39,7 @@ type rpcError struct {
 type sessionUpdateParams struct {
 	SessionId string            `json:"sessionId"`
 	Update    acp.SessionUpdate `json:"update"`
+	Time      time.Time         `json:"time"`
 }
 
 // ----------------------------------------------------------------------------
@@ -237,6 +239,7 @@ func (b *Bridge) emitUpdate(update acp.SessionUpdate) {
 		Params: sessionUpdateParams{
 			SessionId: b.sessionId,
 			Update:    update,
+			Time:      time.Now(),
 		},
 	}
 	b.broadcast(msg)
@@ -261,6 +264,7 @@ func (b *Bridge) flushChunkBufferLocked() {
 	b.chunkText.Reset()
 
 	contentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
+	now := time.Now()
 	msg := jsonRPCMsg{
 		JSONRPC: "2.0",
 		Method:  "session/update",
@@ -270,6 +274,7 @@ func (b *Bridge) flushChunkBufferLocked() {
 				Kind:    kind,
 				Content: json.RawMessage(contentRaw),
 			},
+			Time: now,
 		},
 	}
 	// broadcast without holding chunkMu to avoid lock-order inversion.
@@ -347,6 +352,7 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 				Kind:    acp.SessionUpdateKindUserMessageChunk,
 				Content: json.RawMessage(userContentRaw),
 			},
+			Time: time.Now(),
 		},
 	})
 


### PR DESCRIPTION
## Summary

- `sessionUpdateParams` に `time time.Time` フィールドを追加し、全ての `session/update` JSON-RPC 通知にサーバー側のタイムスタンプを含めるようにした
- `emitUpdate()`、`flushChunkBufferLocked()`、`SendPrompt()` の3箇所で `time.Now()` をセットするよう修正

## 背景

UI (agentapi-ui) がメッセージ履歴を `GET /messages` で取得する際、各メッセージに `time` フィールドがなかったため、UI 側で `new Date().toISOString()` (取得時刻) を代わりに使用していた。これにより、履歴を再生するとすべてのメッセージが同じ時刻（ページロード時刻）になってしまい、正確な投稿日時が表示できなかった。

## 関連

agentapi-ui 側の対応 PR (takutakahashi/agentapi-ui) も別途作成済み。UI 側では `params.time` が存在する場合にそれを優先して使用するよう修正する。

## Test plan

- [ ] ACP セッションでメッセージ送受信後、`GET /messages` レスポンスの各 `session/update` 通知の `params.time` にタイムスタンプが含まれることを確認
- [ ] ページリロード後の履歴表示で正確な投稿時刻が表示されることを UI で確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)