### PR TITLE
feat: codex-acp sessions で Stop hook による通知・メモリ保存を実現

### DIFF
--- a/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
+++ b/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "agentapi-proxy.labels" . | nindent 4 }}
 data:
   requirements.toml: |
-    {{- .Values.kubernetesSession.codexRequirements.tomlContent | nindent 4 }}
+    {{- .Values.kubernetesSession.codexRequirements.tomlContent | default "" | nindent 4 }}
 {{- end }}

--- a/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
+++ b/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if (.Values.kubernetesSession.codexRequirements).enabled }}
+{{- if .Values.kubernetesSession.codexRequirements.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
+++ b/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.kubernetesSession.enabled (.Values.kubernetesSession.codexRequirements).enabled }}
+{{- if (.Values.kubernetesSession.codexRequirements).enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
+++ b/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.kubernetesSession.enabled (.Values.kubernetesSession.codexRequirements).enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-codex-requirements
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+data:
+  requirements.toml: |
+    {{- .Values.kubernetesSession.codexRequirements.tomlContent | nindent 4 }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
+++ b/helm/agentapi-proxy/templates/codex-requirements-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubernetesSession.codexRequirements.enabled }}
+{{- if ((.Values.kubernetesSession.codexRequirements).enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -282,7 +282,7 @@ spec:
             # Settings base secret (proxy-side merge of settings.json)
             - name: AGENTAPI_K8S_SESSION_SETTINGS_BASE_SECRET
               value: {{ .Values.kubernetesSession.settingsBaseSecret | default "agentapi-settings-base" | quote }}
-            {{- if (.Values.kubernetesSession.codexRequirements).enabled }}
+            {{- if .Values.kubernetesSession.codexRequirements.enabled }}
             # ConfigMap name for /etc/codex/requirements.toml (codex-acp managed hooks)
             - name: AGENTAPI_K8S_SESSION_CODEX_REQUIREMENTS_CONFIGMAP_NAME
               value: {{ include "agentapi-proxy.fullname" . }}-codex-requirements

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -282,6 +282,11 @@ spec:
             # Settings base secret (proxy-side merge of settings.json)
             - name: AGENTAPI_K8S_SESSION_SETTINGS_BASE_SECRET
               value: {{ .Values.kubernetesSession.settingsBaseSecret | default "agentapi-settings-base" | quote }}
+            {{- if (.Values.kubernetesSession.codexRequirements).enabled }}
+            # ConfigMap name for /etc/codex/requirements.toml (codex-acp managed hooks)
+            - name: AGENTAPI_K8S_SESSION_CODEX_REQUIREMENTS_CONFIGMAP_NAME
+              value: {{ include "agentapi-proxy.fullname" . }}-codex-requirements
+            {{- end }}
             # Schedule Worker configuration (enabled by default)
             - name: AGENTAPI_SCHEDULE_WORKER_ENABLED
               value: {{ ((.Values.scheduleWorker).enabled) | default true | quote }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -282,7 +282,7 @@ spec:
             # Settings base secret (proxy-side merge of settings.json)
             - name: AGENTAPI_K8S_SESSION_SETTINGS_BASE_SECRET
               value: {{ .Values.kubernetesSession.settingsBaseSecret | default "agentapi-settings-base" | quote }}
-            {{- if .Values.kubernetesSession.codexRequirements.enabled }}
+            {{- if ((.Values.kubernetesSession.codexRequirements).enabled) }}
             # ConfigMap name for /etc/codex/requirements.toml (codex-acp managed hooks)
             - name: AGENTAPI_K8S_SESSION_CODEX_REQUIREMENTS_CONFIGMAP_NAME
               value: {{ include "agentapi-proxy.fullname" . }}-codex-requirements

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -443,17 +443,11 @@ kubernetesSession:
 
       [[hooks.Stop.hooks]]
       type = "command"
-      command = "agentapi-proxy client send-notification --title=\"Claude Code 完了\" --body=\"セッションが正常に完了しました。お疲れ様でした！\" --notify-session-id \"$AGENTAPI_SESSION_ID\""
+      command = "agentapi-proxy client send-notification --notify-session-id \"$AGENTAPI_SESSION_ID\""
 
       [[hooks.Stop.hooks]]
       type = "command"
       command = "agentapi-proxy client memory save-session >> /tmp/memory-save-session.log 2>&1"
-
-      [[hooks.UserPromptSubmit]]
-
-      [[hooks.UserPromptSubmit.hooks]]
-      type = "command"
-      command = "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"UserPromptSubmit\", \"additionalContext\": \"⚠️ 作業完了時の必須チェック（該当する場合は必ず実行）:\\n1. PR を作成する\\n2. agentapi-proxy client task create または task update でユーザータスクを作成・更新する\\n3. agentapi-proxy client send-notification で通知を送る\"}}'"
 
   # Slack Integration
   # claude-posts runs as a subprocess inside the agentapi container (not as a sidecar).

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -439,11 +439,14 @@ kubernetesSession:
     # TOML content for /etc/codex/requirements.toml.
     # Mirrors the managed-settings.json hooks (Notification excluded — Codex does not support it).
     tomlContent: |
+      [hooks]
+      managed_dir = "/etc/codex"
+
       [[hooks.Stop]]
 
       [[hooks.Stop.hooks]]
       type = "command"
-      command = "agentapi-proxy client send-notification --notify-session-id \"$AGENTAPI_SESSION_ID\""
+      command = "agentapi-proxy client send-notification --endpoint http://$AGENTAPI_PROXY_SERVICE_HOST:$AGENTAPI_PROXY_SERVICE_PORT --title \"codex-acp セッションが完了しました\" --body \"セッション $AGENTAPI_SESSION_ID が終了しました\" --notify-user-id \"$AGENTAPI_USER_ID\" >> /tmp/notification.log 2>&1"
 
       [[hooks.Stop.hooks]]
       type = "command"

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -430,6 +430,31 @@ kubernetesSession:
   #       }
   settingsBaseSecret: "agentapi-settings-base"
 
+  # Codex requirements ConfigMap for codex-acp sessions.
+  # When enabled, a ConfigMap is created containing /etc/codex/requirements.toml
+  # whose hooks are auto-trusted by codex_core (HookTrustStatus::Managed).
+  # This solves the trust gate that prevents user-layer ~/.codex/hooks.json from executing.
+  codexRequirements:
+    enabled: true
+    # TOML content for /etc/codex/requirements.toml.
+    # Mirrors the managed-settings.json hooks (Notification excluded — Codex does not support it).
+    tomlContent: |
+      [[hooks.Stop]]
+
+      [[hooks.Stop.hooks]]
+      type = "command"
+      command = "agentapi-proxy client send-notification --title=\"Claude Code 完了\" --body=\"セッションが正常に完了しました。お疲れ様でした！\" --notify-session-id \"$AGENTAPI_SESSION_ID\""
+
+      [[hooks.Stop.hooks]]
+      type = "command"
+      command = "agentapi-proxy client memory save-session >> /tmp/memory-save-session.log 2>&1"
+
+      [[hooks.UserPromptSubmit]]
+
+      [[hooks.UserPromptSubmit.hooks]]
+      type = "command"
+      command = "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"UserPromptSubmit\", \"additionalContext\": \"⚠️ 作業完了時の必須チェック（該当する場合は必ず実行）:\\n1. PR を作成する\\n2. agentapi-proxy client task create または task update でユーザータスクを作成・更新する\\n3. agentapi-proxy client send-notification で通知を送る\"}}'"
+
   # Slack Integration
   # claude-posts runs as a subprocess inside the agentapi container (not as a sidecar).
   # Requires agent_type=claude-agentapi to produce the history file.

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -410,23 +410,6 @@ func (m *KubernetesSessionManager) CreateSession(ctx context.Context, id string,
 	}
 	session.SetProvisionSettings(sessionSettings)
 
-	// For codex-acp sessions, create /etc/codex/requirements.toml as a ConfigMap so
-	// hooks are treated as managed (auto-trusted) by codex_core. Must be created before
-	// the Deployment because the Deployment volume references this ConfigMap.
-	if req.AgentType == "codex-acp" && sessionSettings != nil {
-		codexHooks := buildCodexHooksJSON(sessionSettings.Claude.SettingsJSON)
-		if codexHooks == nil {
-			codexHooks = make(map[string]interface{})
-		}
-		tomlContent := buildCodexRequirementsTOML(codexHooks)
-		if tomlContent != "" {
-			if err := m.createCodexRequirementsConfigMap(ctx, session, tomlContent); err != nil {
-				log.Printf("[K8S_SESSION] Warning: failed to create codex requirements ConfigMap: %v", err)
-				// Continue anyway - session will work without managed hooks
-			}
-		}
-	}
-
 	// Create Deployment
 	if err := m.createDeployment(ctx, session, req); err != nil {
 		if m.isPVCEnabled() {
@@ -1880,108 +1863,6 @@ func buildCodexHooksJSON(settingsJSON map[string]interface{}) map[string]interfa
 	return map[string]interface{}{"hooks": hooksMap}
 }
 
-// codexHookEvents lists the hook event names that codex_core understands.
-// Notification is Claude Code-only and must be excluded from requirements.toml.
-var codexHookEvents = []string{
-	"Stop", "UserPromptSubmit", "SessionStart",
-	"PreToolUse", "PostToolUse", "PermissionRequest",
-	"PreCompact", "PostCompact",
-}
-
-// buildCodexRequirementsTOML converts a hooks JSON map (Claude Code format) into a
-// TOML string suitable for /etc/codex/requirements.toml. Hooks from that file are
-// treated as "managed" by codex_core and executed without user trust approval.
-// Managed hooks from /etc/claude-code/managed-settings.json are merged in as well.
-func buildCodexRequirementsTOML(hooksJSON map[string]interface{}) string {
-	if len(hooksJSON) == 0 {
-		return ""
-	}
-
-	merged := sessionsettings.MergeCodexManagedHooks(hooksJSON)
-	hooksMap, ok := merged["hooks"].(map[string]interface{})
-	if !ok || len(hooksMap) == 0 {
-		return ""
-	}
-
-	var sb strings.Builder
-	for _, event := range codexHookEvents {
-		groups, ok := hooksMap[event].([]interface{})
-		if !ok || len(groups) == 0 {
-			continue
-		}
-		for _, group := range groups {
-			groupMap, ok := group.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			hooks, ok := groupMap["hooks"].([]interface{})
-			if !ok || len(hooks) == 0 {
-				continue
-			}
-			fmt.Fprintf(&sb, "\n[[hooks.%s]]\n", event)
-			for _, h := range hooks {
-				hookMap, ok := h.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				cmd, _ := hookMap["command"].(string)
-				typ, _ := hookMap["type"].(string)
-				if typ == "" {
-					typ = "command"
-				}
-				fmt.Fprintf(&sb, "\n[[hooks.%s.hooks]]\n", event)
-				fmt.Fprintf(&sb, "type = %q\n", typ)
-				fmt.Fprintf(&sb, "command = %q\n", cmd)
-			}
-		}
-	}
-	return sb.String()
-}
-
-// codexRequirementsConfigMapName returns the ConfigMap name for /etc/codex/requirements.toml.
-func codexRequirementsConfigMapName(sessionID string) string {
-	return fmt.Sprintf("agentapi-session-%s-codex-reqs", sessionID)
-}
-
-// createCodexRequirementsConfigMap creates a ConfigMap containing requirements.toml
-// for a codex-acp session. The ConfigMap is mounted at /etc/codex/ in the session pod.
-func (m *KubernetesSessionManager) createCodexRequirementsConfigMap(
-	ctx context.Context,
-	session *KubernetesSession,
-	tomlContent string,
-) error {
-	cmName := codexRequirementsConfigMapName(session.id)
-	cm := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cmName,
-			Namespace: m.namespace,
-			Labels: map[string]string{
-				"agentapi.proxy/session-id": session.id,
-				"agentapi.proxy/resource":   "codex-requirements",
-			},
-		},
-		Data: map[string]string{
-			"requirements.toml": tomlContent,
-		},
-	}
-	_, err := m.client.CoreV1().ConfigMaps(m.namespace).Create(ctx, cm, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to create codex requirements ConfigMap: %w", err)
-	}
-	log.Printf("[K8S_SESSION] Created codex requirements ConfigMap %s for session %s", cmName, session.id)
-	return nil
-}
-
-// deleteCodexRequirementsConfigMap deletes the codex requirements ConfigMap for a session.
-func (m *KubernetesSessionManager) deleteCodexRequirementsConfigMap(ctx context.Context, session *KubernetesSession) error {
-	cmName := codexRequirementsConfigMapName(session.id)
-	err := m.client.CoreV1().ConfigMaps(m.namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete codex requirements ConfigMap %s: %w", cmName, err)
-	}
-	return nil
-}
-
 // createOneshotSettingsSecret creates a Secret containing settings.json with Stop hook
 // This is used when oneshot is enabled to automatically delete the session after stopping
 func (m *KubernetesSessionManager) createOneshotSettingsSecret(
@@ -2131,15 +2012,15 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 		},
 	})
 
-	// For codex-acp sessions, mount /etc/codex/requirements.toml from a ConfigMap so that
-	// hooks are treated as managed (auto-trusted) by codex_core.
-	if session.Request().AgentType == "codex-acp" {
+	// For codex-acp sessions, mount /etc/codex/requirements.toml from a pre-created Helm
+	// ConfigMap so that hooks are treated as managed (auto-trusted) by codex_core.
+	if session.Request().AgentType == "codex-acp" && m.k8sConfig.CodexRequirementsConfigMapName != "" {
 		volumes = append(volumes, corev1.Volume{
 			Name: "codex-requirements",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: codexRequirementsConfigMapName(session.id),
+						Name: m.k8sConfig.CodexRequirementsConfigMapName,
 					},
 				},
 			},
@@ -2434,11 +2315,6 @@ func (m *KubernetesSessionManager) deleteSessionResources(ctx context.Context, s
 	// Delete oneshot settings Secret (bug fix - was not being deleted before)
 	if err := m.deleteOneshotSettingsSecret(ctx, session); err != nil {
 		errs = append(errs, fmt.Sprintf("oneshot-settings-secret: %v", err))
-	}
-
-	// Delete codex requirements ConfigMap (codex-acp sessions only; no-op otherwise)
-	if err := m.deleteCodexRequirementsConfigMap(ctx, session); err != nil {
-		errs = append(errs, fmt.Sprintf("codex-requirements-configmap: %v", err))
 	}
 
 	if len(errs) > 0 {
@@ -3071,7 +2947,7 @@ func (m *KubernetesSessionManager) buildMainContainerVolumeMounts(session *Kuber
 
 	// For codex-acp sessions, mount the managed requirements ConfigMap at /etc/codex/
 	// so codex_core reads hooks as managed (auto-trusted) without user approval.
-	if session.Request().AgentType == "codex-acp" {
+	if session.Request().AgentType == "codex-acp" && m.k8sConfig.CodexRequirementsConfigMapName != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "codex-requirements",
 			MountPath: "/etc/codex",

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -410,6 +410,23 @@ func (m *KubernetesSessionManager) CreateSession(ctx context.Context, id string,
 	}
 	session.SetProvisionSettings(sessionSettings)
 
+	// For codex-acp sessions, create /etc/codex/requirements.toml as a ConfigMap so
+	// hooks are treated as managed (auto-trusted) by codex_core. Must be created before
+	// the Deployment because the Deployment volume references this ConfigMap.
+	if req.AgentType == "codex-acp" && sessionSettings != nil {
+		codexHooks := buildCodexHooksJSON(sessionSettings.Claude.SettingsJSON)
+		if codexHooks == nil {
+			codexHooks = make(map[string]interface{})
+		}
+		tomlContent := buildCodexRequirementsTOML(codexHooks)
+		if tomlContent != "" {
+			if err := m.createCodexRequirementsConfigMap(ctx, session, tomlContent); err != nil {
+				log.Printf("[K8S_SESSION] Warning: failed to create codex requirements ConfigMap: %v", err)
+				// Continue anyway - session will work without managed hooks
+			}
+		}
+	}
+
 	// Create Deployment
 	if err := m.createDeployment(ctx, session, req); err != nil {
 		if m.isPVCEnabled() {
@@ -1863,6 +1880,108 @@ func buildCodexHooksJSON(settingsJSON map[string]interface{}) map[string]interfa
 	return map[string]interface{}{"hooks": hooksMap}
 }
 
+// codexHookEvents lists the hook event names that codex_core understands.
+// Notification is Claude Code-only and must be excluded from requirements.toml.
+var codexHookEvents = []string{
+	"Stop", "UserPromptSubmit", "SessionStart",
+	"PreToolUse", "PostToolUse", "PermissionRequest",
+	"PreCompact", "PostCompact",
+}
+
+// buildCodexRequirementsTOML converts a hooks JSON map (Claude Code format) into a
+// TOML string suitable for /etc/codex/requirements.toml. Hooks from that file are
+// treated as "managed" by codex_core and executed without user trust approval.
+// Managed hooks from /etc/claude-code/managed-settings.json are merged in as well.
+func buildCodexRequirementsTOML(hooksJSON map[string]interface{}) string {
+	if len(hooksJSON) == 0 {
+		return ""
+	}
+
+	merged := sessionsettings.MergeCodexManagedHooks(hooksJSON)
+	hooksMap, ok := merged["hooks"].(map[string]interface{})
+	if !ok || len(hooksMap) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for _, event := range codexHookEvents {
+		groups, ok := hooksMap[event].([]interface{})
+		if !ok || len(groups) == 0 {
+			continue
+		}
+		for _, group := range groups {
+			groupMap, ok := group.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			hooks, ok := groupMap["hooks"].([]interface{})
+			if !ok || len(hooks) == 0 {
+				continue
+			}
+			fmt.Fprintf(&sb, "\n[[hooks.%s]]\n", event)
+			for _, h := range hooks {
+				hookMap, ok := h.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				cmd, _ := hookMap["command"].(string)
+				typ, _ := hookMap["type"].(string)
+				if typ == "" {
+					typ = "command"
+				}
+				fmt.Fprintf(&sb, "\n[[hooks.%s.hooks]]\n", event)
+				fmt.Fprintf(&sb, "type = %q\n", typ)
+				fmt.Fprintf(&sb, "command = %q\n", cmd)
+			}
+		}
+	}
+	return sb.String()
+}
+
+// codexRequirementsConfigMapName returns the ConfigMap name for /etc/codex/requirements.toml.
+func codexRequirementsConfigMapName(sessionID string) string {
+	return fmt.Sprintf("agentapi-session-%s-codex-reqs", sessionID)
+}
+
+// createCodexRequirementsConfigMap creates a ConfigMap containing requirements.toml
+// for a codex-acp session. The ConfigMap is mounted at /etc/codex/ in the session pod.
+func (m *KubernetesSessionManager) createCodexRequirementsConfigMap(
+	ctx context.Context,
+	session *KubernetesSession,
+	tomlContent string,
+) error {
+	cmName := codexRequirementsConfigMapName(session.id)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: m.namespace,
+			Labels: map[string]string{
+				"agentapi.proxy/session-id": session.id,
+				"agentapi.proxy/resource":   "codex-requirements",
+			},
+		},
+		Data: map[string]string{
+			"requirements.toml": tomlContent,
+		},
+	}
+	_, err := m.client.CoreV1().ConfigMaps(m.namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create codex requirements ConfigMap: %w", err)
+	}
+	log.Printf("[K8S_SESSION] Created codex requirements ConfigMap %s for session %s", cmName, session.id)
+	return nil
+}
+
+// deleteCodexRequirementsConfigMap deletes the codex requirements ConfigMap for a session.
+func (m *KubernetesSessionManager) deleteCodexRequirementsConfigMap(ctx context.Context, session *KubernetesSession) error {
+	cmName := codexRequirementsConfigMapName(session.id)
+	err := m.client.CoreV1().ConfigMaps(m.namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete codex requirements ConfigMap %s: %w", cmName, err)
+	}
+	return nil
+}
+
 // createOneshotSettingsSecret creates a Secret containing settings.json with Stop hook
 // This is used when oneshot is enabled to automatically delete the session after stopping
 func (m *KubernetesSessionManager) createOneshotSettingsSecret(
@@ -2011,6 +2130,21 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	})
+
+	// For codex-acp sessions, mount /etc/codex/requirements.toml from a ConfigMap so that
+	// hooks are treated as managed (auto-trusted) by codex_core.
+	if session.Request().AgentType == "codex-acp" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "codex-requirements",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: codexRequirementsConfigMapName(session.id),
+					},
+				},
+			},
+		})
+	}
 
 	return volumes
 }
@@ -2300,6 +2434,11 @@ func (m *KubernetesSessionManager) deleteSessionResources(ctx context.Context, s
 	// Delete oneshot settings Secret (bug fix - was not being deleted before)
 	if err := m.deleteOneshotSettingsSecret(ctx, session); err != nil {
 		errs = append(errs, fmt.Sprintf("oneshot-settings-secret: %v", err))
+	}
+
+	// Delete codex requirements ConfigMap (codex-acp sessions only; no-op otherwise)
+	if err := m.deleteCodexRequirementsConfigMap(ctx, session); err != nil {
+		errs = append(errs, fmt.Sprintf("codex-requirements-configmap: %v", err))
 	}
 
 	if len(errs) > 0 {
@@ -2929,6 +3068,16 @@ func (m *KubernetesSessionManager) buildMainContainerVolumeMounts(session *Kuber
 		Name:      "claude-agentapi-history",
 		MountPath: "/opt/claude-agentapi",
 	})
+
+	// For codex-acp sessions, mount the managed requirements ConfigMap at /etc/codex/
+	// so codex_core reads hooks as managed (auto-trusted) without user approval.
+	if session.Request().AgentType == "codex-acp" {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "codex-requirements",
+			MountPath: "/etc/codex",
+			ReadOnly:  true,
+		})
+	}
 
 	return volumeMounts
 }

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1849,6 +1849,20 @@ func (m *KubernetesSessionManager) getSessionMetaFromSecret(ctx context.Context,
 	return &settings.Session
 }
 
+// buildCodexHooksJSON converts a Claude Code settings.json hooks map into the
+// equivalent Codex hooks.json structure. The hook entry format is identical between
+// the two runtimes, so we copy the hooks subtree directly.
+func buildCodexHooksJSON(settingsJSON map[string]interface{}) map[string]interface{} {
+	if settingsJSON == nil {
+		return nil
+	}
+	hooksMap, ok := settingsJSON["hooks"].(map[string]interface{})
+	if !ok || len(hooksMap) == 0 {
+		return nil
+	}
+	return map[string]interface{}{"hooks": hooksMap}
+}
+
 // createOneshotSettingsSecret creates a Secret containing settings.json with Stop hook
 // This is used when oneshot is enabled to automatically delete the session after stopping
 func (m *KubernetesSessionManager) createOneshotSettingsSecret(
@@ -3627,13 +3641,22 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		log.Printf("[K8S_SESSION] Injected cycle Stop hook for session %s (max-count=%d)", session.id, req.CycleMaxCount)
 	}
 
+	// For codex-acp sessions, inject the same Stop hooks into ~/.codex/hooks.json
+	// so that cycle and oneshot behavior works under the Codex CLI hook system.
+	var codexHooksJSON map[string]interface{}
+	if req.AgentType == "codex-acp" {
+		codexHooksJSON = buildCodexHooksJSON(settingsJSON)
+		log.Printf("[K8S_SESSION] Injected Codex hooks for codex-acp session %s", session.id)
+	}
+
 	settings.Claude = sessionsettings.ClaudeConfig{
 		ClaudeJSON: map[string]interface{}{
 			"hasCompletedOnboarding":        true,
 			"bypassPermissionsModeAccepted": true,
 		},
-		SettingsJSON: settingsJSON,
-		MCPServers:   materialized.MCPServers,
+		SettingsJSON:   settingsJSON,
+		MCPServers:     materialized.MCPServers,
+		CodexHooksJSON: codexHooksJSON,
 	}
 
 	// Repository info

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2012,9 +2012,11 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 		},
 	})
 
-	// For codex-acp sessions, mount /etc/codex/requirements.toml from a pre-created Helm
-	// ConfigMap so that hooks are treated as managed (auto-trusted) by codex_core.
-	if session.Request().AgentType == "codex-acp" && m.k8sConfig.CodexRequirementsConfigMapName != "" {
+	// Mount /etc/codex/requirements.toml from a pre-created Helm ConfigMap so that
+	// codex-acp hooks are treated as managed (auto-trusted) by codex_core. Mounted on
+	// all sessions (including stock pre-warmed pods) because the agent type is not known
+	// at stock creation time — Claude Code ignores this path so it is harmless elsewhere.
+	if m.k8sConfig.CodexRequirementsConfigMapName != "" {
 		volumes = append(volumes, corev1.Volume{
 			Name: "codex-requirements",
 			VolumeSource: corev1.VolumeSource{
@@ -2945,9 +2947,10 @@ func (m *KubernetesSessionManager) buildMainContainerVolumeMounts(session *Kuber
 		MountPath: "/opt/claude-agentapi",
 	})
 
-	// For codex-acp sessions, mount the managed requirements ConfigMap at /etc/codex/
-	// so codex_core reads hooks as managed (auto-trusted) without user approval.
-	if session.Request().AgentType == "codex-acp" && m.k8sConfig.CodexRequirementsConfigMapName != "" {
+	// Mount the managed requirements ConfigMap at /etc/codex/ so codex_core reads hooks
+	// as managed (auto-trusted) without user approval. Mounted on all sessions so stock
+	// pods already have it when adopted as codex-acp sessions.
+	if m.k8sConfig.CodexRequirementsConfigMapName != "" {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "codex-requirements",
 			MountPath: "/etc/codex",

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -8,9 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -360,9 +357,6 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 		},
 	})
 
-	// Run UserPromptSubmit hooks before kicking off the agent turn.
-	go runCodexHooks("UserPromptSubmit")
-
 	b.setStatus("running")
 
 	go func() {
@@ -371,9 +365,6 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 		// Flush any chunk that was still buffered when the agent turn ended.
 		b.flushChunkBuffer()
 		b.setStatus("stable")
-
-		// Run Stop hooks (send-notification, cycle, etc.) after the turn ends.
-		go runCodexHooks("Stop")
 
 		if err != nil {
 			log.Printf("[bridge] Prompt error (session=%s): %v", b.sessionId, err)
@@ -510,53 +501,6 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 		case sub.ch <- raw:
 		default:
 			// Slow subscriber – drop the message rather than blocking.
-		}
-	}
-}
-
-// codexHooksConfig is the shape of ~/.codex/hooks.json.
-type codexHooksConfig struct {
-	Hooks map[string][]struct {
-		Hooks []struct {
-			Type    string `json:"type"`
-			Command string `json:"command"`
-		} `json:"hooks"`
-	} `json:"hooks"`
-}
-
-// runCodexHooks reads ~/.codex/hooks.json and runs all command hooks registered
-// for eventName. Each command is executed via "sh -c" inheriting the current
-// environment so that AGENTAPI_SESSION_ID and AGENTAPI_KEY are available.
-// Commands are run sequentially; the function returns after all complete.
-func runCodexHooks(eventName string) {
-	home := os.Getenv("HOME")
-	if home == "" {
-		home = "/home/agentapi"
-	}
-	hookFile := filepath.Join(home, ".codex", "hooks.json")
-
-	data, err := os.ReadFile(hookFile)
-	if err != nil {
-		return // hooks.json absent — nothing to do
-	}
-
-	var cfg codexHooksConfig
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		log.Printf("[bridge] Warning: failed to parse %s: %v", hookFile, err)
-		return
-	}
-
-	entries := cfg.Hooks[eventName]
-	for _, entry := range entries {
-		for _, h := range entry.Hooks {
-			if h.Type != "command" || h.Command == "" {
-				continue
-			}
-			cmd := exec.Command("sh", "-c", h.Command)
-			cmd.Env = os.Environ()
-			if out, err := cmd.CombinedOutput(); err != nil {
-				log.Printf("[bridge] Hook %s command error: %v (output: %s)", eventName, err, strings.TrimSpace(string(out)))
-			}
 		}
 	}
 }

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -8,6 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -357,6 +360,9 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 		},
 	})
 
+	// Run UserPromptSubmit hooks before kicking off the agent turn.
+	go runCodexHooks("UserPromptSubmit")
+
 	b.setStatus("running")
 
 	go func() {
@@ -365,6 +371,9 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
 		// Flush any chunk that was still buffered when the agent turn ended.
 		b.flushChunkBuffer()
 		b.setStatus("stable")
+
+		// Run Stop hooks (send-notification, cycle, etc.) after the turn ends.
+		go runCodexHooks("Stop")
 
 		if err != nil {
 			log.Printf("[bridge] Prompt error (session=%s): %v", b.sessionId, err)
@@ -501,6 +510,53 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 		case sub.ch <- raw:
 		default:
 			// Slow subscriber – drop the message rather than blocking.
+		}
+	}
+}
+
+// codexHooksConfig is the shape of ~/.codex/hooks.json.
+type codexHooksConfig struct {
+	Hooks map[string][]struct {
+		Hooks []struct {
+			Type    string `json:"type"`
+			Command string `json:"command"`
+		} `json:"hooks"`
+	} `json:"hooks"`
+}
+
+// runCodexHooks reads ~/.codex/hooks.json and runs all command hooks registered
+// for eventName. Each command is executed via "sh -c" inheriting the current
+// environment so that AGENTAPI_SESSION_ID and AGENTAPI_KEY are available.
+// Commands are run sequentially; the function returns after all complete.
+func runCodexHooks(eventName string) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "/home/agentapi"
+	}
+	hookFile := filepath.Join(home, ".codex", "hooks.json")
+
+	data, err := os.ReadFile(hookFile)
+	if err != nil {
+		return // hooks.json absent — nothing to do
+	}
+
+	var cfg codexHooksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		log.Printf("[bridge] Warning: failed to parse %s: %v", hookFile, err)
+		return
+	}
+
+	entries := cfg.Hooks[eventName]
+	for _, entry := range entries {
+		for _, h := range entry.Hooks {
+			if h.Type != "command" || h.Command == "" {
+				continue
+			}
+			cmd := exec.Command("sh", "-c", h.Command)
+			cmd.Env = os.Environ()
+			if out, err := cmd.CombinedOutput(); err != nil {
+				log.Printf("[bridge] Hook %s command error: %v (output: %s)", eventName, err, strings.TrimSpace(string(out)))
+			}
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -650,6 +650,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.github_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")
+	_ = v.BindEnv("kubernetes_session.codex_requirements_configmap_name", "AGENTAPI_K8S_SESSION_CODEX_REQUIREMENTS_CONFIGMAP_NAME")
 
 	// MCP servers configuration
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -294,6 +294,12 @@ type KubernetesSessionConfig struct {
 	// SlackBotTokenSecretKey is the key within the Secret that holds the Slack bot token
 	// Defaults to "bot-token"
 	SlackBotTokenSecretKey string `json:"slack_bot_token_secret_key" mapstructure:"slack_bot_token_secret_key"`
+
+	// CodexRequirementsConfigMapName is the name of a pre-created ConfigMap containing
+	// requirements.toml for /etc/codex/. When set, this ConfigMap is mounted into codex-acp
+	// session pods so that hooks are treated as managed (auto-trusted) by codex_core.
+	// Typically created by the Helm chart. When empty, no managed hooks are mounted.
+	CodexRequirementsConfigMapName string `json:"codex_requirements_configmap_name" mapstructure:"codex_requirements_configmap_name"`
 }
 
 // MemoryConfig represents memory backend configuration

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -244,9 +244,15 @@ func generateCodexHooksJSON(outputDir string, hooksJSON map[string]interface{}) 
 	return nil
 }
 
-// mergeCodexManagedHooks reads managed-settings.json and appends its hook entries
+// MergeCodexManagedHooks reads managed-settings.json and appends its hook entries
 // to each matching event in hooksJSON. Unknown events are added as new entries.
 // Returns the original hooksJSON unchanged if the file is absent or unreadable.
+// Exported so callers outside this package (e.g. the session manager) can reuse the logic.
+func MergeCodexManagedHooks(hooksJSON map[string]interface{}) map[string]interface{} {
+	return mergeCodexManagedHooks(hooksJSON)
+}
+
+// mergeCodexManagedHooks is the unexported implementation; call MergeCodexManagedHooks externally.
 func mergeCodexManagedHooks(hooksJSON map[string]interface{}) map[string]interface{} {
 	data, err := os.ReadFile(managedSettingsPath)
 	if err != nil {

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -57,6 +57,11 @@ func Compile(opts CompileOptions) error {
 		return fmt.Errorf("failed to generate settings.json: %w", err)
 	}
 
+	// 3b. Generate ~/.codex/hooks.json (codex-acp sessions only)
+	if err := generateCodexHooksJSON(opts.OutputDir, settings.Claude.CodexHooksJSON); err != nil {
+		return fmt.Errorf("failed to generate codex hooks.json: %w", err)
+	}
+
 	// 4. Generate env file
 	if err := generateEnvFile(opts.EnvFilePath, settings.Env); err != nil {
 		return fmt.Errorf("failed to generate env file: %w", err)
@@ -201,6 +206,32 @@ func generateEnvFile(envFilePath string, env map[string]string) error {
 	}
 
 	log.Printf("[COMPILE-SETTINGS] Generated %s (%d variables)", envFilePath, len(env))
+	return nil
+}
+
+// generateCodexHooksJSON creates ~/.codex/hooks.json for Codex CLI hook configuration.
+// Only written when hooksJSON is non-empty (i.e., for codex-acp sessions).
+func generateCodexHooksJSON(outputDir string, hooksJSON map[string]interface{}) error {
+	if len(hooksJSON) == 0 {
+		return nil
+	}
+
+	codexDir := filepath.Join(outputDir, ".codex")
+	if err := os.MkdirAll(codexDir, 0755); err != nil {
+		return fmt.Errorf("failed to create .codex directory: %w", err)
+	}
+
+	hooksPath := filepath.Join(codexDir, "hooks.json")
+	data, err := json.MarshalIndent(hooksJSON, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal codex hooks.json: %w", err)
+	}
+
+	if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write codex hooks.json: %w", err)
+	}
+
+	log.Printf("[COMPILE-SETTINGS] Generated %s", hooksPath)
 	return nil
 }
 

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -209,12 +209,21 @@ func generateEnvFile(envFilePath string, env map[string]string) error {
 	return nil
 }
 
+// managedSettingsPath is the well-known location for organisation-managed Claude Code policy.
+// The same file is read by the Codex hook generator to keep both runtimes in sync.
+const managedSettingsPath = "/etc/claude-code/managed-settings.json"
+
 // generateCodexHooksJSON creates ~/.codex/hooks.json for Codex CLI hook configuration.
 // Only written when hooksJSON is non-empty (i.e., for codex-acp sessions).
+// Hooks from managed-settings.json are merged in so the same organisation-wide policy
+// (UserPromptSubmit, Stop notifications, etc.) applies to Codex sessions too.
 func generateCodexHooksJSON(outputDir string, hooksJSON map[string]interface{}) error {
 	if len(hooksJSON) == 0 {
 		return nil
 	}
+
+	// Merge hooks from the managed-settings policy file (mirrors Claude Code behaviour).
+	hooksJSON = mergeCodexManagedHooks(hooksJSON)
 
 	codexDir := filepath.Join(outputDir, ".codex")
 	if err := os.MkdirAll(codexDir, 0755); err != nil {
@@ -233,6 +242,59 @@ func generateCodexHooksJSON(outputDir string, hooksJSON map[string]interface{}) 
 
 	log.Printf("[COMPILE-SETTINGS] Generated %s", hooksPath)
 	return nil
+}
+
+// mergeCodexManagedHooks reads managed-settings.json and appends its hook entries
+// to each matching event in hooksJSON. Unknown events are added as new entries.
+// Returns the original hooksJSON unchanged if the file is absent or unreadable.
+func mergeCodexManagedHooks(hooksJSON map[string]interface{}) map[string]interface{} {
+	data, err := os.ReadFile(managedSettingsPath)
+	if err != nil {
+		return hooksJSON // file absent — nothing to merge
+	}
+
+	var managed map[string]interface{}
+	if err := json.Unmarshal(data, &managed); err != nil {
+		log.Printf("[COMPILE-SETTINGS] Warning: failed to parse %s: %v", managedSettingsPath, err)
+		return hooksJSON
+	}
+
+	managedHooks, ok := managed["hooks"].(map[string]interface{})
+	if !ok || len(managedHooks) == 0 {
+		return hooksJSON
+	}
+
+	// Work on a shallow copy so we don't mutate the caller's map.
+	merged := make(map[string]interface{}, len(hooksJSON))
+	for k, v := range hooksJSON {
+		merged[k] = v
+	}
+
+	baseHooks, ok := merged["hooks"].(map[string]interface{})
+	if !ok {
+		baseHooks = make(map[string]interface{})
+	}
+	// Clone the inner hooks map too.
+	innerHooks := make(map[string]interface{}, len(baseHooks))
+	for k, v := range baseHooks {
+		innerHooks[k] = v
+	}
+
+	for event, entries := range managedHooks {
+		managedList, ok := entries.([]interface{})
+		if !ok {
+			continue
+		}
+		if existing, ok := innerHooks[event].([]interface{}); ok {
+			innerHooks[event] = append(existing, managedList...)
+		} else {
+			innerHooks[event] = managedList
+		}
+	}
+
+	merged["hooks"] = innerHooks
+	log.Printf("[COMPILE-SETTINGS] Merged %d hook event(s) from %s into codex hooks.json", len(managedHooks), managedSettingsPath)
+	return merged
 }
 
 // generateStartupScript creates executable shell script with the startup command.

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -178,9 +178,10 @@ type SessionMeta struct {
 
 // ClaudeConfig holds Claude-related configuration data.
 type ClaudeConfig struct {
-	ClaudeJSON   map[string]interface{} `yaml:"claude_json,omitempty"   json:"claude_json,omitempty"`
-	SettingsJSON map[string]interface{} `yaml:"settings_json,omitempty" json:"settings_json,omitempty"`
-	MCPServers   map[string]interface{} `yaml:"mcp_servers,omitempty"   json:"mcp_servers,omitempty"`
+	ClaudeJSON     map[string]interface{} `yaml:"claude_json,omitempty"      json:"claude_json,omitempty"`
+	SettingsJSON   map[string]interface{} `yaml:"settings_json,omitempty"    json:"settings_json,omitempty"`
+	MCPServers     map[string]interface{} `yaml:"mcp_servers,omitempty"      json:"mcp_servers,omitempty"`
+	CodexHooksJSON map[string]interface{} `yaml:"codex_hooks_json,omitempty" json:"codex_hooks_json,omitempty"`
 }
 
 // RepositoryConfig holds repository information.


### PR DESCRIPTION
## Summary

- codex-acp セッション終了時に Stop hook を自動実行する機能を追加
- `/etc/codex/requirements.toml` を Helm ConfigMap でマウントし、codex_core の managed hooks (自動信頼) として実行
- セッション終了時に `send-notification` と `memory save-session` が動作する

## 技術的背景

codex_core の hook trust 機構により、`~/.codex/hooks.json` に書かれた user-level hooks は `trusted_hash` が SQLite に登録されていないとサイレントにブロックされる。一方 `/etc/codex/requirements.toml` に書かれた hooks は `HookTrustStatus::Managed` として自動信頼・無条件実行される。

## 変更内容

### Helm
- `templates/codex-requirements-configmap.yaml`: Stop hook を含む ConfigMap を新規追加
- `values.yaml`: `kubernetesSession.codexRequirements` セクション追加
- `templates/deployment.yaml`: `AGENTAPI_K8S_SESSION_CODEX_REQUIREMENTS_CONFIGMAP_NAME` 環境変数を追加

### Go
- `pkg/config/config.go`: `codex_requirements_configmap_name` の `BindEnv` 追加（これが抜けていたため env var が読まれなかった）
- `pkg/sessionsettings/`: `CodexHooksJSON` フィールドと生成ロジック追加
- `internal/infrastructure/services/kubernetes_session_manager.go`:
  - codex-requirements volume を **全セッション**（stock pre-warm 含む）にマウント（agent type が判明するのは adoption 時のため）
  - codex-acp セッション用の hooks JSON 生成ロジック追加

## Bug Fixes

1. **`BindEnv` 欠落**: env var が config struct に読み込まれず volume が常に追加されなかった
2. **stock セッションの agent type 問題**: pre-warm 時は AgentType が空のため `AgentType == "codex-acp"` チェックが通らず、adoption 後もデプロイ spec は変更不可（pod 再起動を避けるため）→ 全セッションに volume をマウントする方針に変更

## Test plan

- [x] dev 環境デプロイ済み (`0.3.0-dev.20260515043228.b26a58c`)
- [x] 新規 stock セッション pod に `/etc/codex/requirements.toml` がマウントされることを確認
- [x] codex-acp セッション (449c1e24) を作成し、Stop hook が発火して `/tmp/hook-test.log` にタイムスタンプが記録されることを確認
- [x] memory save hook が成功し、セッションメモリ (c02723dd) が作成されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)