### PR TITLE
feat: extend GitHub sync to include personal settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -597,10 +597,13 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	}
 
 	// Override GitSync fields from env vars (viper Unmarshal may miss deeply nested env-only keys)
-	if kmsKeyARN := v.GetString("git_sync.encryption.kms_key_arn"); kmsKeyARN != "" {
+	kmsKeyARN := v.GetString("git_sync.encryption.kms_key_arn")
+	awsRegion := v.GetString("git_sync.encryption.aws_region")
+	log.Printf("[CONFIG] GitSync KMS key ARN from viper: %q (pre-unmarshal: %q)", kmsKeyARN, config.GitSync.Encryption.KMSKeyARN)
+	if kmsKeyARN != "" {
 		config.GitSync.Encryption.KMSKeyARN = kmsKeyARN
 	}
-	if awsRegion := v.GetString("git_sync.encryption.aws_region"); awsRegion != "" {
+	if awsRegion != "" {
 		config.GitSync.Encryption.AWSRegion = awsRegion
 	}
 	if installationID := v.GetString("git_sync.github_app.installation_id"); installationID != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -596,6 +596,20 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 		log.Printf("[CONFIG] Initialized AWS auth config from environment variables")
 	}
 
+	// Override GitSync fields from env vars (viper Unmarshal may miss deeply nested env-only keys)
+	if kmsKeyARN := v.GetString("git_sync.encryption.kms_key_arn"); kmsKeyARN != "" {
+		config.GitSync.Encryption.KMSKeyARN = kmsKeyARN
+	}
+	if awsRegion := v.GetString("git_sync.encryption.aws_region"); awsRegion != "" {
+		config.GitSync.Encryption.AWSRegion = awsRegion
+	}
+	if installationID := v.GetString("git_sync.github_app.installation_id"); installationID != "" {
+		config.GitSync.GitHubApp.InstallationID = installationID
+	}
+	if syncInterval := v.GetString("git_sync.sync_interval"); syncInterval != "" {
+		config.GitSync.SyncInterval = syncInterval
+	}
+
 	// Override fields if environment variables are set (even if structures already exist)
 	if config.Auth.Static != nil {
 		if v.IsSet("auth.static.keys_file") {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -599,7 +599,6 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	// Override GitSync fields from env vars (viper Unmarshal may miss deeply nested env-only keys)
 	kmsKeyARN := v.GetString("git_sync.encryption.kms_key_arn")
 	awsRegion := v.GetString("git_sync.encryption.aws_region")
-	log.Printf("[CONFIG] GitSync KMS key ARN from viper: %q (pre-unmarshal: %q)", kmsKeyARN, config.GitSync.Encryption.KMSKeyARN)
 	if kmsKeyARN != "" {
 		config.GitSync.Encryption.KMSKeyARN = kmsKeyARN
 	}

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -100,6 +100,7 @@ func (h *Handlers) UpdateConfig(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusForbidden, "access denied")
 	}
 
+	log.Printf("[SYNC] UpdateConfig: kmsKeyARN=%q awsRegion=%q", h.kmsKeyARN, h.awsRegion)
 	if h.kmsKeyARN == "" || h.awsRegion == "" {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "GitHub sync encryption is not configured on this proxy")
 	}

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -100,7 +100,6 @@ func (h *Handlers) UpdateConfig(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusForbidden, "access denied")
 	}
 
-	log.Printf("[SYNC] UpdateConfig: kmsKeyARN=%q awsRegion=%q", h.kmsKeyARN, h.awsRegion)
 	if h.kmsKeyARN == "" || h.awsRegion == "" {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "GitHub sync encryption is not configured on this proxy")
 	}

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -24,7 +24,7 @@ import (
 //
 //	<rootPath>/<settingsName>/schedules/<id>.yaml
 //	<rootPath>/<settingsName>/webhooks/<id>.yaml
-//	<rootPath>/<settingsName>/settings.yaml   (team only)
+//	<rootPath>/<settingsName>/settings.yaml
 //	<rootPath>/<settingsName>/files/<id>.yaml (personal only)
 //	<rootPath>/<settingsName>/slackbots/<id>.yaml
 //	<rootPath>/<settingsName>/.sync-meta.yaml
@@ -153,6 +153,9 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		}
 		if err := s.exportUserSlackbots(ctx, userID, dek, rootPath, files); err != nil {
 			log.Printf("[SYNC] user slackbot export warning for %s: %v", settingsName, err)
+		}
+		if err := s.exportPersonalSettings(ctx, userID, dek, rootPath, files); err != nil {
+			log.Printf("[SYNC] personal settings export warning for %s: %v", settingsName, err)
 		}
 	} else {
 		if err := s.exportTeamSchedules(ctx, settingsName, userID, dek, rootPath, files); err != nil {
@@ -306,10 +309,7 @@ func (s *Syncer) importFileByPath(ctx context.Context, filePath string, content 
 		}
 		return s.importWebhookFile(ctx, content, settingsName, userID, dek)
 	case rel == "settings.yaml":
-		if !personal {
-			return s.importSettingsFile(ctx, content, settingsName, userID, dek)
-		}
-		return nil
+		return s.importSettingsFile(ctx, content, settingsName, userID, dek)
 	case strings.HasPrefix(rel, "files/"):
 		if personal {
 			return s.importUserFileRecord(ctx, content, userID, dek)
@@ -519,6 +519,14 @@ func (s *Syncer) exportTeamSettings(ctx context.Context, settingsName, userID st
 	}
 	files[rootPath+settingsName+"/settings.yaml"] = data
 	return nil
+}
+
+// exportPersonalSettings exports personal settings (identified by userID) to
+// {rootPath}/{userID}/settings.yaml. GitSync configuration is excluded from the
+// export by the underlying exporter, so re-importing on another instance will
+// not overwrite the target's sync configuration.
+func (s *Syncer) exportPersonalSettings(ctx context.Context, userID string, dek []byte, rootPath string, files map[string][]byte) error {
+	return s.exportTeamSettings(ctx, userID, userID, dek, rootPath, files)
 }
 
 // --- User resource export ---


### PR DESCRIPTION
## Summary

- `Push`: 個人同期ブランチに `exportPersonalSettings` を追加。`{rootPath}/{userID}/settings.yaml` に出力される
- `Pull`: `importFileByPath` の `settings.yaml` ケースで personal/team 両方に `importSettingsFile` を呼ぶよう変更
- GitSync 設定（DEK・KMS キー等）はエクスポーター側が元から含めないため、GitHub には push されない。Pull 時も `convertSettingsImport` が既存エンティティをベースにするため、ローカルの GitSync 設定は保持される

## Test plan

- [ ] CI 通過確認
- [ ] `POST /sync/push` (personal sync) で `settings.yaml` が GitHub に出力されることを確認
- [ ] `POST /sync/pull` (personal sync) で settings が取り込まれ、GitSync 設定は上書きされないことを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)