### PR TITLE
fix(acp): auto-reconnect to bridge SSE, replay history via Last-Event-ID

### DIFF
--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
@@ -565,6 +566,9 @@ func (c *ACPController) HandleSessionSSE(ctx echo.Context) error {
 
 	log.Printf("[ACP] HandleSessionSSE: connecting to bridge SSE (sessionId=%s, addr=%s)", sessionId, addr)
 
+	// Forward Last-Event-ID so the bridge replays only missed messages.
+	lastEventID := ctx.Request().Header.Get("Last-Event-ID")
+
 	w := ctx.Response()
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -580,79 +584,147 @@ func (c *ACPController) HandleSessionSSE(ctx echo.Context) error {
 		flusher.Flush()
 	}
 
-	// Stream live events from the bridge's /sse endpoint.
-	// History is NOT replayed here; clients fetch it via GET /{sessionId}/messages.
-	c.streamBridgeSSE(ctx.Request().Context(), addr, w, flusher, hasFlusher)
+	// Stream events from the bridge's /sse endpoint, forwarding Last-Event-ID so
+	// the bridge replays history from the correct position on reconnect.
+	c.streamBridgeSSE(ctx.Request().Context(), addr, w, flusher, hasFlusher, lastEventID)
 	return nil
 }
 
+// sseEvent holds the fields of a parsed SSE event.
+type sseEvent struct {
+	id   string
+	data string
+	err  error
+}
+
 // streamBridgeSSE proxies the ACP bridge's /sse stream to the current response writer.
+//
+// When the bridge-side SSE connection drops (e.g. transient network hiccup or bridge
+// restart), this function immediately reconnects to the bridge and resumes from the
+// last forwarded event ID — keeping the client-side SSE stream alive the whole time.
+// History replay is handled by the bridge's Last-Event-ID support, so no messages are
+// lost during the reconnection window.
+//
 // A keepalive comment is sent every 15 seconds so that NGINX proxy_read_timeout does not
-// drop the connection while the agent is idle between messages.
-func (c *ACPController) streamBridgeSSE(ctx interface{ Done() <-chan struct{} }, addr string, w io.Writer, flusher http.Flusher, hasFlusher bool) {
-	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/sse", nil)
-	if err != nil {
-		log.Printf("[ACP] SSE: failed to create bridge request: %v", err)
-		return
-	}
-	req.Header.Set("Accept", "text/event-stream")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		log.Printf("[ACP] SSE: failed to connect to bridge: %v", err)
-		return
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	type readResult struct {
-		data []byte
-		err  error
-	}
-	readCh := make(chan readResult, 4)
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			n, rdErr := resp.Body.Read(buf)
-			if n > 0 {
-				chunk := make([]byte, n)
-				copy(chunk, buf[:n])
-				readCh <- readResult{data: chunk}
-			}
-			if rdErr != nil {
-				readCh <- readResult{err: rdErr}
-				return
-			}
-		}
-	}()
-
+// drop the client connection while the agent is idle between messages.
+func (c *ACPController) streamBridgeSSE(
+	ctx interface{ Done() <-chan struct{} },
+	addr string,
+	w io.Writer,
+	flusher http.Flusher,
+	hasFlusher bool,
+	lastEventID string,
+) {
 	keepaliveTicker := time.NewTicker(15 * time.Second)
 	defer keepaliveTicker.Stop()
 
 	for {
+		// Check client disconnection before each (re)connection attempt.
 		select {
 		case <-ctx.Done():
 			return
-		case rr := <-readCh:
-			if rr.err != nil {
+		default:
+		}
+
+		eventCh, cleanup := c.dialBridgeSSE(ctx, addr, lastEventID)
+
+		// Drain events from this bridge connection until it drops or the client leaves.
+	drainLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				cleanup()
 				return
-			}
-			// Pass through SSE lines, re-emitting only "data:" lines as proper SSE events.
-			for _, line := range strings.Split(string(rr.data), "\n") {
-				if strings.HasPrefix(line, "data: ") {
-					jsonData := strings.TrimPrefix(line, "data: ")
-					if jsonData != "" {
-						_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", jsonData)
-						if hasFlusher {
-							flusher.Flush()
-						}
-					}
+			case ev, ok := <-eventCh:
+				if !ok {
+					// Bridge SSE ended — clean up and reconnect immediately.
+					cleanup()
+					log.Printf("[ACP] SSE: bridge SSE dropped (lastEventID=%s), reconnecting...", lastEventID)
+					break drainLoop
 				}
-			}
-		case <-keepaliveTicker.C:
-			_, _ = fmt.Fprintf(w, ": keepalive\n\n")
-			if hasFlusher {
-				flusher.Flush()
+				if ev.err != nil {
+					cleanup()
+					log.Printf("[ACP] SSE: bridge read error (lastEventID=%s): %v", lastEventID, ev.err)
+					break drainLoop
+				}
+				if ev.id != "" {
+					lastEventID = ev.id
+					_, _ = fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", ev.id, ev.data)
+				} else {
+					_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", ev.data)
+				}
+				if hasFlusher {
+					flusher.Flush()
+				}
+			case <-keepaliveTicker.C:
+				_, _ = fmt.Fprintf(w, ": keepalive\n\n")
+				if hasFlusher {
+					flusher.Flush()
+				}
 			}
 		}
 	}
+}
+
+// dialBridgeSSE opens a single SSE connection to the bridge and returns a channel of
+// parsed events plus a cleanup function. The goroutine exits when the response body
+// closes (bridge dropped or ctx cancelled via cleanup).
+func (c *ACPController) dialBridgeSSE(
+	ctx interface{ Done() <-chan struct{} },
+	addr, lastEventID string,
+) (<-chan sseEvent, func()) {
+	eventCh := make(chan sseEvent, 8)
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/sse", nil) //nolint:noctx
+	if err != nil {
+		log.Printf("[ACP] SSE: failed to create bridge request: %v", err)
+		close(eventCh)
+		return eventCh, func() {}
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("[ACP] SSE: failed to connect to bridge: %v", err)
+		close(eventCh)
+		return eventCh, func() {}
+	}
+
+	// cleanup closes the response body, which unblocks the scanner goroutine.
+	cleanup := func() { _ = resp.Body.Close() }
+
+	go func() {
+		defer close(eventCh)
+		scanner := bufio.NewScanner(resp.Body)
+		var cur sseEvent
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "id: "):
+				cur.id = strings.TrimPrefix(line, "id: ")
+			case strings.HasPrefix(line, "data: "):
+				cur.data = strings.TrimPrefix(line, "data: ")
+			case line == "": // blank line = event boundary
+				if cur.data != "" {
+					select {
+					case eventCh <- cur:
+					case <-ctx.Done():
+						return
+					}
+				}
+				cur = sseEvent{}
+			}
+		}
+		if scanErr := scanner.Err(); scanErr != nil {
+			select {
+			case eventCh <- sseEvent{err: scanErr}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return eventCh, cleanup
 }

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -626,6 +626,7 @@ func (c *ACPController) streamBridgeSSE(
 		default:
 		}
 
+		connStart := time.Now()
 		eventCh, cleanup := c.dialBridgeSSE(ctx, addr, lastEventID)
 
 		// Drain events from this bridge connection until it drops or the client leaves.
@@ -637,7 +638,6 @@ func (c *ACPController) streamBridgeSSE(
 				return
 			case ev, ok := <-eventCh:
 				if !ok {
-					// Bridge SSE ended — clean up and reconnect immediately.
 					cleanup()
 					log.Printf("[ACP] SSE: bridge SSE dropped (lastEventID=%s), reconnecting...", lastEventID)
 					break drainLoop
@@ -661,6 +661,17 @@ func (c *ACPController) streamBridgeSSE(
 				if hasFlusher {
 					flusher.Flush()
 				}
+			}
+		}
+
+		// If the connection failed or dropped very quickly (e.g. DNS error, bridge not yet
+		// ready), wait at least 1 second before the next attempt to prevent a busy loop
+		// that would spin at CPU speed and flood the logs.
+		if elapsed := time.Since(connStart); elapsed < time.Second {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second - elapsed):
 			}
 		}
 	}

--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -618,6 +618,12 @@ func (c *ACPController) streamBridgeSSE(
 	keepaliveTicker := time.NewTicker(15 * time.Second)
 	defer keepaliveTicker.Stop()
 
+	const (
+		backoffMin = time.Second
+		backoffMax = 30 * time.Second
+	)
+	backoff := backoffMin
+
 	for {
 		// Check client disconnection before each (re)connection attempt.
 		select {
@@ -628,6 +634,8 @@ func (c *ACPController) streamBridgeSSE(
 
 		connStart := time.Now()
 		eventCh, cleanup := c.dialBridgeSSE(ctx, addr, lastEventID)
+
+		gotEvent := false
 
 		// Drain events from this bridge connection until it drops or the client leaves.
 	drainLoop:
@@ -647,6 +655,7 @@ func (c *ACPController) streamBridgeSSE(
 					log.Printf("[ACP] SSE: bridge read error (lastEventID=%s): %v", lastEventID, ev.err)
 					break drainLoop
 				}
+				gotEvent = true
 				if ev.id != "" {
 					lastEventID = ev.id
 					_, _ = fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", ev.id, ev.data)
@@ -664,15 +673,27 @@ func (c *ACPController) streamBridgeSSE(
 			}
 		}
 
-		// If the connection failed or dropped very quickly (e.g. DNS error, bridge not yet
-		// ready), wait at least 1 second before the next attempt to prevent a busy loop
-		// that would spin at CPU speed and flood the logs.
-		if elapsed := time.Since(connStart); elapsed < time.Second {
+		// Reset backoff when the connection was healthy (delivered at least one event
+		// or stayed alive for over 5 seconds). Otherwise use exponential backoff so
+		// permanently unreachable bridges (deleted sessions) don't spin-log.
+		elapsed := time.Since(connStart)
+		if gotEvent || elapsed >= 5*time.Second {
+			backoff = backoffMin
+		}
+
+		wait := backoff - elapsed
+		if wait > 0 {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Second - elapsed):
+			case <-time.After(wait):
 			}
+		}
+
+		// Double backoff for next attempt, capped at backoffMax.
+		backoff *= 2
+		if backoff > backoffMax {
+			backoff = backoffMax
 		}
 	}
 }

--- a/internal/interfaces/controllers/acp_controller_test.go
+++ b/internal/interfaces/controllers/acp_controller_test.go
@@ -34,7 +34,7 @@ type fakeSession struct {
 	description string
 }
 
-func (s *fakeSession) ID() string                   { return s.id }
+func (s *fakeSession) ID() string                    { return s.id }
 func (s *fakeSession) Addr() string                  { return s.addr }
 func (s *fakeSession) UserID() string                { return s.userID }
 func (s *fakeSession) Scope() entities.ResourceScope { return s.scope }

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -340,6 +340,23 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 
 	log.Printf("[bridge] SendPrompt (session=%s, clientID=%s, textLen=%d)", b.sessionId, clientID, len(text))
 
+	// Broadcast the user's prompt as a synthetic session/update notification.
+	// The ACP server does not echo user messages, so we emit it here to ensure
+	// it appears in both the SSE live stream and GET /messages history.
+	userContentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
+	b.broadcast(jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: b.sessionId,
+			Update: acp.SessionUpdate{
+				Kind:    acp.SessionUpdateKindUserMessageChunk,
+				Content: json.RawMessage(userContentRaw),
+			},
+			Time: time.Now(),
+		},
+	})
+
 	b.setStatus("running")
 
 	go func() {
@@ -392,9 +409,17 @@ func (b *Bridge) Cancel(ctx context.Context) error {
 	return b.acp.Cancel(ctx)
 }
 
+// SubscribeFromCurrent is a sentinel value for SubscribeFrom that means
+// "subscribe from the current position without replaying any history".
+// Use this when the caller obtains history separately (e.g. GET /messages).
+const SubscribeFromCurrent = -2
+
 // SubscribeFrom subscribes to new messages and atomically returns a snapshot of
 // history starting from lastEventID+1. This prevents race conditions where messages
 // could be missed between fetching history and subscribing to the live channel.
+//
+// Pass SubscribeFromCurrent as lastEventID to subscribe from the current position
+// without replaying any history (useful when history is fetched via GET /messages).
 //
 // Callers must invoke the returned cancel function when done.
 // The returned nextIdx is the history index that the first channel message will have.
@@ -405,12 +430,17 @@ func (b *Bridge) SubscribeFrom(lastEventID int) (<-chan json.RawMessage, []json.
 
 	b.histMu.RLock()
 	histLen := len(b.history)
-	start := lastEventID + 1
-	if start < 0 {
-		start = 0
-	}
-	if start > histLen {
-		start = histLen
+	var start int
+	if lastEventID == SubscribeFromCurrent {
+		start = histLen // no replay: subscribe from current position
+	} else {
+		start = lastEventID + 1
+		if start < 0 {
+			start = 0
+		}
+		if start > histLen {
+			start = histLen
+		}
 	}
 	history := make([]json.RawMessage, histLen-start)
 	copy(history, b.history[start:])

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -340,22 +340,6 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 
 	log.Printf("[bridge] SendPrompt (session=%s, clientID=%s, textLen=%d)", b.sessionId, clientID, len(text))
 
-	// Record the user's prompt as a synthetic session/update notification so
-	// it appears in GET /messages history alongside the agent's replies.
-	userContentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
-	b.broadcast(jsonRPCMsg{
-		JSONRPC: "2.0",
-		Method:  "session/update",
-		Params: sessionUpdateParams{
-			SessionId: b.sessionId,
-			Update: acp.SessionUpdate{
-				Kind:    acp.SessionUpdateKindUserMessageChunk,
-				Content: json.RawMessage(userContentRaw),
-			},
-			Time: time.Now(),
-		},
-	})
-
 	b.setStatus("running")
 
 	go func() {

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -408,17 +408,36 @@ func (b *Bridge) Cancel(ctx context.Context) error {
 	return b.acp.Cancel(ctx)
 }
 
-// Subscribe returns a channel of raw JSON-RPC messages and a cancel function.
-// The cancel function must be called when the subscriber disconnects.
-func (b *Bridge) Subscribe() (<-chan json.RawMessage, func()) {
-	sub := &subscriber{ch: make(chan json.RawMessage, 128)}
-
+// SubscribeFrom subscribes to new messages and atomically returns a snapshot of
+// history starting from lastEventID+1. This prevents race conditions where messages
+// could be missed between fetching history and subscribing to the live channel.
+//
+// Callers must invoke the returned cancel function when done.
+// The returned nextIdx is the history index that the first channel message will have.
+func (b *Bridge) SubscribeFrom(lastEventID int) (<-chan json.RawMessage, []json.RawMessage, int, func()) {
+	// Hold subsMu first to block concurrent broadcasts while we snapshot history
+	// and add the subscriber atomically. broadcast() must also acquire subsMu first.
 	b.subsMu.Lock()
+
+	b.histMu.RLock()
+	histLen := len(b.history)
+	start := lastEventID + 1
+	if start < 0 {
+		start = 0
+	}
+	if start > histLen {
+		start = histLen
+	}
+	history := make([]json.RawMessage, histLen-start)
+	copy(history, b.history[start:])
+	b.histMu.RUnlock()
+
+	sub := &subscriber{ch: make(chan json.RawMessage, 128)}
 	b.subs = append(b.subs, sub)
 	count := len(b.subs)
 	b.subsMu.Unlock()
 
-	log.Printf("[bridge] SSE subscriber connected (session=%s, total=%d)", b.sessionId, count)
+	log.Printf("[bridge] SSE subscriber connected (session=%s, total=%d, lastEventID=%d, histLen=%d)", b.sessionId, count, lastEventID, histLen)
 
 	cancel := func() {
 		b.subsMu.Lock()
@@ -433,7 +452,7 @@ func (b *Bridge) Subscribe() (<-chan json.RawMessage, func()) {
 		close(sub.ch)
 		log.Printf("[bridge] SSE subscriber disconnected (session=%s, remaining=%d)", b.sessionId, remaining)
 	}
-	return sub.ch, cancel
+	return sub.ch, history, histLen, cancel
 }
 
 // ----------------------------------------------------------------------------
@@ -452,13 +471,17 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 		log.Printf("[bridge] broadcast: %s", raw)
 	}
 
-	// Persist to history so reconnecting clients can replay.
+	// Acquire subsMu FIRST (same order as SubscribeFrom) to ensure that when a
+	// new subscriber is being added concurrently, the boundary between history
+	// and live channel messages is consistent with no gaps or duplicates.
+	b.subsMu.Lock()
+	defer b.subsMu.Unlock()
+
+	// Persist to history inside subsMu so SubscribeFrom sees a consistent snapshot.
 	b.histMu.Lock()
 	b.history = append(b.history, raw)
 	b.histMu.Unlock()
 
-	b.subsMu.Lock()
-	defer b.subsMu.Unlock()
 	for _, sub := range b.subs {
 		select {
 		case sub.ch <- raw:

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -233,14 +234,18 @@ func (s *Server) handleRPC(c echo.Context) error {
 // GET /sse
 //
 // Server-Sent Events stream of JSON-RPC 2.0 messages from the ACP agent.
-// Each SSE event has type "message" and carries a raw JSON-RPC object:
+// Supports the SSE Last-Event-ID resumption mechanism: if the client sends a
+// Last-Event-ID header, only messages with a higher index are replayed, then
+// live events are streamed. On first connect (no Last-Event-ID) all history is
+// replayed so the client gets the full conversation context.
 //
+// Each SSE event carries an id (0-based history index) and a raw JSON-RPC object:
+//
+//	id: 0
 //	event: message
 //	data: {"jsonrpc":"2.0","method":"session/update","params":{...}}
 //
-//	event: message
-//	data: {"jsonrpc":"2.0","id":1,"method":"session/request_permission","params":{...}}
-//
+//	id: 1
 //	event: message
 //	data: {"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}
 func (s *Server) handleSSE(c echo.Context) error {
@@ -251,15 +256,34 @@ func (s *Server) handleSSE(c echo.Context) error {
 	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
-	log.Printf("[acp-server] GET /sse connected (remoteAddr=%s, lastEventID=%q)", c.RealIP(), c.Request().Header.Get("Last-Event-ID"))
+	lastEventIDStr := c.Request().Header.Get("Last-Event-ID")
+	lastEventID := -1
+	if lastEventIDStr != "" {
+		if id, err := strconv.Atoi(lastEventIDStr); err == nil {
+			lastEventID = id
+		}
+	}
+	log.Printf("[acp-server] GET /sse connected (remoteAddr=%s, lastEventID=%d)", c.RealIP(), lastEventID)
 
-	ch, cancel := s.bridge.Subscribe()
+	ch, history, nextIdx, cancel := s.bridge.SubscribeFrom(lastEventID)
 	defer func() {
 		cancel()
 		log.Printf("[acp-server] GET /sse disconnected (remoteAddr=%s)", c.RealIP())
 	}()
 
 	flusher, hasFlusher := w.Writer.(http.Flusher)
+
+	// Replay history events that the client missed (or all of them on first connect).
+	historyStartIdx := lastEventID + 1
+	if historyStartIdx < 0 {
+		historyStartIdx = 0
+	}
+	for i, msg := range history {
+		_, _ = fmt.Fprintf(w, "id: %d\nevent: message\ndata: %s\n\n", historyStartIdx+i, msg)
+	}
+	if hasFlusher {
+		flusher.Flush()
+	}
 
 	ctx := c.Request().Context()
 	for {
@@ -270,7 +294,8 @@ func (s *Server) handleSSE(c echo.Context) error {
 			if !open {
 				return nil
 			}
-			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", raw)
+			_, _ = fmt.Fprintf(w, "id: %d\nevent: message\ndata: %s\n\n", nextIdx, raw)
+			nextIdx++
 			if hasFlusher {
 				flusher.Flush()
 			}

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -257,7 +257,10 @@ func (s *Server) handleSSE(c echo.Context) error {
 	w.WriteHeader(http.StatusOK)
 
 	lastEventIDStr := c.Request().Header.Get("Last-Event-ID")
-	lastEventID := -1
+	// Default: subscribe from current position (no history replay).
+	// Clients that want history should call GET /messages first, then reconnect
+	// with Last-Event-ID to resume from a known point.
+	lastEventID := SubscribeFromCurrent
 	if lastEventIDStr != "" {
 		if id, err := strconv.Atoi(lastEventIDStr); err == nil {
 			lastEventID = id


### PR DESCRIPTION
## 問題

ACP モードで `/acp` への SSE 接続が切れると、クライアントが再接続しても bridge が処理中に発行したメッセージが失われ、コメントへの追従がなくなる。

根本原因は2つ：
1. bridge の SSE が切れると proxy がクライアントの SSE も終了させていた（再接続ラウンドトリップ中にメッセージ損失）
2. proxy→bridge の SSE 読み取りが固定バッファ分割で行われており、大きなイベントがチャンク境界で壊れていた

## 変更内容

### `pkg/acp/bridge/bridge.go`
- `SubscribeFrom(lastEventID int)` を追加：`subsMu` を保持したまま history スナップショットと購読を**アトミックに**行い、再接続時のメッセージ欠損ウィンドウをゼロにする
- `broadcast()` のロック順序を `subsMu → histMu` に統一（デッドロック防止）

### `pkg/acp/bridge/server.go`
- `GET /sse` が `Last-Event-ID` ヘッダーを受け付け、指定 ID 以降の history を replay してから live stream に移行
- 各 SSE イベントに `id: N`（0-based の history インデックス）を付与

### `internal/interfaces/controllers/acp_controller.go`
- `streamBridgeSSE()` を**再接続ループ**に変更：bridge SSE が落ちてもクライアントの SSE ストリームを維持したまま即時 bridge 再接続
- `bufio.Scanner` による行読み取りでチャンク境界問題を解消
- `id:` フィールドをクライアントに透過転送、`Last-Event-ID` を bridge リクエストに付与

## 対応する UI 側 PR

takutakahashi/agentapi-ui の PR も同時作成済み（`id:` フィールド追跡 + 即時再接続）。

## Test plan
- [ ] `make build` が通る
- [ ] `go test ./internal/...` が通る
- [ ] ACP モードでコメント送信後に応答が届くことを確認
- [ ] bridge pod 再起動時にクライアントの SSE が維持されることを確認