### PR TITLE
feat(acp): assign id: to every SSE event for ACP-compliant Last-Event-ID tracking

### DIFF
--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -533,8 +533,11 @@ func (c *ACPController) proxyResultToBridge(ctx echo.Context, req acpRequest) er
 // ----------------------------------------------------------------------------
 
 // HandleSessionSSE handles GET /acp with Acp-Session-Id header.
-// Streams live session/update notifications from the per-session bridge until
-// the client disconnects. History is NOT replayed here; clients fetch it separately.
+// Streams session/update notifications from the per-session bridge until the client
+// disconnects. On a fresh connection (no Last-Event-ID) the bridge replays its full
+// in-memory event history first, then switches to live streaming — this is the
+// ACP-compliant way to deliver message history without a separate /messages REST call.
+// On reconnect with Last-Event-ID the bridge replays only events after that id.
 func (c *ACPController) HandleSessionSSE(ctx echo.Context) error {
 	log.Printf("[ACP] HandleSessionSSE: called (method=%s, origin=%s, headers=%v)",
 		ctx.Request().Method,
@@ -624,6 +627,11 @@ func (c *ACPController) streamBridgeSSE(
 	)
 	backoff := backoffMin
 
+	// Sequential counter used to assign id: fields when the bridge does not provide them.
+	// The ACP spec requires every SSE event to carry an id: field so that clients can track
+	// Last-Event-ID for efficient resumption on reconnect.
+	var seqNum int64
+
 	for {
 		// Check client disconnection before each (re)connection attempt.
 		select {
@@ -656,12 +664,16 @@ func (c *ACPController) streamBridgeSSE(
 					break drainLoop
 				}
 				gotEvent = true
-				if ev.id != "" {
-					lastEventID = ev.id
-					_, _ = fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", ev.id, ev.data)
-				} else {
-					_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", ev.data)
+				// Assign id: on every event. Use the bridge-provided id when available;
+				// otherwise generate a monotone sequential id so clients can always
+				// track Last-Event-ID for ACP-compliant resumption on reconnect.
+				seqNum++
+				eventID := ev.id
+				if eventID == "" {
+					eventID = fmt.Sprintf("%d", seqNum)
 				}
+				lastEventID = eventID
+				_, _ = fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", eventID, ev.data)
 				if hasFlusher {
 					flusher.Flush()
 				}


### PR DESCRIPTION
## Summary

The [ACP spec](https://agentclientprotocol.com/) requires every SSE event to carry an `id:` field so that clients can send `Last-Event-ID` on reconnect for efficient stream resumption.

Previously, events forwarded from the bridge without their own `id:` field were emitted to the client without any `id:`, making `Last-Event-ID`-based resumption impossible.

This PR ensures every event in the `GET /acp` SSE stream has an `id:`:

- **Bridge provides `id:`** → forwarded as-is (unchanged behaviour)
- **Bridge omits `id:`** → proxy assigns a monotone sequential `id:` (`1`, `2`, `3`, …) scoped to the current client connection

The sequence counter resets when the client reconnects (proxy reconnects to the bridge), which is correct because the bridge replays full history on each fresh SSE connect anyway.

Also updated the `HandleSessionSSE` doc comment to reflect the correct ACP-compliant history model: history arrives via SSE replay on fresh connect (no `Last-Event-ID`), not via a separate `/messages` REST call.

## Companion PR

- agentapi-ui: https://github.com/takutakahashi/agentapi-ui/pull/514 — removes the non-ACP `GET /{sessionId}/messages` history call and tracks `Last-Event-ID` from SSE events; shows ACP SSE connection state in the header

## Test plan

- [ ] Fresh SSE connect: every event has `id: N` in the response (verify with `curl -N -H "Acp-Session-Id: <id>" <host>/acp`)
- [ ] `Last-Event-ID` forwarded to bridge on reconnect (`dialBridgeSSE` log shows the last id)
- [ ] Build passes: `go build ./...` ✓

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)