### PR TITLE
feat: GitHub bidirectional resource sync with AWS KMS encryption

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -759,6 +759,7 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 	taskGroupRepo := proxyServer.GetTaskGroupRepository()
 
 	userFileRepo := portrepos.UserFileRepository(repositories.NewKubernetesUserFileRepository(client, namespace))
+	slackbotRepo := portrepos.SlackBotRepository(repositories.NewKubernetesSlackBotRepository(client, namespace))
 
 	syncHandlers := githubsync.NewHandlers(
 		settingsRepo,
@@ -768,6 +769,7 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 		taskRepo,
 		taskGroupRepo,
 		userFileRepo,
+		slackbotRepo,
 	)
 	proxyServer.AddCustomHandler(syncHandlers)
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -16,7 +16,9 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
 	mcpiface "github.com/takutakahashi/agentapi-proxy/internal/interfaces/mcp"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	githubsync "github.com/takutakahashi/agentapi-proxy/pkg/github_sync"
 	importexport "github.com/takutakahashi/agentapi-proxy/pkg/import"
 	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionmanager"
@@ -104,6 +106,9 @@ func runProxy(cmd *cobra.Command, args []string) {
 
 	// Register import/export handlers (requires Kubernetes mode)
 	registerImportExportHandlers(configData, proxyServer)
+
+	// Register GitHub sync handlers (requires Kubernetes mode)
+	registerGitHubSyncHandlers(configData, proxyServer)
 
 	// Register SlackBot handlers (requires Kubernetes mode)
 	registerSlackBotHandlers(configData, proxyServer)
@@ -723,6 +728,50 @@ func registerSessionManagerHandlers(configData *config.Config, proxyServer *app.
 	handlers := sessionmanager.NewHandlers(sessionManager, configData.SessionManager.HMACSecret)
 	proxyServer.AddCustomHandler(handlers)
 	log.Printf("[SESSION_MANAGER] Session manager handler registered")
+}
+
+// registerGitHubSyncHandlers registers GitHub bidirectional sync REST API handlers.
+func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Server) {
+	log.Printf("[GITHUB_SYNC] Registering GitHub sync handlers...")
+
+	restConfig, err := ctrl.GetConfig()
+	if err != nil {
+		log.Printf("[GITHUB_SYNC] Kubernetes config not available, skipping GitHub sync handlers: %v", err)
+		return
+	}
+
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		log.Printf("[GITHUB_SYNC] Failed to create Kubernetes client, skipping GitHub sync handlers: %v", err)
+		return
+	}
+
+	namespace := configData.KubernetesSession.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	scheduleManager := schedule.NewKubernetesManager(client, namespace)
+	webhookRepo := repositories.NewKubernetesWebhookRepository(client, namespace)
+	settingsRepo := proxyServer.GetSettingsRepository()
+	memoryRepo := proxyServer.GetMemoryRepository()
+	taskRepo := proxyServer.GetTaskRepository()
+	taskGroupRepo := proxyServer.GetTaskGroupRepository()
+
+	userFileRepo := portrepos.UserFileRepository(repositories.NewKubernetesUserFileRepository(client, namespace))
+
+	syncHandlers := githubsync.NewHandlers(
+		settingsRepo,
+		scheduleManager,
+		webhookRepo,
+		memoryRepo,
+		taskRepo,
+		taskGroupRepo,
+		userFileRepo,
+	)
+	proxyServer.AddCustomHandler(syncHandlers)
+
+	log.Printf("[GITHUB_SYNC] GitHub sync handlers registered successfully")
 }
 
 // registerMCPHandler registers MCP HTTP handler

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -779,6 +779,17 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 	)
 	proxyServer.AddCustomHandler(syncHandlers)
 
+	if interval := configData.GitSync.SyncInterval; interval != "" && interval != "0" {
+		d, err := time.ParseDuration(interval)
+		if err != nil {
+			log.Printf("[GITHUB_SYNC] Invalid sync_interval %q: %v — periodic sync disabled", interval, err)
+		} else {
+			worker := githubsync.NewWorker(syncHandlers.Syncer(), settingsRepo, d)
+			go worker.Start(context.Background())
+			log.Printf("[GITHUB_SYNC] Periodic sync worker started (interval=%s)", interval)
+		}
+	}
+
 	log.Printf("[GITHUB_SYNC] GitHub sync handlers registered successfully")
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -773,6 +773,8 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 		taskGroupRepo,
 		userFileRepo,
 		slackbotRepo,
+		configData.GitSync.Encryption.KMSKeyARN,
+		configData.GitSync.Encryption.AWSRegion,
 	)
 	proxyServer.AddCustomHandler(syncHandlers)
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -784,9 +784,37 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 		if err != nil {
 			log.Printf("[GITHUB_SYNC] Invalid sync_interval %q: %v — periodic sync disabled", interval, err)
 		} else {
-			worker := githubsync.NewWorker(syncHandlers.Syncer(), settingsRepo, d)
-			go worker.Start(context.Background())
-			log.Printf("[GITHUB_SYNC] Periodic sync worker started (interval=%s)", interval)
+			syncNamespace := configData.GitSync.Namespace
+			if syncNamespace == "" {
+				syncNamespace = namespace
+			}
+			leaseDuration := 15 * time.Second
+			renewDeadline := 10 * time.Second
+			retryPeriod := 2 * time.Second
+			if v := configData.GitSync.LeaseDuration; v != "" {
+				if parsed, parseErr := time.ParseDuration(v); parseErr == nil {
+					leaseDuration = parsed
+				}
+			}
+			if v := configData.GitSync.RenewDeadline; v != "" {
+				if parsed, parseErr := time.ParseDuration(v); parseErr == nil {
+					renewDeadline = parsed
+				}
+			}
+			if v := configData.GitSync.RetryPeriod; v != "" {
+				if parsed, parseErr := time.ParseDuration(v); parseErr == nil {
+					retryPeriod = parsed
+				}
+			}
+			electionConfig := schedule.LeaderElectionConfig{
+				LeaseDuration: leaseDuration,
+				RenewDeadline: renewDeadline,
+				RetryPeriod:   retryPeriod,
+				Namespace:     syncNamespace,
+			}
+			leaderWorker := githubsync.NewLeaderWorker(syncHandlers.Syncer(), settingsRepo, d, client, electionConfig)
+			go leaderWorker.Run(context.Background())
+			log.Printf("[GITHUB_SYNC] Periodic sync worker started with leader election (interval=%s)", interval)
 		}
 	}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -746,7 +746,10 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 		return
 	}
 
-	namespace := configData.KubernetesSession.Namespace
+	namespace := configData.ScheduleWorker.Namespace
+	if namespace == "" {
+		namespace = configData.KubernetesSession.Namespace
+	}
 	if namespace == "" {
 		namespace = "default"
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -775,6 +775,7 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 		slackbotRepo,
 		configData.GitSync.Encryption.KMSKeyARN,
 		configData.GitSync.Encryption.AWSRegion,
+		configData.GitSync.GitHubApp.InstallationID,
 	)
 	proxyServer.AddCustomHandler(syncHandlers)
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.30.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.2
@@ -105,7 +106,6 @@ require (
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/term v0.38.0 // indirect

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -446,7 +446,7 @@ kubernetesSession:
 
       [[hooks.Stop.hooks]]
       type = "command"
-      command = "agentapi-proxy client send-notification --endpoint http://$AGENTAPI_PROXY_SERVICE_HOST:$AGENTAPI_PROXY_SERVICE_PORT --title \"codex-acp セッションが完了しました\" --body \"セッション $AGENTAPI_SESSION_ID が終了しました\" --notify-user-id \"$AGENTAPI_USER_ID\" >> /tmp/notification.log 2>&1"
+      command = "agentapi-proxy client send-notification --title \"Session completed\" --body \"$AGENTAPI_SESSION_ID\" --notify-user-id \"$AGENTAPI_USER_ID\" > /tmp/notify.log 2>&1"
 
       [[hooks.Stop.hooks]]
       type = "command"

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -102,6 +102,25 @@ type ExternalSessionManagerEntry struct {
 	Default bool `json:"default,omitempty"`
 }
 
+// SyncEncryptionConfig holds AWS KMS configuration for GitHub sync encryption
+type SyncEncryptionConfig struct {
+	KMSKeyARN    string `json:"kms_key_arn"`
+	AWSRegion    string `json:"aws_region"`
+	EncryptedDEK string `json:"encrypted_dek,omitempty"` // base64(KMS.Encrypt(DEK)), empty until first push
+	DEKVersion   int    `json:"dek_version,omitempty"`
+}
+
+// GitSyncConfig holds configuration for GitHub bidirectional sync
+type GitSyncConfig struct {
+	Enabled      bool                 `json:"enabled"`
+	RepoFullName string               `json:"repo_full_name"` // "owner/repo"
+	Branch       string               `json:"branch"`
+	RootPath     string               `json:"root_path"` // e.g. "agentapi-config/" (trailing slash)
+	AutoPush     bool                 `json:"auto_push"`
+	GitHubToken  string               `json:"github_token,omitempty"` // PAT for sync (stored encrypted in K8s Secret)
+	Encryption   SyncEncryptionConfig `json:"encryption"`
+}
+
 // Settings represents user or team settings
 type Settings struct {
 	name                    string
@@ -116,6 +135,7 @@ type Settings struct {
 	slackUserID             string            // Slack DM notification user ID
 	notificationChannels    []string          // Active notification channels (e.g. "web", "slack")
 	externalSessionManagers []ExternalSessionManagerEntry
+	gitSync                 *GitSyncConfig
 	createdAt               time.Time
 	updatedAt               time.Time
 }
@@ -336,4 +356,15 @@ func (s *Settings) Validate() error {
 	}
 
 	return nil
+}
+
+// GitSync returns the GitHub sync configuration
+func (s *Settings) GitSync() *GitSyncConfig {
+	return s.gitSync
+}
+
+// SetGitSync sets the GitHub sync configuration
+func (s *Settings) SetGitSync(g *GitSyncConfig) {
+	s.gitSync = g
+	s.updatedAt = time.Now()
 }

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -119,6 +119,7 @@ type GitSyncConfig struct {
 	AutoPush     bool                 `json:"auto_push"`
 	GitHubToken  string               `json:"github_token,omitempty"` // PAT for sync (stored encrypted in K8s Secret)
 	Encryption   SyncEncryptionConfig `json:"encryption"`
+	LastPushedAt time.Time            `json:"last_pushed_at,omitempty"` // time of last successful push
 }
 
 // Settings represents user or team settings

--- a/internal/infrastructure/repositories/external_memory_repository.go
+++ b/internal/infrastructure/repositories/external_memory_repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -458,6 +459,8 @@ func (r *ExternalMemoryRepository) filterUserIDs(filter portrepos.MemoryFilter) 
 }
 
 // listAllMemories fetches all memories for a user by paginating through the list endpoint.
+// If a paginated request fails (e.g. memory-server 500 on page N>1), it logs a warning
+// and returns the memories collected so far rather than failing completely.
 func (r *ExternalMemoryRepository) listAllMemories(ctx context.Context, token, userID string) ([]*msMemory, error) {
 	var all []*msMemory
 	var nextToken *string
@@ -470,22 +473,39 @@ func (r *ExternalMemoryRepository) listAllMemories(ctx context.Context, token, u
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 		if err != nil {
+			if nextToken != nil {
+				// Partial result is still useful.
+				log.Printf("[MEMORY] Warning: list page failed for user %q: %v — returning %d collected so far", userID, err, len(all))
+				return all, nil
+			}
 			return nil, err
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 
 		resp, err := r.httpClient.Do(req)
 		if err != nil {
+			if nextToken != nil {
+				log.Printf("[MEMORY] Warning: list page failed for user %q: %v — returning %d collected so far", userID, err, len(all))
+				return all, nil
+			}
 			return nil, err
 		}
 		defer resp.Body.Close() //nolint:errcheck
 
 		if resp.StatusCode != http.StatusOK {
+			if nextToken != nil {
+				log.Printf("[MEMORY] Warning: list page returned HTTP %d for user %q — returning %d collected so far", resp.StatusCode, userID, len(all))
+				return all, nil
+			}
 			return nil, fmt.Errorf("list memories: HTTP %d", resp.StatusCode)
 		}
 
 		var result msListResult
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			if nextToken != nil {
+				log.Printf("[MEMORY] Warning: decode list page failed for user %q: %v — returning %d collected so far", userID, err, len(all))
+				return all, nil
+			}
 			return nil, err
 		}
 

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -88,6 +88,7 @@ type gitSyncJSON struct {
 	AutoPush     bool                     `json:"auto_push"`
 	GitHubToken  string                   `json:"github_token,omitempty"`
 	Encryption   syncEncryptionConfigJSON `json:"encryption"`
+	LastPushedAt *time.Time               `json:"last_pushed_at,omitempty"`
 }
 
 // KubernetesSettingsRepository implements SettingsRepository using Kubernetes Secrets
@@ -303,7 +304,7 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 	}
 
 	if gitSync := settings.GitSync(); gitSync != nil {
-		sj.GitSync = &gitSyncJSON{
+		j := &gitSyncJSON{
 			Enabled:      gitSync.Enabled,
 			RepoFullName: gitSync.RepoFullName,
 			Branch:       gitSync.Branch,
@@ -317,6 +318,10 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 				DEKVersion:   gitSync.Encryption.DEKVersion,
 			},
 		}
+		if !gitSync.LastPushedAt.IsZero() {
+			j.LastPushedAt = &gitSync.LastPushedAt
+		}
+		sj.GitSync = j
 	}
 
 	return json.Marshal(sj)
@@ -446,6 +451,9 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 				EncryptedDEK: sj.GitSync.Encryption.EncryptedDEK,
 				DEKVersion:   sj.GitSync.Encryption.DEKVersion,
 			},
+		}
+		if sj.GitSync.LastPushedAt != nil {
+			gs.LastPushedAt = *sj.GitSync.LastPushedAt
 		}
 		settings.SetGitSync(gs)
 		settings.SetUpdatedAt(sj.UpdatedAt)

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -41,6 +41,7 @@ type settingsJSON struct {
 	SlackUserID             string                                 `json:"slack_user_id,omitempty"`             // Slack DM notification user ID
 	NotificationChannels    []string                               `json:"notification_channels,omitempty"`     // Active notification channels
 	ExternalSessionManagers []entities.ExternalSessionManagerEntry `json:"external_session_managers,omitempty"` // Registered external session managers
+	GitSync                 *gitSyncJSON                           `json:"git_sync,omitempty"`
 	CreatedAt               time.Time                              `json:"created_at"`
 	UpdatedAt               time.Time                              `json:"updated_at"`
 }
@@ -68,6 +69,25 @@ type mcpServerJSON struct {
 // marketplaceJSON is the JSON representation of a single marketplace
 type marketplaceJSON struct {
 	URL string `json:"url"`
+}
+
+// syncEncryptionConfigJSON is the JSON representation of sync encryption config
+type syncEncryptionConfigJSON struct {
+	KMSKeyARN    string `json:"kms_key_arn"`
+	AWSRegion    string `json:"aws_region"`
+	EncryptedDEK string `json:"encrypted_dek,omitempty"`
+	DEKVersion   int    `json:"dek_version,omitempty"`
+}
+
+// gitSyncJSON is the JSON representation of GitHub sync configuration
+type gitSyncJSON struct {
+	Enabled      bool                     `json:"enabled"`
+	RepoFullName string                   `json:"repo_full_name"`
+	Branch       string                   `json:"branch"`
+	RootPath     string                   `json:"root_path"`
+	AutoPush     bool                     `json:"auto_push"`
+	GitHubToken  string                   `json:"github_token,omitempty"`
+	Encryption   syncEncryptionConfigJSON `json:"encryption"`
 }
 
 // KubernetesSettingsRepository implements SettingsRepository using Kubernetes Secrets
@@ -282,6 +302,23 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 		sj.ExternalSessionManagers = managers
 	}
 
+	if gitSync := settings.GitSync(); gitSync != nil {
+		sj.GitSync = &gitSyncJSON{
+			Enabled:      gitSync.Enabled,
+			RepoFullName: gitSync.RepoFullName,
+			Branch:       gitSync.Branch,
+			RootPath:     gitSync.RootPath,
+			AutoPush:     gitSync.AutoPush,
+			GitHubToken:  gitSync.GitHubToken,
+			Encryption: syncEncryptionConfigJSON{
+				KMSKeyARN:    gitSync.Encryption.KMSKeyARN,
+				AWSRegion:    gitSync.Encryption.AWSRegion,
+				EncryptedDEK: gitSync.Encryption.EncryptedDEK,
+				DEKVersion:   gitSync.Encryption.DEKVersion,
+			},
+		}
+	}
+
 	return json.Marshal(sj)
 }
 
@@ -392,6 +429,25 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 
 	if len(sj.ExternalSessionManagers) > 0 {
 		settings.SetExternalSessionManagers(sj.ExternalSessionManagers)
+		settings.SetUpdatedAt(sj.UpdatedAt)
+	}
+
+	if sj.GitSync != nil {
+		gs := &entities.GitSyncConfig{
+			Enabled:      sj.GitSync.Enabled,
+			RepoFullName: sj.GitSync.RepoFullName,
+			Branch:       sj.GitSync.Branch,
+			RootPath:     sj.GitSync.RootPath,
+			AutoPush:     sj.GitSync.AutoPush,
+			GitHubToken:  sj.GitSync.GitHubToken,
+			Encryption: entities.SyncEncryptionConfig{
+				KMSKeyARN:    sj.GitSync.Encryption.KMSKeyARN,
+				AWSRegion:    sj.GitSync.Encryption.AWSRegion,
+				EncryptedDEK: sj.GitSync.Encryption.EncryptedDEK,
+				DEKVersion:   sj.GitSync.Encryption.DEKVersion,
+			},
+		}
+		settings.SetGitSync(gs)
 		settings.SetUpdatedAt(sj.UpdatedAt)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -424,6 +424,15 @@ type GitSyncProxyConfig struct {
 	// SyncInterval is how often the periodic sync worker runs (e.g. "5m", "1h").
 	// An empty value or "0" disables the periodic worker.
 	SyncInterval string `json:"sync_interval" mapstructure:"sync_interval"`
+	// Namespace overrides the Kubernetes namespace for the leader election lease.
+	// Falls back to schedule_worker.namespace or kubernetes_session.namespace if empty.
+	Namespace string `json:"namespace" mapstructure:"namespace"`
+	// LeaseDuration is the duration that non-leader candidates will wait to force acquire leadership.
+	LeaseDuration string `json:"lease_duration" mapstructure:"lease_duration"`
+	// RenewDeadline is the duration that the acting master will retry refreshing leadership before giving up.
+	RenewDeadline string `json:"renew_deadline" mapstructure:"renew_deadline"`
+	// RetryPeriod is the duration the LeaderElector clients should wait between tries of actions.
+	RetryPeriod string `json:"retry_period" mapstructure:"retry_period"`
 }
 
 // SlackConfig represents Slack bot (Socket Mode) configuration
@@ -777,6 +786,10 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("git_sync.encryption.kms_key_arn", "AGENTAPI_GIT_SYNC_ENCRYPTION_KMS_KEY_ARN")
 	_ = v.BindEnv("git_sync.encryption.aws_region", "AGENTAPI_GIT_SYNC_ENCRYPTION_AWS_REGION")
 	_ = v.BindEnv("git_sync.github_app.installation_id", "AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID")
+	_ = v.BindEnv("git_sync.namespace", "AGENTAPI_GIT_SYNC_NAMESPACE")
+	_ = v.BindEnv("git_sync.lease_duration", "AGENTAPI_GIT_SYNC_LEASE_DURATION")
+	_ = v.BindEnv("git_sync.renew_deadline", "AGENTAPI_GIT_SYNC_RENEW_DEADLINE")
+	_ = v.BindEnv("git_sync.retry_period", "AGENTAPI_GIT_SYNC_RETRY_PERIOD")
 }
 
 // setDefaults sets default values for viper configuration
@@ -874,6 +887,11 @@ func setDefaults(v *viper.Viper) {
 
 	// Slack defaults
 	v.SetDefault("slack.dry_run", false)
+
+	// GitHub sync worker leader election defaults
+	v.SetDefault("git_sync.lease_duration", "15s")
+	v.SetDefault("git_sync.renew_deadline", "10s")
+	v.SetDefault("git_sync.retry_period", "2s")
 
 	// Redis defaults (empty addr = disabled)
 	v.SetDefault("redis.addr", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -392,6 +392,23 @@ type Config struct {
 	// Redis holds optional Redis configuration for cross-pod status synchronisation.
 	// When Redis.Addr is empty the feature is disabled and a no-op fallback is used.
 	Redis RedisConfig `json:"redis" mapstructure:"redis"`
+	// GitSync holds proxy-level GitHub sync settings (e.g. KMS encryption key).
+	GitSync GitSyncProxyConfig `json:"git_sync" mapstructure:"git_sync"`
+}
+
+// GitSyncEncryptionProxyConfig holds proxy-level AWS KMS settings for GitHub sync.
+// These are set by the operator and are NOT configurable by individual users.
+type GitSyncEncryptionProxyConfig struct {
+	// KMSKeyARN is the ARN of the AWS KMS key used to encrypt sync DEKs.
+	KMSKeyARN string `json:"kms_key_arn" mapstructure:"kms_key_arn"`
+	// AWSRegion is the AWS region where the KMS key resides.
+	AWSRegion string `json:"aws_region" mapstructure:"aws_region"`
+}
+
+// GitSyncProxyConfig holds proxy-level GitHub sync settings.
+type GitSyncProxyConfig struct {
+	// Encryption is the KMS encryption configuration used for all user sync operations.
+	Encryption GitSyncEncryptionProxyConfig `json:"encryption" mapstructure:"encryption"`
 }
 
 // SlackConfig represents Slack bot (Socket Mode) configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -405,10 +405,22 @@ type GitSyncEncryptionProxyConfig struct {
 	AWSRegion string `json:"aws_region" mapstructure:"aws_region"`
 }
 
+// GitSyncGitHubAppConfig holds GitHub App fallback settings for sync token generation.
+// When a user has no personal GitHub token configured, the proxy uses these credentials
+// to generate an installation access token on their behalf.
+// App ID and PEM are read from GITHUB_APP_ID and GITHUB_APP_PEM / GITHUB_APP_PEM_PATH env vars.
+type GitSyncGitHubAppConfig struct {
+	// InstallationID is the GitHub App installation ID to use as a token fallback.
+	// If empty, the GitHub App fallback is disabled.
+	InstallationID string `json:"installation_id" mapstructure:"installation_id"`
+}
+
 // GitSyncProxyConfig holds proxy-level GitHub sync settings.
 type GitSyncProxyConfig struct {
 	// Encryption is the KMS encryption configuration used for all user sync operations.
 	Encryption GitSyncEncryptionProxyConfig `json:"encryption" mapstructure:"encryption"`
+	// GitHubApp is the optional GitHub App fallback for token generation.
+	GitHubApp GitSyncGitHubAppConfig `json:"github_app" mapstructure:"github_app"`
 }
 
 // SlackConfig represents Slack bot (Socket Mode) configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -771,6 +771,12 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("redis.dial_timeout", "AGENTAPI_REDIS_DIAL_TIMEOUT")
 	_ = v.BindEnv("redis.read_timeout", "AGENTAPI_REDIS_READ_TIMEOUT")
 	_ = v.BindEnv("redis.write_timeout", "AGENTAPI_REDIS_WRITE_TIMEOUT")
+
+	// GitHub sync proxy configuration
+	_ = v.BindEnv("git_sync.sync_interval", "AGENTAPI_GIT_SYNC_SYNC_INTERVAL")
+	_ = v.BindEnv("git_sync.encryption.kms_key_arn", "AGENTAPI_GIT_SYNC_ENCRYPTION_KMS_KEY_ARN")
+	_ = v.BindEnv("git_sync.encryption.aws_region", "AGENTAPI_GIT_SYNC_ENCRYPTION_AWS_REGION")
+	_ = v.BindEnv("git_sync.github_app.installation_id", "AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID")
 }
 
 // setDefaults sets default values for viper configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -421,6 +421,9 @@ type GitSyncProxyConfig struct {
 	Encryption GitSyncEncryptionProxyConfig `json:"encryption" mapstructure:"encryption"`
 	// GitHubApp is the optional GitHub App fallback for token generation.
 	GitHubApp GitSyncGitHubAppConfig `json:"github_app" mapstructure:"github_app"`
+	// SyncInterval is how often the periodic sync worker runs (e.g. "5m", "1h").
+	// An empty value or "0" disables the periodic worker.
+	SyncInterval string `json:"sync_interval" mapstructure:"sync_interval"`
 }
 
 // SlackConfig represents Slack bot (Socket Mode) configuration

--- a/pkg/github_sync/encryptor.go
+++ b/pkg/github_sync/encryptor.go
@@ -1,0 +1,176 @@
+package githubsync
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+)
+
+const (
+	// encPrefix identifies encrypted field values in YAML exports
+	encPrefix = "enc:v1:"
+	// dekSize is 256-bit AES key
+	dekSize = 32
+	// nonceSize is 96-bit GCM nonce
+	nonceSize = 12
+)
+
+// sensitiveKeyPatterns are substrings that mark a key as sensitive
+var sensitiveKeyPatterns = []string{
+	"SECRET", "TOKEN", "KEY", "PASSWORD", "PASS",
+	"CREDENTIAL", "AUTH", "PRIVATE", "API_KEY",
+}
+
+// SyncEncryptor manages fixed-DEK AWS KMS envelope encryption for GitHub sync.
+// The DEK is generated once per GitSyncConfig and stored encrypted in Settings.
+type SyncEncryptor struct {
+	kmsClient *kms.Client
+	kmsKeyARN string
+}
+
+// NewSyncEncryptor creates a SyncEncryptor using AWS default credentials
+// (IRSA > env vars > ~/.aws).
+func NewSyncEncryptor(ctx context.Context, kmsKeyARN, awsRegion string) (*SyncEncryptor, error) {
+	if kmsKeyARN == "" {
+		return nil, fmt.Errorf("kms_key_arn is required for GitHub sync encryption")
+	}
+	if awsRegion == "" {
+		return nil, fmt.Errorf("aws_region is required for GitHub sync encryption")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(awsRegion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	return &SyncEncryptor{
+		kmsClient: kms.NewFromConfig(cfg),
+		kmsKeyARN: kmsKeyARN,
+	}, nil
+}
+
+// GenerateAndEncryptDEK generates a fresh random 256-bit DEK, encrypts it with KMS,
+// and returns both the raw DEK bytes (for immediate use) and the base64 encrypted DEK
+// (for storage in GitSyncConfig.Encryption.EncryptedDEK).
+func (e *SyncEncryptor) GenerateAndEncryptDEK(ctx context.Context) (dek []byte, encryptedDEK string, err error) {
+	dek = make([]byte, dekSize)
+	if _, err = rand.Read(dek); err != nil {
+		return nil, "", fmt.Errorf("failed to generate DEK: %w", err)
+	}
+
+	result, err := e.kmsClient.Encrypt(ctx, &kms.EncryptInput{
+		KeyId:     aws.String(e.kmsKeyARN),
+		Plaintext: dek,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("KMS encrypt DEK failed: %w", err)
+	}
+
+	encryptedDEK = base64.StdEncoding.EncodeToString(result.CiphertextBlob)
+	return dek, encryptedDEK, nil
+}
+
+// DecryptDEK decrypts the base64-encoded encrypted DEK stored in GitSyncConfig.
+func (e *SyncEncryptor) DecryptDEK(ctx context.Context, encryptedDEK string) ([]byte, error) {
+	ciphertext, err := base64.StdEncoding.DecodeString(encryptedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64-decode encryptedDEK: %w", err)
+	}
+
+	result, err := e.kmsClient.Decrypt(ctx, &kms.DecryptInput{
+		CiphertextBlob: ciphertext,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("KMS decrypt DEK failed: %w", err)
+	}
+
+	return result.Plaintext, nil
+}
+
+// EncryptField encrypts a plaintext value with AES-256-GCM using a deterministic nonce.
+// The nonce = HMAC-SHA256(DEK, plaintext)[:12] — same plaintext+DEK always yields the
+// same ciphertext, keeping git diffs clean.
+// Returns "enc:v1:<base64(nonce||ciphertext)>".
+func EncryptField(dek []byte, plaintext string) (string, error) {
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return "", fmt.Errorf("AES cipher init failed: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("GCM init failed: %w", err)
+	}
+
+	mac := hmac.New(sha256.New, dek)
+	mac.Write([]byte(plaintext))
+	nonce := mac.Sum(nil)[:nonceSize]
+
+	ciphertext := gcm.Seal(nil, nonce, []byte(plaintext), nil)
+
+	combined := make([]byte, nonceSize+len(ciphertext))
+	copy(combined[:nonceSize], nonce)
+	copy(combined[nonceSize:], ciphertext)
+	return encPrefix + base64.StdEncoding.EncodeToString(combined), nil
+}
+
+// DecryptField decrypts a value produced by EncryptField.
+// If the value does not have the enc:v1: prefix it is returned as-is (plaintext pass-through).
+func DecryptField(dek []byte, value string) (string, error) {
+	if !strings.HasPrefix(value, encPrefix) {
+		return value, nil
+	}
+
+	encoded := strings.TrimPrefix(value, encPrefix)
+	combined, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("failed to base64-decode encrypted field: %w", err)
+	}
+	if len(combined) < nonceSize {
+		return "", fmt.Errorf("encrypted field too short")
+	}
+
+	nonce := combined[:nonceSize]
+	ciphertext := combined[nonceSize:]
+
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return "", fmt.Errorf("AES cipher init failed: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("GCM init failed: %w", err)
+	}
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("AES-GCM decryption failed: %w", err)
+	}
+
+	return string(plaintext), nil
+}
+
+// IsEncrypted returns true when the value carries the enc:v1: prefix.
+func IsEncrypted(value string) bool {
+	return strings.HasPrefix(value, encPrefix)
+}
+
+// IsSensitiveKey returns true when an env-var or header key name suggests its value is secret.
+func IsSensitiveKey(key string) bool {
+	upper := strings.ToUpper(key)
+	for _, p := range sensitiveKeyPatterns {
+		if strings.Contains(upper, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/github_sync/github_client.go
+++ b/pkg/github_sync/github_client.go
@@ -1,0 +1,155 @@
+package githubsync
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v57/github"
+	"golang.org/x/oauth2"
+)
+
+// GitHubSyncClient wraps the GitHub Git Data API for atomic batch push/pull.
+type GitHubSyncClient struct {
+	client *github.Client
+	owner  string
+	repo   string
+}
+
+// NewGitHubSyncClient creates a client authenticated with the given PAT.
+// repoFullName must be "owner/repo".
+func NewGitHubSyncClient(ctx context.Context, token, repoFullName string) (*GitHubSyncClient, error) {
+	parts := strings.SplitN(repoFullName, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("repoFullName must be 'owner/repo', got %q", repoFullName)
+	}
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+	return &GitHubSyncClient{
+		client: github.NewClient(tc),
+		owner:  parts[0],
+		repo:   parts[1],
+	}, nil
+}
+
+// PushFiles commits files to the repository in a single atomic commit.
+// files maps repo-relative paths to content. nil content entries delete the file.
+// Returns the new commit SHA.
+func (c *GitHubSyncClient) PushFiles(ctx context.Context, branch, commitMessage string, files map[string][]byte) (string, error) {
+	// 1. Resolve current HEAD SHA
+	ref, _, err := c.client.Git.GetRef(ctx, c.owner, c.repo, "refs/heads/"+branch)
+	if err != nil {
+		return "", fmt.Errorf("get ref %s: %w", branch, err)
+	}
+	headSHA := ref.Object.GetSHA()
+
+	// 2. Get base tree SHA from HEAD commit
+	commit, _, err := c.client.Git.GetCommit(ctx, c.owner, c.repo, headSHA)
+	if err != nil {
+		return "", fmt.Errorf("get commit %s: %w", headSHA, err)
+	}
+	baseTreeSHA := commit.Tree.GetSHA()
+
+	// 3. Build tree entries
+	entries := make([]*github.TreeEntry, 0, len(files))
+	for path, content := range files {
+		if content == nil {
+			// Deletion: SHA = nil clears the entry
+			entries = append(entries, &github.TreeEntry{
+				Path: github.String(path),
+				Mode: github.String("100644"),
+				Type: github.String("blob"),
+			})
+			continue
+		}
+		encoded := base64.StdEncoding.EncodeToString(content)
+		blob, _, err := c.client.Git.CreateBlob(ctx, c.owner, c.repo, &github.Blob{
+			Content:  github.String(encoded),
+			Encoding: github.String("base64"),
+		})
+		if err != nil {
+			return "", fmt.Errorf("create blob for %s: %w", path, err)
+		}
+		entries = append(entries, &github.TreeEntry{
+			Path: github.String(path),
+			Mode: github.String("100644"),
+			Type: github.String("blob"),
+			SHA:  blob.SHA,
+		})
+	}
+
+	if len(entries) == 0 {
+		return headSHA, nil
+	}
+
+	// 4. Create new tree on top of base tree
+	newTree, _, err := c.client.Git.CreateTree(ctx, c.owner, c.repo, baseTreeSHA, entries)
+	if err != nil {
+		return "", fmt.Errorf("create tree: %w", err)
+	}
+
+	// 5. Create commit
+	newCommit, _, err := c.client.Git.CreateCommit(ctx, c.owner, c.repo, &github.Commit{
+		Message: github.String(commitMessage),
+		Tree:    &github.Tree{SHA: newTree.SHA},
+		Parents: []*github.Commit{{SHA: github.String(headSHA)}},
+	}, nil)
+	if err != nil {
+		return "", fmt.Errorf("create commit: %w", err)
+	}
+
+	// 6. Fast-forward branch ref
+	_, _, err = c.client.Git.UpdateRef(ctx, c.owner, c.repo, &github.Reference{
+		Ref:    github.String("refs/heads/" + branch),
+		Object: &github.GitObject{SHA: newCommit.SHA},
+	}, false)
+	if err != nil {
+		return "", fmt.Errorf("update ref: %w", err)
+	}
+
+	return newCommit.GetSHA(), nil
+}
+
+// ListFiles returns repo-relative paths of all blobs under the given prefix on the branch.
+func (c *GitHubSyncClient) ListFiles(ctx context.Context, branch, prefix string) ([]string, error) {
+	ref, _, err := c.client.Git.GetRef(ctx, c.owner, c.repo, "refs/heads/"+branch)
+	if err != nil {
+		return nil, fmt.Errorf("get ref %s: %w", branch, err)
+	}
+
+	tree, _, err := c.client.Git.GetTree(ctx, c.owner, c.repo, ref.Object.GetSHA(), true)
+	if err != nil {
+		return nil, fmt.Errorf("get tree: %w", err)
+	}
+
+	var paths []string
+	for _, entry := range tree.Entries {
+		if entry.GetType() != "blob" {
+			continue
+		}
+		p := entry.GetPath()
+		if strings.HasPrefix(p, prefix) {
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
+}
+
+// GetFile returns the decoded content of a single file from the repository.
+func (c *GitHubSyncClient) GetFile(ctx context.Context, branch, path string) ([]byte, error) {
+	opts := &github.RepositoryContentGetOptions{Ref: branch}
+	fc, _, _, err := c.client.Repositories.GetContents(ctx, c.owner, c.repo, path, opts)
+	if err != nil {
+		return nil, fmt.Errorf("get file %s: %w", path, err)
+	}
+	if fc == nil {
+		return nil, fmt.Errorf("file %s not found", path)
+	}
+	content, err := fc.GetContent()
+	if err != nil {
+		return nil, fmt.Errorf("decode file %s: %w", path, err)
+	}
+	return []byte(content), nil
+}

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -48,6 +48,9 @@ func NewHandlers(
 // GetName implements app.CustomHandler.
 func (h *Handlers) GetName() string { return "GitHubSyncHandlers" }
 
+// Syncer returns the underlying Syncer for use by the periodic worker.
+func (h *Handlers) Syncer() *Syncer { return h.syncer }
+
 // RegisterRoutes implements app.CustomHandler.
 func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *app.Server) error {
 	e.GET("/sync/config/:name", h.GetConfig)

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -110,9 +110,17 @@ func (h *Handlers) UpdateConfig(c echo.Context) error {
 	existing := settings.GitSync()
 	encDEK := ""
 	dekVersion := 0
+	existingToken := ""
 	if existing != nil {
 		encDEK = existing.Encryption.EncryptedDEK
 		dekVersion = existing.Encryption.DEKVersion
+		existingToken = existing.GitHubToken
+	}
+
+	// Preserve existing token if the request doesn't supply a new one.
+	token := req.GitHubToken
+	if token == "" {
+		token = existingToken
 	}
 
 	gs := &entities.GitSyncConfig{
@@ -121,7 +129,7 @@ func (h *Handlers) UpdateConfig(c echo.Context) error {
 		Branch:       req.Branch,
 		RootPath:     req.RootPath,
 		AutoPush:     req.AutoPush,
-		GitHubToken:  req.GitHubToken,
+		GitHubToken:  token,
 		Encryption: entities.SyncEncryptionConfig{
 			KMSKeyARN:    req.Encryption.KMSKeyARN,
 			AWSRegion:    req.Encryption.AWSRegion,
@@ -257,11 +265,12 @@ func (h *Handlers) canModifySettings(user *entities.User, name string) bool {
 // toConfigResponse converts GitSyncConfig to the public response (token redacted).
 func toConfigResponse(gs *entities.GitSyncConfig) *SyncConfigResponse {
 	return &SyncConfigResponse{
-		Enabled:      gs.Enabled,
-		RepoFullName: gs.RepoFullName,
-		Branch:       gs.Branch,
-		RootPath:     gs.RootPath,
-		AutoPush:     gs.AutoPush,
+		Enabled:        gs.Enabled,
+		RepoFullName:   gs.RepoFullName,
+		Branch:         gs.Branch,
+		RootPath:       gs.RootPath,
+		AutoPush:       gs.AutoPush,
+		HasGitHubToken: gs.GitHubToken != "",
 		Encryption: SyncEncryptionResponse{
 			KMSKeyARN:  gs.Encryption.KMSKeyARN,
 			AWSRegion:  gs.Encryption.AWSRegion,

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -1,0 +1,271 @@
+package githubsync
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/app"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
+)
+
+// Handlers implements app.CustomHandler for GitHub sync endpoints.
+type Handlers struct {
+	syncer       *Syncer
+	settingsRepo portrepos.SettingsRepository
+}
+
+// NewHandlers creates a Handlers instance registering all required repositories.
+func NewHandlers(
+	settingsRepo portrepos.SettingsRepository,
+	scheduleRepo schedule.Manager,
+	webhookRepo portrepos.WebhookRepository,
+	memoryRepo portrepos.MemoryRepository,
+	taskRepo portrepos.TaskRepository,
+	taskGroupRepo portrepos.TaskGroupRepository,
+	userFileRepo portrepos.UserFileRepository,
+) *Handlers {
+	return &Handlers{
+		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo),
+		settingsRepo: settingsRepo,
+	}
+}
+
+// GetName implements app.CustomHandler.
+func (h *Handlers) GetName() string { return "GitHubSyncHandlers" }
+
+// RegisterRoutes implements app.CustomHandler.
+func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *app.Server) error {
+	e.GET("/sync/config/:name", h.GetConfig)
+	e.PUT("/sync/config/:name", h.UpdateConfig)
+	e.DELETE("/sync/config/:name", h.DeleteConfig)
+	e.POST("/sync/push/:name", h.Push)
+	e.POST("/sync/pull/:name", h.Pull)
+	e.POST("/sync/rotate-key/:name", h.RotateKey)
+	log.Printf("[SYNC] Registered GitHub sync endpoints (/sync/*)")
+	return nil
+}
+
+// GetConfig handles GET /sync/config/:name
+func (h *Handlers) GetConfig(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	name := c.Param("name")
+	if !h.canAccessSettings(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	settings, err := h.settingsRepo.FindByName(c.Request().Context(), name)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "settings not found")
+	}
+
+	gs := settings.GitSync()
+	if gs == nil {
+		return c.JSON(http.StatusOK, map[string]interface{}{"enabled": false})
+	}
+
+	return c.JSON(http.StatusOK, toConfigResponse(gs))
+}
+
+// UpdateConfig handles PUT /sync/config/:name
+func (h *Handlers) UpdateConfig(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	name := c.Param("name")
+	if !h.canModifySettings(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	var req UpdateSyncConfigRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if req.Encryption.KMSKeyARN == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "encryption.kms_key_arn is required")
+	}
+	if req.Encryption.AWSRegion == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "encryption.aws_region is required")
+	}
+	if req.RepoFullName == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "repo_full_name is required")
+	}
+
+	settings, err := h.settingsRepo.FindByName(c.Request().Context(), name)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "settings not found")
+	}
+
+	existing := settings.GitSync()
+	encDEK := ""
+	dekVersion := 0
+	if existing != nil {
+		encDEK = existing.Encryption.EncryptedDEK
+		dekVersion = existing.Encryption.DEKVersion
+	}
+
+	gs := &entities.GitSyncConfig{
+		Enabled:      req.Enabled,
+		RepoFullName: req.RepoFullName,
+		Branch:       req.Branch,
+		RootPath:     req.RootPath,
+		AutoPush:     req.AutoPush,
+		GitHubToken:  req.GitHubToken,
+		Encryption: entities.SyncEncryptionConfig{
+			KMSKeyARN:    req.Encryption.KMSKeyARN,
+			AWSRegion:    req.Encryption.AWSRegion,
+			EncryptedDEK: encDEK,
+			DEKVersion:   dekVersion,
+		},
+	}
+	if gs.Branch == "" {
+		gs.Branch = "main"
+	}
+	if gs.RootPath == "" {
+		gs.RootPath = "agentapi-config/"
+	}
+
+	settings.SetGitSync(gs)
+	if err := h.settingsRepo.Save(c.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save config")
+	}
+
+	return c.JSON(http.StatusOK, toConfigResponse(gs))
+}
+
+// DeleteConfig handles DELETE /sync/config/:name
+func (h *Handlers) DeleteConfig(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	name := c.Param("name")
+	if !h.canModifySettings(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	settings, err := h.settingsRepo.FindByName(c.Request().Context(), name)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "settings not found")
+	}
+
+	settings.SetGitSync(nil)
+	if err := h.settingsRepo.Save(c.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save settings")
+	}
+
+	return c.JSON(http.StatusOK, map[string]bool{"deleted": true})
+}
+
+// Push handles POST /sync/push/:name
+func (h *Handlers) Push(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	name := c.Param("name")
+	if !h.canModifySettings(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	var req PushRequest
+	_ = c.Bind(&req) // optional body
+
+	resp, err := h.syncer.Push(c.Request().Context(), name, string(user.ID()), req.CommitMessage)
+	if err != nil {
+		log.Printf("[SYNC] push error for %s: %v", name, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("push failed: %v", err))
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// Pull handles POST /sync/pull/:name
+func (h *Handlers) Pull(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	name := c.Param("name")
+	if !h.canModifySettings(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	var req PullRequest
+	_ = c.Bind(&req)
+
+	resp, err := h.syncer.Pull(c.Request().Context(), name, string(user.ID()), req.DeleteOrphans)
+	if err != nil {
+		log.Printf("[SYNC] pull error for %s: %v", name, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("pull failed: %v", err))
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// RotateKey handles POST /sync/rotate-key/:name
+func (h *Handlers) RotateKey(c echo.Context) error {
+	user := auth.GetUserFromContext(c)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	name := c.Param("name")
+	if !h.canModifySettings(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+
+	resp, err := h.syncer.RotateKey(c.Request().Context(), name, string(user.ID()))
+	if err != nil {
+		log.Printf("[SYNC] rotate-key error for %s: %v", name, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("rotate-key failed: %v", err))
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// --- access control helpers ---
+
+func (h *Handlers) canAccessSettings(user *entities.User, name string) bool {
+	if user.IsAdmin() {
+		return true
+	}
+	if string(user.ID()) == name {
+		return true
+	}
+	return user.IsMemberOfTeam(name)
+}
+
+func (h *Handlers) canModifySettings(user *entities.User, name string) bool {
+	return h.canAccessSettings(user, name)
+}
+
+// toConfigResponse converts GitSyncConfig to the public response (token redacted).
+func toConfigResponse(gs *entities.GitSyncConfig) *SyncConfigResponse {
+	return &SyncConfigResponse{
+		Enabled:      gs.Enabled,
+		RepoFullName: gs.RepoFullName,
+		Branch:       gs.Branch,
+		RootPath:     gs.RootPath,
+		AutoPush:     gs.AutoPush,
+		Encryption: SyncEncryptionResponse{
+			KMSKeyARN:  gs.Encryption.KMSKeyARN,
+			AWSRegion:  gs.Encryption.AWSRegion,
+			DEKVersion: gs.Encryption.DEKVersion,
+			DEKReady:   gs.Encryption.EncryptedDEK != "",
+		},
+	}
+}

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -28,9 +28,10 @@ func NewHandlers(
 	taskRepo portrepos.TaskRepository,
 	taskGroupRepo portrepos.TaskGroupRepository,
 	userFileRepo portrepos.UserFileRepository,
+	slackbotRepo portrepos.SlackBotRepository,
 ) *Handlers {
 	return &Handlers{
-		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo),
+		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo, slackbotRepo),
 		settingsRepo: settingsRepo,
 	}
 }

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -23,6 +23,8 @@ type Handlers struct {
 
 // NewHandlers creates a Handlers instance registering all required repositories.
 // kmsKeyARN and awsRegion come from proxy-level config; users cannot override them.
+// githubAppInstallID is optional — when set, it enables GitHub App token fallback for users
+// who have not configured a personal GitHub token.
 func NewHandlers(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
@@ -33,9 +35,10 @@ func NewHandlers(
 	userFileRepo portrepos.UserFileRepository,
 	slackbotRepo portrepos.SlackBotRepository,
 	kmsKeyARN, awsRegion string,
+	githubAppInstallID string,
 ) *Handlers {
 	return &Handlers{
-		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo, slackbotRepo),
+		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo, slackbotRepo, githubAppInstallID),
 		settingsRepo: settingsRepo,
 		kmsKeyARN:    kmsKeyARN,
 		awsRegion:    awsRegion,

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -17,9 +17,12 @@ import (
 type Handlers struct {
 	syncer       *Syncer
 	settingsRepo portrepos.SettingsRepository
+	kmsKeyARN    string
+	awsRegion    string
 }
 
 // NewHandlers creates a Handlers instance registering all required repositories.
+// kmsKeyARN and awsRegion come from proxy-level config; users cannot override them.
 func NewHandlers(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
@@ -29,10 +32,13 @@ func NewHandlers(
 	taskGroupRepo portrepos.TaskGroupRepository,
 	userFileRepo portrepos.UserFileRepository,
 	slackbotRepo portrepos.SlackBotRepository,
+	kmsKeyARN, awsRegion string,
 ) *Handlers {
 	return &Handlers{
 		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo, slackbotRepo),
 		settingsRepo: settingsRepo,
+		kmsKeyARN:    kmsKeyARN,
+		awsRegion:    awsRegion,
 	}
 }
 
@@ -88,15 +94,13 @@ func (h *Handlers) UpdateConfig(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusForbidden, "access denied")
 	}
 
+	if h.kmsKeyARN == "" || h.awsRegion == "" {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "GitHub sync encryption is not configured on this proxy")
+	}
+
 	var req UpdateSyncConfigRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
-	}
-	if req.Encryption.KMSKeyARN == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "encryption.kms_key_arn is required")
-	}
-	if req.Encryption.AWSRegion == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "encryption.aws_region is required")
 	}
 	if req.RepoFullName == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "repo_full_name is required")
@@ -131,8 +135,8 @@ func (h *Handlers) UpdateConfig(c echo.Context) error {
 		AutoPush:     req.AutoPush,
 		GitHubToken:  token,
 		Encryption: entities.SyncEncryptionConfig{
-			KMSKeyARN:    req.Encryption.KMSKeyARN,
-			AWSRegion:    req.Encryption.AWSRegion,
+			KMSKeyARN:    h.kmsKeyARN,
+			AWSRegion:    h.awsRegion,
 			EncryptedDEK: encDEK,
 			DEKVersion:   dekVersion,
 		},
@@ -262,7 +266,7 @@ func (h *Handlers) canModifySettings(user *entities.User, name string) bool {
 	return h.canAccessSettings(user, name)
 }
 
-// toConfigResponse converts GitSyncConfig to the public response (token redacted).
+// toConfigResponse converts GitSyncConfig to the public response (token and KMS details redacted).
 func toConfigResponse(gs *entities.GitSyncConfig) *SyncConfigResponse {
 	return &SyncConfigResponse{
 		Enabled:        gs.Enabled,
@@ -272,8 +276,6 @@ func toConfigResponse(gs *entities.GitSyncConfig) *SyncConfigResponse {
 		AutoPush:       gs.AutoPush,
 		HasGitHubToken: gs.GitHubToken != "",
 		Encryption: SyncEncryptionResponse{
-			KMSKeyARN:  gs.Encryption.KMSKeyARN,
-			AWSRegion:  gs.Encryption.AWSRegion,
 			DEKVersion: gs.Encryption.DEKVersion,
 			DEKReady:   gs.Encryption.EncryptedDEK != "",
 		},

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	infraservices "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
@@ -31,6 +32,7 @@ type Syncer struct {
 	settingsRepo portrepos.SettingsRepository
 	scheduleRepo schedule.Manager
 	webhookRepo  portrepos.WebhookRepository
+	slackbotRepo portrepos.SlackBotRepository
 	userFileRepo portrepos.UserFileRepository
 }
 
@@ -39,15 +41,17 @@ func NewSyncer(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
 	webhookRepo portrepos.WebhookRepository,
-	_ portrepos.MemoryRepository, // unused — kept for call-site compatibility
-	_ portrepos.TaskRepository, // unused
+	_ portrepos.MemoryRepository,   // unused — kept for call-site compatibility
+	_ portrepos.TaskRepository,     // unused
 	_ portrepos.TaskGroupRepository, // unused
 	userFileRepo portrepos.UserFileRepository,
+	slackbotRepo portrepos.SlackBotRepository,
 ) *Syncer {
 	return &Syncer{
 		settingsRepo: settingsRepo,
 		scheduleRepo: scheduleRepo,
 		webhookRepo:  webhookRepo,
+		slackbotRepo: slackbotRepo,
 		userFileRepo: userFileRepo,
 	}
 }
@@ -108,6 +112,15 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		if err := s.exportUserFiles(ctx, userID, dek, rootPath, files); err != nil {
 			log.Printf("[SYNC] user file export warning for %s: %v", settingsName, err)
 		}
+		if err := s.exportUserSchedules(ctx, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] user schedule export warning for %s: %v", settingsName, err)
+		}
+		if err := s.exportUserWebhooks(ctx, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] user webhook export warning for %s: %v", settingsName, err)
+		}
+		if err := s.exportUserSlackbots(ctx, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] user slackbot export warning for %s: %v", settingsName, err)
+		}
 	} else {
 		if err := s.exportTeamSchedules(ctx, settingsName, userID, dek, rootPath, files); err != nil {
 			log.Printf("[SYNC] schedule export warning for %s: %v", settingsName, err)
@@ -117,6 +130,9 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		}
 		if err := s.exportTeamSettings(ctx, settingsName, userID, dek, rootPath, files); err != nil {
 			log.Printf("[SYNC] settings export warning for %s: %v", settingsName, err)
+		}
+		if err := s.exportTeamSlackbots(ctx, settingsName, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] slackbot export warning for %s: %v", settingsName, err)
 		}
 	}
 
@@ -249,14 +265,24 @@ func (s *Syncer) importFileByPath(ctx context.Context, filePath string, content 
 	settingsName, userID string, dek []byte, teamPrefix, userPrefix string) error {
 
 	switch {
+	// Team sync paths
 	case strings.HasPrefix(filePath, teamPrefix+"schedules/"):
 		return s.importScheduleFile(ctx, content, settingsName, userID, dek)
 	case strings.HasPrefix(filePath, teamPrefix+"webhooks/"):
 		return s.importWebhookFile(ctx, content, settingsName, userID, dek)
 	case filePath == teamPrefix+"settings.yaml":
 		return s.importSettingsFile(ctx, content, settingsName, userID, dek)
+	case strings.HasPrefix(filePath, teamPrefix+"slackbots/"):
+		return s.importSlackbotFile(ctx, content, entities.ScopeTeam, userID, settingsName, dek)
+	// Personal sync paths
 	case strings.HasPrefix(filePath, userPrefix+"files/"):
 		return s.importUserFileRecord(ctx, content, userID, dek)
+	case strings.HasPrefix(filePath, userPrefix+"schedules/"):
+		return s.importUserScheduleFile(ctx, content, userID, dek)
+	case strings.HasPrefix(filePath, userPrefix+"webhooks/"):
+		return s.importUserWebhookFile(ctx, content, userID, dek)
+	case strings.HasPrefix(filePath, userPrefix+"slackbots/"):
+		return s.importSlackbotFile(ctx, content, entities.ScopeUser, userID, "", dek)
 	default:
 		return nil
 	}
@@ -490,6 +516,118 @@ func (s *Syncer) exportUserFiles(ctx context.Context, userID string, dek []byte,
 	return nil
 }
 
+func (s *Syncer) exportUserSchedules(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.scheduleRepo == nil {
+		return nil
+	}
+	schedules, err := s.scheduleRepo.List(ctx, schedule.ScheduleFilter{
+		Scope:  entities.ScopeUser,
+		UserID: userID,
+	})
+	if err != nil {
+		return fmt.Errorf("list user schedules: %w", err)
+	}
+	dir := rootPath + "users/" + userID + "/schedules/"
+	for _, sc := range schedules {
+		si := scheduleToImport(sc)
+		wrapper := &importexport.TeamResources{
+			Metadata:  importexport.ResourceMetadata{TeamID: userID},
+			Schedules: []importexport.ScheduleImport{si},
+		}
+		if err := encryptTeamResourcesFields(wrapper, dek); err != nil {
+			log.Printf("[SYNC] Warning: encrypt user schedule %s: %v", sc.ID, err)
+			continue
+		}
+		data, err := yaml.Marshal(wrapper.Schedules[0])
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal user schedule %s: %v", sc.ID, err)
+			continue
+		}
+		files[dir+sc.ID+".yaml"] = data
+	}
+	return nil
+}
+
+func (s *Syncer) exportUserWebhooks(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.webhookRepo == nil {
+		return nil
+	}
+	webhooks, err := s.webhookRepo.List(ctx, portrepos.WebhookFilter{
+		Scope:  entities.ScopeUser,
+		UserID: userID,
+	})
+	if err != nil {
+		return fmt.Errorf("list user webhooks: %w", err)
+	}
+	dir := rootPath + "users/" + userID + "/webhooks/"
+	for _, wh := range webhooks {
+		wi := webhookToImport(wh)
+		wrapper := &importexport.TeamResources{
+			Metadata: importexport.ResourceMetadata{TeamID: userID},
+			Webhooks: []importexport.WebhookImport{wi},
+		}
+		if err := encryptTeamResourcesFields(wrapper, dek); err != nil {
+			log.Printf("[SYNC] Warning: encrypt user webhook %s: %v", wh.ID(), err)
+			continue
+		}
+		data, err := yaml.Marshal(wrapper.Webhooks[0])
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal user webhook %s: %v", wh.ID(), err)
+			continue
+		}
+		files[dir+wh.ID()+".yaml"] = data
+	}
+	return nil
+}
+
+func (s *Syncer) exportUserSlackbots(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.slackbotRepo == nil {
+		return nil
+	}
+	bots, err := s.slackbotRepo.List(ctx, portrepos.SlackBotFilter{
+		Scope:  entities.ScopeUser,
+		UserID: userID,
+	})
+	if err != nil {
+		return fmt.Errorf("list user slackbots: %w", err)
+	}
+	dir := rootPath + "users/" + userID + "/slackbots/"
+	for _, bot := range bots {
+		rec := slackbotToRecord(bot, dek)
+		data, err := yaml.Marshal(rec)
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal user slackbot %s: %v", bot.ID(), err)
+			continue
+		}
+		files[dir+bot.ID()+".yaml"] = data
+	}
+	return nil
+}
+
+func (s *Syncer) exportTeamSlackbots(ctx context.Context, settingsName string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.slackbotRepo == nil {
+		return nil
+	}
+	bots, err := s.slackbotRepo.List(ctx, portrepos.SlackBotFilter{
+		Scope:  entities.ScopeTeam,
+		TeamID: settingsName,
+	})
+	if err != nil {
+		return fmt.Errorf("list team slackbots: %w", err)
+	}
+	dir := rootPath + "teams/" + settingsName + "/slackbots/"
+	for _, bot := range bots {
+		rec := slackbotToRecord(bot, dek)
+		data, err := yaml.Marshal(rec)
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal team slackbot %s: %v", bot.ID(), err)
+			continue
+		}
+		files[dir+bot.ID()+".yaml"] = data
+	}
+	return nil
+}
+
 // --- Import handlers ---
 
 func (s *Syncer) importScheduleFile(ctx context.Context, data []byte, settingsName, userID string, dek []byte) error {
@@ -582,6 +720,172 @@ func (s *Syncer) importUserFileRecord(ctx context.Context, data []byte, userID s
 		return fmt.Errorf("save file %s: %w", rec.Name, err)
 	}
 	return nil
+}
+
+func (s *Syncer) importUserScheduleFile(ctx context.Context, data []byte, userID string, dek []byte) error {
+	var si importexport.ScheduleImport
+	if err := yaml.Unmarshal(data, &si); err != nil {
+		return fmt.Errorf("unmarshal schedule: %w", err)
+	}
+	wrapper := &importexport.TeamResources{
+		Metadata:  importexport.ResourceMetadata{TeamID: userID},
+		Schedules: []importexport.ScheduleImport{si},
+	}
+	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("decrypt schedule: %w", err)
+	}
+	si = wrapper.Schedules[0]
+
+	// Find existing user-scoped schedule by ID or name
+	var existing *schedule.Schedule
+	if schedules, err := s.scheduleRepo.List(ctx, schedule.ScheduleFilter{
+		Scope:  entities.ScopeUser,
+		UserID: userID,
+	}); err == nil {
+		for _, sc := range schedules {
+			if si.ID != "" && sc.ID == si.ID {
+				existing = sc
+				break
+			}
+		}
+		if existing == nil {
+			for _, sc := range schedules {
+				if sc.Name == si.Name {
+					existing = sc
+					break
+				}
+			}
+		}
+	}
+
+	id := si.ID
+	if id == "" {
+		id = uuid.New().String()
+	}
+	var sc *schedule.Schedule
+	if existing != nil {
+		sc = existing
+	} else {
+		sc = &schedule.Schedule{ID: id}
+	}
+	sc.Name = si.Name
+	sc.UserID = userID
+	sc.Scope = entities.ScopeUser
+	sc.TeamID = ""
+	if si.Status != "" {
+		sc.Status = schedule.ScheduleStatus(si.Status)
+	} else {
+		sc.Status = schedule.ScheduleStatusActive
+	}
+	sc.ScheduledAt = si.ScheduledAt
+	sc.CronExpr = si.CronExpr
+	sc.Timezone = si.Timezone
+	sc.SessionConfig = schedule.SessionConfig{
+		Tags:        si.SessionConfig.Tags,
+		Environment: si.SessionConfig.Environment,
+	}
+	if si.SessionConfig.Params != nil {
+		sc.SessionConfig.Params = &entities.SessionParams{
+			Message: si.SessionConfig.Params.InitialMessage,
+		}
+	}
+
+	if existing != nil {
+		return s.scheduleRepo.Update(ctx, sc)
+	}
+	return s.scheduleRepo.Create(ctx, sc)
+}
+
+func (s *Syncer) importUserWebhookFile(ctx context.Context, data []byte, userID string, dek []byte) error {
+	var wi importexport.WebhookImport
+	if err := yaml.Unmarshal(data, &wi); err != nil {
+		return fmt.Errorf("unmarshal webhook: %w", err)
+	}
+	wrapper := &importexport.TeamResources{
+		Metadata: importexport.ResourceMetadata{TeamID: userID},
+		Webhooks: []importexport.WebhookImport{wi},
+	}
+	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("decrypt webhook: %w", err)
+	}
+	noopSvc := infraservices.NewNoopEncryptionService()
+	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+	_, err := importer.Import(ctx, wrapper, userID, importexport.ImportOptions{
+		Mode:           importexport.ImportModeUpsert,
+		IDField:        "name",
+		AllowPartial:   true,
+		SkipValidation: true,
+	})
+	return err
+}
+
+func (s *Syncer) importSlackbotFile(ctx context.Context, data []byte, scope entities.ResourceScope, userID, teamID string, dek []byte) error {
+	if s.slackbotRepo == nil {
+		return nil
+	}
+	var rec slackbotRecord
+	if err := yaml.Unmarshal(data, &rec); err != nil {
+		return fmt.Errorf("unmarshal slackbot: %w", err)
+	}
+	// Decrypt environment
+	env := make(map[string]string, len(rec.Environment))
+	for k, v := range rec.Environment {
+		if IsEncrypted(v) {
+			plain, err := DecryptField(dek, v)
+			if err != nil {
+				return fmt.Errorf("decrypt slackbot env %s: %w", k, err)
+			}
+			env[k] = plain
+		} else {
+			env[k] = v
+		}
+	}
+
+	id := rec.ID
+	if id == "" {
+		id = uuid.New().String()
+	}
+	existing, _ := s.slackbotRepo.Get(ctx, id)
+
+	bot := existing
+	if bot == nil {
+		bot = entities.NewSlackBot(id, rec.Name, userID)
+	}
+	bot.SetScope(scope)
+	if teamID != "" {
+		bot.SetTeamID(teamID)
+	}
+	if rec.Status != "" {
+		bot.SetStatus(entities.SlackBotStatus(rec.Status))
+	}
+	if rec.BotTokenSecretName != "" {
+		bot.SetBotTokenSecretName(rec.BotTokenSecretName)
+	}
+	if rec.BotTokenSecretKey != "" {
+		bot.SetBotTokenSecretKey(rec.BotTokenSecretKey)
+	}
+	if rec.AppTokenSecretKey != "" {
+		bot.SetAppTokenSecretKey(rec.AppTokenSecretKey)
+	}
+	bot.SetAllowedEventTypes(rec.AllowedEventTypes)
+	bot.SetAllowedChannelNames(rec.AllowedChannelNames)
+	bot.SetAllowedUserIDs(rec.AllowedUserIDs)
+	if rec.MaxSessions > 0 {
+		bot.SetMaxSessions(rec.MaxSessions)
+	}
+	bot.SetNotifyOnSessionCreated(rec.NotifyOnSession)
+	bot.SetAllowBotMessages(rec.AllowBotMessages)
+	if len(env) > 0 || len(rec.Tags) > 0 {
+		sc := entities.NewWebhookSessionConfig()
+		sc.SetEnvironment(env)
+		sc.SetTags(rec.Tags)
+		bot.SetSessionConfig(sc)
+	}
+
+	if existing != nil {
+		return s.slackbotRepo.Update(ctx, bot)
+	}
+	return s.slackbotRepo.Create(ctx, bot)
 }
 
 // --- Encryption helpers ---
@@ -797,6 +1101,149 @@ type userFileRecord struct {
 	Permissions string `yaml:"permissions,omitempty"`
 	CreatedAt   string `yaml:"created_at,omitempty"`
 	UpdatedAt   string `yaml:"updated_at,omitempty"`
+}
+
+// scheduleToImport converts a schedule to ScheduleImport with plaintext environment.
+// Call encryptTeamResourcesFields afterward to encrypt sensitive values.
+func scheduleToImport(sc *schedule.Schedule) importexport.ScheduleImport {
+	si := importexport.ScheduleImport{
+		ID:          sc.ID,
+		Name:        sc.Name,
+		Status:      string(sc.Status),
+		ScheduledAt: sc.ScheduledAt,
+		CronExpr:    sc.CronExpr,
+		Timezone:    sc.Timezone,
+		SessionConfig: importexport.SessionConfigImport{
+			Tags:        sc.SessionConfig.Tags,
+			Environment: sc.SessionConfig.Environment,
+		},
+	}
+	if sc.SessionConfig.Params != nil {
+		si.SessionConfig.Params = &importexport.SessionParamsImport{
+			InitialMessage: sc.SessionConfig.Params.Message,
+		}
+	}
+	return si
+}
+
+// webhookToImport converts a Webhook entity to WebhookImport with plaintext secrets.
+// Call encryptTeamResourcesFields afterward.
+func webhookToImport(wh *entities.Webhook) importexport.WebhookImport {
+	wi := importexport.WebhookImport{
+		ID:              wh.ID(),
+		Name:            wh.Name(),
+		Status:          string(wh.Status()),
+		WebhookType:     string(wh.WebhookType()),
+		Secret:          wh.Secret(),
+		SignatureHeader: wh.SignatureHeader(),
+		SignatureType:   string(wh.SignatureType()),
+		SignaturePrefix: wh.SignaturePrefix(),
+		MaxSessions:     wh.MaxSessions(),
+		Triggers:        []importexport.WebhookTriggerImport{},
+	}
+	if gh := wh.GitHub(); gh != nil {
+		wi.GitHub = &importexport.GitHubConfigImport{
+			EnterpriseURL:       gh.EnterpriseURL(),
+			AllowedEvents:       gh.AllowedEvents(),
+			AllowedRepositories: gh.AllowedRepositories(),
+		}
+	}
+	if sc := wh.SessionConfig(); sc != nil {
+		wi.SessionConfig = &importexport.SessionConfigImport{
+			Environment: sc.Environment(),
+			Tags:        sc.Tags(),
+		}
+	}
+	for _, t := range wh.Triggers() {
+		ti := importexport.WebhookTriggerImport{
+			Name:        t.Name(),
+			Priority:    t.Priority(),
+			Enabled:     t.Enabled(),
+			StopOnMatch: t.StopOnMatch(),
+		}
+		cond := t.Conditions()
+		if cond.GitHub() != nil {
+			gh := cond.GitHub()
+			ti.Conditions.GitHub = &importexport.GitHubConditionsImport{
+				Events:       gh.Events(),
+				Actions:      gh.Actions(),
+				Branches:     gh.Branches(),
+				Repositories: gh.Repositories(),
+				Labels:       gh.Labels(),
+				Paths:        gh.Paths(),
+				BaseBranches: gh.BaseBranches(),
+				Draft:        gh.Draft(),
+				Sender:       gh.Sender(),
+			}
+		}
+		if tsc := t.SessionConfig(); tsc != nil {
+			ti.SessionConfig = &importexport.SessionConfigImport{
+				Environment: tsc.Environment(),
+				Tags:        tsc.Tags(),
+			}
+		}
+		wi.Triggers = append(wi.Triggers, ti)
+	}
+	return wi
+}
+
+type slackbotRecord struct {
+	ID                  string            `yaml:"id"`
+	Name                string            `yaml:"name"`
+	UserID              string            `yaml:"user_id"`
+	Scope               string            `yaml:"scope"`
+	TeamID              string            `yaml:"team_id,omitempty"`
+	Status              string            `yaml:"status"`
+	BotTokenSecretName  string            `yaml:"bot_token_secret_name,omitempty"`
+	BotTokenSecretKey   string            `yaml:"bot_token_secret_key,omitempty"`
+	AppTokenSecretKey   string            `yaml:"app_token_secret_key,omitempty"`
+	AllowedEventTypes   []string          `yaml:"allowed_event_types,omitempty"`
+	AllowedChannelNames []string          `yaml:"allowed_channel_names,omitempty"`
+	AllowedUserIDs      []string          `yaml:"allowed_user_ids,omitempty"`
+	Environment         map[string]string `yaml:"environment,omitempty"`
+	Tags                map[string]string `yaml:"tags,omitempty"`
+	MaxSessions         int               `yaml:"max_sessions,omitempty"`
+	NotifyOnSession     *bool             `yaml:"notify_on_session_created,omitempty"`
+	AllowBotMessages    *bool             `yaml:"allow_bot_messages,omitempty"`
+	CreatedAt           string            `yaml:"created_at,omitempty"`
+	UpdatedAt           string            `yaml:"updated_at,omitempty"`
+}
+
+func slackbotToRecord(bot *entities.SlackBot, dek []byte) slackbotRecord {
+	rec := slackbotRecord{
+		ID:                  bot.ID(),
+		Name:                bot.Name(),
+		UserID:              bot.UserID(),
+		Scope:               string(bot.Scope()),
+		TeamID:              bot.TeamID(),
+		Status:              string(bot.Status()),
+		BotTokenSecretName:  bot.BotTokenSecretName(),
+		BotTokenSecretKey:   bot.BotTokenSecretKey(),
+		AppTokenSecretKey:   bot.AppTokenSecretKey(),
+		AllowedEventTypes:   bot.AllowedEventTypes(),
+		AllowedChannelNames: bot.AllowedChannelNames(),
+		AllowedUserIDs:      bot.AllowedUserIDs(),
+		MaxSessions:         bot.MaxSessions(),
+		NotifyOnSession:     bot.RawNotifyOnSessionCreated(),
+		AllowBotMessages:    bot.RawAllowBotMessages(),
+		CreatedAt:           bot.CreatedAt().Format(time.RFC3339),
+		UpdatedAt:           bot.UpdatedAt().Format(time.RFC3339),
+	}
+	if sc := bot.SessionConfig(); sc != nil {
+		env := make(map[string]string, len(sc.Environment()))
+		for k, v := range sc.Environment() {
+			if IsSensitiveKey(k) && !IsEncrypted(v) {
+				if enc, err := EncryptField(dek, v); err == nil {
+					env[k] = enc
+					continue
+				}
+			}
+			env[k] = v
+		}
+		rec.Environment = env
+		rec.Tags = sc.Tags()
+	}
+	return rec
 }
 
 func newUserFileFromRecord(rec userFileRecord, content string) *entities.UserFile {

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -31,12 +31,12 @@ import (
 // A push from a personal settings (settingsName == userID) exports only
 // user resources; a push from a team settings exports only team resources.
 type Syncer struct {
-	settingsRepo           portrepos.SettingsRepository
-	scheduleRepo           schedule.Manager
-	webhookRepo            portrepos.WebhookRepository
-	slackbotRepo           portrepos.SlackBotRepository
-	userFileRepo           portrepos.UserFileRepository
-	githubAppInstallID     string // fallback installation ID when no personal token
+	settingsRepo       portrepos.SettingsRepository
+	scheduleRepo       schedule.Manager
+	webhookRepo        portrepos.WebhookRepository
+	slackbotRepo       portrepos.SlackBotRepository
+	userFileRepo       portrepos.UserFileRepository
+	githubAppInstallID string // fallback installation ID when no personal token
 }
 
 // NewSyncer creates a Syncer. Non-nil repos are synced.

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1,0 +1,742 @@
+package githubsync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	infraservices "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	importexport "github.com/takutakahashi/agentapi-proxy/pkg/import"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
+	"gopkg.in/yaml.v3"
+)
+
+// Syncer orchestrates bidirectional GitHub sync for a user or team.
+type Syncer struct {
+	settingsRepo  portrepos.SettingsRepository
+	scheduleRepo  schedule.Manager
+	webhookRepo   portrepos.WebhookRepository
+	memoryRepo    portrepos.MemoryRepository
+	taskRepo      portrepos.TaskRepository
+	taskGroupRepo portrepos.TaskGroupRepository
+	userFileRepo  portrepos.UserFileRepository
+}
+
+// NewSyncer creates a Syncer. Non-nil repos are synced.
+func NewSyncer(
+	settingsRepo portrepos.SettingsRepository,
+	scheduleRepo schedule.Manager,
+	webhookRepo portrepos.WebhookRepository,
+	memoryRepo portrepos.MemoryRepository,
+	taskRepo portrepos.TaskRepository,
+	taskGroupRepo portrepos.TaskGroupRepository,
+	userFileRepo portrepos.UserFileRepository,
+) *Syncer {
+	return &Syncer{
+		settingsRepo:  settingsRepo,
+		scheduleRepo:  scheduleRepo,
+		webhookRepo:   webhookRepo,
+		memoryRepo:    memoryRepo,
+		taskRepo:      taskRepo,
+		taskGroupRepo: taskGroupRepo,
+		userFileRepo:  userFileRepo,
+	}
+}
+
+// Push exports all resources for settingsName and commits them to GitHub.
+// settingsName is the user ID or team slug (same key as /settings/:name).
+func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMessage string) (*PushResponse, error) {
+	settings, err := s.settingsRepo.FindByName(ctx, settingsName)
+	if err != nil {
+		return nil, fmt.Errorf("settings not found for %q: %w", settingsName, err)
+	}
+
+	cfg := settings.GitSync()
+	if cfg == nil || !cfg.Enabled {
+		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
+	}
+
+	token := cfg.GitHubToken
+	if token == "" {
+		return nil, fmt.Errorf("github_token is required in git_sync config for %q", settingsName)
+	}
+
+	enc, err := NewSyncEncryptor(ctx, cfg.Encryption.KMSKeyARN, cfg.Encryption.AWSRegion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init sync encryptor: %w", err)
+	}
+
+	// Get or generate fixed DEK
+	var dek []byte
+	if cfg.Encryption.EncryptedDEK == "" {
+		var encDEK string
+		dek, encDEK, err = enc.GenerateAndEncryptDEK(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate DEK: %w", err)
+		}
+		cfg.Encryption.EncryptedDEK = encDEK
+		cfg.Encryption.DEKVersion = 1
+		settings.SetGitSync(cfg)
+		if saveErr := s.settingsRepo.Save(ctx, settings); saveErr != nil {
+			return nil, fmt.Errorf("failed to save new DEK: %w", saveErr)
+		}
+		log.Printf("[SYNC] Generated new DEK (v1) for %s", settingsName)
+	} else {
+		dek, err = enc.DecryptDEK(ctx, cfg.Encryption.EncryptedDEK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt DEK: %w", err)
+		}
+	}
+
+	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+	files := make(map[string][]byte)
+
+	if err := s.exportTeamResources(ctx, settingsName, userID, dek, rootPath, files); err != nil {
+		log.Printf("[SYNC] team resource export warning for %s: %v", settingsName, err)
+	}
+
+	if err := s.exportUserResources(ctx, userID, dek, rootPath, files); err != nil {
+		log.Printf("[SYNC] user resource export warning for %s: %v", settingsName, err)
+	}
+
+	meta := SyncMeta{
+		APIVersion: "agentapi-proxy/v1",
+		Kind:       "SyncMeta",
+		SyncedAt:   time.Now().UTC(),
+		Encryption: SyncMetaEnc{
+			Provider:   "aws_kms",
+			KMSKeyARN:  cfg.Encryption.KMSKeyARN,
+			Algorithm:  "AES-256-GCM",
+			DEKVersion: cfg.Encryption.DEKVersion,
+		},
+	}
+	if metaBytes, merr := yaml.Marshal(meta); merr == nil {
+		files[rootPath+".sync-meta.yaml"] = metaBytes
+	}
+
+	if len(files) == 0 {
+		return &PushResponse{PushedAt: time.Now()}, nil
+	}
+
+	if commitMessage == "" {
+		commitMessage = fmt.Sprintf("agentapi-proxy sync: %s", time.Now().UTC().Format(time.RFC3339))
+	}
+
+	ghClient, err := NewGitHubSyncClient(ctx, token, cfg.RepoFullName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
+	}
+
+	sha, err := ghClient.PushFiles(ctx, cfg.Branch, commitMessage, files)
+	if err != nil {
+		return nil, fmt.Errorf("failed to push to GitHub: %w", err)
+	}
+
+	return &PushResponse{
+		CommitSHA: sha,
+		PushedAt:  time.Now(),
+		Summary:   SyncSummary{FilesWritten: len(files)},
+	}, nil
+}
+
+// Pull downloads resources from GitHub and imports them.
+func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOrphans bool) (*PullResponse, error) {
+	settings, err := s.settingsRepo.FindByName(ctx, settingsName)
+	if err != nil {
+		return nil, fmt.Errorf("settings not found for %q: %w", settingsName, err)
+	}
+
+	cfg := settings.GitSync()
+	if cfg == nil || !cfg.Enabled {
+		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
+	}
+
+	token := cfg.GitHubToken
+	if token == "" {
+		return nil, fmt.Errorf("github_token is required in git_sync config for %q", settingsName)
+	}
+
+	if cfg.Encryption.EncryptedDEK == "" {
+		return nil, fmt.Errorf("no DEK found — push at least once before pulling")
+	}
+
+	enc, err := NewSyncEncryptor(ctx, cfg.Encryption.KMSKeyARN, cfg.Encryption.AWSRegion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init sync encryptor: %w", err)
+	}
+	dek, err := enc.DecryptDEK(ctx, cfg.Encryption.EncryptedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt DEK: %w", err)
+	}
+
+	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+
+	ghClient, err := NewGitHubSyncClient(ctx, token, cfg.RepoFullName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
+	}
+
+	paths, err := ghClient.ListFiles(ctx, cfg.Branch, rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list GitHub files: %w", err)
+	}
+
+	filesWritten := 0
+	for _, path := range paths {
+		if strings.HasSuffix(path, ".sync-meta.yaml") {
+			continue
+		}
+		content, err := ghClient.GetFile(ctx, cfg.Branch, path)
+		if err != nil {
+			log.Printf("[SYNC] Warning: failed to get %s: %v", path, err)
+			continue
+		}
+		rel := strings.TrimPrefix(path, rootPath)
+		if err := s.importFile(ctx, rel, content, settingsName, userID, dek); err != nil {
+			log.Printf("[SYNC] Warning: failed to import %s: %v", rel, err)
+			continue
+		}
+		filesWritten++
+	}
+
+	return &PullResponse{
+		PulledAt: time.Now(),
+		Summary:  SyncSummary{FilesWritten: filesWritten},
+	}, nil
+}
+
+// RotateKey generates a fresh DEK, re-encrypts all GitHub files, and updates Settings.
+func (s *Syncer) RotateKey(ctx context.Context, settingsName, userID string) (*RotateKeyResponse, error) {
+	settings, err := s.settingsRepo.FindByName(ctx, settingsName)
+	if err != nil {
+		return nil, fmt.Errorf("settings not found for %q: %w", settingsName, err)
+	}
+
+	cfg := settings.GitSync()
+	if cfg == nil || !cfg.Enabled {
+		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
+	}
+
+	if cfg.Encryption.EncryptedDEK == "" {
+		return nil, fmt.Errorf("no existing DEK — push at least once before rotating")
+	}
+
+	enc, err := NewSyncEncryptor(ctx, cfg.Encryption.KMSKeyARN, cfg.Encryption.AWSRegion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init sync encryptor: %w", err)
+	}
+
+	oldDEK, err := enc.DecryptDEK(ctx, cfg.Encryption.EncryptedDEK)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt old DEK: %w", err)
+	}
+
+	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+
+	ghClient, err := NewGitHubSyncClient(ctx, cfg.GitHubToken, cfg.RepoFullName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
+	}
+
+	paths, err := ghClient.ListFiles(ctx, cfg.Branch, rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files: %w", err)
+	}
+
+	newDEK, newEncDEK, err := enc.GenerateAndEncryptDEK(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate new DEK: %w", err)
+	}
+	newVersion := cfg.Encryption.DEKVersion + 1
+
+	files := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		content, err := ghClient.GetFile(ctx, cfg.Branch, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get %s during rotation: %w", path, err)
+		}
+		reenc, err := reencryptYAML(content, oldDEK, newDEK)
+		if err != nil {
+			return nil, fmt.Errorf("failed to re-encrypt %s: %w", path, err)
+		}
+		files[path] = reenc
+	}
+
+	sha, err := ghClient.PushFiles(ctx, cfg.Branch,
+		fmt.Sprintf("agentapi-proxy key rotation: DEK v%d", newVersion), files)
+	if err != nil {
+		return nil, fmt.Errorf("failed to push re-encrypted files: %w", err)
+	}
+
+	cfg.Encryption.EncryptedDEK = newEncDEK
+	cfg.Encryption.DEKVersion = newVersion
+	settings.SetGitSync(cfg)
+	if err := s.settingsRepo.Save(ctx, settings); err != nil {
+		return nil, fmt.Errorf("failed to save new DEK: %w", err)
+	}
+
+	return &RotateKeyResponse{
+		CommitSHA:  sha,
+		RotatedAt:  time.Now(),
+		DEKVersion: newVersion,
+	}, nil
+}
+
+// exportTeamResources exports schedules/webhooks/settings via the existing exporter.
+func (s *Syncer) exportTeamResources(ctx context.Context, settingsName, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	noopSvc := infraservices.NewNoopEncryptionService()
+	exporter := importexport.NewExporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+
+	resources, err := exporter.Export(ctx, settingsName, userID, importexport.ExportOptions{
+		Format:         importexport.ExportFormatYAML,
+		IncludeSecrets: true,
+	})
+	if err != nil {
+		return fmt.Errorf("export: %w", err)
+	}
+
+	if err := encryptTeamResourcesFields(resources, dek); err != nil {
+		return fmt.Errorf("encrypt: %w", err)
+	}
+
+	data, err := yaml.Marshal(resources)
+	if err != nil {
+		return fmt.Errorf("serialize: %w", err)
+	}
+
+	files[rootPath+"resources.yaml"] = data
+	return nil
+}
+
+// exportUserResources exports user-scoped memories, tasks, task groups, and files.
+func (s *Syncer) exportUserResources(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	type userExport struct {
+		APIVersion string            `yaml:"apiVersion"`
+		Kind       string            `yaml:"kind"`
+		Memories   []memoryExport    `yaml:"memories,omitempty"`
+		Tasks      []taskExport      `yaml:"tasks,omitempty"`
+		TaskGroups []taskGroupExport `yaml:"task_groups,omitempty"`
+		Files      []userFileExport  `yaml:"files,omitempty"`
+	}
+
+	export := userExport{
+		APIVersion: "agentapi-proxy/v1",
+		Kind:       "UserResources",
+	}
+
+	if s.memoryRepo != nil {
+		memories, err := s.memoryRepo.List(ctx, portrepos.MemoryFilter{
+			Scope:   entities.ScopeUser,
+			OwnerID: userID,
+		})
+		if err == nil {
+			for _, m := range memories {
+				export.Memories = append(export.Memories, memoryExport{
+					ID:        m.ID(),
+					Title:     m.Title(),
+					Content:   m.Content(),
+					Tags:      m.Tags(),
+					Scope:     string(m.Scope()),
+					CreatedAt: m.CreatedAt().Format(time.RFC3339),
+					UpdatedAt: m.UpdatedAt().Format(time.RFC3339),
+				})
+			}
+		}
+	}
+
+	if s.taskRepo != nil {
+		tasks, err := s.taskRepo.List(ctx, portrepos.TaskFilter{
+			Scope:   entities.ScopeUser,
+			OwnerID: userID,
+		})
+		if err == nil {
+			for _, t := range tasks {
+				export.Tasks = append(export.Tasks, taskExport{
+					ID:        t.ID(),
+					Title:     t.Title(),
+					Status:    string(t.Status()),
+					TaskType:  string(t.TaskType()),
+					SessionID: t.SessionID(),
+					CreatedAt: t.CreatedAt().Format(time.RFC3339),
+					UpdatedAt: t.UpdatedAt().Format(time.RFC3339),
+				})
+			}
+		}
+	}
+
+	if s.taskGroupRepo != nil {
+		groups, err := s.taskGroupRepo.List(ctx, portrepos.TaskGroupFilter{
+			Scope:   entities.ScopeUser,
+			OwnerID: userID,
+		})
+		if err == nil {
+			for _, g := range groups {
+				export.TaskGroups = append(export.TaskGroups, taskGroupExport{
+					ID:          g.ID(),
+					Name:        g.Name(),
+					Description: g.Description(),
+					CreatedAt:   g.CreatedAt().Format(time.RFC3339),
+					UpdatedAt:   g.UpdatedAt().Format(time.RFC3339),
+				})
+			}
+		}
+	}
+
+	if s.userFileRepo != nil {
+		ufiles, err := s.userFileRepo.List(ctx, userID)
+		if err == nil {
+			for _, f := range ufiles {
+				encContent, encErr := EncryptField(dek, f.Content())
+				if encErr != nil {
+					log.Printf("[SYNC] Warning: encrypt file %s content: %v", f.Name(), encErr)
+					encContent = ""
+				}
+				export.Files = append(export.Files, userFileExport{
+					ID:          f.ID(),
+					Name:        f.Name(),
+					Path:        f.Path(),
+					Content:     encContent,
+					Permissions: f.Permissions(),
+					CreatedAt:   f.CreatedAt().Format(time.RFC3339),
+					UpdatedAt:   f.UpdatedAt().Format(time.RFC3339),
+				})
+			}
+		}
+	}
+
+	data, err := yaml.Marshal(export)
+	if err != nil {
+		return fmt.Errorf("serialize: %w", err)
+	}
+	files[rootPath+"user-resources.yaml"] = data
+	return nil
+}
+
+// importFile dispatches a file to the appropriate import handler.
+func (s *Syncer) importFile(ctx context.Context, relPath string, content []byte, settingsName, userID string, dek []byte) error {
+	switch relPath {
+	case "resources.yaml":
+		return s.importTeamResources(ctx, content, settingsName, userID, dek)
+	case "user-resources.yaml":
+		return s.importUserResources(ctx, content, userID, dek)
+	default:
+		return nil
+	}
+}
+
+func (s *Syncer) importTeamResources(ctx context.Context, data []byte, settingsName, userID string, dek []byte) error {
+	var resources importexport.TeamResources
+	if err := yaml.Unmarshal(data, &resources); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	if err := decryptTeamResourcesFields(&resources, dek); err != nil {
+		return fmt.Errorf("decrypt: %w", err)
+	}
+
+	noopSvc := infraservices.NewNoopEncryptionService()
+	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+	_, err := importer.Import(ctx, &resources, userID, importexport.ImportOptions{
+		Mode:         importexport.ImportModeUpsert,
+		IDField:      "name",
+		AllowPartial: true,
+	})
+	return err
+}
+
+func (s *Syncer) importUserResources(ctx context.Context, data []byte, userID string, dek []byte) error {
+	type userImport struct {
+		Memories []memoryExport   `yaml:"memories"`
+		Files    []userFileExport `yaml:"files"`
+	}
+
+	var imp userImport
+	if err := yaml.Unmarshal(data, &imp); err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	if s.memoryRepo != nil {
+		for _, m := range imp.Memories {
+			scope := entities.ResourceScope(m.Scope)
+			if scope == "" {
+				scope = entities.ScopeUser
+			}
+			mem := entities.NewMemoryWithTags(m.ID, m.Title, m.Content, scope, userID, "", m.Tags)
+			if createErr := s.memoryRepo.Create(ctx, mem); createErr != nil {
+				// Try update if create fails (entry already exists)
+				if updateErr := s.memoryRepo.Update(ctx, mem); updateErr != nil {
+					log.Printf("[SYNC] Warning: upsert memory %s: create=%v update=%v", m.ID, createErr, updateErr)
+				}
+			}
+		}
+	}
+
+	if s.userFileRepo != nil {
+		for _, f := range imp.Files {
+			plainContent := f.Content
+			if IsEncrypted(plainContent) {
+				dec, err := DecryptField(dek, plainContent)
+				if err != nil {
+					log.Printf("[SYNC] Warning: decrypt file %s content: %v", f.Name, err)
+					continue
+				}
+				plainContent = dec
+			}
+			uf := entities.NewUserFile(f.ID, f.Name, f.Path, plainContent, f.Permissions)
+			if err := s.userFileRepo.Save(ctx, userID, uf); err != nil {
+				log.Printf("[SYNC] Warning: save file %s: %v", f.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// encryptTeamResourcesFields encrypts sensitive plaintext fields using the fixed DEK.
+func encryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error {
+	encryptMapValues := func(m map[string]string, context string) error {
+		for k, v := range m {
+			if IsSensitiveKey(k) && !IsEncrypted(v) {
+				enc, err := EncryptField(dek, v)
+				if err != nil {
+					return fmt.Errorf("encrypt %s %s: %w", context, k, err)
+				}
+				m[k] = enc
+			}
+		}
+		return nil
+	}
+
+	for i := range r.Schedules {
+		sc := &r.Schedules[i].SessionConfig
+		if err := encryptMapValues(sc.Environment, "schedule env"); err != nil {
+			return err
+		}
+		sc.EnvironmentEncrypted = nil
+	}
+
+	for i := range r.Webhooks {
+		w := &r.Webhooks[i]
+		if w.Secret != "" && !IsEncrypted(w.Secret) {
+			enc, err := EncryptField(dek, w.Secret)
+			if err != nil {
+				return fmt.Errorf("encrypt webhook secret: %w", err)
+			}
+			w.Secret = enc
+		}
+		w.SecretEncrypted = nil
+
+		if sc := w.SessionConfig; sc != nil {
+			if err := encryptMapValues(sc.Environment, "webhook env"); err != nil {
+				return err
+			}
+			sc.EnvironmentEncrypted = nil
+		}
+		for j := range w.Triggers {
+			if sc := w.Triggers[j].SessionConfig; sc != nil {
+				if err := encryptMapValues(sc.Environment, "trigger env"); err != nil {
+					return err
+				}
+				sc.EnvironmentEncrypted = nil
+			}
+		}
+	}
+
+	if s := r.Settings; s != nil {
+		if s.ClaudeCodeOAuthToken != "" && !IsEncrypted(s.ClaudeCodeOAuthToken) {
+			enc, err := EncryptField(dek, s.ClaudeCodeOAuthToken)
+			if err != nil {
+				return fmt.Errorf("encrypt oauth token: %w", err)
+			}
+			s.ClaudeCodeOAuthToken = enc
+		}
+		s.ClaudeCodeOAuthTokenEncrypted = nil
+
+		if b := s.Bedrock; b != nil {
+			if b.SecretAccessKey != "" && !IsEncrypted(b.SecretAccessKey) {
+				enc, err := EncryptField(dek, b.SecretAccessKey)
+				if err != nil {
+					return fmt.Errorf("encrypt bedrock secret key: %w", err)
+				}
+				b.SecretAccessKey = enc
+			}
+			b.SecretAccessKeyEncrypted = nil
+			b.AccessKeyIDEncrypted = nil
+		}
+
+		for _, mcp := range s.MCPServers {
+			if err := encryptMapValues(mcp.Env, "MCP env"); err != nil {
+				return err
+			}
+			mcp.EnvEncrypted = nil
+			if err := encryptMapValues(mcp.Headers, "MCP header"); err != nil {
+				return err
+			}
+			mcp.HeadersEncrypted = nil
+		}
+	}
+
+	return nil
+}
+
+// decryptTeamResourcesFields decrypts enc:v1: values in TeamResources.
+func decryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error {
+	decryptMapValues := func(m map[string]string, context string) error {
+		for k, v := range m {
+			if IsEncrypted(v) {
+				plain, err := DecryptField(dek, v)
+				if err != nil {
+					return fmt.Errorf("decrypt %s %s: %w", context, k, err)
+				}
+				m[k] = plain
+			}
+		}
+		return nil
+	}
+
+	for i := range r.Schedules {
+		if err := decryptMapValues(r.Schedules[i].SessionConfig.Environment, "schedule env"); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.Webhooks {
+		w := &r.Webhooks[i]
+		if IsEncrypted(w.Secret) {
+			plain, err := DecryptField(dek, w.Secret)
+			if err != nil {
+				return fmt.Errorf("decrypt webhook secret: %w", err)
+			}
+			w.Secret = plain
+		}
+		if sc := w.SessionConfig; sc != nil {
+			if err := decryptMapValues(sc.Environment, "webhook env"); err != nil {
+				return err
+			}
+		}
+		for j := range w.Triggers {
+			if sc := w.Triggers[j].SessionConfig; sc != nil {
+				if err := decryptMapValues(sc.Environment, "trigger env"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if s := r.Settings; s != nil {
+		if IsEncrypted(s.ClaudeCodeOAuthToken) {
+			plain, err := DecryptField(dek, s.ClaudeCodeOAuthToken)
+			if err != nil {
+				return fmt.Errorf("decrypt oauth token: %w", err)
+			}
+			s.ClaudeCodeOAuthToken = plain
+		}
+		if b := s.Bedrock; b != nil {
+			if IsEncrypted(b.SecretAccessKey) {
+				plain, err := DecryptField(dek, b.SecretAccessKey)
+				if err != nil {
+					return fmt.Errorf("decrypt bedrock secret key: %w", err)
+				}
+				b.SecretAccessKey = plain
+			}
+		}
+		for _, mcp := range s.MCPServers {
+			if err := decryptMapValues(mcp.Env, "MCP env"); err != nil {
+				return err
+			}
+			if err := decryptMapValues(mcp.Headers, "MCP header"); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// reencryptYAML decrypts all enc:v1: values with oldDEK and re-encrypts with newDEK.
+func reencryptYAML(data, oldDEK, newDEK []byte) ([]byte, error) {
+	var root interface{}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return data, nil // not YAML — pass through unchanged
+	}
+	reencrypted := reencryptValue(root, oldDEK, newDEK)
+	return yaml.Marshal(reencrypted)
+}
+
+func reencryptValue(v interface{}, oldDEK, newDEK []byte) interface{} {
+	switch val := v.(type) {
+	case string:
+		if !IsEncrypted(val) {
+			return val
+		}
+		plain, err := DecryptField(oldDEK, val)
+		if err != nil {
+			return val
+		}
+		enc, err := EncryptField(newDEK, plain)
+		if err != nil {
+			return val
+		}
+		return enc
+	case map[string]interface{}:
+		for k, child := range val {
+			val[k] = reencryptValue(child, oldDEK, newDEK)
+		}
+		return val
+	case []interface{}:
+		for i, child := range val {
+			val[i] = reencryptValue(child, oldDEK, newDEK)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+// --- DTO types for user-scoped resource export ---
+
+type memoryExport struct {
+	ID        string            `yaml:"id"`
+	Title     string            `yaml:"title"`
+	Content   string            `yaml:"content"`
+	Scope     string            `yaml:"scope"`
+	Tags      map[string]string `yaml:"tags,omitempty"`
+	CreatedAt string            `yaml:"created_at"`
+	UpdatedAt string            `yaml:"updated_at"`
+}
+
+type taskExport struct {
+	ID        string `yaml:"id"`
+	Title     string `yaml:"title"`
+	Status    string `yaml:"status"`
+	TaskType  string `yaml:"task_type"`
+	SessionID string `yaml:"session_id,omitempty"`
+	CreatedAt string `yaml:"created_at"`
+	UpdatedAt string `yaml:"updated_at"`
+}
+
+type taskGroupExport struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	CreatedAt   string `yaml:"created_at"`
+	UpdatedAt   string `yaml:"updated_at"`
+}
+
+type userFileExport struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Path        string `yaml:"path"`
+	Content     string `yaml:"content"` // always encrypted with DEK
+	Permissions string `yaml:"permissions,omitempty"`
+	CreatedAt   string `yaml:"created_at"`
+	UpdatedAt   string `yaml:"updated_at"`
+}
+
+// keep errors import satisfied
+var _ = errors.New

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -41,8 +41,8 @@ func NewSyncer(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
 	webhookRepo portrepos.WebhookRepository,
-	_ portrepos.MemoryRepository,   // unused — kept for call-site compatibility
-	_ portrepos.TaskRepository,     // unused
+	_ portrepos.MemoryRepository, // unused — kept for call-site compatibility
+	_ portrepos.TaskRepository, // unused
 	_ portrepos.TaskGroupRepository, // unused
 	userFileRepo portrepos.UserFileRepository,
 	slackbotRepo portrepos.SlackBotRepository,

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -442,9 +442,10 @@ func (s *Syncer) importTeamResources(ctx context.Context, data []byte, settingsN
 	noopSvc := infraservices.NewNoopEncryptionService()
 	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
 	_, err := importer.Import(ctx, &resources, userID, importexport.ImportOptions{
-		Mode:         importexport.ImportModeUpsert,
-		IDField:      "name",
-		AllowPartial: true,
+		Mode:           importexport.ImportModeUpsert,
+		IDField:        "name",
+		AllowPartial:   true,
+		SkipValidation: true,
 	})
 	return err
 }
@@ -467,10 +468,11 @@ func (s *Syncer) importUserResources(ctx context.Context, data []byte, userID st
 				scope = entities.ScopeUser
 			}
 			mem := entities.NewMemoryWithTags(m.ID, m.Title, m.Content, scope, userID, "", m.Tags)
-			if createErr := s.memoryRepo.Create(ctx, mem); createErr != nil {
-				// Try update if create fails (entry already exists)
-				if updateErr := s.memoryRepo.Update(ctx, mem); updateErr != nil {
-					log.Printf("[SYNC] Warning: upsert memory %s: create=%v update=%v", m.ID, createErr, updateErr)
+			// Try Update first to preserve the exported ID (no-op if already up-to-date).
+			// Fall back to Create only when the entry doesn't exist (404).
+			if updateErr := s.memoryRepo.Update(ctx, mem); updateErr != nil {
+				if createErr := s.memoryRepo.Create(ctx, mem); createErr != nil {
+					log.Printf("[SYNC] Warning: upsert memory %s: update=%v create=%v", m.ID, updateErr, createErr)
 				}
 			}
 		}

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -2,7 +2,6 @@ package githubsync
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -17,14 +16,22 @@ import (
 )
 
 // Syncer orchestrates bidirectional GitHub sync for a user or team.
+//
+// File layout in GitHub:
+//
+//	<rootPath>/teams/<settingsName>/schedules/<id>.yaml
+//	<rootPath>/teams/<settingsName>/webhooks/<id>.yaml
+//	<rootPath>/teams/<settingsName>/settings.yaml
+//	<rootPath>/users/<userID>/files/<id>.yaml
+//	<rootPath>/.sync-meta.yaml
+//
+// A push from a personal settings (settingsName == userID) exports only
+// user resources; a push from a team settings exports only team resources.
 type Syncer struct {
-	settingsRepo  portrepos.SettingsRepository
-	scheduleRepo  schedule.Manager
-	webhookRepo   portrepos.WebhookRepository
-	memoryRepo    portrepos.MemoryRepository
-	taskRepo      portrepos.TaskRepository
-	taskGroupRepo portrepos.TaskGroupRepository
-	userFileRepo  portrepos.UserFileRepository
+	settingsRepo portrepos.SettingsRepository
+	scheduleRepo schedule.Manager
+	webhookRepo  portrepos.WebhookRepository
+	userFileRepo portrepos.UserFileRepository
 }
 
 // NewSyncer creates a Syncer. Non-nil repos are synced.
@@ -32,24 +39,26 @@ func NewSyncer(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
 	webhookRepo portrepos.WebhookRepository,
-	memoryRepo portrepos.MemoryRepository,
-	taskRepo portrepos.TaskRepository,
-	taskGroupRepo portrepos.TaskGroupRepository,
+	_ portrepos.MemoryRepository, // unused — kept for call-site compatibility
+	_ portrepos.TaskRepository, // unused
+	_ portrepos.TaskGroupRepository, // unused
 	userFileRepo portrepos.UserFileRepository,
 ) *Syncer {
 	return &Syncer{
-		settingsRepo:  settingsRepo,
-		scheduleRepo:  scheduleRepo,
-		webhookRepo:   webhookRepo,
-		memoryRepo:    memoryRepo,
-		taskRepo:      taskRepo,
-		taskGroupRepo: taskGroupRepo,
-		userFileRepo:  userFileRepo,
+		settingsRepo: settingsRepo,
+		scheduleRepo: scheduleRepo,
+		webhookRepo:  webhookRepo,
+		userFileRepo: userFileRepo,
 	}
 }
 
+// isPersonalSync returns true when settingsName refers to the caller's own
+// personal settings (as opposed to a team/shared settings name).
+func isPersonalSync(settingsName, userID string) bool {
+	return settingsName == userID
+}
+
 // Push exports all resources for settingsName and commits them to GitHub.
-// settingsName is the user ID or team slug (same key as /settings/:name).
 func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMessage string) (*PushResponse, error) {
 	settings, err := s.settingsRepo.FindByName(ctx, settingsName)
 	if err != nil {
@@ -71,7 +80,6 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		return nil, fmt.Errorf("failed to init sync encryptor: %w", err)
 	}
 
-	// Get or generate fixed DEK
 	var dek []byte
 	if cfg.Encryption.EncryptedDEK == "" {
 		var encDEK string
@@ -96,12 +104,20 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
 	files := make(map[string][]byte)
 
-	if err := s.exportTeamResources(ctx, settingsName, userID, dek, rootPath, files); err != nil {
-		log.Printf("[SYNC] team resource export warning for %s: %v", settingsName, err)
-	}
-
-	if err := s.exportUserResources(ctx, userID, dek, rootPath, files); err != nil {
-		log.Printf("[SYNC] user resource export warning for %s: %v", settingsName, err)
+	if isPersonalSync(settingsName, userID) {
+		if err := s.exportUserFiles(ctx, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] user file export warning for %s: %v", settingsName, err)
+		}
+	} else {
+		if err := s.exportTeamSchedules(ctx, settingsName, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] schedule export warning for %s: %v", settingsName, err)
+		}
+		if err := s.exportTeamWebhooks(ctx, settingsName, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] webhook export warning for %s: %v", settingsName, err)
+		}
+		if err := s.exportTeamSettings(ctx, settingsName, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] settings export warning for %s: %v", settingsName, err)
+		}
 	}
 
 	meta := SyncMeta{
@@ -186,19 +202,37 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 		return nil, fmt.Errorf("failed to list GitHub files: %w", err)
 	}
 
+	personal := isPersonalSync(settingsName, userID)
+	teamPrefix := rootPath + "teams/" + settingsName + "/"
+	userPrefix := rootPath + "users/" + userID + "/"
+
 	filesWritten := 0
-	for _, path := range paths {
-		if strings.HasSuffix(path, ".sync-meta.yaml") {
+	for _, filePath := range paths {
+		rel := strings.TrimPrefix(filePath, rootPath)
+		if strings.HasSuffix(rel, ".sync-meta.yaml") {
 			continue
 		}
-		content, err := ghClient.GetFile(ctx, cfg.Branch, path)
+
+		// Route by scope: personal sync only imports user files; team sync imports team resources.
+		var relevant bool
+		if personal {
+			relevant = strings.HasPrefix(filePath, userPrefix)
+		} else {
+			relevant = strings.HasPrefix(filePath, teamPrefix)
+		}
+		if !relevant {
+			continue
+		}
+
+		content, err := ghClient.GetFile(ctx, cfg.Branch, filePath)
 		if err != nil {
-			log.Printf("[SYNC] Warning: failed to get %s: %v", path, err)
+			log.Printf("[SYNC] Warning: failed to get %s: %v", filePath, err)
 			continue
 		}
-		rel := strings.TrimPrefix(path, rootPath)
-		if err := s.importFile(ctx, rel, content, settingsName, userID, dek); err != nil {
-			log.Printf("[SYNC] Warning: failed to import %s: %v", rel, err)
+
+		if err := s.importFileByPath(ctx, filePath, content, settingsName, userID, dek,
+			teamPrefix, userPrefix); err != nil {
+			log.Printf("[SYNC] Warning: failed to import %s: %v", filePath, err)
 			continue
 		}
 		filesWritten++
@@ -208,6 +242,24 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 		PulledAt: time.Now(),
 		Summary:  SyncSummary{FilesWritten: filesWritten},
 	}, nil
+}
+
+// importFileByPath routes a single GitHub file to the right import handler.
+func (s *Syncer) importFileByPath(ctx context.Context, filePath string, content []byte,
+	settingsName, userID string, dek []byte, teamPrefix, userPrefix string) error {
+
+	switch {
+	case strings.HasPrefix(filePath, teamPrefix+"schedules/"):
+		return s.importScheduleFile(ctx, content, settingsName, userID, dek)
+	case strings.HasPrefix(filePath, teamPrefix+"webhooks/"):
+		return s.importWebhookFile(ctx, content, settingsName, userID, dek)
+	case filePath == teamPrefix+"settings.yaml":
+		return s.importSettingsFile(ctx, content, settingsName, userID, dek)
+	case strings.HasPrefix(filePath, userPrefix+"files/"):
+		return s.importUserFileRecord(ctx, content, userID, dek)
+	default:
+		return nil
+	}
 }
 
 // RotateKey generates a fresh DEK, re-encrypts all GitHub files, and updates Settings.
@@ -255,16 +307,16 @@ func (s *Syncer) RotateKey(ctx context.Context, settingsName, userID string) (*R
 	newVersion := cfg.Encryption.DEKVersion + 1
 
 	files := make(map[string][]byte, len(paths))
-	for _, path := range paths {
-		content, err := ghClient.GetFile(ctx, cfg.Branch, path)
+	for _, p := range paths {
+		content, err := ghClient.GetFile(ctx, cfg.Branch, p)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get %s during rotation: %w", path, err)
+			return nil, fmt.Errorf("failed to get %s during rotation: %w", p, err)
 		}
 		reenc, err := reencryptYAML(content, oldDEK, newDEK)
 		if err != nil {
-			return nil, fmt.Errorf("failed to re-encrypt %s: %w", path, err)
+			return nil, fmt.Errorf("failed to re-encrypt %s: %w", p, err)
 		}
-		files[path] = reenc
+		files[p] = reenc
 	}
 
 	sha, err := ghClient.PushFiles(ctx, cfg.Branch,
@@ -287,11 +339,14 @@ func (s *Syncer) RotateKey(ctx context.Context, settingsName, userID string) (*R
 	}, nil
 }
 
-// exportTeamResources exports schedules/webhooks/settings via the existing exporter.
-func (s *Syncer) exportTeamResources(ctx context.Context, settingsName, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+// --- Team resource export ---
+
+func (s *Syncer) exportTeamSchedules(ctx context.Context, settingsName, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.scheduleRepo == nil {
+		return nil
+	}
 	noopSvc := infraservices.NewNoopEncryptionService()
 	exporter := importexport.NewExporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
-
 	resources, err := exporter.Export(ctx, settingsName, userID, importexport.ExportOptions{
 		Format:         importexport.ExportFormatYAML,
 		IncludeSecrets: true,
@@ -300,148 +355,158 @@ func (s *Syncer) exportTeamResources(ctx context.Context, settingsName, userID s
 		return fmt.Errorf("export: %w", err)
 	}
 
-	if err := encryptTeamResourcesFields(resources, dek); err != nil {
-		return fmt.Errorf("encrypt: %w", err)
+	dir := rootPath + "teams/" + settingsName + "/schedules/"
+	for _, sc := range resources.Schedules {
+		id := sc.ID
+		if id == "" {
+			id = sc.Name
+		}
+		wrapper := &importexport.TeamResources{
+			Metadata:  resources.Metadata,
+			Schedules: []importexport.ScheduleImport{sc},
+		}
+		if err := encryptTeamResourcesFields(wrapper, dek); err != nil {
+			log.Printf("[SYNC] Warning: encrypt schedule %s: %v", id, err)
+			continue
+		}
+		data, err := yaml.Marshal(wrapper.Schedules[0])
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal schedule %s: %v", id, err)
+			continue
+		}
+		files[dir+id+".yaml"] = data
 	}
-
-	data, err := yaml.Marshal(resources)
-	if err != nil {
-		return fmt.Errorf("serialize: %w", err)
-	}
-
-	files[rootPath+"resources.yaml"] = data
 	return nil
 }
 
-// exportUserResources exports user-scoped memories, tasks, task groups, and files.
-func (s *Syncer) exportUserResources(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
-	type userExport struct {
-		APIVersion string            `yaml:"apiVersion"`
-		Kind       string            `yaml:"kind"`
-		Memories   []memoryExport    `yaml:"memories,omitempty"`
-		Tasks      []taskExport      `yaml:"tasks,omitempty"`
-		TaskGroups []taskGroupExport `yaml:"task_groups,omitempty"`
-		Files      []userFileExport  `yaml:"files,omitempty"`
-	}
-
-	export := userExport{
-		APIVersion: "agentapi-proxy/v1",
-		Kind:       "UserResources",
-	}
-
-	if s.memoryRepo != nil {
-		memories, err := s.memoryRepo.List(ctx, portrepos.MemoryFilter{
-			Scope:   entities.ScopeUser,
-			OwnerID: userID,
-		})
-		if err == nil {
-			for _, m := range memories {
-				export.Memories = append(export.Memories, memoryExport{
-					ID:        m.ID(),
-					Title:     m.Title(),
-					Content:   m.Content(),
-					Tags:      m.Tags(),
-					Scope:     string(m.Scope()),
-					CreatedAt: m.CreatedAt().Format(time.RFC3339),
-					UpdatedAt: m.UpdatedAt().Format(time.RFC3339),
-				})
-			}
-		}
-	}
-
-	if s.taskRepo != nil {
-		tasks, err := s.taskRepo.List(ctx, portrepos.TaskFilter{
-			Scope:   entities.ScopeUser,
-			OwnerID: userID,
-		})
-		if err == nil {
-			for _, t := range tasks {
-				export.Tasks = append(export.Tasks, taskExport{
-					ID:        t.ID(),
-					Title:     t.Title(),
-					Status:    string(t.Status()),
-					TaskType:  string(t.TaskType()),
-					SessionID: t.SessionID(),
-					CreatedAt: t.CreatedAt().Format(time.RFC3339),
-					UpdatedAt: t.UpdatedAt().Format(time.RFC3339),
-				})
-			}
-		}
-	}
-
-	if s.taskGroupRepo != nil {
-		groups, err := s.taskGroupRepo.List(ctx, portrepos.TaskGroupFilter{
-			Scope:   entities.ScopeUser,
-			OwnerID: userID,
-		})
-		if err == nil {
-			for _, g := range groups {
-				export.TaskGroups = append(export.TaskGroups, taskGroupExport{
-					ID:          g.ID(),
-					Name:        g.Name(),
-					Description: g.Description(),
-					CreatedAt:   g.CreatedAt().Format(time.RFC3339),
-					UpdatedAt:   g.UpdatedAt().Format(time.RFC3339),
-				})
-			}
-		}
-	}
-
-	if s.userFileRepo != nil {
-		ufiles, err := s.userFileRepo.List(ctx, userID)
-		if err == nil {
-			for _, f := range ufiles {
-				encContent, encErr := EncryptField(dek, f.Content())
-				if encErr != nil {
-					log.Printf("[SYNC] Warning: encrypt file %s content: %v", f.Name(), encErr)
-					encContent = ""
-				}
-				export.Files = append(export.Files, userFileExport{
-					ID:          f.ID(),
-					Name:        f.Name(),
-					Path:        f.Path(),
-					Content:     encContent,
-					Permissions: f.Permissions(),
-					CreatedAt:   f.CreatedAt().Format(time.RFC3339),
-					UpdatedAt:   f.UpdatedAt().Format(time.RFC3339),
-				})
-			}
-		}
-	}
-
-	data, err := yaml.Marshal(export)
-	if err != nil {
-		return fmt.Errorf("serialize: %w", err)
-	}
-	files[rootPath+"user-resources.yaml"] = data
-	return nil
-}
-
-// importFile dispatches a file to the appropriate import handler.
-func (s *Syncer) importFile(ctx context.Context, relPath string, content []byte, settingsName, userID string, dek []byte) error {
-	switch relPath {
-	case "resources.yaml":
-		return s.importTeamResources(ctx, content, settingsName, userID, dek)
-	case "user-resources.yaml":
-		return s.importUserResources(ctx, content, userID, dek)
-	default:
+func (s *Syncer) exportTeamWebhooks(ctx context.Context, settingsName, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.webhookRepo == nil {
 		return nil
 	}
+	noopSvc := infraservices.NewNoopEncryptionService()
+	exporter := importexport.NewExporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+	resources, err := exporter.Export(ctx, settingsName, userID, importexport.ExportOptions{
+		Format:         importexport.ExportFormatYAML,
+		IncludeSecrets: true,
+	})
+	if err != nil {
+		return fmt.Errorf("export: %w", err)
+	}
+
+	dir := rootPath + "teams/" + settingsName + "/webhooks/"
+	for _, wh := range resources.Webhooks {
+		id := wh.ID
+		if id == "" {
+			id = wh.Name
+		}
+		wrapper := &importexport.TeamResources{
+			Metadata: resources.Metadata,
+			Webhooks: []importexport.WebhookImport{wh},
+		}
+		if err := encryptTeamResourcesFields(wrapper, dek); err != nil {
+			log.Printf("[SYNC] Warning: encrypt webhook %s: %v", id, err)
+			continue
+		}
+		data, err := yaml.Marshal(wrapper.Webhooks[0])
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal webhook %s: %v", id, err)
+			continue
+		}
+		files[dir+id+".yaml"] = data
+	}
+	return nil
 }
 
-func (s *Syncer) importTeamResources(ctx context.Context, data []byte, settingsName, userID string, dek []byte) error {
-	var resources importexport.TeamResources
-	if err := yaml.Unmarshal(data, &resources); err != nil {
-		return fmt.Errorf("unmarshal: %w", err)
+func (s *Syncer) exportTeamSettings(ctx context.Context, settingsName, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.settingsRepo == nil {
+		return nil
+	}
+	noopSvc := infraservices.NewNoopEncryptionService()
+	exporter := importexport.NewExporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+	resources, err := exporter.Export(ctx, settingsName, userID, importexport.ExportOptions{
+		Format:         importexport.ExportFormatYAML,
+		IncludeSecrets: true,
+	})
+	if err != nil {
+		return fmt.Errorf("export: %w", err)
+	}
+	if resources.Settings == nil {
+		return nil
 	}
 
-	if err := decryptTeamResourcesFields(&resources, dek); err != nil {
-		return fmt.Errorf("decrypt: %w", err)
+	wrapper := &importexport.TeamResources{
+		Metadata: resources.Metadata,
+		Settings: resources.Settings,
+	}
+	if err := encryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("encrypt settings: %w", err)
+	}
+	data, err := yaml.Marshal(wrapper.Settings)
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	files[rootPath+"teams/"+settingsName+"/settings.yaml"] = data
+	return nil
+}
+
+// --- User resource export ---
+
+func (s *Syncer) exportUserFiles(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	if s.userFileRepo == nil {
+		return nil
+	}
+	ufiles, err := s.userFileRepo.List(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("list user files: %w", err)
 	}
 
+	dir := rootPath + "users/" + userID + "/files/"
+	for _, f := range ufiles {
+		encContent, encErr := EncryptField(dek, f.Content())
+		if encErr != nil {
+			log.Printf("[SYNC] Warning: encrypt file %s: %v", f.Name(), encErr)
+			encContent = ""
+		}
+		rec := userFileRecord{
+			ID:          f.ID(),
+			Name:        f.Name(),
+			Path:        f.Path(),
+			Content:     encContent,
+			Permissions: f.Permissions(),
+			CreatedAt:   f.CreatedAt().Format(time.RFC3339),
+			UpdatedAt:   f.UpdatedAt().Format(time.RFC3339),
+		}
+		data, err := yaml.Marshal(rec)
+		if err != nil {
+			log.Printf("[SYNC] Warning: marshal file %s: %v", f.Name(), err)
+			continue
+		}
+		filename := f.ID()
+		if filename == "" {
+			filename = sanitizeFilename(f.Name())
+		}
+		files[dir+filename+".yaml"] = data
+	}
+	return nil
+}
+
+// --- Import handlers ---
+
+func (s *Syncer) importScheduleFile(ctx context.Context, data []byte, settingsName, userID string, dek []byte) error {
+	var sc importexport.ScheduleImport
+	if err := yaml.Unmarshal(data, &sc); err != nil {
+		return fmt.Errorf("unmarshal schedule: %w", err)
+	}
+	wrapper := &importexport.TeamResources{
+		Metadata:  importexport.ResourceMetadata{TeamID: settingsName},
+		Schedules: []importexport.ScheduleImport{sc},
+	}
+	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("decrypt schedule: %w", err)
+	}
 	noopSvc := infraservices.NewNoopEncryptionService()
 	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
-	_, err := importer.Import(ctx, &resources, userID, importexport.ImportOptions{
+	_, err := importer.Import(ctx, wrapper, userID, importexport.ImportOptions{
 		Mode:           importexport.ImportModeUpsert,
 		IDField:        "name",
 		AllowPartial:   true,
@@ -450,54 +515,76 @@ func (s *Syncer) importTeamResources(ctx context.Context, data []byte, settingsN
 	return err
 }
 
-func (s *Syncer) importUserResources(ctx context.Context, data []byte, userID string, dek []byte) error {
-	type userImport struct {
-		Memories []memoryExport   `yaml:"memories"`
-		Files    []userFileExport `yaml:"files"`
+func (s *Syncer) importWebhookFile(ctx context.Context, data []byte, settingsName, userID string, dek []byte) error {
+	var wh importexport.WebhookImport
+	if err := yaml.Unmarshal(data, &wh); err != nil {
+		return fmt.Errorf("unmarshal webhook: %w", err)
 	}
-
-	var imp userImport
-	if err := yaml.Unmarshal(data, &imp); err != nil {
-		return fmt.Errorf("unmarshal: %w", err)
+	wrapper := &importexport.TeamResources{
+		Metadata: importexport.ResourceMetadata{TeamID: settingsName},
+		Webhooks: []importexport.WebhookImport{wh},
 	}
+	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("decrypt webhook: %w", err)
+	}
+	noopSvc := infraservices.NewNoopEncryptionService()
+	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+	_, err := importer.Import(ctx, wrapper, userID, importexport.ImportOptions{
+		Mode:           importexport.ImportModeUpsert,
+		IDField:        "name",
+		AllowPartial:   true,
+		SkipValidation: true,
+	})
+	return err
+}
 
-	if s.memoryRepo != nil {
-		for _, m := range imp.Memories {
-			scope := entities.ResourceScope(m.Scope)
-			if scope == "" {
-				scope = entities.ScopeUser
-			}
-			mem := entities.NewMemoryWithTags(m.ID, m.Title, m.Content, scope, userID, "", m.Tags)
-			// Try Update first to preserve the exported ID (no-op if already up-to-date).
-			// Fall back to Create only when the entry doesn't exist (404).
-			if updateErr := s.memoryRepo.Update(ctx, mem); updateErr != nil {
-				if createErr := s.memoryRepo.Create(ctx, mem); createErr != nil {
-					log.Printf("[SYNC] Warning: upsert memory %s: update=%v create=%v", m.ID, updateErr, createErr)
-				}
-			}
+func (s *Syncer) importSettingsFile(ctx context.Context, data []byte, settingsName, userID string, dek []byte) error {
+	var si importexport.SettingsImport
+	if err := yaml.Unmarshal(data, &si); err != nil {
+		return fmt.Errorf("unmarshal settings: %w", err)
+	}
+	wrapper := &importexport.TeamResources{
+		Metadata: importexport.ResourceMetadata{TeamID: settingsName},
+		Settings: &si,
+	}
+	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("decrypt settings: %w", err)
+	}
+	noopSvc := infraservices.NewNoopEncryptionService()
+	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
+	_, err := importer.Import(ctx, wrapper, userID, importexport.ImportOptions{
+		Mode:           importexport.ImportModeUpsert,
+		IDField:        "name",
+		AllowPartial:   true,
+		SkipValidation: true,
+	})
+	return err
+}
+
+func (s *Syncer) importUserFileRecord(ctx context.Context, data []byte, userID string, dek []byte) error {
+	if s.userFileRepo == nil {
+		return nil
+	}
+	var rec userFileRecord
+	if err := yaml.Unmarshal(data, &rec); err != nil {
+		return fmt.Errorf("unmarshal file record: %w", err)
+	}
+	plainContent := rec.Content
+	if IsEncrypted(plainContent) {
+		dec, err := DecryptField(dek, plainContent)
+		if err != nil {
+			return fmt.Errorf("decrypt file %s: %w", rec.Name, err)
 		}
+		plainContent = dec
 	}
-
-	if s.userFileRepo != nil {
-		for _, f := range imp.Files {
-			plainContent := f.Content
-			if IsEncrypted(plainContent) {
-				dec, err := DecryptField(dek, plainContent)
-				if err != nil {
-					log.Printf("[SYNC] Warning: decrypt file %s content: %v", f.Name, err)
-					continue
-				}
-				plainContent = dec
-			}
-			uf := entities.NewUserFile(f.ID, f.Name, f.Path, plainContent, f.Permissions)
-			if err := s.userFileRepo.Save(ctx, userID, uf); err != nil {
-				log.Printf("[SYNC] Warning: save file %s: %v", f.Name, err)
-			}
-		}
+	uf := newUserFileFromRecord(rec, plainContent)
+	if err := s.userFileRepo.Save(ctx, userID, uf); err != nil {
+		return fmt.Errorf("save file %s: %w", rec.Name, err)
 	}
-
 	return nil
 }
+
+// --- Encryption helpers ---
 
 // encryptTeamResourcesFields encrypts sensitive plaintext fields using the fixed DEK.
 func encryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error {
@@ -664,7 +751,7 @@ func decryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 func reencryptYAML(data, oldDEK, newDEK []byte) ([]byte, error) {
 	var root interface{}
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return data, nil // not YAML — pass through unchanged
+		return data, nil
 	}
 	reencrypted := reencryptValue(root, oldDEK, newDEK)
 	return yaml.Marshal(reencrypted)
@@ -700,45 +787,41 @@ func reencryptValue(v interface{}, oldDEK, newDEK []byte) interface{} {
 	}
 }
 
-// --- DTO types for user-scoped resource export ---
+// --- DTO types ---
 
-type memoryExport struct {
-	ID        string            `yaml:"id"`
-	Title     string            `yaml:"title"`
-	Content   string            `yaml:"content"`
-	Scope     string            `yaml:"scope"`
-	Tags      map[string]string `yaml:"tags,omitempty"`
-	CreatedAt string            `yaml:"created_at"`
-	UpdatedAt string            `yaml:"updated_at"`
-}
-
-type taskExport struct {
-	ID        string `yaml:"id"`
-	Title     string `yaml:"title"`
-	Status    string `yaml:"status"`
-	TaskType  string `yaml:"task_type"`
-	SessionID string `yaml:"session_id,omitempty"`
-	CreatedAt string `yaml:"created_at"`
-	UpdatedAt string `yaml:"updated_at"`
-}
-
-type taskGroupExport struct {
-	ID          string `yaml:"id"`
-	Name        string `yaml:"name"`
-	Description string `yaml:"description,omitempty"`
-	CreatedAt   string `yaml:"created_at"`
-	UpdatedAt   string `yaml:"updated_at"`
-}
-
-type userFileExport struct {
+type userFileRecord struct {
 	ID          string `yaml:"id"`
 	Name        string `yaml:"name"`
 	Path        string `yaml:"path"`
 	Content     string `yaml:"content"` // always encrypted with DEK
 	Permissions string `yaml:"permissions,omitempty"`
-	CreatedAt   string `yaml:"created_at"`
-	UpdatedAt   string `yaml:"updated_at"`
+	CreatedAt   string `yaml:"created_at,omitempty"`
+	UpdatedAt   string `yaml:"updated_at,omitempty"`
 }
 
-// keep errors import satisfied
-var _ = errors.New
+func newUserFileFromRecord(rec userFileRecord, content string) *entities.UserFile {
+	uf := entities.NewUserFile(rec.ID, rec.Name, rec.Path, content, rec.Permissions)
+	if t, err := time.Parse(time.RFC3339, rec.CreatedAt); err == nil {
+		uf.SetCreatedAt(t)
+	}
+	if t, err := time.Parse(time.RFC3339, rec.UpdatedAt); err == nil {
+		uf.SetUpdatedAt(t)
+	}
+	return uf
+}
+
+// sanitizeFilename replaces characters that are invalid in file paths.
+func sanitizeFilename(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+	)
+	return replacer.Replace(name)
+}

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	importexport "github.com/takutakahashi/agentapi-proxy/pkg/import"
 	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
+	"github.com/takutakahashi/agentapi-proxy/pkg/startup"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,14 +31,17 @@ import (
 // A push from a personal settings (settingsName == userID) exports only
 // user resources; a push from a team settings exports only team resources.
 type Syncer struct {
-	settingsRepo portrepos.SettingsRepository
-	scheduleRepo schedule.Manager
-	webhookRepo  portrepos.WebhookRepository
-	slackbotRepo portrepos.SlackBotRepository
-	userFileRepo portrepos.UserFileRepository
+	settingsRepo           portrepos.SettingsRepository
+	scheduleRepo           schedule.Manager
+	webhookRepo            portrepos.WebhookRepository
+	slackbotRepo           portrepos.SlackBotRepository
+	userFileRepo           portrepos.UserFileRepository
+	githubAppInstallID     string // fallback installation ID when no personal token
 }
 
 // NewSyncer creates a Syncer. Non-nil repos are synced.
+// githubAppInstallID is used to generate a GitHub App installation token when
+// a user has no personal GitHub token configured (empty string disables fallback).
 func NewSyncer(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
@@ -46,13 +51,15 @@ func NewSyncer(
 	_ portrepos.TaskGroupRepository, // unused
 	userFileRepo portrepos.UserFileRepository,
 	slackbotRepo portrepos.SlackBotRepository,
+	githubAppInstallID string,
 ) *Syncer {
 	return &Syncer{
-		settingsRepo: settingsRepo,
-		scheduleRepo: scheduleRepo,
-		webhookRepo:  webhookRepo,
-		slackbotRepo: slackbotRepo,
-		userFileRepo: userFileRepo,
+		settingsRepo:       settingsRepo,
+		scheduleRepo:       scheduleRepo,
+		webhookRepo:        webhookRepo,
+		slackbotRepo:       slackbotRepo,
+		userFileRepo:       userFileRepo,
+		githubAppInstallID: githubAppInstallID,
 	}
 }
 
@@ -60,6 +67,30 @@ func NewSyncer(
 // personal settings (as opposed to a team/shared settings name).
 func isPersonalSync(settingsName, userID string) bool {
 	return settingsName == userID
+}
+
+// resolveToken returns the GitHub token to use for sync operations.
+// If personalToken is non-empty it is returned directly.
+// Otherwise a short-lived GitHub App installation token is generated using
+// GITHUB_APP_ID / GITHUB_APP_PEM env vars and the proxy-configured installation ID.
+func (s *Syncer) resolveToken(personalToken string) (string, error) {
+	if personalToken != "" {
+		return personalToken, nil
+	}
+	if s.githubAppInstallID == "" {
+		return "", fmt.Errorf("github_token is not configured and no GitHub App fallback is set (git_sync.github_app.installation_id)")
+	}
+	appID := os.Getenv("GITHUB_APP_ID")
+	if appID == "" {
+		return "", fmt.Errorf("github_token is not configured and GITHUB_APP_ID env var is not set")
+	}
+	pemPath := os.Getenv("GITHUB_APP_PEM_PATH")
+	token, err := startup.GenerateGitHubAppToken(appID, s.githubAppInstallID, pemPath)
+	if err != nil {
+		return "", fmt.Errorf("github_token is not configured; GitHub App token generation failed: %w", err)
+	}
+	log.Printf("[SYNC] Using GitHub App installation token (installation_id=%s)", s.githubAppInstallID)
+	return token, nil
 }
 
 // Push exports all resources for settingsName and commits them to GitHub.
@@ -74,9 +105,9 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
 	}
 
-	token := cfg.GitHubToken
-	if token == "" {
-		return nil, fmt.Errorf("github_token is required in git_sync config for %q", settingsName)
+	token, err := s.resolveToken(cfg.GitHubToken)
+	if err != nil {
+		return nil, fmt.Errorf("no GitHub token for %q: %w", settingsName, err)
 	}
 
 	enc, err := NewSyncEncryptor(ctx, cfg.Encryption.KMSKeyARN, cfg.Encryption.AWSRegion)
@@ -188,9 +219,9 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
 	}
 
-	token := cfg.GitHubToken
-	if token == "" {
-		return nil, fmt.Errorf("github_token is required in git_sync config for %q", settingsName)
+	token, err := s.resolveToken(cfg.GitHubToken)
+	if err != nil {
+		return nil, fmt.Errorf("no GitHub token for %q: %w", settingsName, err)
 	}
 
 	if cfg.Encryption.EncryptedDEK == "" {
@@ -314,9 +345,14 @@ func (s *Syncer) RotateKey(ctx context.Context, settingsName, userID string) (*R
 		return nil, fmt.Errorf("failed to decrypt old DEK: %w", err)
 	}
 
+	rotateToken, err := s.resolveToken(cfg.GitHubToken)
+	if err != nil {
+		return nil, fmt.Errorf("no GitHub token for %q: %w", settingsName, err)
+	}
+
 	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
 
-	ghClient, err := NewGitHubSyncClient(ctx, cfg.GitHubToken, cfg.RepoFullName)
+	ghClient, err := NewGitHubSyncClient(ctx, rotateToken, cfg.RepoFullName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
 	}

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -22,14 +22,16 @@ import (
 //
 // File layout in GitHub:
 //
-//	<rootPath>/teams/<settingsName>/schedules/<id>.yaml
-//	<rootPath>/teams/<settingsName>/webhooks/<id>.yaml
-//	<rootPath>/teams/<settingsName>/settings.yaml
-//	<rootPath>/users/<userID>/files/<id>.yaml
-//	<rootPath>/.sync-meta.yaml
+//	<rootPath>/<settingsName>/schedules/<id>.yaml
+//	<rootPath>/<settingsName>/webhooks/<id>.yaml
+//	<rootPath>/<settingsName>/settings.yaml   (team only)
+//	<rootPath>/<settingsName>/files/<id>.yaml (personal only)
+//	<rootPath>/<settingsName>/slackbots/<id>.yaml
+//	<rootPath>/<settingsName>/.sync-meta.yaml
 //
-// A push from a personal settings (settingsName == userID) exports only
-// user resources; a push from a team settings exports only team resources.
+// For personal sync settingsName == userID; for team sync settingsName is the team name.
+// Each settings has its own subdirectory under rootPath so multiple settings can share
+// the same repository without conflicting.
 type Syncer struct {
 	settingsRepo       portrepos.SettingsRepository
 	scheduleRepo       schedule.Manager
@@ -179,7 +181,7 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		},
 	}
 	if metaBytes, merr := yaml.Marshal(meta); merr == nil {
-		files[rootPath+".sync-meta.yaml"] = metaBytes
+		files[rootPath+settingsName+"/.sync-meta.yaml"] = metaBytes
 	}
 
 	if len(files) == 0 {
@@ -247,39 +249,22 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 	}
 
 	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+	settingsPrefix := rootPath + settingsName + "/"
 
 	ghClient, err := NewGitHubSyncClient(ctx, token, cfg.RepoFullName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
 	}
 
-	paths, err := ghClient.ListFiles(ctx, cfg.Branch, rootPath)
+	paths, err := ghClient.ListFiles(ctx, cfg.Branch, settingsPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list GitHub files: %w", err)
 	}
 
 	personal := isPersonalSync(settingsName, userID)
-	teamPrefix := rootPath + "teams/" + settingsName + "/"
-	userPrefix := rootPath + "users/" + userID + "/"
 
 	filesWritten := 0
 	for _, filePath := range paths {
-		rel := strings.TrimPrefix(filePath, rootPath)
-		if strings.HasSuffix(rel, ".sync-meta.yaml") {
-			continue
-		}
-
-		// Route by scope: personal sync only imports user files; team sync imports team resources.
-		var relevant bool
-		if personal {
-			relevant = strings.HasPrefix(filePath, userPrefix)
-		} else {
-			relevant = strings.HasPrefix(filePath, teamPrefix)
-		}
-		if !relevant {
-			continue
-		}
-
 		content, err := ghClient.GetFile(ctx, cfg.Branch, filePath)
 		if err != nil {
 			log.Printf("[SYNC] Warning: failed to get %s: %v", filePath, err)
@@ -287,7 +272,7 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 		}
 
 		if err := s.importFileByPath(ctx, filePath, content, settingsName, userID, dek,
-			teamPrefix, userPrefix); err != nil {
+			settingsPrefix, personal); err != nil {
 			log.Printf("[SYNC] Warning: failed to import %s: %v", filePath, err)
 			continue
 		}
@@ -301,28 +286,43 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 }
 
 // importFileByPath routes a single GitHub file to the right import handler.
+// settingsPrefix is "{rootPath}/{settingsName}/"; personal distinguishes user vs team sync.
 func (s *Syncer) importFileByPath(ctx context.Context, filePath string, content []byte,
-	settingsName, userID string, dek []byte, teamPrefix, userPrefix string) error {
+	settingsName, userID string, dek []byte, settingsPrefix string, personal bool) error {
+
+	rel := strings.TrimPrefix(filePath, settingsPrefix)
 
 	switch {
-	// Team sync paths
-	case strings.HasPrefix(filePath, teamPrefix+"schedules/"):
+	case rel == ".sync-meta.yaml":
+		return nil
+	case strings.HasPrefix(rel, "schedules/"):
+		if personal {
+			return s.importUserScheduleFile(ctx, content, userID, dek)
+		}
 		return s.importScheduleFile(ctx, content, settingsName, userID, dek)
-	case strings.HasPrefix(filePath, teamPrefix+"webhooks/"):
+	case strings.HasPrefix(rel, "webhooks/"):
+		if personal {
+			return s.importUserWebhookFile(ctx, content, userID, dek)
+		}
 		return s.importWebhookFile(ctx, content, settingsName, userID, dek)
-	case filePath == teamPrefix+"settings.yaml":
-		return s.importSettingsFile(ctx, content, settingsName, userID, dek)
-	case strings.HasPrefix(filePath, teamPrefix+"slackbots/"):
-		return s.importSlackbotFile(ctx, content, entities.ScopeTeam, userID, settingsName, dek)
-	// Personal sync paths
-	case strings.HasPrefix(filePath, userPrefix+"files/"):
-		return s.importUserFileRecord(ctx, content, userID, dek)
-	case strings.HasPrefix(filePath, userPrefix+"schedules/"):
-		return s.importUserScheduleFile(ctx, content, userID, dek)
-	case strings.HasPrefix(filePath, userPrefix+"webhooks/"):
-		return s.importUserWebhookFile(ctx, content, userID, dek)
-	case strings.HasPrefix(filePath, userPrefix+"slackbots/"):
-		return s.importSlackbotFile(ctx, content, entities.ScopeUser, userID, "", dek)
+	case rel == "settings.yaml":
+		if !personal {
+			return s.importSettingsFile(ctx, content, settingsName, userID, dek)
+		}
+		return nil
+	case strings.HasPrefix(rel, "files/"):
+		if personal {
+			return s.importUserFileRecord(ctx, content, userID, dek)
+		}
+		return nil
+	case strings.HasPrefix(rel, "slackbots/"):
+		scope := entities.ScopeTeam
+		teamID := settingsName
+		if personal {
+			scope = entities.ScopeUser
+			teamID = ""
+		}
+		return s.importSlackbotFile(ctx, content, scope, userID, teamID, dek)
 	default:
 		return nil
 	}
@@ -360,13 +360,14 @@ func (s *Syncer) RotateKey(ctx context.Context, settingsName, userID string) (*R
 	}
 
 	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+	settingsPath := rootPath + settingsName + "/"
 
 	ghClient, err := NewGitHubSyncClient(ctx, rotateToken, cfg.RepoFullName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GitHub client: %w", err)
 	}
 
-	paths, err := ghClient.ListFiles(ctx, cfg.Branch, rootPath)
+	paths, err := ghClient.ListFiles(ctx, cfg.Branch, settingsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list files: %w", err)
 	}
@@ -426,7 +427,7 @@ func (s *Syncer) exportTeamSchedules(ctx context.Context, settingsName, userID s
 		return fmt.Errorf("export: %w", err)
 	}
 
-	dir := rootPath + "teams/" + settingsName + "/schedules/"
+	dir := rootPath + settingsName + "/schedules/"
 	for _, sc := range resources.Schedules {
 		id := sc.ID
 		if id == "" {
@@ -464,7 +465,7 @@ func (s *Syncer) exportTeamWebhooks(ctx context.Context, settingsName, userID st
 		return fmt.Errorf("export: %w", err)
 	}
 
-	dir := rootPath + "teams/" + settingsName + "/webhooks/"
+	dir := rootPath + settingsName + "/webhooks/"
 	for _, wh := range resources.Webhooks {
 		id := wh.ID
 		if id == "" {
@@ -516,7 +517,7 @@ func (s *Syncer) exportTeamSettings(ctx context.Context, settingsName, userID st
 	if err != nil {
 		return fmt.Errorf("marshal settings: %w", err)
 	}
-	files[rootPath+"teams/"+settingsName+"/settings.yaml"] = data
+	files[rootPath+settingsName+"/settings.yaml"] = data
 	return nil
 }
 
@@ -531,7 +532,7 @@ func (s *Syncer) exportUserFiles(ctx context.Context, userID string, dek []byte,
 		return fmt.Errorf("list user files: %w", err)
 	}
 
-	dir := rootPath + "users/" + userID + "/files/"
+	dir := rootPath + userID + "/files/"
 	for _, f := range ufiles {
 		encContent, encErr := EncryptField(dek, f.Content())
 		if encErr != nil {
@@ -572,7 +573,7 @@ func (s *Syncer) exportUserSchedules(ctx context.Context, userID string, dek []b
 	if err != nil {
 		return fmt.Errorf("list user schedules: %w", err)
 	}
-	dir := rootPath + "users/" + userID + "/schedules/"
+	dir := rootPath + userID + "/schedules/"
 	for _, sc := range schedules {
 		si := scheduleToImport(sc)
 		wrapper := &importexport.TeamResources{
@@ -604,7 +605,7 @@ func (s *Syncer) exportUserWebhooks(ctx context.Context, userID string, dek []by
 	if err != nil {
 		return fmt.Errorf("list user webhooks: %w", err)
 	}
-	dir := rootPath + "users/" + userID + "/webhooks/"
+	dir := rootPath + userID + "/webhooks/"
 	for _, wh := range webhooks {
 		wi := webhookToImport(wh)
 		wrapper := &importexport.TeamResources{
@@ -636,7 +637,7 @@ func (s *Syncer) exportUserSlackbots(ctx context.Context, userID string, dek []b
 	if err != nil {
 		return fmt.Errorf("list user slackbots: %w", err)
 	}
-	dir := rootPath + "users/" + userID + "/slackbots/"
+	dir := rootPath + userID + "/slackbots/"
 	for _, bot := range bots {
 		rec := slackbotToRecord(bot, dek)
 		data, err := yaml.Marshal(rec)
@@ -660,7 +661,7 @@ func (s *Syncer) exportTeamSlackbots(ctx context.Context, settingsName string, d
 	if err != nil {
 		return fmt.Errorf("list team slackbots: %w", err)
 	}
-	dir := rootPath + "teams/" + settingsName + "/slackbots/"
+	dir := rootPath + settingsName + "/slackbots/"
 	for _, bot := range bots {
 		rec := slackbotToRecord(bot, dek)
 		data, err := yaml.Marshal(rec)

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -200,9 +200,18 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		return nil, fmt.Errorf("failed to push to GitHub: %w", err)
 	}
 
+	pushedAt := time.Now()
+
+	// Persist last push time so the periodic worker can determine sync direction.
+	cfg.LastPushedAt = pushedAt
+	settings.SetGitSync(cfg)
+	if saveErr := s.settingsRepo.Save(ctx, settings); saveErr != nil {
+		log.Printf("[SYNC] Warning: failed to save LastPushedAt for %s: %v", settingsName, saveErr)
+	}
+
 	return &PushResponse{
 		CommitSHA: sha,
-		PushedAt:  time.Now(),
+		PushedAt:  pushedAt,
 		Summary:   SyncSummary{FilesWritten: len(files)},
 	}, nil
 }

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -797,26 +797,132 @@ func (s *Syncer) importUserScheduleFile(ctx context.Context, data []byte, userID
 }
 
 func (s *Syncer) importUserWebhookFile(ctx context.Context, data []byte, userID string, dek []byte) error {
+	if s.webhookRepo == nil {
+		return nil
+	}
 	var wi importexport.WebhookImport
 	if err := yaml.Unmarshal(data, &wi); err != nil {
 		return fmt.Errorf("unmarshal webhook: %w", err)
 	}
-	wrapper := &importexport.TeamResources{
-		Metadata: importexport.ResourceMetadata{TeamID: userID},
-		Webhooks: []importexport.WebhookImport{wi},
+	// Decrypt secret field inline (ScopeUser — cannot use generic Importer which hardcodes ScopeTeam).
+	if IsEncrypted(wi.Secret) {
+		plain, err := DecryptField(dek, wi.Secret)
+		if err != nil {
+			return fmt.Errorf("decrypt webhook secret: %w", err)
+		}
+		wi.Secret = plain
 	}
-	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
-		return fmt.Errorf("decrypt webhook: %w", err)
-	}
-	noopSvc := infraservices.NewNoopEncryptionService()
-	importer := importexport.NewImporter(s.scheduleRepo, s.webhookRepo, s.settingsRepo, noopSvc)
-	_, err := importer.Import(ctx, wrapper, userID, importexport.ImportOptions{
-		Mode:           importexport.ImportModeUpsert,
-		IDField:        "name",
-		AllowPartial:   true,
-		SkipValidation: true,
+	return s.upsertUserWebhook(ctx, wi, userID)
+}
+
+// upsertUserWebhook creates or updates a personal (ScopeUser) webhook from a WebhookImport.
+// It avoids the generic Importer which hardcodes ScopeTeam.
+func (s *Syncer) upsertUserWebhook(ctx context.Context, wi importexport.WebhookImport, userID string) error {
+	existing, _ := s.webhookRepo.List(ctx, portrepos.WebhookFilter{
+		Scope:  entities.ScopeUser,
+		UserID: userID,
 	})
-	return err
+
+	// Match by ID first, then by name.
+	var found *entities.Webhook
+	for _, w := range existing {
+		if wi.ID != "" && w.ID() == wi.ID {
+			found = w
+			break
+		}
+	}
+	if found == nil {
+		for _, w := range existing {
+			if w.Name() == wi.Name {
+				found = w
+				break
+			}
+		}
+	}
+
+	var wh *entities.Webhook
+	if found != nil {
+		wh = found
+	} else {
+		id := wi.ID
+		if id == "" {
+			id = uuid.New().String()
+		}
+		wh = entities.NewWebhook(id, wi.Name, userID, entities.WebhookType(wi.WebhookType))
+	}
+
+	wh.SetScope(entities.ScopeUser)
+	wh.SetName(wi.Name)
+	if wi.Status != "" {
+		wh.SetStatus(entities.WebhookStatus(wi.Status))
+	}
+	if wi.Secret != "" {
+		wh.SetSecret(wi.Secret)
+	}
+	if wi.SignatureHeader != "" {
+		wh.SetSignatureHeader(wi.SignatureHeader)
+	}
+	if wi.SignatureType != "" {
+		wh.SetSignatureType(entities.WebhookSignatureType(wi.SignatureType))
+	}
+	if wi.SignaturePrefix != "" {
+		wh.SetSignaturePrefix(wi.SignaturePrefix)
+	}
+	if wi.MaxSessions > 0 {
+		wh.SetMaxSessions(wi.MaxSessions)
+	}
+	if wi.GitHub != nil {
+		gh := entities.NewWebhookGitHubConfig()
+		gh.SetEnterpriseURL(wi.GitHub.EnterpriseURL)
+		gh.SetAllowedEvents(wi.GitHub.AllowedEvents)
+		gh.SetAllowedRepositories(wi.GitHub.AllowedRepositories)
+		wh.SetGitHub(gh)
+	}
+	if wi.SessionConfig != nil {
+		sc := entities.NewWebhookSessionConfig()
+		sc.SetEnvironment(wi.SessionConfig.Environment)
+		sc.SetTags(wi.SessionConfig.Tags)
+		wh.SetSessionConfig(sc)
+	}
+
+	triggers := make([]entities.WebhookTrigger, 0, len(wi.Triggers))
+	for _, ti := range wi.Triggers {
+		t := entities.NewWebhookTrigger(uuid.New().String(), ti.Name)
+		t.SetPriority(ti.Priority)
+		t.SetEnabled(ti.Enabled)
+		t.SetStopOnMatch(ti.StopOnMatch)
+		var cond entities.WebhookTriggerConditions
+		if ti.Conditions.GitHub != nil {
+			ghCond := entities.NewWebhookGitHubConditions()
+			ghCond.SetEvents(ti.Conditions.GitHub.Events)
+			ghCond.SetActions(ti.Conditions.GitHub.Actions)
+			ghCond.SetBranches(ti.Conditions.GitHub.Branches)
+			ghCond.SetRepositories(ti.Conditions.GitHub.Repositories)
+			ghCond.SetLabels(ti.Conditions.GitHub.Labels)
+			ghCond.SetPaths(ti.Conditions.GitHub.Paths)
+			ghCond.SetBaseBranches(ti.Conditions.GitHub.BaseBranches)
+			ghCond.SetDraft(ti.Conditions.GitHub.Draft)
+			ghCond.SetSender(ti.Conditions.GitHub.Sender)
+			cond.SetGitHub(ghCond)
+		}
+		if ti.Conditions.GoTemplate != "" {
+			cond.SetGoTemplate(ti.Conditions.GoTemplate)
+		}
+		t.SetConditions(cond)
+		if ti.SessionConfig != nil {
+			tsc := entities.NewWebhookSessionConfig()
+			tsc.SetEnvironment(ti.SessionConfig.Environment)
+			tsc.SetTags(ti.SessionConfig.Tags)
+			t.SetSessionConfig(tsc)
+		}
+		triggers = append(triggers, t)
+	}
+	wh.SetTriggers(triggers)
+
+	if found != nil {
+		return s.webhookRepo.Update(ctx, wh)
+	}
+	return s.webhookRepo.Create(ctx, wh)
 }
 
 func (s *Syncer) importSlackbotFile(ctx context.Context, data []byte, scope entities.ResourceScope, userID, teamID string, dek []byte) error {

--- a/pkg/github_sync/types.go
+++ b/pkg/github_sync/types.go
@@ -75,12 +75,13 @@ type SyncEventRecord struct {
 
 // SyncConfigResponse is returned by GET /sync/config (github_token redacted).
 type SyncConfigResponse struct {
-	Enabled      bool                   `json:"enabled"`
-	RepoFullName string                 `json:"repo_full_name"`
-	Branch       string                 `json:"branch"`
-	RootPath     string                 `json:"root_path"`
-	AutoPush     bool                   `json:"auto_push"`
-	Encryption   SyncEncryptionResponse `json:"encryption"`
+	Enabled         bool                   `json:"enabled"`
+	RepoFullName    string                 `json:"repo_full_name"`
+	Branch          string                 `json:"branch"`
+	RootPath        string                 `json:"root_path"`
+	AutoPush        bool                   `json:"auto_push"`
+	HasGitHubToken  bool                   `json:"has_github_token"`
+	Encryption      SyncEncryptionResponse `json:"encryption"`
 }
 
 // SyncEncryptionResponse is the public view of SyncEncryptionConfig (no secrets).

--- a/pkg/github_sync/types.go
+++ b/pkg/github_sync/types.go
@@ -75,36 +75,28 @@ type SyncEventRecord struct {
 
 // SyncConfigResponse is returned by GET /sync/config (github_token redacted).
 type SyncConfigResponse struct {
-	Enabled         bool                   `json:"enabled"`
-	RepoFullName    string                 `json:"repo_full_name"`
-	Branch          string                 `json:"branch"`
-	RootPath        string                 `json:"root_path"`
-	AutoPush        bool                   `json:"auto_push"`
-	HasGitHubToken  bool                   `json:"has_github_token"`
-	Encryption      SyncEncryptionResponse `json:"encryption"`
+	Enabled        bool                   `json:"enabled"`
+	RepoFullName   string                 `json:"repo_full_name"`
+	Branch         string                 `json:"branch"`
+	RootPath       string                 `json:"root_path"`
+	AutoPush       bool                   `json:"auto_push"`
+	HasGitHubToken bool                   `json:"has_github_token"`
+	Encryption     SyncEncryptionResponse `json:"encryption"`
 }
 
-// SyncEncryptionResponse is the public view of SyncEncryptionConfig (no secrets).
+// SyncEncryptionResponse is the public view of encryption status (no secrets, no KMS ARN).
 type SyncEncryptionResponse struct {
-	KMSKeyARN  string `json:"kms_key_arn"`
-	AWSRegion  string `json:"aws_region"`
-	DEKVersion int    `json:"dek_version"`
-	DEKReady   bool   `json:"dek_ready"` // true when encryptedDEK is non-empty
+	DEKVersion int  `json:"dek_version"`
+	DEKReady   bool `json:"dek_ready"` // true when encryptedDEK is non-empty
 }
 
 // UpdateSyncConfigRequest is the HTTP request body for PUT /sync/config.
+// Encryption settings (KMS key ARN, AWS region) are set at the proxy level and cannot be provided by the user.
 type UpdateSyncConfigRequest struct {
-	Enabled      bool                        `json:"enabled"`
-	RepoFullName string                      `json:"repo_full_name"`
-	Branch       string                      `json:"branch"`
-	RootPath     string                      `json:"root_path"`
-	AutoPush     bool                        `json:"auto_push"`
-	GitHubToken  string                      `json:"github_token,omitempty"`
-	Encryption   UpdateSyncEncryptionRequest `json:"encryption"`
-}
-
-// UpdateSyncEncryptionRequest is the encryption portion of UpdateSyncConfigRequest.
-type UpdateSyncEncryptionRequest struct {
-	KMSKeyARN string `json:"kms_key_arn"`
-	AWSRegion string `json:"aws_region"`
+	Enabled      bool   `json:"enabled"`
+	RepoFullName string `json:"repo_full_name"`
+	Branch       string `json:"branch"`
+	RootPath     string `json:"root_path"`
+	AutoPush     bool   `json:"auto_push"`
+	GitHubToken  string `json:"github_token,omitempty"`
 }

--- a/pkg/github_sync/types.go
+++ b/pkg/github_sync/types.go
@@ -1,0 +1,109 @@
+package githubsync
+
+import "time"
+
+// SyncMeta is stored as .sync-meta.yaml at the rootPath in the GitHub repository.
+// It records the last sync timestamp and encryption parameters (NOT the DEK itself).
+type SyncMeta struct {
+	APIVersion string      `yaml:"apiVersion"`
+	Kind       string      `yaml:"kind"`
+	SyncedAt   time.Time   `yaml:"syncedAt"`
+	Version    string      `yaml:"version"`
+	Encryption SyncMetaEnc `yaml:"encryption"`
+}
+
+// SyncMetaEnc holds encryption metadata stored in .sync-meta.yaml.
+// The encryptedDEK is NOT stored here — it lives in Settings (K8s Secret).
+type SyncMetaEnc struct {
+	Provider   string `yaml:"provider"` // always "aws_kms"
+	KMSKeyARN  string `yaml:"kmsKeyArn"`
+	Algorithm  string `yaml:"algorithm"` // "AES-256-GCM"
+	DEKVersion int    `yaml:"dekVersion"`
+}
+
+// PushRequest is the HTTP request body for POST /sync/push.
+type PushRequest struct {
+	// CommitMessage overrides the default commit message.
+	CommitMessage string `json:"commit_message,omitempty"`
+}
+
+// PushResponse is the HTTP response body for POST /sync/push.
+type PushResponse struct {
+	CommitSHA string      `json:"commit_sha"`
+	PushedAt  time.Time   `json:"pushed_at"`
+	Summary   SyncSummary `json:"summary"`
+}
+
+// PullRequest is the HTTP request body for POST /sync/pull.
+type PullRequest struct {
+	// DeleteOrphans removes local resources that no longer exist in GitHub.
+	DeleteOrphans bool `json:"delete_orphans,omitempty"`
+}
+
+// PullResponse is the HTTP response body for POST /sync/pull.
+type PullResponse struct {
+	PulledAt time.Time   `json:"pulled_at"`
+	Summary  SyncSummary `json:"summary"`
+}
+
+// RotateKeyResponse is the HTTP response body for POST /sync/rotate-key.
+type RotateKeyResponse struct {
+	CommitSHA  string    `json:"commit_sha"`
+	RotatedAt  time.Time `json:"rotated_at"`
+	DEKVersion int       `json:"dek_version"`
+}
+
+// SyncSummary summarises what happened during a push or pull.
+type SyncSummary struct {
+	FilesWritten int `json:"files_written"`
+	FilesDeleted int `json:"files_deleted"`
+}
+
+// SyncStatusResponse is the HTTP response body for GET /sync/status.
+type SyncStatusResponse struct {
+	Config   *SyncConfigResponse `json:"config,omitempty"`
+	LastPush *SyncEventRecord    `json:"last_push,omitempty"`
+	LastPull *SyncEventRecord    `json:"last_pull,omitempty"`
+}
+
+// SyncEventRecord records the result of the last push or pull.
+type SyncEventRecord struct {
+	At        time.Time   `json:"at"`
+	CommitSHA string      `json:"commit_sha,omitempty"`
+	Summary   SyncSummary `json:"summary"`
+}
+
+// SyncConfigResponse is returned by GET /sync/config (github_token redacted).
+type SyncConfigResponse struct {
+	Enabled      bool                   `json:"enabled"`
+	RepoFullName string                 `json:"repo_full_name"`
+	Branch       string                 `json:"branch"`
+	RootPath     string                 `json:"root_path"`
+	AutoPush     bool                   `json:"auto_push"`
+	Encryption   SyncEncryptionResponse `json:"encryption"`
+}
+
+// SyncEncryptionResponse is the public view of SyncEncryptionConfig (no secrets).
+type SyncEncryptionResponse struct {
+	KMSKeyARN  string `json:"kms_key_arn"`
+	AWSRegion  string `json:"aws_region"`
+	DEKVersion int    `json:"dek_version"`
+	DEKReady   bool   `json:"dek_ready"` // true when encryptedDEK is non-empty
+}
+
+// UpdateSyncConfigRequest is the HTTP request body for PUT /sync/config.
+type UpdateSyncConfigRequest struct {
+	Enabled      bool                        `json:"enabled"`
+	RepoFullName string                      `json:"repo_full_name"`
+	Branch       string                      `json:"branch"`
+	RootPath     string                      `json:"root_path"`
+	AutoPush     bool                        `json:"auto_push"`
+	GitHubToken  string                      `json:"github_token,omitempty"`
+	Encryption   UpdateSyncEncryptionRequest `json:"encryption"`
+}
+
+// UpdateSyncEncryptionRequest is the encryption portion of UpdateSyncConfigRequest.
+type UpdateSyncEncryptionRequest struct {
+	KMSKeyARN string `json:"kms_key_arn"`
+	AWSRegion string `json:"aws_region"`
+}

--- a/pkg/github_sync/worker.go
+++ b/pkg/github_sync/worker.go
@@ -1,0 +1,108 @@
+package githubsync
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"gopkg.in/yaml.v3"
+)
+
+// Worker runs periodic bidirectional sync for all enabled git_sync configs.
+// Direction is determined by comparing the remote .sync-meta.yaml syncedAt
+// timestamp against the locally stored LastPushedAt:
+//
+//	remoteSyncedAt > LastPushedAt  →  Pull  (GitHub is newer — someone pushed externally)
+//	otherwise                      →  Push  (local is newer or equal)
+type Worker struct {
+	syncer       *Syncer
+	settingsRepo portrepos.SettingsRepository
+	interval     time.Duration
+}
+
+// NewWorker creates a Worker. interval must be > 0.
+func NewWorker(syncer *Syncer, settingsRepo portrepos.SettingsRepository, interval time.Duration) *Worker {
+	return &Worker{
+		syncer:       syncer,
+		settingsRepo: settingsRepo,
+		interval:     interval,
+	}
+}
+
+// Start runs the periodic sync loop until ctx is cancelled.
+func (w *Worker) Start(ctx context.Context) {
+	log.Printf("[SYNC_WORKER] Starting periodic sync worker (interval=%s)", w.interval)
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[SYNC_WORKER] Stopping periodic sync worker")
+			return
+		case <-ticker.C:
+			w.runOnce(ctx)
+		}
+	}
+}
+
+func (w *Worker) runOnce(ctx context.Context) {
+	allSettings, err := w.settingsRepo.List(ctx)
+	if err != nil {
+		log.Printf("[SYNC_WORKER] Failed to list settings: %v", err)
+		return
+	}
+	for _, s := range allSettings {
+		cfg := s.GitSync()
+		if cfg == nil || !cfg.Enabled {
+			continue
+		}
+		name := s.Name()
+		if err := w.syncOne(ctx, name); err != nil {
+			log.Printf("[SYNC_WORKER] Sync failed for %s: %v", name, err)
+		}
+	}
+}
+
+func (w *Worker) syncOne(ctx context.Context, settingsName string) error {
+	settings, err := w.settingsRepo.FindByName(ctx, settingsName)
+	if err != nil {
+		return err
+	}
+	cfg := settings.GitSync()
+	if cfg == nil || !cfg.Enabled {
+		return nil
+	}
+
+	token, err := w.syncer.resolveToken(cfg.GitHubToken)
+	if err != nil {
+		return err
+	}
+
+	// Fetch remote sync-meta to determine direction.
+	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+	ghClient, err := NewGitHubSyncClient(ctx, token, cfg.RepoFullName)
+	if err != nil {
+		return err
+	}
+
+	remoteSyncedAt := time.Time{}
+	if metaBytes, metaErr := ghClient.GetFile(ctx, cfg.Branch, rootPath+".sync-meta.yaml"); metaErr == nil {
+		var meta SyncMeta
+		if parseErr := yaml.Unmarshal(metaBytes, &meta); parseErr == nil {
+			remoteSyncedAt = meta.SyncedAt
+		}
+	}
+
+	// Determine sync direction.
+	if !remoteSyncedAt.IsZero() && remoteSyncedAt.After(cfg.LastPushedAt) {
+		log.Printf("[SYNC_WORKER] %s: remote is newer (%s > %s) — pulling", settingsName,
+			remoteSyncedAt.Format(time.RFC3339), cfg.LastPushedAt.Format(time.RFC3339))
+		_, err = w.syncer.Pull(ctx, settingsName, settingsName, false)
+	} else {
+		log.Printf("[SYNC_WORKER] %s: local is newer or equal — pushing", settingsName)
+		_, err = w.syncer.Push(ctx, settingsName, settingsName, "")
+	}
+	return err
+}

--- a/pkg/github_sync/worker.go
+++ b/pkg/github_sync/worker.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
 	"gopkg.in/yaml.v3"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Worker runs periodic bidirectional sync for all enabled git_sync configs.
@@ -20,6 +23,11 @@ type Worker struct {
 	syncer       *Syncer
 	settingsRepo portrepos.SettingsRepository
 	interval     time.Duration
+
+	mu      sync.Mutex
+	running bool
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
 }
 
 // NewWorker creates a Worker. interval must be > 0.
@@ -31,15 +39,46 @@ func NewWorker(syncer *Syncer, settingsRepo portrepos.SettingsRepository, interv
 	}
 }
 
-// Start runs the periodic sync loop until ctx is cancelled.
-func (w *Worker) Start(ctx context.Context) {
+// Start begins the periodic sync loop. It returns immediately; the loop runs in the background.
+func (w *Worker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	w.running = true
+	w.stopCh = make(chan struct{})
+	w.mu.Unlock()
+
+	w.wg.Add(1)
+	go w.run(ctx)
 	log.Printf("[SYNC_WORKER] Starting periodic sync worker (interval=%s)", w.interval)
+	return nil
+}
+
+// Stop signals the sync loop to stop and waits for it to exit.
+func (w *Worker) Stop() {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return
+	}
+	w.running = false
+	close(w.stopCh)
+	w.mu.Unlock()
+	w.wg.Wait()
+	log.Printf("[SYNC_WORKER] Stopped periodic sync worker")
+}
+
+func (w *Worker) run(ctx context.Context) {
+	defer w.wg.Done()
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			log.Printf("[SYNC_WORKER] Stopping periodic sync worker")
+			return
+		case <-w.stopCh:
 			return
 		case <-ticker.C:
 			w.runOnce(ctx)
@@ -105,4 +144,42 @@ func (w *Worker) syncOne(ctx context.Context, settingsName string) error {
 		_, err = w.syncer.Push(ctx, settingsName, settingsName, "")
 	}
 	return err
+}
+
+// LeaderWorker wraps Worker with Kubernetes leader election so only one
+// replica in the cluster runs the periodic sync at a time.
+type LeaderWorker struct {
+	worker  *Worker
+	elector *schedule.LeaderElector
+}
+
+// NewLeaderWorker creates a LeaderWorker.
+func NewLeaderWorker(
+	syncer *Syncer,
+	settingsRepo portrepos.SettingsRepository,
+	interval time.Duration,
+	client kubernetes.Interface,
+	electionConfig schedule.LeaderElectionConfig,
+) *LeaderWorker {
+	electionConfig.LeaseName = "agentapi-github-sync-worker"
+	return &LeaderWorker{
+		worker:  NewWorker(syncer, settingsRepo, interval),
+		elector: schedule.NewLeaderElector(client, electionConfig),
+	}
+}
+
+// Run starts the leader election loop. Only the elected leader runs the sync worker.
+func (lw *LeaderWorker) Run(ctx context.Context) {
+	lw.elector.Run(ctx,
+		func(leaderCtx context.Context) {
+			log.Printf("[SYNC_WORKER] Became leader, starting periodic sync worker")
+			if err := lw.worker.Start(leaderCtx); err != nil {
+				log.Printf("[SYNC_WORKER] Failed to start worker: %v", err)
+			}
+		},
+		func() {
+			log.Printf("[SYNC_WORKER] Lost leadership, stopping periodic sync worker")
+			lw.worker.Stop()
+		},
+	)
 }

--- a/pkg/github_sync/worker.go
+++ b/pkg/github_sync/worker.go
@@ -2,6 +2,7 @@ package githubsync
 
 import (
 	"context"
+	"hash/fnv"
 	"log"
 	"strings"
 	"sync"
@@ -14,20 +15,26 @@ import (
 )
 
 // Worker runs periodic bidirectional sync for all enabled git_sync configs.
+//
+// Each settings is synced on a per-tenant schedule: the first sync time is
+// offset by hash(settingsName) % interval so tenants don't hit GitHub simultaneously.
+// Subsequent syncs happen at lastSyncedAt + interval.
+//
 // Direction is determined by comparing the remote .sync-meta.yaml syncedAt
 // timestamp against the locally stored LastPushedAt:
 //
-//	remoteSyncedAt > LastPushedAt  →  Pull  (GitHub is newer — someone pushed externally)
+//	remoteSyncedAt > LastPushedAt  →  Pull  (GitHub is newer)
 //	otherwise                      →  Push  (local is newer or equal)
 type Worker struct {
 	syncer       *Syncer
 	settingsRepo portrepos.SettingsRepository
 	interval     time.Duration
 
-	mu      sync.Mutex
-	running bool
-	stopCh  chan struct{}
-	wg      sync.WaitGroup
+	mu         sync.Mutex
+	running    bool
+	stopCh     chan struct{}
+	wg         sync.WaitGroup
+	nextSyncAt map[string]time.Time // per-settings next sync time
 }
 
 // NewWorker creates a Worker. interval must be > 0.
@@ -36,6 +43,7 @@ func NewWorker(syncer *Syncer, settingsRepo portrepos.SettingsRepository, interv
 		syncer:       syncer,
 		settingsRepo: settingsRepo,
 		interval:     interval,
+		nextSyncAt:   make(map[string]time.Time),
 	}
 }
 
@@ -72,7 +80,12 @@ func (w *Worker) Stop() {
 
 func (w *Worker) run(ctx context.Context) {
 	defer w.wg.Done()
-	ticker := time.NewTicker(w.interval)
+	// Check at finer granularity than the sync interval so per-tenant offsets work.
+	checkInterval := 30 * time.Second
+	if w.interval < checkInterval {
+		checkInterval = w.interval
+	}
+	ticker := time.NewTicker(checkInterval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -92,16 +105,46 @@ func (w *Worker) runOnce(ctx context.Context) {
 		log.Printf("[SYNC_WORKER] Failed to list settings: %v", err)
 		return
 	}
+	now := time.Now()
 	for _, s := range allSettings {
 		cfg := s.GitSync()
 		if cfg == nil || !cfg.Enabled {
 			continue
 		}
 		name := s.Name()
+
+		w.mu.Lock()
+		next, known := w.nextSyncAt[name]
+		if !known {
+			// First encounter: stagger based on deterministic hash of settings name.
+			next = now.Add(tenantOffset(name, w.interval))
+			w.nextSyncAt[name] = next
+		}
+		w.mu.Unlock()
+
+		if now.Before(next) {
+			continue
+		}
+
 		if err := w.syncOne(ctx, name); err != nil {
 			log.Printf("[SYNC_WORKER] Sync failed for %s: %v", name, err)
 		}
+
+		w.mu.Lock()
+		w.nextSyncAt[name] = time.Now().Add(w.interval)
+		w.mu.Unlock()
 	}
+}
+
+// tenantOffset returns a deterministic time offset in [0, interval) for a settings name.
+func tenantOffset(name string, interval time.Duration) time.Duration {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	ms := uint64(interval.Milliseconds())
+	if ms == 0 {
+		return 0
+	}
+	return time.Duration(uint64(h.Sum32())%ms) * time.Millisecond
 }
 
 func (w *Worker) syncOne(ctx context.Context, settingsName string) error {
@@ -119,15 +162,17 @@ func (w *Worker) syncOne(ctx context.Context, settingsName string) error {
 		return err
 	}
 
-	// Fetch remote sync-meta to determine direction.
+	// Fetch per-settings .sync-meta.yaml to determine direction.
 	rootPath := strings.TrimRight(cfg.RootPath, "/") + "/"
+	metaPath := rootPath + settingsName + "/.sync-meta.yaml"
+
 	ghClient, err := NewGitHubSyncClient(ctx, token, cfg.RepoFullName)
 	if err != nil {
 		return err
 	}
 
 	remoteSyncedAt := time.Time{}
-	if metaBytes, metaErr := ghClient.GetFile(ctx, cfg.Branch, rootPath+".sync-meta.yaml"); metaErr == nil {
+	if metaBytes, metaErr := ghClient.GetFile(ctx, cfg.Branch, metaPath); metaErr == nil {
 		var meta SyncMeta
 		if parseErr := yaml.Unmarshal(metaBytes, &meta); parseErr == nil {
 			remoteSyncedAt = meta.SyncedAt

--- a/pkg/import/importer.go
+++ b/pkg/import/importer.go
@@ -48,15 +48,17 @@ func (i *Importer) Import(ctx context.Context, resources *TeamResources, userID 
 		Errors:  []string{},
 	}
 
-	// Validate the resources first
-	if err := i.validator.Validate(resources); err != nil {
-		// In dry-run mode, return validation errors in the result instead of failing immediately
-		if options.DryRun {
-			result.Success = false
-			result.Errors = append(result.Errors, fmt.Sprintf("Validation failed: %v", err))
-			return result, nil
+	// Validate the resources first (skip when called from sync importer)
+	if !options.SkipValidation {
+		if err := i.validator.Validate(resources); err != nil {
+			// In dry-run mode, return validation errors in the result instead of failing immediately
+			if options.DryRun {
+				result.Success = false
+				result.Errors = append(result.Errors, fmt.Sprintf("Validation failed: %v", err))
+				return result, nil
+			}
+			return nil, fmt.Errorf("validation failed: %w", err)
 		}
-		return nil, fmt.Errorf("validation failed: %w", err)
 	}
 
 	// Import schedules

--- a/pkg/import/types.go
+++ b/pkg/import/types.go
@@ -123,11 +123,12 @@ const (
 
 // ImportOptions contains options for import operations
 type ImportOptions struct {
-	DryRun        bool       // Only validate, don't create
-	Mode          ImportMode // Import mode
-	IDField       string     // Field to use for matching: "name" or "id"
-	AllowPartial  bool       // Allow partial success
-	RegenerateAll bool       // Regenerate all secrets
+	DryRun         bool       // Only validate, don't create
+	Mode           ImportMode // Import mode
+	IDField        string     // Field to use for matching: "name" or "id"
+	AllowPartial   bool       // Allow partial success
+	RegenerateAll  bool       // Regenerate all secrets
+	SkipValidation bool       // Skip metadata/schema validation (used by sync importer)
 }
 
 // ImportResult contains the results of an import operation

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3724,10 +3724,267 @@
           }
         }
       }
+    },
+    "/sync/config/{name}": {
+      "get": {
+        "summary": "Get GitHub sync configuration",
+        "description": "Returns the GitHub sync configuration for the specified user or team settings (token redacted).",
+        "tags": ["GitHubSync"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Settings name (user ID or team name)"
+          }
+        ],
+        "responses": {
+          "200": { "description": "Sync configuration" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not found" }
+        },
+        "security": [{ "bearerAuth": [] }]
+      },
+      "put": {
+        "summary": "Update GitHub sync configuration",
+        "description": "Creates or updates the GitHub sync configuration for the specified settings. If a DEK already exists it is preserved.",
+        "tags": ["GitHubSync"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateSyncConfigRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Updated configuration" },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not found" },
+          "500": { "description": "Internal server error" }
+        },
+        "security": [{ "bearerAuth": [] }]
+      },
+      "delete": {
+        "summary": "Delete GitHub sync configuration",
+        "description": "Removes the GitHub sync configuration from the specified settings.",
+        "tags": ["GitHubSync"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Deleted successfully" },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Not found" },
+          "500": { "description": "Internal server error" }
+        },
+        "security": [{ "bearerAuth": [] }]
+      }
+    },
+    "/sync/push/{name}": {
+      "post": {
+        "summary": "Push resources to GitHub",
+        "description": "Exports all resources (memories, tasks, schedules, webhooks, settings, etc.) and commits them to the configured GitHub repository. Sensitive fields are encrypted with AES-256-GCM using an AWS KMS-managed DEK.",
+        "tags": ["GitHubSync"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "commit_message": { "type": "string", "description": "Override the default commit message" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Push succeeded",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PushResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "500": { "description": "Internal server error" }
+        },
+        "security": [{ "bearerAuth": [] }]
+      }
+    },
+    "/sync/pull/{name}": {
+      "post": {
+        "summary": "Pull resources from GitHub",
+        "description": "Downloads resources from the configured GitHub repository and imports them into the local store. Encrypted fields are decrypted using the stored DEK.",
+        "tags": ["GitHubSync"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "delete_orphans": { "type": "boolean", "description": "Remove local resources that no longer exist in GitHub" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pull succeeded",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PullResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "500": { "description": "Internal server error" }
+        },
+        "security": [{ "bearerAuth": [] }]
+      }
+    },
+    "/sync/rotate-key/{name}": {
+      "post": {
+        "summary": "Rotate the sync encryption key",
+        "description": "Generates a new DEK via AWS KMS, re-encrypts all values in the GitHub repository with the new DEK, and commits atomically. The old encryptedDEK is replaced in Settings.",
+        "tags": ["GitHubSync"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key rotated successfully",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RotateKeyResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "500": { "description": "Internal server error" }
+        },
+        "security": [{ "bearerAuth": [] }]
+      }
     }
   },
   "components": {
     "schemas": {
+      "SyncConfigResponse": {
+        "type": "object",
+        "description": "Public view of GitHub sync configuration (token redacted)",
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "repo_full_name": { "type": "string", "example": "owner/repo" },
+          "branch": { "type": "string", "example": "main" },
+          "root_path": { "type": "string", "example": "agentapi-config/" },
+          "auto_push": { "type": "boolean" },
+          "encryption": { "$ref": "#/components/schemas/SyncEncryptionResponse" }
+        }
+      },
+      "SyncEncryptionResponse": {
+        "type": "object",
+        "description": "Public encryption info (no secrets)",
+        "properties": {
+          "kms_key_arn": { "type": "string" },
+          "aws_region": { "type": "string" },
+          "dek_version": { "type": "integer" },
+          "dek_ready": { "type": "boolean", "description": "true when a DEK has been generated and stored" }
+        }
+      },
+      "UpdateSyncConfigRequest": {
+        "type": "object",
+        "required": ["repo_full_name", "encryption"],
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "repo_full_name": { "type": "string", "example": "owner/repo" },
+          "branch": { "type": "string", "example": "main" },
+          "root_path": { "type": "string", "example": "agentapi-config/" },
+          "auto_push": { "type": "boolean" },
+          "github_token": { "type": "string", "description": "GitHub PAT (write-only, not returned)" },
+          "encryption": {
+            "type": "object",
+            "required": ["kms_key_arn", "aws_region"],
+            "properties": {
+              "kms_key_arn": { "type": "string" },
+              "aws_region": { "type": "string" }
+            }
+          }
+        }
+      },
+      "PushResponse": {
+        "type": "object",
+        "properties": {
+          "commit_sha": { "type": "string" },
+          "pushed_at": { "type": "string", "format": "date-time" },
+          "summary": { "$ref": "#/components/schemas/SyncSummary" }
+        }
+      },
+      "PullResponse": {
+        "type": "object",
+        "properties": {
+          "pulled_at": { "type": "string", "format": "date-time" },
+          "summary": { "$ref": "#/components/schemas/SyncSummary" }
+        }
+      },
+      "RotateKeyResponse": {
+        "type": "object",
+        "properties": {
+          "commit_sha": { "type": "string" },
+          "rotated_at": { "type": "string", "format": "date-time" },
+          "dek_version": { "type": "integer" }
+        }
+      },
+      "SyncSummary": {
+        "type": "object",
+        "properties": {
+          "files_written": { "type": "integer" },
+          "files_deleted": { "type": "integer" }
+        }
+      },
       "Memory": {
         "type": "object",
         "description": "A memory entry belonging to a user or team",
@@ -6161,6 +6418,10 @@
     {
       "name": "Files",
       "description": "User-managed files to be placed inside agent sessions"
+    },
+    {
+      "name": "GitHubSync",
+      "description": "Bidirectional GitHub sync for all resources. Secrets are encrypted with AWS KMS envelope encryption (AES-256-GCM, deterministic nonce) before committing to the repository."
     }
   ]
 }


### PR DESCRIPTION
## Summary

GitHub bidirectional sync (push/pull) for agentapi-proxy resources with AWS KMS envelope encryption.

### Sync scope

**Team settings** (`settingsName != userID`):
- `teams/<settingsName>/schedules/<id>.yaml` — one file per schedule (team-scoped)
- `teams/<settingsName>/webhooks/<id>.yaml` — one file per webhook (team-scoped)
- `teams/<settingsName>/slackbots/<id>.yaml` — one file per slackbot (team-scoped)
- `teams/<settingsName>/settings.yaml` — team settings

**Personal settings** (`settingsName == userID`):
- `users/<userID>/schedules/<id>.yaml` — one file per schedule (user-scoped)
- `users/<userID>/webhooks/<id>.yaml` — one file per webhook (user-scoped)
- `users/<userID>/slackbots/<id>.yaml` — one file per slackbot (user-scoped)
- `users/<userID>/files/<id>.yaml` — one file per user file

Memory and task resources are **not synced**.

### File layout

```
<rootPath>/
  teams/<settingsName>/
    schedules/<id>.yaml
    webhooks/<id>.yaml
    slackbots/<id>.yaml
    settings.yaml
  users/<userID>/
    schedules/<id>.yaml
    webhooks/<id>.yaml
    slackbots/<id>.yaml
    files/<id>.yaml
  .sync-meta.yaml
```

### Encryption

- AWS KMS envelope encryption (AES-256-GCM)
- DEK stored encrypted in Settings; rotatable via `POST /sync/rotate-key/:settingsName`
- Environment variables and webhook secrets are encrypted per-field

### Endpoints

- `POST /sync/push/:settingsName` — export resources to GitHub
- `POST /sync/pull/:settingsName` — import resources from GitHub
- `POST /sync/rotate-key/:settingsName` — rotate DEK

## Test plan

- [x] Personal push → `users/<id>/schedules/`, `webhooks/`, `slackbots/`, `files/` created
- [x] Pull → resources restored with original IDs and content
- [ ] Team push → `teams/<name>/schedules/`, `webhooks/`, `slackbots/`, `settings.yaml`
- [ ] Key rotation

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)