### PR TITLE
feat: move GitHub sync config into settings API

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -48,7 +48,12 @@ type CustomHandler interface {
 // NewRouter creates a new Router instance
 func NewRouter(e *echo.Echo, server *Server) *Router {
 	// Create settings controller
-	settingsController := controllers.NewSettingsController(server.settingsRepo, server.notificationSvc)
+	var gitSyncKMSKeyARN, gitSyncAWSRegion string
+	if cfg := server.GetConfig(); cfg != nil {
+		gitSyncKMSKeyARN = cfg.GitSync.Encryption.KMSKeyARN
+		gitSyncAWSRegion = cfg.GitSync.Encryption.AWSRegion
+	}
+	settingsController := controllers.NewSettingsController(server.settingsRepo, server.notificationSvc, gitSyncKMSKeyARN, gitSyncAWSRegion)
 
 	// Create credentials controller
 	var credentialsController *controllers.CredentialsController
@@ -293,6 +298,7 @@ func (r *Router) registerConditionalRoutes() error {
 		r.echo.GET("/settings/:name", r.handlers.settingsController.GetSettings, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.PUT("/settings/:name", r.handlers.settingsController.UpdateSettings, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		r.echo.DELETE("/settings/:name", r.handlers.settingsController.DeleteSettings, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.DELETE("/settings/:name/sync", r.handlers.settingsController.DeleteGitSync, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		log.Printf("[ROUTES] Settings endpoints registered")
 	} else {
 		log.Printf("[ROUTES] Settings repository not available, skipping settings routes")

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -196,6 +196,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 	settingsRepo = repositories.NewKubernetesSettingsRepository(
 		k8sSessionManager.GetClient(),
 		k8sSessionManager.GetNamespace(),
+		encryptionRegistry,
 	)
 	// Set settings repository in session manager for Bedrock integration
 	k8sSessionManager.SetSettingsRepository(settingsRepo)

--- a/internal/infrastructure/repositories/kubernetes_settings_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_settings_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -14,6 +15,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	domainservices "github.com/takutakahashi/agentapi-proxy/internal/domain/services"
+	infraservices "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 )
 
 const (
@@ -27,6 +30,16 @@ const (
 	SettingsSecretPrefix = "agentapi-settings-"
 )
 
+// encryptedEnvVarJSON is the JSON representation of a single encrypted env var value.
+// It embeds the encryption metadata needed to select the correct decryptor.
+type encryptedEnvVarJSON struct {
+	EncryptedValue string    `json:"v"`
+	Algorithm      string    `json:"alg"`
+	KeyID          string    `json:"kid"`
+	EncryptedAt    time.Time `json:"at"`
+	Version        string    `json:"ver,omitempty"`
+}
+
 // settingsJSON is the JSON representation of settings stored in Secret
 type settingsJSON struct {
 	Name                    string                                 `json:"name"`
@@ -36,7 +49,8 @@ type settingsJSON struct {
 	ClaudeCodeOAuthToken    string                                 `json:"claude_code_oauth_token,omitempty"`
 	AuthMode                string                                 `json:"auth_mode,omitempty"`
 	EnabledPlugins          []string                               `json:"enabled_plugins,omitempty"`           // plugin@marketplace format
-	EnvVars                 map[string]string                      `json:"env_vars,omitempty"`                  // Custom environment variables
+	EnvVars                 map[string]string                      `json:"env_vars,omitempty"`                  // plain env vars (legacy / noop)
+	EncryptedEnvVars        map[string]encryptedEnvVarJSON         `json:"encrypted_env_vars,omitempty"`        // encrypted env vars
 	PreferredTeamID         string                                 `json:"preferred_team_id,omitempty"`         // "org/team-slug" format
 	SlackUserID             string                                 `json:"slack_user_id,omitempty"`             // Slack DM notification user ID
 	NotificationChannels    []string                               `json:"notification_channels,omitempty"`     // Active notification channels
@@ -93,15 +107,24 @@ type gitSyncJSON struct {
 
 // KubernetesSettingsRepository implements SettingsRepository using Kubernetes Secrets
 type KubernetesSettingsRepository struct {
-	client    kubernetes.Interface
-	namespace string
+	client             kubernetes.Interface
+	namespace          string
+	encryptionRegistry *infraservices.EncryptionServiceRegistry // optional; nil = store env_vars as plain text
 }
 
-// NewKubernetesSettingsRepository creates a new KubernetesSettingsRepository
-func NewKubernetesSettingsRepository(client kubernetes.Interface, namespace string) *KubernetesSettingsRepository {
+// NewKubernetesSettingsRepository creates a new KubernetesSettingsRepository.
+// An optional EncryptionServiceRegistry may be passed to enable at-rest encryption of
+// env_vars.  If nil (or if the primary algorithm is "noop"), env_vars are stored as
+// plain text in the legacy env_vars field.
+func NewKubernetesSettingsRepository(client kubernetes.Interface, namespace string, registry ...*infraservices.EncryptionServiceRegistry) *KubernetesSettingsRepository {
+	var reg *infraservices.EncryptionServiceRegistry
+	if len(registry) > 0 {
+		reg = registry[0]
+	}
 	return &KubernetesSettingsRepository{
-		client:    client,
-		namespace: namespace,
+		client:             client,
+		namespace:          namespace,
+		encryptionRegistry: reg,
 	}
 }
 
@@ -114,8 +137,7 @@ func (r *KubernetesSettingsRepository) Save(ctx context.Context, settings *entit
 	secretName := r.secretName(settings.Name())
 	labelValue := sanitizeLabelValue(settings.Name())
 
-	// Convert to JSON (without encryption)
-	data, err := r.toJSON(settings)
+	data, err := r.toJSON(ctx, settings)
 	if err != nil {
 		return fmt.Errorf("failed to marshal settings: %w", err)
 	}
@@ -164,7 +186,7 @@ func (r *KubernetesSettingsRepository) FindByName(ctx context.Context, name stri
 		return nil, fmt.Errorf("failed to get settings secret: %w", err)
 	}
 
-	settings, err := r.fromSecret(secret)
+	settings, err := r.fromSecret(ctx, secret)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +241,7 @@ func (r *KubernetesSettingsRepository) List(ctx context.Context) ([]*entities.Se
 
 	var settingsList []*entities.Settings
 	for _, secret := range secrets.Items {
-		settings, err := r.fromSecret(&secret)
+		settings, err := r.fromSecret(ctx, &secret)
 		if err != nil {
 			// Skip invalid settings
 			continue
@@ -235,8 +257,25 @@ func (r *KubernetesSettingsRepository) secretName(name string) string {
 	return SettingsSecretPrefix + sanitizeSecretName(name)
 }
 
-// toJSON converts Settings entity to JSON bytes without encryption
-func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]byte, error) {
+// encryptionSvc returns the primary encryption service, or nil if no registry is configured.
+func (r *KubernetesSettingsRepository) encryptionSvc() domainservices.EncryptionService {
+	if r.encryptionRegistry == nil {
+		return nil
+	}
+	return r.encryptionRegistry.GetForEncryption()
+}
+
+// decryptionSvc returns the appropriate decryption service for the given metadata, or nil if no registry is configured.
+func (r *KubernetesSettingsRepository) decryptionSvc(metadata domainservices.EncryptionMetadata) domainservices.EncryptionService {
+	if r.encryptionRegistry == nil {
+		return nil
+	}
+	return r.encryptionRegistry.GetForDecryption(metadata)
+}
+
+// toJSON converts Settings entity to JSON bytes, encrypting env_vars when a non-noop
+// EncryptionServiceRegistry is configured.
+func (r *KubernetesSettingsRepository) toJSON(ctx context.Context, settings *entities.Settings) ([]byte, error) {
 	sj := &settingsJSON{
 		Name:                 settings.Name(),
 		ClaudeCodeOAuthToken: settings.ClaudeCodeOAuthToken(),
@@ -284,7 +323,24 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 	}
 
 	if envVars := settings.EnvVars(); len(envVars) > 0 {
-		sj.EnvVars = envVars
+		if enc := r.encryptionSvc(); enc != nil && enc.Algorithm() != "noop" {
+			sj.EncryptedEnvVars = make(map[string]encryptedEnvVarJSON, len(envVars))
+			for k, v := range envVars {
+				encrypted, err := enc.Encrypt(ctx, v)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encrypt env var %q: %w", k, err)
+				}
+				sj.EncryptedEnvVars[k] = encryptedEnvVarJSON{
+					EncryptedValue: encrypted.EncryptedValue,
+					Algorithm:      encrypted.Metadata.Algorithm,
+					KeyID:          encrypted.Metadata.KeyID,
+					EncryptedAt:    encrypted.Metadata.EncryptedAt,
+					Version:        encrypted.Metadata.Version,
+				}
+			}
+		} else {
+			sj.EnvVars = envVars
+		}
 	}
 
 	if preferredTeamID := settings.PreferredTeamID(); preferredTeamID != "" {
@@ -327,8 +383,8 @@ func (r *KubernetesSettingsRepository) toJSON(settings *entities.Settings) ([]by
 	return json.Marshal(sj)
 }
 
-// fromSecret converts a Kubernetes Secret to Settings entity
-func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entities.Settings, error) {
+// fromSecret converts a Kubernetes Secret to Settings entity, decrypting env_vars as needed.
+func (r *KubernetesSettingsRepository) fromSecret(ctx context.Context, secret *corev1.Secret) (*entities.Settings, error) {
 	data, ok := secret.Data[SecretKeySettings]
 	if !ok {
 		return nil, fmt.Errorf("secret missing settings data")
@@ -408,10 +464,49 @@ func (r *KubernetesSettingsRepository) fromSecret(secret *corev1.Secret) (*entit
 		settings.SetUpdatedAt(sj.UpdatedAt)
 	}
 
-	if len(sj.EnvVars) > 0 {
-		settings.SetEnvVars(sj.EnvVars)
-		// Reset updatedAt since SetEnvVars updates it
-		settings.SetUpdatedAt(sj.UpdatedAt)
+	// Load env vars: encrypted_env_vars takes precedence; plain env_vars serves as
+	// fallback for legacy data and is merged for keys not present in the encrypted map.
+	{
+		merged := make(map[string]string)
+		// 1. Decrypt encrypted_env_vars
+		if len(sj.EncryptedEnvVars) > 0 {
+			for k, ev := range sj.EncryptedEnvVars {
+				decSvc := r.decryptionSvc(domainservices.EncryptionMetadata{
+					Algorithm:   ev.Algorithm,
+					KeyID:       ev.KeyID,
+					EncryptedAt: ev.EncryptedAt,
+					Version:     ev.Version,
+				})
+				if decSvc == nil {
+					log.Printf("[SETTINGS] No decryption service for env var %q (alg=%s kid=%s), skipping", k, ev.Algorithm, ev.KeyID)
+					continue
+				}
+				plaintext, err := decSvc.Decrypt(ctx, &domainservices.EncryptedData{
+					EncryptedValue: ev.EncryptedValue,
+					Metadata: domainservices.EncryptionMetadata{
+						Algorithm:   ev.Algorithm,
+						KeyID:       ev.KeyID,
+						EncryptedAt: ev.EncryptedAt,
+						Version:     ev.Version,
+					},
+				})
+				if err != nil {
+					log.Printf("[SETTINGS] Failed to decrypt env var %q: %v, skipping", k, err)
+					continue
+				}
+				merged[k] = plaintext
+			}
+		}
+		// 2. Merge plain env_vars (backward compat; don't overwrite already-decrypted keys)
+		for k, v := range sj.EnvVars {
+			if _, exists := merged[k]; !exists {
+				merged[k] = v
+			}
+		}
+		if len(merged) > 0 {
+			settings.SetEnvVars(merged)
+			settings.SetUpdatedAt(sj.UpdatedAt)
+		}
 	}
 
 	if sj.PreferredTeamID != "" {

--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -21,15 +21,19 @@ const BaseSettingsName = "base"
 
 // SettingsController handles settings-related HTTP requests
 type SettingsController struct {
-	repo            repositories.SettingsRepository
-	notificationSvc *notification.Service // Optional
+	repo             repositories.SettingsRepository
+	notificationSvc  *notification.Service // Optional
+	gitSyncKMSKeyARN string                // optional; non-empty when GitHub sync encryption is configured
+	gitSyncAWSRegion string
 }
 
 // NewSettingsController creates new settings controller
-func NewSettingsController(repo repositories.SettingsRepository, notificationSvc *notification.Service) *SettingsController {
+func NewSettingsController(repo repositories.SettingsRepository, notificationSvc *notification.Service, gitSyncKMSKeyARN, gitSyncAWSRegion string) *SettingsController {
 	return &SettingsController{
-		repo:            repo,
-		notificationSvc: notificationSvc,
+		repo:             repo,
+		notificationSvc:  notificationSvc,
+		gitSyncKMSKeyARN: gitSyncKMSKeyARN,
+		gitSyncAWSRegion: gitSyncAWSRegion,
 	}
 }
 
@@ -63,6 +67,33 @@ type MarketplaceRequest struct {
 	URL string `json:"url"`
 }
 
+// GitSyncConfigRequest is the request body for GitHub sync configuration
+type GitSyncConfigRequest struct {
+	Enabled      bool   `json:"enabled"`
+	RepoFullName string `json:"repo_full_name"`
+	Branch       string `json:"branch,omitempty"`
+	RootPath     string `json:"root_path,omitempty"`
+	AutoPush     bool   `json:"auto_push"`
+	GitHubToken  string `json:"github_token,omitempty"`
+}
+
+// GitSyncEncryptionResponse is the public encryption info for GitHub sync (no secrets)
+type GitSyncEncryptionResponse struct {
+	DEKVersion int  `json:"dek_version,omitempty"`
+	DEKReady   bool `json:"dek_ready"`
+}
+
+// GitSyncConfigResponse is the response for GitHub sync configuration (token redacted)
+type GitSyncConfigResponse struct {
+	Enabled        bool                      `json:"enabled"`
+	RepoFullName   string                    `json:"repo_full_name,omitempty"`
+	Branch         string                    `json:"branch,omitempty"`
+	RootPath       string                    `json:"root_path,omitempty"`
+	AutoPush       bool                      `json:"auto_push"`
+	HasGitHubToken bool                      `json:"has_github_token"`
+	Encryption     GitSyncEncryptionResponse `json:"encryption"`
+}
+
 // UpdateSettingsRequest is the request body for updating settings
 type UpdateSettingsRequest struct {
 	Bedrock                 *BedrockSettingsRequest          `json:"bedrock"`
@@ -76,6 +107,7 @@ type UpdateSettingsRequest struct {
 	SlackUserID             *string                          `json:"slack_user_id,omitempty"`             // Slack DM notification user ID
 	NotificationChannels    *[]string                        `json:"notification_channels,omitempty"`     // Active notification channels (e.g. ["web", "slack"])
 	ExternalSessionManagers *[]ExternalSessionManagerRequest `json:"external_session_managers,omitempty"` // External session managers (Proxy B registrations)
+	GitSync                 *GitSyncConfigRequest            `json:"git_sync,omitempty"`                  // GitHub sync configuration
 }
 
 // ExternalSessionManagerRequest represents a single external session manager registration
@@ -126,6 +158,7 @@ type SettingsResponse struct {
 	SlackUserID             string                           `json:"slack_user_id,omitempty"`             // Slack DM notification user ID
 	NotificationChannels    []string                         `json:"notification_channels,omitempty"`     // Active notification channels
 	ExternalSessionManagers []ExternalSessionManagerResponse `json:"external_session_managers,omitempty"` // Registered external session managers
+	GitSync                 *GitSyncConfigResponse           `json:"git_sync,omitempty"`                  // GitHub sync configuration (token redacted)
 	CreatedAt               string                           `json:"created_at"`
 	UpdatedAt               string                           `json:"updated_at"`
 }
@@ -465,6 +498,48 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 		settings.SetExternalSessionManagers(updated)
 	}
 
+	// Update GitHub sync configuration
+	if req.GitSync != nil {
+		if c.gitSyncKMSKeyARN == "" || c.gitSyncAWSRegion == "" {
+			return echo.NewHTTPError(http.StatusServiceUnavailable, "GitHub sync encryption is not configured on this proxy")
+		}
+		existing := settings.GitSync()
+		encDEK := ""
+		dekVersion := 0
+		existingToken := ""
+		if existing != nil {
+			encDEK = existing.Encryption.EncryptedDEK
+			dekVersion = existing.Encryption.DEKVersion
+			existingToken = existing.GitHubToken
+		}
+		token := req.GitSync.GitHubToken
+		if token == "" {
+			token = existingToken
+		}
+		branch := req.GitSync.Branch
+		if branch == "" {
+			branch = "main"
+		}
+		rootPath := req.GitSync.RootPath
+		if rootPath == "" {
+			rootPath = "agentapi-config/"
+		}
+		settings.SetGitSync(&entities.GitSyncConfig{
+			Enabled:      req.GitSync.Enabled,
+			RepoFullName: req.GitSync.RepoFullName,
+			Branch:       branch,
+			RootPath:     rootPath,
+			AutoPush:     req.GitSync.AutoPush,
+			GitHubToken:  token,
+			Encryption: entities.SyncEncryptionConfig{
+				KMSKeyARN:    c.gitSyncKMSKeyARN,
+				AWSRegion:    c.gitSyncAWSRegion,
+				EncryptedDEK: encDEK,
+				DEKVersion:   dekVersion,
+			},
+		})
+	}
+
 	// Determine and set auth_mode
 	authMode := c.determineAuthMode(settings, req.AuthMode)
 	settings.SetAuthMode(authMode)
@@ -480,6 +555,39 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, c.toResponse(settings))
+}
+
+// DeleteGitSync handles DELETE /settings/:name/sync
+// Removes only the GitHub sync configuration from the specified settings.
+func (c *SettingsController) DeleteGitSync(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	name := ctx.Param("name")
+	if name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Name is required")
+	}
+
+	if !c.canModify(user, name) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	settings, err := c.repo.FindByName(ctx.Request().Context(), name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return echo.NewHTTPError(http.StatusNotFound, "Settings not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get settings")
+	}
+
+	settings.SetGitSync(nil)
+	if err := c.repo.Save(ctx.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to save settings")
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]bool{"deleted": true})
 }
 
 // DeleteSettings handles DELETE /settings/:name
@@ -717,6 +825,21 @@ func (c *SettingsController) toResponse(settings *entities.Settings) *SettingsRe
 	resp.PreferredTeamID = settings.PreferredTeamID()
 	resp.SlackUserID = settings.SlackUserID()
 	resp.NotificationChannels = settings.NotificationChannels()
+
+	if gs := settings.GitSync(); gs != nil {
+		resp.GitSync = &GitSyncConfigResponse{
+			Enabled:        gs.Enabled,
+			RepoFullName:   gs.RepoFullName,
+			Branch:         gs.Branch,
+			RootPath:       gs.RootPath,
+			AutoPush:       gs.AutoPush,
+			HasGitHubToken: gs.GitHubToken != "",
+			Encryption: GitSyncEncryptionResponse{
+				DEKVersion: gs.Encryption.DEKVersion,
+				DEKReady:   gs.Encryption.EncryptedDEK != "",
+			},
+		}
+	}
 
 	// External session managers: never return the HMAC secret — indicate only whether one is set.
 	if managers := settings.ExternalSessionManagers(); len(managers) > 0 {

--- a/internal/interfaces/controllers/settings_controller_test.go
+++ b/internal/interfaces/controllers/settings_controller_test.go
@@ -219,7 +219,7 @@ func TestUpdateSettings_PreserveExistingCredentials(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			h := NewSettingsController(repo, nil)
+			h := NewSettingsController(repo, nil, "", "")
 
 			body, err := json.Marshal(tt.requestBody)
 			require.NoError(t, err)

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -53,14 +53,14 @@ func (h *Handlers) Syncer() *Syncer { return h.syncer }
 
 // RegisterRoutes implements app.CustomHandler.
 func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *app.Server) error {
-	e.GET("/sync/config/:name", h.GetConfig)
-	e.PUT("/sync/config/:name", h.UpdateConfig)
-	e.DELETE("/sync/config/:name", h.DeleteConfig)
-	e.POST("/sync/push/:name", h.Push)
-	e.POST("/sync/pull/:name", h.Pull)
-	e.POST("/sync/rotate-key/:name", h.RotateKey)
-	e.POST("/sync/all", h.SyncAll)
-	log.Printf("[SYNC] Registered GitHub sync endpoints (/sync/*)")
+	e.GET("/settings/:name/sync", h.GetConfig)
+	e.PUT("/settings/:name/sync", h.UpdateConfig)
+	e.DELETE("/settings/:name/sync", h.DeleteConfig)
+	e.POST("/settings/:name/sync/push", h.Push)
+	e.POST("/settings/:name/sync/pull", h.Pull)
+	e.POST("/settings/:name/sync/rotate-key", h.RotateKey)
+	e.POST("/settings/sync/all", h.SyncAll)
+	log.Printf("[SYNC] Registered GitHub sync endpoints (/settings/:name/sync/*)")
 	return nil
 }
 

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -15,16 +15,14 @@ import (
 
 // Handlers implements app.CustomHandler for GitHub sync endpoints.
 type Handlers struct {
-	syncer       *Syncer
-	settingsRepo portrepos.SettingsRepository
-	kmsKeyARN    string
-	awsRegion    string
+	syncer *Syncer
 }
 
 // NewHandlers creates a Handlers instance registering all required repositories.
-// kmsKeyARN and awsRegion come from proxy-level config; users cannot override them.
 // githubAppInstallID is optional — when set, it enables GitHub App token fallback for users
 // who have not configured a personal GitHub token.
+// kmsKeyARN and awsRegion are no longer used by Handlers directly; they are managed
+// by the SettingsController and stored in settings.GitSync.Encryption.
 func NewHandlers(
 	settingsRepo portrepos.SettingsRepository,
 	scheduleRepo schedule.Manager,
@@ -38,10 +36,7 @@ func NewHandlers(
 	githubAppInstallID string,
 ) *Handlers {
 	return &Handlers{
-		syncer:       NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo, slackbotRepo, githubAppInstallID),
-		settingsRepo: settingsRepo,
-		kmsKeyARN:    kmsKeyARN,
-		awsRegion:    awsRegion,
+		syncer: NewSyncer(settingsRepo, scheduleRepo, webhookRepo, memoryRepo, taskRepo, taskGroupRepo, userFileRepo, slackbotRepo, githubAppInstallID),
 	}
 }
 
@@ -53,9 +48,6 @@ func (h *Handlers) Syncer() *Syncer { return h.syncer }
 
 // RegisterRoutes implements app.CustomHandler.
 func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *app.Server) error {
-	e.GET("/settings/:name/sync", h.GetConfig)
-	e.PUT("/settings/:name/sync", h.UpdateConfig)
-	e.DELETE("/settings/:name/sync", h.DeleteConfig)
 	e.POST("/settings/:name/sync/push", h.Push)
 	e.POST("/settings/:name/sync/pull", h.Pull)
 	e.POST("/settings/:name/sync/rotate-key", h.RotateKey)
@@ -64,131 +56,7 @@ func (h *Handlers) RegisterRoutes(e *echo.Echo, _ *app.Server) error {
 	return nil
 }
 
-// GetConfig handles GET /sync/config/:name
-func (h *Handlers) GetConfig(c echo.Context) error {
-	user := auth.GetUserFromContext(c)
-	if user == nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
-	}
-
-	name := c.Param("name")
-	if !h.canAccessSettings(user, name) {
-		return echo.NewHTTPError(http.StatusForbidden, "access denied")
-	}
-
-	settings, err := h.settingsRepo.FindByName(c.Request().Context(), name)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "settings not found")
-	}
-
-	gs := settings.GitSync()
-	if gs == nil {
-		return c.JSON(http.StatusOK, map[string]interface{}{"enabled": false})
-	}
-
-	return c.JSON(http.StatusOK, toConfigResponse(gs))
-}
-
-// UpdateConfig handles PUT /sync/config/:name
-func (h *Handlers) UpdateConfig(c echo.Context) error {
-	user := auth.GetUserFromContext(c)
-	if user == nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
-	}
-
-	name := c.Param("name")
-	if !h.canModifySettings(user, name) {
-		return echo.NewHTTPError(http.StatusForbidden, "access denied")
-	}
-
-	if h.kmsKeyARN == "" || h.awsRegion == "" {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, "GitHub sync encryption is not configured on this proxy")
-	}
-
-	var req UpdateSyncConfigRequest
-	if err := c.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
-	}
-	if req.RepoFullName == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "repo_full_name is required")
-	}
-
-	settings, err := h.settingsRepo.FindByName(c.Request().Context(), name)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "settings not found")
-	}
-
-	existing := settings.GitSync()
-	encDEK := ""
-	dekVersion := 0
-	existingToken := ""
-	if existing != nil {
-		encDEK = existing.Encryption.EncryptedDEK
-		dekVersion = existing.Encryption.DEKVersion
-		existingToken = existing.GitHubToken
-	}
-
-	// Preserve existing token if the request doesn't supply a new one.
-	token := req.GitHubToken
-	if token == "" {
-		token = existingToken
-	}
-
-	gs := &entities.GitSyncConfig{
-		Enabled:      req.Enabled,
-		RepoFullName: req.RepoFullName,
-		Branch:       req.Branch,
-		RootPath:     req.RootPath,
-		AutoPush:     req.AutoPush,
-		GitHubToken:  token,
-		Encryption: entities.SyncEncryptionConfig{
-			KMSKeyARN:    h.kmsKeyARN,
-			AWSRegion:    h.awsRegion,
-			EncryptedDEK: encDEK,
-			DEKVersion:   dekVersion,
-		},
-	}
-	if gs.Branch == "" {
-		gs.Branch = "main"
-	}
-	if gs.RootPath == "" {
-		gs.RootPath = "agentapi-config/"
-	}
-
-	settings.SetGitSync(gs)
-	if err := h.settingsRepo.Save(c.Request().Context(), settings); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save config")
-	}
-
-	return c.JSON(http.StatusOK, toConfigResponse(gs))
-}
-
-// DeleteConfig handles DELETE /sync/config/:name
-func (h *Handlers) DeleteConfig(c echo.Context) error {
-	user := auth.GetUserFromContext(c)
-	if user == nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
-	}
-
-	name := c.Param("name")
-	if !h.canModifySettings(user, name) {
-		return echo.NewHTTPError(http.StatusForbidden, "access denied")
-	}
-
-	settings, err := h.settingsRepo.FindByName(c.Request().Context(), name)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusNotFound, "settings not found")
-	}
-
-	settings.SetGitSync(nil)
-	if err := h.settingsRepo.Save(c.Request().Context(), settings); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save settings")
-	}
-
-	return c.JSON(http.StatusOK, map[string]bool{"deleted": true})
-}
-
-// Push handles POST /sync/push/:name
+// Push handles POST /settings/:name/sync/push
 func (h *Handlers) Push(c echo.Context) error {
 	user := auth.GetUserFromContext(c)
 	if user == nil {
@@ -294,20 +162,4 @@ func (h *Handlers) canAccessSettings(user *entities.User, name string) bool {
 
 func (h *Handlers) canModifySettings(user *entities.User, name string) bool {
 	return h.canAccessSettings(user, name)
-}
-
-// toConfigResponse converts GitSyncConfig to the public response (token and KMS details redacted).
-func toConfigResponse(gs *entities.GitSyncConfig) *SyncConfigResponse {
-	return &SyncConfigResponse{
-		Enabled:        gs.Enabled,
-		RepoFullName:   gs.RepoFullName,
-		Branch:         gs.Branch,
-		RootPath:       gs.RootPath,
-		AutoPush:       gs.AutoPush,
-		HasGitHubToken: gs.GitHubToken != "",
-		Encryption: SyncEncryptionResponse{
-			DEKVersion: gs.Encryption.DEKVersion,
-			DEKReady:   gs.Encryption.EncryptedDEK != "",
-		},
-	}
 }

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1137,7 +1137,7 @@ func (s *Syncer) importSlackbotFile(ctx context.Context, data []byte, scope enti
 func encryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error {
 	encryptMapValues := func(m map[string]string, context string) error {
 		for k, v := range m {
-			if IsSensitiveKey(k) && !IsEncrypted(v) {
+			if !IsEncrypted(v) {
 				enc, err := EncryptField(dek, v)
 				if err != nil {
 					return fmt.Errorf("encrypt %s %s: %w", context, k, err)

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1215,6 +1215,11 @@ func encryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 			}
 			mcp.HeadersEncrypted = nil
 		}
+
+		if err := encryptMapValues(s.EnvVars, "settings env_vars"); err != nil {
+			return err
+		}
+		s.EnvVarsEncrypted = nil
 	}
 
 	return nil
@@ -1288,6 +1293,10 @@ func decryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 			if err := decryptMapValues(mcp.Headers, "MCP header"); err != nil {
 				return err
 			}
+		}
+
+		if err := decryptMapValues(s.EnvVars, "settings env_vars"); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/github_sync/types.go
+++ b/pkg/github_sync/types.go
@@ -59,35 +59,11 @@ type SyncSummary struct {
 	FilesDeleted int `json:"files_deleted"`
 }
 
-// SyncStatusResponse is the HTTP response body for GET /sync/status.
-type SyncStatusResponse struct {
-	Config   *SyncConfigResponse `json:"config,omitempty"`
-	LastPush *SyncEventRecord    `json:"last_push,omitempty"`
-	LastPull *SyncEventRecord    `json:"last_pull,omitempty"`
-}
-
 // SyncEventRecord records the result of the last push or pull.
 type SyncEventRecord struct {
 	At        time.Time   `json:"at"`
 	CommitSHA string      `json:"commit_sha,omitempty"`
 	Summary   SyncSummary `json:"summary"`
-}
-
-// SyncConfigResponse is returned by GET /sync/config (github_token redacted).
-type SyncConfigResponse struct {
-	Enabled        bool                   `json:"enabled"`
-	RepoFullName   string                 `json:"repo_full_name"`
-	Branch         string                 `json:"branch"`
-	RootPath       string                 `json:"root_path"`
-	AutoPush       bool                   `json:"auto_push"`
-	HasGitHubToken bool                   `json:"has_github_token"`
-	Encryption     SyncEncryptionResponse `json:"encryption"`
-}
-
-// SyncEncryptionResponse is the public view of encryption status (no secrets, no KMS ARN).
-type SyncEncryptionResponse struct {
-	DEKVersion int  `json:"dek_version"`
-	DEKReady   bool `json:"dek_ready"` // true when encryptedDEK is non-empty
 }
 
 // SyncAllRequest is the HTTP request body for POST /sync/all.
@@ -111,15 +87,4 @@ type SyncAllResult struct {
 	Push         *PushResponse `json:"push,omitempty"`
 	Pull         *PullResponse `json:"pull,omitempty"`
 	Error        string        `json:"error,omitempty"`
-}
-
-// UpdateSyncConfigRequest is the HTTP request body for PUT /sync/config.
-// Encryption settings (KMS key ARN, AWS region) are set at the proxy level and cannot be provided by the user.
-type UpdateSyncConfigRequest struct {
-	Enabled      bool   `json:"enabled"`
-	RepoFullName string `json:"repo_full_name"`
-	Branch       string `json:"branch"`
-	RootPath     string `json:"root_path"`
-	AutoPush     bool   `json:"auto_push"`
-	GitHubToken  string `json:"github_token,omitempty"`
 }

--- a/pkg/import/exporter.go
+++ b/pkg/import/exporter.go
@@ -414,6 +414,24 @@ func (e *Exporter) convertSettingsToImport(ctx context.Context, s *entities.Sett
 		}
 	}
 
+	// Encrypt EnvVars
+	if envVars := s.EnvVars(); len(envVars) > 0 {
+		settingsImport.EnvVars = make(map[string]string)
+		if e.shouldEncrypt() {
+			settingsImport.EnvVarsEncrypted = make(map[string]*EncryptedSecretData)
+			for k, v := range envVars {
+				encrypted, err := e.encryptionService.Encrypt(ctx, v)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encrypt env var %s: %w", k, err)
+				}
+				settingsImport.EnvVars[k] = encrypted.EncryptedValue
+				settingsImport.EnvVarsEncrypted[k] = e.toEncryptedSecretData(encrypted)
+			}
+		} else if e.isNoopEncryption() {
+			settingsImport.EnvVars = envVars
+		}
+	}
+
 	return settingsImport, nil
 }
 

--- a/pkg/import/importer.go
+++ b/pkg/import/importer.go
@@ -894,6 +894,37 @@ func (i *Importer) convertSettingsImport(ctx context.Context, settingsImport Set
 		settingsEntity.SetEnabledPlugins(settingsImport.EnabledPlugins)
 	}
 
+	// Decrypt EnvVars
+	if len(settingsImport.EnvVars) > 0 {
+		envVars := make(map[string]string)
+		for k, v := range settingsImport.EnvVars {
+			if settingsImport.EnvVarsEncrypted != nil && settingsImport.EnvVarsEncrypted[k] != nil {
+				if i.encryptionService == nil {
+					return nil, fmt.Errorf("encrypted env var %s found but encryption service not configured", k)
+				}
+				encrypted := &services.EncryptedData{
+					EncryptedValue: v,
+					Metadata: services.EncryptionMetadata{
+						Algorithm:   settingsImport.EnvVarsEncrypted[k].Algorithm,
+						KeyID:       settingsImport.EnvVarsEncrypted[k].KeyID,
+						EncryptedAt: settingsImport.EnvVarsEncrypted[k].EncryptedAt,
+						Version:     settingsImport.EnvVarsEncrypted[k].Version,
+					},
+				}
+				plaintext, err := i.encryptionService.Decrypt(ctx, encrypted)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decrypt env var %s: %w", k, err)
+				}
+				envVars[k] = plaintext
+			} else if v != "" {
+				envVars[k] = v
+			}
+		}
+		if len(envVars) > 0 {
+			settingsEntity.SetEnvVars(envVars)
+		}
+	}
+
 	return settingsEntity, nil
 }
 

--- a/pkg/import/types.go
+++ b/pkg/import/types.go
@@ -195,14 +195,16 @@ type EncryptedSecretData struct {
 
 // SettingsImport represents settings for import/export
 type SettingsImport struct {
-	Name                          string                        `yaml:"name" toml:"name" json:"name"`
-	Bedrock                       *BedrockSettingsImport        `yaml:"bedrock,omitempty" toml:"bedrock,omitempty" json:"bedrock,omitempty"`
-	MCPServers                    map[string]*MCPServerImport   `yaml:"mcp_servers,omitempty" toml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
-	Marketplaces                  map[string]*MarketplaceImport `yaml:"marketplaces,omitempty" toml:"marketplaces,omitempty" json:"marketplaces,omitempty"`
-	ClaudeCodeOAuthToken          string                        `yaml:"claude_code_oauth_token,omitempty" toml:"claude_code_oauth_token,omitempty" json:"claude_code_oauth_token,omitempty"`
-	ClaudeCodeOAuthTokenEncrypted *EncryptedSecretData          `yaml:"claude_code_oauth_token_encrypted,omitempty" toml:"claude_code_oauth_token_encrypted,omitempty" json:"claude_code_oauth_token_encrypted,omitempty"`
-	AuthMode                      string                        `yaml:"auth_mode,omitempty" toml:"auth_mode,omitempty" json:"auth_mode,omitempty"`
-	EnabledPlugins                []string                      `yaml:"enabled_plugins,omitempty" toml:"enabled_plugins,omitempty" json:"enabled_plugins,omitempty"`
+	Name                          string                          `yaml:"name" toml:"name" json:"name"`
+	Bedrock                       *BedrockSettingsImport          `yaml:"bedrock,omitempty" toml:"bedrock,omitempty" json:"bedrock,omitempty"`
+	MCPServers                    map[string]*MCPServerImport     `yaml:"mcp_servers,omitempty" toml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+	Marketplaces                  map[string]*MarketplaceImport   `yaml:"marketplaces,omitempty" toml:"marketplaces,omitempty" json:"marketplaces,omitempty"`
+	ClaudeCodeOAuthToken          string                          `yaml:"claude_code_oauth_token,omitempty" toml:"claude_code_oauth_token,omitempty" json:"claude_code_oauth_token,omitempty"`
+	ClaudeCodeOAuthTokenEncrypted *EncryptedSecretData            `yaml:"claude_code_oauth_token_encrypted,omitempty" toml:"claude_code_oauth_token_encrypted,omitempty" json:"claude_code_oauth_token_encrypted,omitempty"`
+	AuthMode                      string                          `yaml:"auth_mode,omitempty" toml:"auth_mode,omitempty" json:"auth_mode,omitempty"`
+	EnabledPlugins                []string                        `yaml:"enabled_plugins,omitempty" toml:"enabled_plugins,omitempty" json:"enabled_plugins,omitempty"`
+	EnvVars                       map[string]string               `yaml:"env_vars,omitempty" toml:"env_vars,omitempty" json:"env_vars,omitempty"`
+	EnvVarsEncrypted              map[string]*EncryptedSecretData `yaml:"env_vars_encrypted,omitempty" toml:"env_vars_encrypted,omitempty" json:"env_vars_encrypted,omitempty"`
 }
 
 // BedrockSettingsImport represents Bedrock settings for import/export

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3726,60 +3726,9 @@
       }
     },
     "/settings/{name}/sync": {
-      "get": {
-        "summary": "Get GitHub sync configuration",
-        "description": "Returns the GitHub sync configuration for the specified user or team settings (token redacted).",
-        "tags": ["GitHubSync"],
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" },
-            "description": "Settings name (user ID or team name)"
-          }
-        ],
-        "responses": {
-          "200": { "description": "Sync configuration" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "404": { "description": "Not found" }
-        },
-        "security": [{ "bearerAuth": [] }]
-      },
-      "put": {
-        "summary": "Update GitHub sync configuration",
-        "description": "Creates or updates the GitHub sync configuration for the specified settings. If a DEK already exists it is preserved.",
-        "tags": ["GitHubSync"],
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateSyncConfigRequest" }
-            }
-          }
-        },
-        "responses": {
-          "200": { "description": "Updated configuration" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "404": { "description": "Not found" },
-          "500": { "description": "Internal server error" }
-        },
-        "security": [{ "bearerAuth": [] }]
-      },
       "delete": {
         "summary": "Delete GitHub sync configuration",
-        "description": "Removes the GitHub sync configuration from the specified settings.",
+        "description": "Removes the GitHub sync configuration from the specified settings. The sync config can also be set via PUT /settings/{name} with a git_sync field.",
         "tags": ["GitHubSync"],
         "parameters": [
           {
@@ -3953,7 +3902,7 @@
   },
   "components": {
     "schemas": {
-      "SyncConfigResponse": {
+      "GitSyncConfigResponse": {
         "type": "object",
         "description": "Public view of GitHub sync configuration (token redacted)",
         "properties": {
@@ -3962,37 +3911,29 @@
           "branch": { "type": "string", "example": "main" },
           "root_path": { "type": "string", "example": "agentapi-config/" },
           "auto_push": { "type": "boolean" },
+          "has_github_token": { "type": "boolean", "description": "true when a GitHub token is configured" },
           "encryption": { "$ref": "#/components/schemas/SyncEncryptionResponse" }
+        }
+      },
+      "GitSyncConfigRequest": {
+        "type": "object",
+        "description": "GitHub sync configuration. Encryption settings (KMS key ARN, AWS region) are set at the proxy level.",
+        "required": ["repo_full_name"],
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "repo_full_name": { "type": "string", "example": "owner/repo" },
+          "branch": { "type": "string", "example": "main", "description": "Defaults to 'main' if omitted" },
+          "root_path": { "type": "string", "example": "agentapi-config/", "description": "Defaults to 'agentapi-config/' if omitted" },
+          "auto_push": { "type": "boolean" },
+          "github_token": { "type": "string", "description": "GitHub PAT (write-only, not returned). Existing token is preserved if omitted." }
         }
       },
       "SyncEncryptionResponse": {
         "type": "object",
         "description": "Public encryption info (no secrets)",
         "properties": {
-          "kms_key_arn": { "type": "string" },
-          "aws_region": { "type": "string" },
           "dek_version": { "type": "integer" },
           "dek_ready": { "type": "boolean", "description": "true when a DEK has been generated and stored" }
-        }
-      },
-      "UpdateSyncConfigRequest": {
-        "type": "object",
-        "required": ["repo_full_name", "encryption"],
-        "properties": {
-          "enabled": { "type": "boolean" },
-          "repo_full_name": { "type": "string", "example": "owner/repo" },
-          "branch": { "type": "string", "example": "main" },
-          "root_path": { "type": "string", "example": "agentapi-config/" },
-          "auto_push": { "type": "boolean" },
-          "github_token": { "type": "string", "description": "GitHub PAT (write-only, not returned)" },
-          "encryption": {
-            "type": "object",
-            "required": ["kms_key_arn", "aws_region"],
-            "properties": {
-              "kms_key_arn": { "type": "string" },
-              "aws_region": { "type": "string" }
-            }
-          }
         }
       },
       "PushResponse": {
@@ -5461,6 +5402,10 @@
           "slack_user_id": {
             "type": "string",
             "description": "Slack user ID for DM notifications. Set to empty string to remove."
+          },
+          "git_sync": {
+            "$ref": "#/components/schemas/GitSyncConfigRequest",
+            "description": "GitHub sync configuration. If omitted, the existing sync configuration is preserved."
           }
         }
       },
@@ -5632,6 +5577,10 @@
           "slack_user_id": {
             "type": "string",
             "description": "Slack user ID for DM notifications."
+          },
+          "git_sync": {
+            "$ref": "#/components/schemas/GitSyncConfigResponse",
+            "description": "GitHub sync configuration (token redacted). Null if not configured."
           },
           "created_at": {
             "type": "string",

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3725,7 +3725,7 @@
         }
       }
     },
-    "/sync/config/{name}": {
+    "/settings/{name}/sync": {
       "get": {
         "summary": "Get GitHub sync configuration",
         "description": "Returns the GitHub sync configuration for the specified user or team settings (token redacted).",
@@ -3799,7 +3799,7 @@
         "security": [{ "bearerAuth": [] }]
       }
     },
-    "/sync/push/{name}": {
+    "/settings/{name}/sync/push": {
       "post": {
         "summary": "Push resources to GitHub",
         "description": "Exports all resources (memories, tasks, schedules, webhooks, settings, etc.) and commits them to the configured GitHub repository. Sensitive fields are encrypted with AES-256-GCM using an AWS KMS-managed DEK.",
@@ -3840,7 +3840,7 @@
         "security": [{ "bearerAuth": [] }]
       }
     },
-    "/sync/pull/{name}": {
+    "/settings/{name}/sync/pull": {
       "post": {
         "summary": "Pull resources from GitHub",
         "description": "Downloads resources from the configured GitHub repository and imports them into the local store. Encrypted fields are decrypted using the stored DEK.",
@@ -3881,7 +3881,7 @@
         "security": [{ "bearerAuth": [] }]
       }
     },
-    "/sync/rotate-key/{name}": {
+    "/settings/{name}/sync/rotate-key": {
       "post": {
         "summary": "Rotate the sync encryption key",
         "description": "Generates a new DEK via AWS KMS, re-encrypts all values in the GitHub repository with the new DEK, and commits atomically. The old encryptedDEK is replaced in Settings.",
@@ -3910,7 +3910,7 @@
         "security": [{ "bearerAuth": [] }]
       }
     },
-    "/sync/all": {
+    "/settings/sync/all": {
       "post": {
         "summary": "Sync all tenants",
         "description": "Syncs GitHub for every settings tenant that has sync enabled. Only accessible by admin users. The direction (push/pull) is determined automatically per tenant by comparing the remote .sync-meta.yaml syncedAt timestamp against the local LastPushedAt: if GitHub is newer the tenant is pulled, otherwise pushed. Push is idempotent: no commit is created when file contents are unchanged.",


### PR DESCRIPTION
## Summary

### GitHub Sync 設定の settings API への統合

- Sync configuration (CRUD) は既存の `/settings/:name` API に統合：
  - `GET /settings/:name` レスポンスに `git_sync` フィールドを追加
  - `PUT /settings/:name` で `git_sync` フィールドを受け付けてconfig設定
  - `DELETE /settings/:name/sync` で sync config のみを削除
- アクション系エンドポイントを settings 名前空間に移動：
  - `POST /settings/:name/sync/push`
  - `POST /settings/:name/sync/pull`
  - `POST /settings/:name/sync/rotate-key`
  - `POST /settings/sync/all` (admin only)
- 旧 `/sync/config/:name` GET/PUT/DELETE を削除
- `SettingsController` がKMS設定を受け取り、`git_sync` 書き込み時に暗号化設定を付与

agentapi-ui 側も同様に更新済み（別途PR）

### env_vars の暗号化保存（旧 PR #748 を統合）

- 非 noop な `EncryptionServiceRegistry` が設定されている場合、`env_vars` を `encrypted_env_vars` として K8s Secret に暗号化保存
- 各エントリにアルゴリズム・キーID・タイムスタンプを埋め込み、復号時に正しいサービスを選択
- レガシーな plain `env_vars` は読み込み時にマージ（後方互換性あり）
- `server.go` で `NewKubernetesSettingsRepository` に `encryptionRegistry` を渡すよう更新

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] `PUT /settings/:name` に `git_sync` フィールドを含めて送信できる
- [ ] `GET /settings/:name` レスポンスに `git_sync` フィールドが含まれる
- [ ] `DELETE /settings/:name/sync` で git_sync 設定のみ削除できる
- [ ] 暗号化設定時、Secret 内 `settings.json` に `encrypted_env_vars` が保存される
- [ ] 読み込み時、`encrypted_env_vars` が透過的に復号される

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)