### PR TITLE
feat(acp): add ACP session management endpoints

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -26,6 +26,7 @@ type HandlerRegistry struct {
 	notificationHandlers     *controllers.NotificationHandlers
 	healthController         *controllers.HealthController
 	sessionController        *controllers.SessionController
+	acpController            *controllers.ACPController
 	settingsController       *controllers.SettingsController
 	credentialsController    *controllers.CredentialsController
 	userController           *controllers.UserController
@@ -124,6 +125,8 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] File controller initialized")
 	}
 
+	acpController := controllers.NewACPController(server, server)
+
 	return &Router{
 		echo:   e,
 		server: server,
@@ -131,6 +134,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 			notificationHandlers:     controllers.NewNotificationHandlers(server.notificationSvc, server.sessionManager),
 			healthController:         controllers.NewHealthController(),
 			sessionController:        sessionController,
+			acpController:            acpController,
 			settingsController:       settingsController,
 			credentialsController:    credentialsController,
 			userController:           controllers.NewUserController(),
@@ -181,6 +185,12 @@ func (r *Router) registerCoreRoutes() error {
 	// Must be registered before the /:sessionId/* catch-all route
 	r.echo.StaticFS("/public", spec.FS())
 	log.Printf("[ROUTES] Static file serving registered at /public/*")
+
+	// ACP (Agent Client Protocol) JSON-RPC 2.0 endpoints
+	log.Printf("[ROUTES] Registering ACP endpoints...")
+	r.echo.POST("/acp", r.handlers.acpController.HandleRPC, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+	r.echo.GET("/acp/sse", r.handlers.acpController.HandleSSE, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+	log.Printf("[ROUTES] ACP endpoints registered")
 
 	// Session management routes
 	log.Printf("[ROUTES] Registering session management endpoints...")

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -334,8 +334,10 @@ func (c *ACPController) handleSessionResume(ctx echo.Context, req acpRequest) er
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "permission denied"))
 	}
 
+	// "active" is the proxy-level status for a running K8s session.
+	// "running"/"stable" are agentapi-level statuses used in other contexts.
 	status := session.Status()
-	if status != "running" && status != "stable" {
+	if status != "active" && status != "running" && status != "stable" {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "session is not active (status: "+status+")"))
 	}
 

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -138,7 +138,8 @@ type sessionNewParams struct {
 	Meta       struct {
 		Tags   map[string]string `json:"tags"`
 		Params struct {
-			Message string `json:"message"`
+			Message   string `json:"message"`
+			AgentType string `json:"agentType"`
 		} `json:"params"`
 	} `json:"_meta"`
 }
@@ -172,7 +173,8 @@ func (c *ACPController) handleSessionNew(ctx echo.Context, req acpRequest) error
 		Scope: entities.ScopeUser,
 		Tags:  tags,
 		Params: &entities.SessionParams{
-			Message: params.Meta.Params.Message,
+			Message:   params.Meta.Params.Message,
+			AgentType: params.Meta.Params.AgentType,
 		},
 	}
 

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -1,0 +1,545 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+const (
+	acpProtocolVersion = "2025-01-15"
+	acpSessionListLimit = 20
+)
+
+// ACPController handles ACP (Agent Client Protocol) JSON-RPC 2.0 endpoints.
+// POST /acp  – JSON-RPC request/response
+// GET  /acp/sse – SSE stream of session/update notifications
+type ACPController struct {
+	sessionManagerProvider SessionManagerProvider
+	sessionCreator         SessionCreator
+}
+
+// NewACPController creates a new ACPController.
+func NewACPController(
+	sessionManagerProvider SessionManagerProvider,
+	sessionCreator SessionCreator,
+) *ACPController {
+	return &ACPController{
+		sessionManagerProvider: sessionManagerProvider,
+		sessionCreator:         sessionCreator,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Wire types
+// ----------------------------------------------------------------------------
+
+type acpRequest struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method"`
+	Params  json.RawMessage  `json:"params,omitempty"`
+}
+
+type acpResponse struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Result  interface{}      `json:"result,omitempty"`
+	Error   *acpRPCError     `json:"error,omitempty"`
+}
+
+type acpRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func acpSuccessResp(id *json.RawMessage, result interface{}) acpResponse {
+	return acpResponse{JSONRPC: "2.0", ID: id, Result: result}
+}
+
+func acpErrResp(id *json.RawMessage, code int, message string) acpResponse {
+	return acpResponse{JSONRPC: "2.0", ID: id, Error: &acpRPCError{Code: code, Message: message}}
+}
+
+// ----------------------------------------------------------------------------
+// HandleRPC – POST /acp
+// ----------------------------------------------------------------------------
+
+// HandleRPC handles POST /acp (JSON-RPC 2.0).
+func (c *ACPController) HandleRPC(ctx echo.Context) error {
+	var req acpRequest
+	if err := ctx.Bind(&req); err != nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(nil, -32700, "Parse error"))
+	}
+	if req.JSONRPC != "2.0" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32600, "Invalid Request: jsonrpc must be \"2.0\""))
+	}
+
+	switch req.Method {
+	case "initialize":
+		return c.handleInitialize(ctx, req)
+	case "session/new":
+		return c.handleSessionNew(ctx, req)
+	case "session/list":
+		return c.handleSessionList(ctx, req)
+	case "session/close":
+		return c.handleSessionClose(ctx, req)
+	case "session/resume":
+		return c.handleSessionResume(ctx, req)
+	case "session/load":
+		return c.handleSessionLoad(ctx, req)
+	case "session/prompt", "session/cancel":
+		return c.proxyToBridge(ctx, req)
+	default:
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32601, "Method not found: "+req.Method))
+	}
+}
+
+// ----------------------------------------------------------------------------
+// initialize
+// ----------------------------------------------------------------------------
+
+func (c *ACPController) handleInitialize(ctx echo.Context, req acpRequest) error {
+	result := map[string]interface{}{
+		"protocolVersion": acpProtocolVersion,
+		"capabilities": map[string]interface{}{
+			"sessionCapabilities": map[string]bool{
+				"list":        true,
+				"close":       true,
+				"resume":      true,
+				"loadSession": true,
+			},
+		},
+		"serverInfo": map[string]string{
+			"name": "agentapi-proxy",
+		},
+	}
+	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, result))
+}
+
+// ----------------------------------------------------------------------------
+// session/new
+// ----------------------------------------------------------------------------
+
+type sessionNewParams struct {
+	Cwd        string      `json:"cwd"`
+	McpServers interface{} `json:"mcpServers"`
+	Meta       struct {
+		Tags   map[string]string `json:"tags"`
+		Params struct {
+			Message string `json:"message"`
+		} `json:"params"`
+	} `json:"_meta"`
+}
+
+func (c *ACPController) handleSessionNew(ctx echo.Context, req acpRequest) error {
+	var params sessionNewParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
+		}
+	}
+	if params.Cwd == "" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "cwd is required"))
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	userID := authzCtx.PersonalScope.UserID
+	userRole := "user"
+	if authzCtx.User != nil && len(authzCtx.User.Roles()) > 0 {
+		userRole = string(authzCtx.User.Roles()[0])
+	}
+	teams := authzCtx.TeamScope.Teams
+
+	tags := make(map[string]string)
+	for k, v := range params.Meta.Tags {
+		tags[k] = v
+	}
+	tags["cwd"] = params.Cwd
+
+	startReq := entities.StartRequest{
+		Scope: entities.ScopeUser,
+		Tags:  tags,
+		Params: &entities.SessionParams{
+			Message: params.Meta.Params.Message,
+		},
+	}
+
+	resolvedScope, resolvedTeamID := authzCtx.ResolveScope(string(startReq.Scope), startReq.TeamID)
+	startReq.Scope = entities.ResourceScope(resolvedScope)
+	startReq.TeamID = resolvedTeamID
+
+	sessionID := uuid.New().String()
+	_, err := c.sessionCreator.CreateSession(sessionID, startReq, userID, userRole, teams)
+	if err != nil {
+		log.Printf("[ACP] session/new failed: %v", err)
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to create session: "+err.Error()))
+	}
+
+	log.Printf("[ACP] session/new created sessionId=%s for user=%s", sessionID, userID)
+	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, map[string]string{
+		"sessionId": sessionID,
+	}))
+}
+
+// ----------------------------------------------------------------------------
+// session/list
+// ----------------------------------------------------------------------------
+
+type sessionListParams struct {
+	Cwd    string `json:"cwd"`
+	Cursor string `json:"cursor"`
+}
+
+func (c *ACPController) handleSessionList(ctx echo.Context, req acpRequest) error {
+	var params sessionListParams
+	if len(req.Params) > 0 {
+		_ = json.Unmarshal(req.Params, &params)
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	userID := authzCtx.PersonalScope.UserID
+
+	filter := entities.SessionFilter{
+		UserID: userID,
+		Scope:  entities.ScopeUser,
+	}
+	if params.Cwd != "" {
+		filter.Tags = map[string]string{"cwd": params.Cwd}
+	}
+
+	sessions := c.sessionManagerProvider.GetSessionManager().ListSessions(filter)
+
+	// Decode cursor to determine start index.
+	startIdx := 0
+	if params.Cursor != "" {
+		if decoded, err := base64.StdEncoding.DecodeString(params.Cursor); err == nil {
+			cursorID := string(decoded)
+			for i, s := range sessions {
+				if s.ID() == cursorID {
+					startIdx = i + 1
+					break
+				}
+			}
+		}
+	}
+
+	endIdx := startIdx + acpSessionListLimit
+	var nextCursor string
+	if endIdx < len(sessions) {
+		nextCursor = base64.StdEncoding.EncodeToString([]byte(sessions[endIdx-1].ID()))
+	} else {
+		endIdx = len(sessions)
+	}
+
+	result := make([]map[string]interface{}, 0, endIdx-startIdx)
+	for _, s := range sessions[startIdx:endIdx] {
+		result = append(result, map[string]interface{}{
+			"sessionId": s.ID(),
+			"cwd":       s.Tags()["cwd"],
+			"title":     s.Description(),
+			"updatedAt": s.UpdatedAt().Format(time.RFC3339),
+			"_meta": map[string]interface{}{
+				"status": s.Status(),
+				"scope":  string(s.Scope()),
+				"teamId": s.TeamID(),
+				"tags":   s.Tags(),
+			},
+		})
+	}
+
+	resp := map[string]interface{}{
+		"sessions": result,
+	}
+	if nextCursor != "" {
+		resp["nextCursor"] = nextCursor
+	}
+	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, resp))
+}
+
+// ----------------------------------------------------------------------------
+// session/close
+// ----------------------------------------------------------------------------
+
+func (c *ACPController) handleSessionClose(ctx echo.Context, req acpRequest) error {
+	var params struct {
+		SessionId string `json:"sessionId"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
+		}
+	}
+	if params.SessionId == "" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "sessionId is required"))
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	session := c.sessionManagerProvider.GetSessionManager().GetSession(params.SessionId)
+	if session == nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "session not found"))
+	}
+	if !authzCtx.CanModifyResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "permission denied"))
+	}
+
+	if err := c.sessionCreator.DeleteSessionByID(params.SessionId); err != nil {
+		log.Printf("[ACP] session/close failed: %v", err)
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to close session: "+err.Error()))
+	}
+
+	log.Printf("[ACP] session/close sessionId=%s", params.SessionId)
+	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
+}
+
+// ----------------------------------------------------------------------------
+// session/resume
+// ----------------------------------------------------------------------------
+
+func (c *ACPController) handleSessionResume(ctx echo.Context, req acpRequest) error {
+	var params struct {
+		SessionId string `json:"sessionId"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
+		}
+	}
+	if params.SessionId == "" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "sessionId is required"))
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	session := c.sessionManagerProvider.GetSessionManager().GetSession(params.SessionId)
+	if session == nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "session not found"))
+	}
+	if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "permission denied"))
+	}
+
+	status := session.Status()
+	if status != "running" && status != "stable" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "session is not active (status: "+status+")"))
+	}
+
+	log.Printf("[ACP] session/resume sessionId=%s status=%s", params.SessionId, status)
+	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
+}
+
+// ----------------------------------------------------------------------------
+// session/load
+// ----------------------------------------------------------------------------
+
+// handleSessionLoad confirms the session exists and returns {}.
+// History replay is handled by the SSE endpoint (GET /acp/sse) which automatically
+// replays stored bridge messages when a client connects.
+func (c *ACPController) handleSessionLoad(ctx echo.Context, req acpRequest) error {
+	var params struct {
+		SessionId string `json:"sessionId"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
+		}
+	}
+	if params.SessionId == "" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "sessionId is required"))
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	session := c.sessionManagerProvider.GetSessionManager().GetSession(params.SessionId)
+	if session == nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "session not found"))
+	}
+	if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "permission denied"))
+	}
+
+	log.Printf("[ACP] session/load sessionId=%s (history replay via GET /acp/sse)", params.SessionId)
+	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
+}
+
+// ----------------------------------------------------------------------------
+// proxy to bridge (session/prompt, session/cancel)
+// ----------------------------------------------------------------------------
+
+func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
+	var params struct {
+		SessionId string `json:"sessionId"`
+	}
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
+		}
+	}
+	if params.SessionId == "" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "sessionId is required"))
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	session := c.sessionManagerProvider.GetSessionManager().GetSession(params.SessionId)
+	if session == nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "session not found"))
+	}
+	if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "permission denied"))
+	}
+
+	addr := session.Addr()
+	if addr == "" {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "session has no address"))
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to marshal request"))
+	}
+
+	bridgeURL := "http://" + addr + "/rpc"
+	log.Printf("[ACP] proxy %s → %s", req.Method, bridgeURL)
+
+	resp, err := http.Post(bridgeURL, "application/json", bytes.NewReader(body)) //nolint:gosec
+	if err != nil {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "bridge unreachable: "+err.Error()))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusAccepted {
+		// Async: result will arrive via SSE.
+		return ctx.JSON(http.StatusAccepted, map[string]bool{"ok": true})
+	}
+
+	var bridgeResp interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&bridgeResp)
+	return ctx.JSON(resp.StatusCode, bridgeResp)
+}
+
+// ----------------------------------------------------------------------------
+// HandleSSE – GET /acp/sse
+// ----------------------------------------------------------------------------
+
+// HandleSSE handles GET /acp/sse?session_id=<id>.
+// On connect it replays the stored message history from the bridge, then streams
+// live session/update notifications until the client disconnects.
+func (c *ACPController) HandleSSE(ctx echo.Context) error {
+	sessionId := ctx.QueryParam("session_id")
+	if sessionId == "" {
+		return ctx.JSON(http.StatusBadRequest, map[string]string{"message": "session_id is required"})
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	session := c.sessionManagerProvider.GetSessionManager().GetSession(sessionId)
+	if session == nil {
+		return ctx.JSON(http.StatusNotFound, map[string]string{"message": "session not found"})
+	}
+	if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return ctx.JSON(http.StatusForbidden, map[string]string{"message": "permission denied"})
+	}
+
+	addr := session.Addr()
+	if addr == "" {
+		return ctx.JSON(http.StatusServiceUnavailable, map[string]string{"message": "session has no address"})
+	}
+
+	w := ctx.Response()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, hasFlusher := w.Writer.(http.Flusher)
+
+	// Replay history from the bridge's /messages endpoint.
+	if err := c.replayHistory(addr, w, flusher, hasFlusher); err != nil {
+		log.Printf("[ACP] SSE history replay error (session=%s): %v", sessionId, err)
+	}
+
+	// Stream live events from the bridge's /sse endpoint.
+	c.streamBridgeSSE(ctx.Request().Context(), addr, w, flusher, hasFlusher)
+	return nil
+}
+
+// replayHistory fetches and writes all stored bridge messages as SSE events.
+func (c *ACPController) replayHistory(addr string, w io.Writer, flusher http.Flusher, hasFlusher bool) error {
+	resp, err := http.Get("http://" + addr + "/messages") //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var histResp struct {
+		Messages []json.RawMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&histResp); err != nil {
+		return err
+	}
+
+	for _, raw := range histResp.Messages {
+		if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", raw); err != nil {
+			return err
+		}
+		if hasFlusher {
+			flusher.Flush()
+		}
+	}
+	return nil
+}
+
+// streamBridgeSSE proxies the bridge's /sse stream to the current response writer.
+func (c *ACPController) streamBridgeSSE(ctx interface{ Done() <-chan struct{} }, addr string, w io.Writer, flusher http.Flusher, hasFlusher bool) {
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/sse", nil)
+	if err != nil {
+		log.Printf("[ACP] SSE: failed to create bridge request: %v", err)
+		return
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("[ACP] SSE: failed to connect to bridge: %v", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			data := buf[:n]
+			// Pass through SSE lines, re-emitting only "data:" lines as proper SSE events.
+			for _, line := range strings.Split(string(data), "\n") {
+				if strings.HasPrefix(line, "data: ") {
+					jsonData := strings.TrimPrefix(line, "data: ")
+					if jsonData != "" {
+						_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", jsonData)
+						if hasFlusher {
+							flusher.Flush()
+						}
+					}
+				}
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -377,7 +377,7 @@ func (c *ACPController) handleSessionLoad(ctx echo.Context, req acpRequest) erro
 }
 
 // ----------------------------------------------------------------------------
-// session/prompt and session/cancel → agentapi native API
+// session/prompt and session/cancel
 // ----------------------------------------------------------------------------
 
 type sessionPromptParams struct {
@@ -388,9 +388,9 @@ type sessionPromptParams struct {
 	} `json:"prompt"`
 }
 
-// proxyToBridge translates ACP session/prompt and session/cancel to the agentapi
-// native HTTP API (POST /message). The session address in K8s points directly to
-// the agentapi process, which has no /rpc endpoint.
+// proxyToBridge handles session/prompt and session/cancel.
+// It tries the ACP /rpc endpoint first (used by claude-acp agent type), and falls
+// back to the agentapi REST /message endpoint for standard agentapi sessions.
 func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 	var baseParams struct {
 		SessionId string `json:"sessionId"`
@@ -418,12 +418,16 @@ func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "session has no address"))
 	}
 
+	// Try ACP /rpc endpoint (claude-acp agent type runs an ACP bridge that exposes /rpc).
+	if handled, err := c.tryRPCProxy(ctx, req, addr); handled {
+		return err
+	}
+
+	// Fall back to agentapi REST API (standard agentapi sessions, no /rpc endpoint).
 	if req.Method == "session/cancel" {
-		// Send Ctrl+C as a raw keystroke to interrupt the agent.
 		return c.sendAgentapiMessage(ctx, req, addr, "raw", "\x03")
 	}
 
-	// session/prompt: extract text content blocks and send as a user message.
 	var promptParams sessionPromptParams
 	if len(req.Params) > 0 {
 		if err := json.Unmarshal(req.Params, &promptParams); err != nil {
@@ -439,11 +443,41 @@ func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 	if len(textParts) == 0 {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "no text content in prompt"))
 	}
-	content := strings.Join(textParts, "\n")
-	return c.sendAgentapiMessage(ctx, req, addr, "user", content)
+	return c.sendAgentapiMessage(ctx, req, addr, "user", strings.Join(textParts, "\n"))
 }
 
-// sendAgentapiMessage POSTs to the agentapi /message endpoint.
+// tryRPCProxy POSTs the JSON-RPC request to the backend /rpc endpoint.
+// Returns (true, result) if the backend has /rpc; returns (false, nil) on 404 so the
+// caller can fall back to the agentapi REST API.
+func (c *ACPController) tryRPCProxy(ctx echo.Context, req acpRequest, addr string) (bool, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return true, ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to marshal request"))
+	}
+
+	rpcURL := "http://" + addr + "/rpc"
+	log.Printf("[ACP] %s → POST %s (trying ACP bridge)", req.Method, rpcURL)
+
+	resp, err := http.Post(rpcURL, "application/json", bytes.NewReader(body)) //nolint:gosec
+	if err != nil {
+		return true, ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "bridge unreachable: "+err.Error()))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		log.Printf("[ACP] %s: /rpc not found, falling back to agentapi REST", req.Method)
+		return false, nil
+	}
+	if resp.StatusCode == http.StatusAccepted {
+		return true, ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
+	}
+
+	var rpcResp interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&rpcResp)
+	return true, ctx.JSON(resp.StatusCode, rpcResp)
+}
+
+// sendAgentapiMessage POSTs to the agentapi REST /message endpoint.
 func (c *ACPController) sendAgentapiMessage(ctx echo.Context, req acpRequest, addr, msgType, content string) error {
 	body, err := json.Marshal(map[string]string{"type": msgType, "content": content})
 	if err != nil {
@@ -462,8 +496,6 @@ func (c *ACPController) sendAgentapiMessage(ctx echo.Context, req acpRequest, ad
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
 	}
-	var agentResp interface{}
-	_ = json.NewDecoder(resp.Body).Decode(&agentResp)
 	return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, fmt.Sprintf("agentapi error (HTTP %d)", resp.StatusCode)))
 }
 
@@ -539,9 +571,21 @@ func (c *ACPController) replayHistory(addr string, w io.Writer, flusher http.Flu
 	return nil
 }
 
-// streamBridgeSSE proxies the agentapi /events SSE stream to the current response writer.
+// streamBridgeSSE proxies the backend SSE stream to the current response writer.
+// It tries /sse first (ACP bridge, used by claude-acp) and falls back to /events
+// (standard agentapi) if /sse returns 404.
 func (c *ACPController) streamBridgeSSE(ctx interface{ Done() <-chan struct{} }, addr string, w io.Writer, flusher http.Flusher, hasFlusher bool) {
-	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/events", nil)
+	sseURL := "http://" + addr + "/sse"
+	probeReq, _ := http.NewRequest(http.MethodGet, sseURL, nil)
+	if probeResp, err := http.DefaultClient.Do(probeReq); err == nil && probeResp.StatusCode == http.StatusNotFound {
+		_ = probeResp.Body.Close()
+		sseURL = "http://" + addr + "/events"
+		log.Printf("[ACP] SSE: /sse not found, falling back to /events")
+	} else if probeResp != nil {
+		_ = probeResp.Body.Close()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, sseURL, nil)
 	if err != nil {
 		log.Printf("[ACP] SSE: failed to create bridge request: %v", err)
 		return

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	acpProtocolVersion = "2025-01-15"
+	acpProtocolVersion  = "2025-01-15"
 	acpSessionListLimit = 20
 )
 
@@ -181,15 +181,18 @@ func (c *ACPController) handleSessionNew(ctx echo.Context, req acpRequest) error
 	startReq.TeamID = resolvedTeamID
 
 	sessionID := uuid.New().String()
-	_, err := c.sessionCreator.CreateSession(sessionID, startReq, userID, userRole, teams)
+	session, err := c.sessionCreator.CreateSession(sessionID, startReq, userID, userRole, teams)
 	if err != nil {
 		log.Printf("[ACP] session/new failed: %v", err)
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to create session: "+err.Error()))
 	}
 
-	log.Printf("[ACP] session/new created sessionId=%s for user=%s", sessionID, userID)
+	// Use the actual session ID from the returned entity: a stock K8s session may have been
+	// adopted with a different ID than the one we generated.
+	actualID := session.ID()
+	log.Printf("[ACP] session/new created sessionId=%s for user=%s", actualID, userID)
 	return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, map[string]string{
-		"sessionId": sessionID,
+		"sessionId": actualID,
 	}))
 }
 

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -425,13 +425,13 @@ func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode == http.StatusAccepted {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
 	}
 
 	var rpcResp interface{}
 	_ = json.NewDecoder(resp.Body).Decode(&rpcResp)
-	return ctx.JSON(resp.StatusCode, rpcResp)
+	return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, fmt.Sprintf("bridge error (HTTP %d)", resp.StatusCode)))
 }
 
 // ----------------------------------------------------------------------------

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -375,24 +375,35 @@ func (c *ACPController) handleSessionLoad(ctx echo.Context, req acpRequest) erro
 }
 
 // ----------------------------------------------------------------------------
-// proxy to bridge (session/prompt, session/cancel)
+// session/prompt and session/cancel → agentapi native API
 // ----------------------------------------------------------------------------
 
+type sessionPromptParams struct {
+	SessionId string `json:"sessionId"`
+	Prompt    []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"prompt"`
+}
+
+// proxyToBridge translates ACP session/prompt and session/cancel to the agentapi
+// native HTTP API (POST /message). The session address in K8s points directly to
+// the agentapi process, which has no /rpc endpoint.
 func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
-	var params struct {
+	var baseParams struct {
 		SessionId string `json:"sessionId"`
 	}
 	if len(req.Params) > 0 {
-		if err := json.Unmarshal(req.Params, &params); err != nil {
+		if err := json.Unmarshal(req.Params, &baseParams); err != nil {
 			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
 		}
 	}
-	if params.SessionId == "" {
+	if baseParams.SessionId == "" {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "sessionId is required"))
 	}
 
 	authzCtx := auth.GetAuthorizationContext(ctx)
-	session := c.sessionManagerProvider.GetSessionManager().GetSession(params.SessionId)
+	session := c.sessionManagerProvider.GetSessionManager().GetSession(baseParams.SessionId)
 	if session == nil {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "session not found"))
 	}
@@ -405,28 +416,53 @@ func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "session has no address"))
 	}
 
-	body, err := json.Marshal(req)
+	if req.Method == "session/cancel" {
+		// Send Ctrl+C as a raw keystroke to interrupt the agent.
+		return c.sendAgentapiMessage(ctx, req, addr, "raw", "\x03")
+	}
+
+	// session/prompt: extract text content blocks and send as a user message.
+	var promptParams sessionPromptParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &promptParams); err != nil {
+			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
+		}
+	}
+	var textParts []string
+	for _, block := range promptParams.Prompt {
+		if block.Type == "text" && block.Text != "" {
+			textParts = append(textParts, block.Text)
+		}
+	}
+	if len(textParts) == 0 {
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "no text content in prompt"))
+	}
+	content := strings.Join(textParts, "\n")
+	return c.sendAgentapiMessage(ctx, req, addr, "user", content)
+}
+
+// sendAgentapiMessage POSTs to the agentapi /message endpoint.
+func (c *ACPController) sendAgentapiMessage(ctx echo.Context, req acpRequest, addr, msgType, content string) error {
+	body, err := json.Marshal(map[string]string{"type": msgType, "content": content})
 	if err != nil {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to marshal request"))
 	}
 
-	bridgeURL := "http://" + addr + "/rpc"
-	log.Printf("[ACP] proxy %s → %s", req.Method, bridgeURL)
+	msgURL := "http://" + addr + "/message"
+	log.Printf("[ACP] %s → POST %s (type=%s)", req.Method, msgURL, msgType)
 
-	resp, err := http.Post(bridgeURL, "application/json", bytes.NewReader(body)) //nolint:gosec
+	resp, err := http.Post(msgURL, "application/json", bytes.NewReader(body)) //nolint:gosec
 	if err != nil {
-		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "bridge unreachable: "+err.Error()))
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "agentapi unreachable: "+err.Error()))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode == http.StatusAccepted {
-		// Async: result will arrive via SSE.
-		return ctx.JSON(http.StatusAccepted, map[string]bool{"ok": true})
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
 	}
-
-	var bridgeResp interface{}
-	_ = json.NewDecoder(resp.Body).Decode(&bridgeResp)
-	return ctx.JSON(resp.StatusCode, bridgeResp)
+	var agentResp interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&agentResp)
+	return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, fmt.Sprintf("agentapi error (HTTP %d)", resp.StatusCode)))
 }
 
 // ----------------------------------------------------------------------------
@@ -501,9 +537,9 @@ func (c *ACPController) replayHistory(addr string, w io.Writer, flusher http.Flu
 	return nil
 }
 
-// streamBridgeSSE proxies the bridge's /sse stream to the current response writer.
+// streamBridgeSSE proxies the agentapi /events SSE stream to the current response writer.
 func (c *ACPController) streamBridgeSSE(ctx interface{ Done() <-chan struct{} }, addr string, w io.Writer, flusher http.Flusher, hasFlusher bool) {
-	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/sse", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/events", nil)
 	if err != nil {
 		log.Printf("[ACP] SSE: failed to create bridge request: %v", err)
 		return

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -377,20 +377,11 @@ func (c *ACPController) handleSessionLoad(ctx echo.Context, req acpRequest) erro
 }
 
 // ----------------------------------------------------------------------------
-// session/prompt and session/cancel
+// session/prompt and session/cancel → ACP bridge /rpc
 // ----------------------------------------------------------------------------
 
-type sessionPromptParams struct {
-	SessionId string `json:"sessionId"`
-	Prompt    []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	} `json:"prompt"`
-}
-
-// proxyToBridge handles session/prompt and session/cancel.
-// It tries the ACP /rpc endpoint first (used by claude-acp agent type), and falls
-// back to the agentapi REST /message endpoint for standard agentapi sessions.
+// proxyToBridge forwards session/prompt and session/cancel to the ACP bridge's
+// /rpc endpoint. Requires the session to run with an ACP-native agent (e.g. claude-acp).
 func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 	var baseParams struct {
 		SessionId string `json:"sessionId"`
@@ -418,85 +409,27 @@ func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "session has no address"))
 	}
 
-	// Try ACP /rpc endpoint (claude-acp agent type runs an ACP bridge that exposes /rpc).
-	if handled, err := c.tryRPCProxy(ctx, req, addr); handled {
-		return err
-	}
-
-	// Fall back to agentapi REST API (standard agentapi sessions, no /rpc endpoint).
-	if req.Method == "session/cancel" {
-		return c.sendAgentapiMessage(ctx, req, addr, "raw", "\x03")
-	}
-
-	var promptParams sessionPromptParams
-	if len(req.Params) > 0 {
-		if err := json.Unmarshal(req.Params, &promptParams); err != nil {
-			return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "invalid params: "+err.Error()))
-		}
-	}
-	var textParts []string
-	for _, block := range promptParams.Prompt {
-		if block.Type == "text" && block.Text != "" {
-			textParts = append(textParts, block.Text)
-		}
-	}
-	if len(textParts) == 0 {
-		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32602, "no text content in prompt"))
-	}
-	return c.sendAgentapiMessage(ctx, req, addr, "user", strings.Join(textParts, "\n"))
-}
-
-// tryRPCProxy POSTs the JSON-RPC request to the backend /rpc endpoint.
-// Returns (true, result) if the backend has /rpc; returns (false, nil) on 404 so the
-// caller can fall back to the agentapi REST API.
-func (c *ACPController) tryRPCProxy(ctx echo.Context, req acpRequest, addr string) (bool, error) {
 	body, err := json.Marshal(req)
-	if err != nil {
-		return true, ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to marshal request"))
-	}
-
-	rpcURL := "http://" + addr + "/rpc"
-	log.Printf("[ACP] %s → POST %s (trying ACP bridge)", req.Method, rpcURL)
-
-	resp, err := http.Post(rpcURL, "application/json", bytes.NewReader(body)) //nolint:gosec
-	if err != nil {
-		return true, ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "bridge unreachable: "+err.Error()))
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound {
-		log.Printf("[ACP] %s: /rpc not found, falling back to agentapi REST", req.Method)
-		return false, nil
-	}
-	if resp.StatusCode == http.StatusAccepted {
-		return true, ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
-	}
-
-	var rpcResp interface{}
-	_ = json.NewDecoder(resp.Body).Decode(&rpcResp)
-	return true, ctx.JSON(resp.StatusCode, rpcResp)
-}
-
-// sendAgentapiMessage POSTs to the agentapi REST /message endpoint.
-func (c *ACPController) sendAgentapiMessage(ctx echo.Context, req acpRequest, addr, msgType, content string) error {
-	body, err := json.Marshal(map[string]string{"type": msgType, "content": content})
 	if err != nil {
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to marshal request"))
 	}
 
-	msgURL := "http://" + addr + "/message"
-	log.Printf("[ACP] %s → POST %s (type=%s)", req.Method, msgURL, msgType)
+	rpcURL := "http://" + addr + "/rpc"
+	log.Printf("[ACP] %s → POST %s", req.Method, rpcURL)
 
-	resp, err := http.Post(msgURL, "application/json", bytes.NewReader(body)) //nolint:gosec
+	resp, err := http.Post(rpcURL, "application/json", bytes.NewReader(body)) //nolint:gosec
 	if err != nil {
-		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "agentapi unreachable: "+err.Error()))
+		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "bridge unreachable: "+err.Error()))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+	if resp.StatusCode == http.StatusAccepted {
 		return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
 	}
-	return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, fmt.Sprintf("agentapi error (HTTP %d)", resp.StatusCode)))
+
+	var rpcResp interface{}
+	_ = json.NewDecoder(resp.Body).Decode(&rpcResp)
+	return ctx.JSON(resp.StatusCode, rpcResp)
 }
 
 // ----------------------------------------------------------------------------
@@ -571,21 +504,9 @@ func (c *ACPController) replayHistory(addr string, w io.Writer, flusher http.Flu
 	return nil
 }
 
-// streamBridgeSSE proxies the backend SSE stream to the current response writer.
-// It tries /sse first (ACP bridge, used by claude-acp) and falls back to /events
-// (standard agentapi) if /sse returns 404.
+// streamBridgeSSE proxies the ACP bridge's /sse stream to the current response writer.
 func (c *ACPController) streamBridgeSSE(ctx interface{ Done() <-chan struct{} }, addr string, w io.Writer, flusher http.Flusher, hasFlusher bool) {
-	sseURL := "http://" + addr + "/sse"
-	probeReq, _ := http.NewRequest(http.MethodGet, sseURL, nil)
-	if probeResp, err := http.DefaultClient.Do(probeReq); err == nil && probeResp.StatusCode == http.StatusNotFound {
-		_ = probeResp.Body.Close()
-		sseURL = "http://" + addr + "/events"
-		log.Printf("[ACP] SSE: /sse not found, falling back to /events")
-	} else if probeResp != nil {
-		_ = probeResp.Body.Close()
-	}
-
-	req, err := http.NewRequest(http.MethodGet, sseURL, nil)
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/sse", nil)
 	if err != nil {
 		log.Printf("[ACP] SSE: failed to create bridge request: %v", err)
 		return

--- a/internal/interfaces/controllers/acp_controller_test.go
+++ b/internal/interfaces/controllers/acp_controller_test.go
@@ -1,0 +1,471 @@
+package controllers_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// ----------------------------------------------------------------------------
+// Fakes
+// ----------------------------------------------------------------------------
+
+type fakeSession struct {
+	id          string
+	addr        string
+	userID      string
+	scope       entities.ResourceScope
+	teamID      string
+	tags        map[string]string
+	status      string
+	startedAt   time.Time
+	updatedAt   time.Time
+	description string
+}
+
+func (s *fakeSession) ID() string                   { return s.id }
+func (s *fakeSession) Addr() string                  { return s.addr }
+func (s *fakeSession) UserID() string                { return s.userID }
+func (s *fakeSession) Scope() entities.ResourceScope { return s.scope }
+func (s *fakeSession) TeamID() string                { return s.teamID }
+func (s *fakeSession) Tags() map[string]string       { return s.tags }
+func (s *fakeSession) Status() string                { return s.status }
+func (s *fakeSession) StartedAt() time.Time          { return s.startedAt }
+func (s *fakeSession) UpdatedAt() time.Time          { return s.updatedAt }
+func (s *fakeSession) LastMessageAt() time.Time      { return s.updatedAt }
+func (s *fakeSession) Description() string           { return s.description }
+func (s *fakeSession) Cancel()                       {}
+
+// fakeSessionManager implements repositories.SessionManager for tests.
+type fakeSessionManager struct {
+	sessions map[string]*fakeSession
+}
+
+func (m *fakeSessionManager) GetSession(id string) entities.Session {
+	s, ok := m.sessions[id]
+	if !ok {
+		return nil
+	}
+	return s
+}
+
+func (m *fakeSessionManager) ListSessions(filter entities.SessionFilter) []entities.Session {
+	out := make([]entities.Session, 0)
+	for _, s := range m.sessions {
+		if filter.UserID != "" && s.userID != filter.UserID {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// Stubs to satisfy repositories.SessionManager interface.
+func (m *fakeSessionManager) CreateSession(_ context.Context, _ string, _ *entities.RunServerRequest, _ []byte) (entities.Session, error) {
+	return nil, nil
+}
+func (m *fakeSessionManager) DeleteSession(_ string) error { return nil }
+func (m *fakeSessionManager) SendMessage(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (m *fakeSessionManager) StopAgent(_ context.Context, _ string) error { return nil }
+func (m *fakeSessionManager) GetMessages(_ context.Context, _ string) ([]repositories.Message, error) {
+	return nil, nil
+}
+func (m *fakeSessionManager) Shutdown(_ time.Duration) error { return nil }
+
+// testSessionManagerProvider adapts fakeSessionManager to controllers.SessionManagerProvider.
+type testSessionManagerProvider struct {
+	mgr *fakeSessionManager
+}
+
+func (p *testSessionManagerProvider) GetSessionManager() repositories.SessionManager {
+	return p.mgr
+}
+
+// fakeSessionCreator tracks CreateSession and DeleteSessionByID calls.
+type fakeSessionCreator struct {
+	created []string
+	deleted []string
+}
+
+func (c *fakeSessionCreator) CreateSession(sessionID string, req entities.StartRequest, userID, userRole string, teams []string) (entities.Session, error) {
+	c.created = append(c.created, sessionID)
+	return &fakeSession{id: sessionID, userID: userID, scope: req.Scope, status: "running"}, nil
+}
+
+func (c *fakeSessionCreator) DeleteSessionByID(sessionID string) error {
+	c.deleted = append(c.deleted, sessionID)
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// Test helpers
+// ----------------------------------------------------------------------------
+
+func newEchoWithACP(sessions map[string]*fakeSession) (*echo.Echo, *controllers.ACPController, *fakeSessionCreator) {
+	e := echo.New()
+	if sessions == nil {
+		sessions = map[string]*fakeSession{}
+	}
+	mgr := &fakeSessionManager{sessions: sessions}
+	creator := &fakeSessionCreator{}
+	provider := &testSessionManagerProvider{mgr: mgr}
+	ctrl := controllers.NewACPController(provider, creator)
+	return e, ctrl, creator
+}
+
+func rpcBody(method string, params interface{}) string {
+	p, _ := json.Marshal(params)
+	return `{"jsonrpc":"2.0","id":1,"method":"` + method + `","params":` + string(p) + `}`
+}
+
+func setupEchoContext(e *echo.Echo, method, path, body string, userID string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	authzCtx := &auth.AuthorizationContext{
+		PersonalScope: auth.PersonalScopeAuth{
+			UserID:    userID,
+			CanCreate: true,
+			CanRead:   true,
+		},
+	}
+	c.Set("authz_context", authzCtx)
+	return c, rec
+}
+
+func parseRPCResponse(t *testing.T, rec *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v\nbody: %s", err, rec.Body.String())
+	}
+	return resp
+}
+
+// ----------------------------------------------------------------------------
+// Tests: initialize
+// ----------------------------------------------------------------------------
+
+func TestACPController_Initialize(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp", rpcBody("initialize", map[string]string{}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("HandleRPC error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	resp := parseRPCResponse(t, rec)
+	if resp["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc=2.0, got %v", resp["jsonrpc"])
+	}
+
+	result, ok := resp["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("result is not an object: %v", resp["result"])
+	}
+	if result["protocolVersion"] != "2025-01-15" {
+		t.Errorf("unexpected protocolVersion: %v", result["protocolVersion"])
+	}
+
+	caps := result["capabilities"].(map[string]interface{})
+	sessionCaps := caps["sessionCapabilities"].(map[string]interface{})
+	for _, key := range []string{"list", "close", "resume", "loadSession"} {
+		if sessionCaps[key] != true {
+			t.Errorf("expected sessionCapabilities.%s=true, got %v", key, sessionCaps[key])
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: session/list
+// ----------------------------------------------------------------------------
+
+func TestACPController_SessionList_Empty(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp", rpcBody("session/list", map[string]string{}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	result := resp["result"].(map[string]interface{})
+	sessions := result["sessions"].([]interface{})
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(sessions))
+	}
+	if _, hasNext := result["nextCursor"]; hasNext {
+		t.Error("should not have nextCursor on empty result")
+	}
+}
+
+func TestACPController_SessionList_ReturnsACPFields(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	s := &fakeSession{
+		id:          "sess-1",
+		userID:      "user1",
+		scope:       entities.ScopeUser,
+		tags:        map[string]string{"cwd": "/project"},
+		status:      "running",
+		description: "test session",
+		updatedAt:   now,
+	}
+	e, ctrl, _ := newEchoWithACP(map[string]*fakeSession{"sess-1": s})
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp", rpcBody("session/list", map[string]string{}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	result := resp["result"].(map[string]interface{})
+	sessions := result["sessions"].([]interface{})
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+
+	sess := sessions[0].(map[string]interface{})
+	if sess["sessionId"] != "sess-1" {
+		t.Errorf("unexpected sessionId: %v", sess["sessionId"])
+	}
+	if sess["cwd"] != "/project" {
+		t.Errorf("unexpected cwd: %v", sess["cwd"])
+	}
+	if sess["title"] != "test session" {
+		t.Errorf("unexpected title: %v", sess["title"])
+	}
+
+	meta := sess["_meta"].(map[string]interface{})
+	if meta["status"] != "running" {
+		t.Errorf("unexpected status in _meta: %v", meta["status"])
+	}
+	if meta["scope"] != "user" {
+		t.Errorf("unexpected scope in _meta: %v", meta["scope"])
+	}
+}
+
+func TestACPController_SessionList_NoNextCursorWhenFewResults(t *testing.T) {
+	sessions := map[string]*fakeSession{}
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("sess-%d", i)
+		sessions[id] = &fakeSession{id: id, userID: "user1", scope: entities.ScopeUser, status: "running", updatedAt: time.Now()}
+	}
+	e, ctrl, _ := newEchoWithACP(sessions)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp", rpcBody("session/list", map[string]string{}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	result := resp["result"].(map[string]interface{})
+	if _, hasNext := result["nextCursor"]; hasNext {
+		t.Error("should not have nextCursor when fewer than limit sessions")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: session/close
+// ----------------------------------------------------------------------------
+
+func TestACPController_SessionClose_OK(t *testing.T) {
+	s := &fakeSession{
+		id:     "sess-del",
+		userID: "user1",
+		scope:  entities.ScopeUser,
+		status: "running",
+	}
+	e, ctrl, creator := newEchoWithACP(map[string]*fakeSession{"sess-del": s})
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/close", map[string]string{"sessionId": "sess-del"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	resp := parseRPCResponse(t, rec)
+	if resp["error"] != nil {
+		t.Errorf("unexpected error in response: %v", resp["error"])
+	}
+	if len(creator.deleted) != 1 || creator.deleted[0] != "sess-del" {
+		t.Errorf("expected session deleted, got: %v", creator.deleted)
+	}
+}
+
+func TestACPController_SessionClose_NotFound(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/close", map[string]string{"sessionId": "nonexistent"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	rpcErr := resp["error"].(map[string]interface{})
+	if rpcErr["code"].(float64) != -32602 {
+		t.Errorf("expected -32602, got %v", rpcErr["code"])
+	}
+}
+
+func TestACPController_SessionClose_MissingSessionId(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/close", map[string]string{}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	rpcErr := resp["error"].(map[string]interface{})
+	if rpcErr["code"].(float64) != -32602 {
+		t.Errorf("expected -32602, got %v", rpcErr["code"])
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: session/resume
+// ----------------------------------------------------------------------------
+
+func TestACPController_SessionResume_Running(t *testing.T) {
+	s := &fakeSession{id: "sess-run", userID: "user1", scope: entities.ScopeUser, status: "running"}
+	e, ctrl, _ := newEchoWithACP(map[string]*fakeSession{"sess-run": s})
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/resume", map[string]string{"sessionId": "sess-run"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	if resp["error"] != nil {
+		t.Errorf("unexpected error: %v", resp["error"])
+	}
+}
+
+func TestACPController_SessionResume_Stable(t *testing.T) {
+	s := &fakeSession{id: "sess-stable", userID: "user1", scope: entities.ScopeUser, status: "stable"}
+	e, ctrl, _ := newEchoWithACP(map[string]*fakeSession{"sess-stable": s})
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/resume", map[string]string{"sessionId": "sess-stable"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	if resp["error"] != nil {
+		t.Errorf("unexpected error: %v", resp["error"])
+	}
+}
+
+func TestACPController_SessionResume_Stopped(t *testing.T) {
+	s := &fakeSession{id: "sess-stopped", userID: "user1", scope: entities.ScopeUser, status: "stopped"}
+	e, ctrl, _ := newEchoWithACP(map[string]*fakeSession{"sess-stopped": s})
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/resume", map[string]string{"sessionId": "sess-stopped"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	if resp["error"] == nil {
+		t.Error("expected error for stopped session")
+	}
+}
+
+func TestACPController_SessionResume_NotFound(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/resume", map[string]string{"sessionId": "ghost"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	rpcErr := resp["error"].(map[string]interface{})
+	if rpcErr["code"].(float64) != -32602 {
+		t.Errorf("expected -32602, got %v", rpcErr["code"])
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: session/load
+// ----------------------------------------------------------------------------
+
+func TestACPController_SessionLoad_OK(t *testing.T) {
+	s := &fakeSession{id: "sess-load", userID: "user1", scope: entities.ScopeUser, status: "running"}
+	e, ctrl, _ := newEchoWithACP(map[string]*fakeSession{"sess-load": s})
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/load", map[string]string{"sessionId": "sess-load"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	if resp["error"] != nil {
+		t.Errorf("unexpected error: %v", resp["error"])
+	}
+}
+
+func TestACPController_SessionLoad_NotFound(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("session/load", map[string]string{"sessionId": "ghost"}), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	if resp["error"] == nil {
+		t.Error("expected error for nonexistent session")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests: error cases
+// ----------------------------------------------------------------------------
+
+func TestACPController_UnknownMethod(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp",
+		rpcBody("unknown/method", nil), "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	rpcErr := resp["error"].(map[string]interface{})
+	if rpcErr["code"].(float64) != -32601 {
+		t.Errorf("expected -32601, got %v", rpcErr["code"])
+	}
+}
+
+func TestACPController_InvalidJsonrpcVersion(t *testing.T) {
+	e, ctrl, _ := newEchoWithACP(nil)
+	body := `{"jsonrpc":"1.0","id":1,"method":"initialize","params":{}}`
+	c, rec := setupEchoContext(e, http.MethodPost, "/acp", body, "user1")
+
+	if err := ctrl.HandleRPC(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp := parseRPCResponse(t, rec)
+	rpcErr := resp["error"].(map[string]interface{})
+	if rpcErr["code"].(float64) != -32600 {
+		t.Errorf("expected -32600, got %v", rpcErr["code"])
+	}
+}

--- a/misc/acp_e2e.go
+++ b/misc/acp_e2e.go
@@ -194,21 +194,20 @@ func (c *acpClient) sseEvents(sessionID string, timeout time.Duration) ([]string
 	return lines, nil
 }
 
-// waitActive polls session/list until the session is found with addr resolvable
-// and the agentapi /status reports "stable".
+// waitActive polls until both the proxy-level status is "active" and the agentapi
+// process itself reports "stable".
 func waitActive(c *acpClient, sessionID string, timeout time.Duration) string {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		addr := sessionAddr(c, sessionID)
-		if addr != "" {
-			st := agentapiStatus(addr)
-			if st == "stable" {
+		addr, proxyStatus := sessionAddrAndStatus(c, sessionID)
+		if addr != "" && proxyStatus == "active" {
+			if agentapiStatus(addr) == "stable" {
 				return addr
 			}
 		}
 		time.Sleep(5 * time.Second)
 	}
-	fail("session never became stable within timeout")
+	fail("session never became active within timeout")
 	return ""
 }
 
@@ -224,29 +223,30 @@ func waitForPong(c *acpClient, sessionID string, timeout time.Duration) bool {
 	return false
 }
 
-func sessionAddr(c *acpClient, sessionID string) string {
+func sessionAddrAndStatus(c *acpClient, sessionID string) (addr, status string) {
 	req, _ := http.NewRequest(http.MethodGet, c.proxyURL+"/search", nil)
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return ""
+		return "", ""
 	}
 	defer resp.Body.Close()
 	var result struct {
 		Sessions []struct {
 			SessionID string `json:"session_id"`
 			Addr      string `json:"addr"`
+			Status    string `json:"status"`
 		} `json:"sessions"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return ""
+		return "", ""
 	}
 	for _, s := range result.Sessions {
 		if s.SessionID == sessionID {
-			return s.Addr
+			return s.Addr, s.Status
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func agentapiStatus(addr string) string {

--- a/misc/acp_e2e_test.go
+++ b/misc/acp_e2e_test.go
@@ -1,0 +1,279 @@
+//go:build ignore
+
+// ACP E2E test script for the claude-acp agent type.
+// Run with:
+//
+//	PROXY_URL=http://... API_KEY=... go run misc/acp_e2e_test.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	proxyURL := os.Getenv("PROXY_URL")
+	if proxyURL == "" {
+		proxyURL = "http://agentapi-proxy.agentapi-ui-dev.svc.cluster.local:8080"
+	}
+	apiKey := os.Getenv("API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "API_KEY env var required")
+		os.Exit(1)
+	}
+
+	c := &acpClient{proxyURL: proxyURL, apiKey: apiKey}
+
+	step("1. initialize")
+	initResult := must(c.call("initialize", map[string]any{
+		"protocolVersion":    1,
+		"clientCapabilities": map[string]any{},
+	}))
+	fmt.Printf("  protocolVersion: %v\n", dig(initResult, "protocolVersion"))
+	fmt.Printf("  capabilities: %v\n", dig(initResult, "capabilities"))
+
+	step("2. session/new (claude-acp)")
+	newResult := must(c.call("session/new", map[string]any{
+		"cwd":        "/home/agentapi/workdir",
+		"mcpServers": []any{},
+		"_meta": map[string]any{
+			"tags": map[string]string{"source": "acp-e2e-test"},
+			"params": map[string]string{
+				"message":   "ACP e2e test – reply PONG when asked",
+				"agentType": "claude-acp",
+			},
+		},
+	}))
+	sessionID, _ := newResult["sessionId"].(string)
+	fmt.Printf("  sessionId: %s\n", sessionID)
+
+	step("3. wait for session to become active")
+	addr := waitActive(c, sessionID, 90*time.Second)
+	fmt.Printf("  addr: %s\n", addr)
+
+	step("4. session/list")
+	listResult := must(c.call("session/list", map[string]any{}))
+	sessions, _ := listResult["sessions"].([]any)
+	found := false
+	for _, s := range sessions {
+		sm, _ := s.(map[string]any)
+		if sm["sessionId"] == sessionID {
+			fmt.Printf("  found in list: title=%v meta=%v\n", sm["title"], sm["_meta"])
+			found = true
+		}
+	}
+	if !found {
+		fail("session not found in session/list")
+	}
+
+	step("5. session/resume")
+	must(c.call("session/resume", map[string]any{"sessionId": sessionID}))
+	fmt.Println("  OK")
+
+	step("6. session/load")
+	must(c.call("session/load", map[string]any{"sessionId": sessionID}))
+	fmt.Println("  OK (history replay via GET /acp/sse)")
+
+	step("7. session/prompt")
+	must(c.call("session/prompt", map[string]any{
+		"sessionId": sessionID,
+		"prompt":    []any{map[string]string{"type": "text", "text": "Reply with the single word PONG."}},
+	}))
+	fmt.Println("  sent (async)")
+
+	step("8. wait for agent response via SSE")
+	pong := waitForPong(c, sessionID, 30*time.Second)
+	if pong {
+		fmt.Println("  agent replied PONG ✓")
+	} else {
+		fail("did not see PONG in SSE within timeout")
+	}
+
+	step("9. session/cancel")
+	must(c.call("session/cancel", map[string]any{"sessionId": sessionID}))
+	fmt.Println("  OK")
+
+	step("10. session/close")
+	must(c.call("session/close", map[string]any{"sessionId": sessionID}))
+	fmt.Println("  OK")
+
+	step("11. verify session gone from list")
+	listAfter := must(c.call("session/list", map[string]any{}))
+	sessionsAfter, _ := listAfter["sessions"].([]any)
+	for _, s := range sessionsAfter {
+		sm, _ := s.(map[string]any)
+		if sm["sessionId"] == sessionID {
+			fail("session still appears in list after close")
+		}
+	}
+	fmt.Println("  session removed ✓")
+
+	fmt.Println("\n✓ All ACP E2E checks passed")
+}
+
+// ----------------------------------------------------------------------------
+// helpers
+// ----------------------------------------------------------------------------
+
+type acpClient struct {
+	proxyURL string
+	apiKey   string
+	seq      int
+}
+
+func (c *acpClient) call(method string, params any) (map[string]any, error) {
+	c.seq++
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      c.seq,
+		"method":  method,
+		"params":  params,
+	}
+	body, _ := json.Marshal(req)
+	httpReq, _ := http.NewRequest(http.MethodPost, c.proxyURL+"/acp", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", method, err)
+	}
+	defer resp.Body.Close()
+
+	var rpcResp struct {
+		Result map[string]any `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, fmt.Errorf("%s: decode: %w", method, err)
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("%s: RPC error %d: %s", method, rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	return rpcResp.Result, nil
+}
+
+// sseEvents fetches GET /acp/sse and returns all data lines received within timeout.
+func (c *acpClient) sseEvents(sessionID string, timeout time.Duration) ([]string, error) {
+	req, _ := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("%s/acp/sse?session_id=%s", c.proxyURL, sessionID), nil)
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "text/event-stream")
+
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var lines []string
+	buf := make([]byte, 4096)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			for _, line := range strings.Split(string(buf[:n]), "\n") {
+				if strings.HasPrefix(line, "data: ") {
+					lines = append(lines, strings.TrimPrefix(line, "data: "))
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return lines, nil
+}
+
+// waitActive polls session/list until the session is found with addr resolvable
+// and the agentapi /status reports "stable".
+func waitActive(c *acpClient, sessionID string, timeout time.Duration) string {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		addr := sessionAddr(c, sessionID)
+		if addr != "" {
+			st := agentapiStatus(addr)
+			if st == "stable" {
+				return addr
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	fail("session never became stable within timeout")
+	return ""
+}
+
+// waitForPong reads SSE events and returns true if an agent_message_chunk containing
+// "PONG" is observed within timeout.
+func waitForPong(c *acpClient, sessionID string, timeout time.Duration) bool {
+	lines, _ := c.sseEvents(sessionID, timeout)
+	for _, line := range lines {
+		if strings.Contains(strings.ToUpper(line), "PONG") {
+			return true
+		}
+	}
+	return false
+}
+
+func sessionAddr(c *acpClient, sessionID string) string {
+	req, _ := http.NewRequest(http.MethodGet, c.proxyURL+"/search", nil)
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Sessions []struct {
+			SessionID string `json:"session_id"`
+			Addr      string `json:"addr"`
+		} `json:"sessions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ""
+	}
+	for _, s := range result.Sessions {
+		if s.SessionID == sessionID {
+			return s.Addr
+		}
+	}
+	return ""
+}
+
+func agentapiStatus(addr string) string {
+	resp, err := http.Get("http://" + addr + "/status") //nolint:gosec
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	var st struct {
+		Status string `json:"status"`
+	}
+	_ = json.Unmarshal(b, &st)
+	return st.Status
+}
+
+func dig(m map[string]any, key string) any { return m[key] }
+
+func must(m map[string]any, err error) map[string]any {
+	if err != nil {
+		fail(err.Error())
+	}
+	return m
+}
+
+func step(s string) { fmt.Printf("\n=== %s ===\n", s) }
+func fail(msg string) {
+	fmt.Fprintf(os.Stderr, "FAIL: %s\n", msg)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

- `POST /acp` — JSON-RPC 2.0 エンドポイント。ACP セッション管理メソッドを実装
- `GET /acp/sse` — SSE ストリーム。接続時にブリッジの履歴を replay し、その後ライブ通知を配信

### 実装メソッド

| Method | 処理 |
|--------|------|
| `initialize` | capabilities を返す（list/close/resume/loadSession: true） |
| `session/new` | セッション作成。`cwd` → Tags["cwd"]、`_meta.tags/params` をマッピング |
| `session/list` | セッション一覧。cursor ページネーション対応（limit 20） |
| `session/close` | セッション削除 |
| `session/resume` | セッション存在・状態確認のみ（running/stable で OK） |
| `session/load` | セッション存在確認のみ（履歴 replay は GET /acp/sse で対応） |
| `session/prompt` | ブリッジの /rpc にプロキシ |
| `session/cancel` | ブリッジの /rpc にプロキシ |

### 設計上の決定

- **scope/teamId**: 認証情報から自動解決
- **tags / 初期メッセージ**: _meta 拡張フィールドで受け取る
- **session/load の履歴 replay**: GET /acp/sse 接続時にブリッジの /messages を読んで自動再生

## Test plan

- [x] initialize — capabilities フィールドの確認
- [x] session/list — ACP フィールド形式・_meta の確認
- [x] session/close — 正常系・Not Found・sessionId 未指定
- [x] session/resume — running/stable 成功、stopped エラー、Not Found
- [x] session/load — 正常系・Not Found
- [x] 未知メソッド → -32601、jsonrpc 不正 → -32600
- [x] lint 0 issues

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)