### PR TITLE
feat: add MCP tools for Schedule, Webhook, and SlackBot

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -99,7 +99,7 @@ func runProxy(cmd *cobra.Command, args []string) {
 	}
 
 	// Register schedule handlers (independent of worker status, but requires Kubernetes mode)
-	registerScheduleHandlers(configData, proxyServer)
+	scheduleMgr := registerScheduleHandlers(configData, proxyServer)
 
 	// Register webhook handlers (requires Kubernetes mode)
 	registerWebhookHandlers(configData, proxyServer)
@@ -116,8 +116,8 @@ func runProxy(cmd *cobra.Command, args []string) {
 	// Start Slack Socket Mode manager (requires Kubernetes mode)
 	startSlackSocketManager(configData, proxyServer)
 
-	// Register MCP handler
-	registerMCPHandler(proxyServer, port)
+	// Register MCP handler (pass schedule manager for schedule tools support)
+	registerMCPHandler(proxyServer, port, scheduleMgr)
 
 	// Register session manager handler (small-cluster / forwarding mode)
 	registerSessionManagerHandlers(configData, proxyServer)
@@ -183,21 +183,22 @@ func runProxy(cmd *cobra.Command, args []string) {
 	log.Printf("Server shutdown complete")
 }
 
-// registerScheduleHandlers registers schedule REST API handlers
-func registerScheduleHandlers(configData *config.Config, proxyServer *app.Server) {
+// registerScheduleHandlers registers schedule REST API handlers and returns the schedule manager
+// for use by other handlers (e.g., MCP). Returns nil if Kubernetes is not available.
+func registerScheduleHandlers(configData *config.Config, proxyServer *app.Server) schedule.Manager {
 	log.Printf("[SCHEDULE_HANDLERS] Registering schedule handlers...")
 
 	// Create Kubernetes client
 	restConfig, err := ctrl.GetConfig()
 	if err != nil {
 		log.Printf("[SCHEDULE_HANDLERS] Kubernetes config not available, skipping schedule handlers: %v", err)
-		return
+		return nil
 	}
 
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		log.Printf("[SCHEDULE_HANDLERS] Failed to create Kubernetes client, skipping schedule handlers: %v", err)
-		return
+		return nil
 	}
 
 	// Determine namespace
@@ -223,6 +224,7 @@ func registerScheduleHandlers(configData *config.Config, proxyServer *app.Server
 	proxyServer.AddCustomHandler(scheduleHandlers)
 
 	log.Printf("[SCHEDULE_HANDLERS] Schedule handlers registered successfully")
+	return scheduleManager
 }
 
 // startScheduleWorker starts the schedule worker with leader election
@@ -509,6 +511,9 @@ func registerWebhookHandlers(configData *config.Config, proxyServer *app.Server)
 		log.Printf("[WEBHOOK_HANDLERS] Default GitHub Enterprise host configured: %s", configData.Webhook.GitHubEnterpriseHost)
 	}
 
+	// Store webhook repo on server for MCP access
+	proxyServer.SetWebhookRepository(webhookRepo)
+
 	// Create and register webhook handlers with baseURL from config
 	webhookHandlers := webhook.NewHandlers(webhookRepo, proxyServer.GetSessionManager(), configData.Webhook.BaseURL, proxyServer.GetMemoryRepository())
 	proxyServer.AddCustomHandler(webhookHandlers)
@@ -605,6 +610,9 @@ func registerSlackBotHandlers(configData *config.Config, proxyServer *app.Server
 
 	// Create SlackBot repository
 	slackbotRepo := repositories.NewKubernetesSlackBotRepository(client, namespace)
+
+	// Store slackbot repo on server for MCP access
+	proxyServer.SetSlackBotRepository(slackbotRepo)
 
 	// Create and register SlackBot management handlers (no event reception - handled by Socket Mode)
 	slackbotHandlers := slackbot.NewHandlers(slackbotRepo)
@@ -822,11 +830,11 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 }
 
 // registerMCPHandler registers MCP HTTP handler
-func registerMCPHandler(proxyServer *app.Server, port string) {
+func registerMCPHandler(proxyServer *app.Server, port string, scheduleManager schedule.Manager) {
 	log.Printf("[MCP_HANDLER] Registering MCP handler...")
 
 	// Create and register MCP handler with server dependencies
-	mcpHandler := mcpiface.NewMCPHandler(proxyServer)
+	mcpHandler := mcpiface.NewMCPHandler(proxyServer, scheduleManager)
 	proxyServer.AddCustomHandler(mcpHandler)
 
 	log.Printf("[MCP_HANDLER] MCP handler registered successfully at /mcp")

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -58,6 +58,8 @@ type Server struct {
 	taskGroupRepo    portrepos.TaskGroupRepository    // Task group repository
 	sessionRouteRepo portrepos.SessionRouteRepository // Session route repository for proxy B routing
 	userFileRepo     portrepos.UserFileRepository     // User-managed files repository
+	webhookRepo      portrepos.WebhookRepository      // Webhook repository
+	slackBotRepo     portrepos.SlackBotRepository     // SlackBot repository
 	router           *Router                          // Router for custom handler registration
 }
 
@@ -1048,6 +1050,26 @@ func (s *Server) GetTaskRepository() portrepos.TaskRepository {
 // GetTaskGroupRepository returns the task group repository
 func (s *Server) GetTaskGroupRepository() portrepos.TaskGroupRepository {
 	return s.taskGroupRepo
+}
+
+// GetWebhookRepository returns the webhook repository
+func (s *Server) GetWebhookRepository() portrepos.WebhookRepository {
+	return s.webhookRepo
+}
+
+// SetWebhookRepository sets the webhook repository
+func (s *Server) SetWebhookRepository(repo portrepos.WebhookRepository) {
+	s.webhookRepo = repo
+}
+
+// GetSlackBotRepository returns the SlackBot repository
+func (s *Server) GetSlackBotRepository() portrepos.SlackBotRepository {
+	return s.slackBotRepo
+}
+
+// SetSlackBotRepository sets the SlackBot repository
+func (s *Server) SetSlackBotRepository(repo portrepos.SlackBotRepository) {
+	s.slackBotRepo = repo
 }
 
 // ExtractRepositoryInfo extracts repository information from tags.

--- a/internal/interfaces/mcp/handler.go
+++ b/internal/interfaces/mcp/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
 )
 
 // Context key for authenticated user
@@ -22,22 +23,28 @@ const userContextKey contextKey = "mcp_authenticated_user"
 
 // MCPHandler implements the CustomHandler interface for MCP endpoints
 type MCPHandler struct {
-	sessionManager repositories.SessionManager
-	shareRepo      repositories.ShareRepository
-	taskRepo       repositories.TaskRepository
-	taskGroupRepo  repositories.TaskGroupRepository
-	memoryRepo     repositories.MemoryRepository
-	httpHandler    http.Handler
+	sessionManager  repositories.SessionManager
+	shareRepo       repositories.ShareRepository
+	taskRepo        repositories.TaskRepository
+	taskGroupRepo   repositories.TaskGroupRepository
+	memoryRepo      repositories.MemoryRepository
+	webhookRepo     repositories.WebhookRepository
+	slackBotRepo    repositories.SlackBotRepository
+	scheduleManager schedule.Manager
+	httpHandler     http.Handler
 }
 
-// NewMCPHandler creates a new MCP handler for the /mcp endpoint
-func NewMCPHandler(server *app.Server) *MCPHandler {
+// NewMCPHandler creates a new MCP handler for the /mcp endpoint.
+// scheduleManager may be nil if schedule features are not available.
+func NewMCPHandler(server *app.Server, scheduleManager schedule.Manager) *MCPHandler {
 	// Get dependencies from server
 	sessionManager := server.GetSessionManager()
 	shareRepo := server.GetShareRepository()
 	taskRepo := server.GetTaskRepository()
 	taskGroupRepo := server.GetTaskGroupRepository()
 	memoryRepo := server.GetMemoryRepository()
+	webhookRepo := server.GetWebhookRepository()
+	slackBotRepo := server.GetSlackBotRepository()
 
 	// Create HTTP handler using go-sdk's streamable HTTP handler
 	// Use stateless mode for simpler session management
@@ -47,11 +54,14 @@ func NewMCPHandler(server *app.Server) *MCPHandler {
 	}
 
 	handler := &MCPHandler{
-		sessionManager: sessionManager,
-		shareRepo:      shareRepo,
-		taskRepo:       taskRepo,
-		taskGroupRepo:  taskGroupRepo,
-		memoryRepo:     memoryRepo,
+		sessionManager:  sessionManager,
+		shareRepo:       shareRepo,
+		taskRepo:        taskRepo,
+		taskGroupRepo:   taskGroupRepo,
+		memoryRepo:      memoryRepo,
+		webhookRepo:     webhookRepo,
+		slackBotRepo:    slackBotRepo,
+		scheduleManager: scheduleManager,
 	}
 
 	// Create factory function that creates a new MCP server per request with authenticated user
@@ -90,7 +100,7 @@ func NewMCPHandler(server *app.Server) *MCPHandler {
 		}
 
 		// Create new MCP server instance with authenticated user and repositories
-		mcpServer := NewMCPServer(sessionManager, shareRepo, taskRepo, taskGroupRepo, memoryRepo, authenticatedUserID, authenticatedTeams, authenticatedGithubToken, authenticatedSessionID, opts)
+		mcpServer := NewMCPServer(sessionManager, shareRepo, taskRepo, taskGroupRepo, memoryRepo, webhookRepo, slackBotRepo, scheduleManager, authenticatedUserID, authenticatedTeams, authenticatedGithubToken, authenticatedSessionID, opts)
 
 		// Register all tools
 		mcpServer.RegisterTools()

--- a/internal/interfaces/mcp/schedule_tools.go
+++ b/internal/interfaces/mcp/schedule_tools.go
@@ -1,0 +1,305 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpusecases "github.com/takutakahashi/agentapi-proxy/internal/usecases/mcp"
+)
+
+// --- Schedule Tool Input/Output types ---
+
+type ListSchedulesToolInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type ScheduleSessionParamsOutput struct {
+	Message      string `json:"message,omitempty"`
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+type ScheduleSessionConfigOutput struct {
+	Environment  map[string]string            `json:"environment,omitempty"`
+	Tags         map[string]string            `json:"tags,omitempty"`
+	Params       *ScheduleSessionParamsOutput `json:"params,omitempty"`
+	MemoryKey    map[string]string            `json:"memory_key,omitempty"`
+	ReuseSession bool                         `json:"reuse_session,omitempty"`
+	ReuseMessage string                       `json:"reuse_message,omitempty"`
+}
+
+type ScheduleExecutionOutput struct {
+	ExecutedAt    time.Time `json:"executed_at"`
+	SessionID     string    `json:"session_id,omitempty"`
+	Status        string    `json:"status"`
+	Error         string    `json:"error,omitempty"`
+	SessionReused bool      `json:"session_reused,omitempty"`
+}
+
+type ScheduleOutput struct {
+	ID              string                      `json:"id"`
+	Name            string                      `json:"name"`
+	UserID          string                      `json:"user_id"`
+	Scope           string                      `json:"scope"`
+	TeamID          string                      `json:"team_id,omitempty"`
+	Status          string                      `json:"status"`
+	ScheduledAt     *time.Time                  `json:"scheduled_at,omitempty"`
+	CronExpr        string                      `json:"cron_expr,omitempty"`
+	Timezone        string                      `json:"timezone,omitempty"`
+	SessionConfig   ScheduleSessionConfigOutput `json:"session_config"`
+	LastExecution   *ScheduleExecutionOutput    `json:"last_execution,omitempty"`
+	NextExecutionAt *time.Time                  `json:"next_execution_at,omitempty"`
+	ExecutionCount  int                         `json:"execution_count"`
+	CreatedAt       time.Time                   `json:"created_at"`
+	UpdatedAt       time.Time                   `json:"updated_at"`
+}
+
+type ListSchedulesToolOutput struct {
+	Schedules []ScheduleOutput `json:"schedules"`
+	Total     int              `json:"total"`
+}
+
+type GetScheduleToolInput struct {
+	ScheduleID string `json:"schedule_id"`
+}
+
+type GetScheduleToolOutput struct {
+	Schedule ScheduleOutput `json:"schedule"`
+}
+
+type CreateScheduleToolInput struct {
+	Name          string                      `json:"name"`
+	Scope         string                      `json:"scope,omitempty"`
+	TeamID        string                      `json:"team_id,omitempty"`
+	ScheduledAt   *time.Time                  `json:"scheduled_at,omitempty"`
+	CronExpr      string                      `json:"cron_expr,omitempty"`
+	Timezone      string                      `json:"timezone,omitempty"`
+	SessionConfig ScheduleSessionConfigOutput `json:"session_config"`
+}
+
+type CreateScheduleToolOutput struct {
+	Schedule ScheduleOutput `json:"schedule"`
+}
+
+type UpdateScheduleToolInput struct {
+	ScheduleID    string                       `json:"schedule_id"`
+	Name          *string                      `json:"name,omitempty"`
+	Status        *string                      `json:"status,omitempty"`
+	ScheduledAt   *time.Time                   `json:"scheduled_at,omitempty"`
+	CronExpr      *string                      `json:"cron_expr,omitempty"`
+	Timezone      *string                      `json:"timezone,omitempty"`
+	SessionConfig *ScheduleSessionConfigOutput `json:"session_config,omitempty"`
+}
+
+type UpdateScheduleToolOutput struct {
+	Schedule ScheduleOutput `json:"schedule"`
+}
+
+type DeleteScheduleToolInput struct {
+	ScheduleID string `json:"schedule_id"`
+}
+
+type DeleteScheduleToolOutput struct {
+	Message    string `json:"message"`
+	ScheduleID string `json:"schedule_id"`
+}
+
+// --- Conversion helpers ---
+
+func toScheduleOutput(info mcpusecases.ScheduleInfo) ScheduleOutput {
+	out := ScheduleOutput{
+		ID:              info.ID,
+		Name:            info.Name,
+		UserID:          info.UserID,
+		Scope:           info.Scope,
+		TeamID:          info.TeamID,
+		Status:          info.Status,
+		ScheduledAt:     info.ScheduledAt,
+		CronExpr:        info.CronExpr,
+		Timezone:        info.Timezone,
+		ExecutionCount:  info.ExecutionCount,
+		NextExecutionAt: info.NextExecutionAt,
+		CreatedAt:       info.CreatedAt,
+		UpdatedAt:       info.UpdatedAt,
+		SessionConfig:   toScheduleSessionConfigOutput(info.SessionConfig),
+	}
+	if info.LastExecution != nil {
+		exec := ScheduleExecutionOutput{
+			ExecutedAt:    info.LastExecution.ExecutedAt,
+			SessionID:     info.LastExecution.SessionID,
+			Status:        info.LastExecution.Status,
+			Error:         info.LastExecution.Error,
+			SessionReused: info.LastExecution.SessionReused,
+		}
+		out.LastExecution = &exec
+	}
+	return out
+}
+
+func toScheduleSessionConfigOutput(info mcpusecases.ScheduleSessionConfigInfo) ScheduleSessionConfigOutput {
+	out := ScheduleSessionConfigOutput{
+		Environment:  info.Environment,
+		Tags:         info.Tags,
+		MemoryKey:    info.MemoryKey,
+		ReuseSession: info.ReuseSession,
+		ReuseMessage: info.ReuseMessage,
+	}
+	if info.Params != nil {
+		out.Params = &ScheduleSessionParamsOutput{
+			Message:      info.Params.Message,
+			AgentType:    info.Params.AgentType,
+			Oneshot:      info.Params.Oneshot,
+			RepoFullName: info.Params.RepoFullName,
+		}
+	}
+	return out
+}
+
+func fromScheduleSessionConfigOutput(out ScheduleSessionConfigOutput) mcpusecases.ScheduleSessionConfigInfo {
+	info := mcpusecases.ScheduleSessionConfigInfo{
+		Environment:  out.Environment,
+		Tags:         out.Tags,
+		MemoryKey:    out.MemoryKey,
+		ReuseSession: out.ReuseSession,
+		ReuseMessage: out.ReuseMessage,
+	}
+	if out.Params != nil {
+		info.Params = &mcpusecases.ScheduleSessionParams{
+			Message:      out.Params.Message,
+			AgentType:    out.Params.AgentType,
+			Oneshot:      out.Params.Oneshot,
+			RepoFullName: out.Params.RepoFullName,
+		}
+	}
+	return info
+}
+
+// --- Schedule Tool Handlers ---
+
+func (s *MCPServer) handleListSchedules(ctx context.Context, req *mcp.CallToolRequest, input ListSchedulesToolInput) (*mcp.CallToolResult, ListSchedulesToolOutput, error) {
+	if s.scheduleUseCase == nil {
+		return nil, ListSchedulesToolOutput{}, fmt.Errorf("schedule tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, ListSchedulesToolOutput{}, fmt.Errorf("authentication required")
+	}
+
+	schedules, err := s.scheduleUseCase.ListSchedules(ctx, mcpusecases.ListSchedulesInput{
+		Scope:  input.Scope,
+		TeamID: input.TeamID,
+		Status: input.Status,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, ListSchedulesToolOutput{}, fmt.Errorf("failed to list schedules: %w", err)
+	}
+
+	out := ListSchedulesToolOutput{
+		Schedules: make([]ScheduleOutput, 0, len(schedules)),
+		Total:     len(schedules),
+	}
+	for _, sc := range schedules {
+		out.Schedules = append(out.Schedules, toScheduleOutput(sc))
+	}
+	return nil, out, nil
+}
+
+func (s *MCPServer) handleGetSchedule(ctx context.Context, req *mcp.CallToolRequest, input GetScheduleToolInput) (*mcp.CallToolResult, GetScheduleToolOutput, error) {
+	if s.scheduleUseCase == nil {
+		return nil, GetScheduleToolOutput{}, fmt.Errorf("schedule tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, GetScheduleToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.ScheduleID == "" {
+		return nil, GetScheduleToolOutput{}, fmt.Errorf("schedule_id is required")
+	}
+
+	info, err := s.scheduleUseCase.GetSchedule(ctx, input.ScheduleID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, GetScheduleToolOutput{}, fmt.Errorf("failed to get schedule: %w", err)
+	}
+
+	return nil, GetScheduleToolOutput{Schedule: toScheduleOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleCreateSchedule(ctx context.Context, req *mcp.CallToolRequest, input CreateScheduleToolInput) (*mcp.CallToolResult, CreateScheduleToolOutput, error) {
+	if s.scheduleUseCase == nil {
+		return nil, CreateScheduleToolOutput{}, fmt.Errorf("schedule tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, CreateScheduleToolOutput{}, fmt.Errorf("authentication required")
+	}
+
+	info, err := s.scheduleUseCase.CreateSchedule(ctx, mcpusecases.CreateScheduleInput{
+		Name:          input.Name,
+		Scope:         input.Scope,
+		TeamID:        input.TeamID,
+		ScheduledAt:   input.ScheduledAt,
+		CronExpr:      input.CronExpr,
+		Timezone:      input.Timezone,
+		SessionConfig: fromScheduleSessionConfigOutput(input.SessionConfig),
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, CreateScheduleToolOutput{}, fmt.Errorf("failed to create schedule: %w", err)
+	}
+
+	return nil, CreateScheduleToolOutput{Schedule: toScheduleOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleUpdateSchedule(ctx context.Context, req *mcp.CallToolRequest, input UpdateScheduleToolInput) (*mcp.CallToolResult, UpdateScheduleToolOutput, error) {
+	if s.scheduleUseCase == nil {
+		return nil, UpdateScheduleToolOutput{}, fmt.Errorf("schedule tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, UpdateScheduleToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.ScheduleID == "" {
+		return nil, UpdateScheduleToolOutput{}, fmt.Errorf("schedule_id is required")
+	}
+
+	var sessionConfig *mcpusecases.ScheduleSessionConfigInfo
+	if input.SessionConfig != nil {
+		cfg := fromScheduleSessionConfigOutput(*input.SessionConfig)
+		sessionConfig = &cfg
+	}
+
+	info, err := s.scheduleUseCase.UpdateSchedule(ctx, input.ScheduleID, mcpusecases.UpdateScheduleInput{
+		Name:          input.Name,
+		Status:        input.Status,
+		ScheduledAt:   input.ScheduledAt,
+		CronExpr:      input.CronExpr,
+		Timezone:      input.Timezone,
+		SessionConfig: sessionConfig,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, UpdateScheduleToolOutput{}, fmt.Errorf("failed to update schedule: %w", err)
+	}
+
+	return nil, UpdateScheduleToolOutput{Schedule: toScheduleOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleDeleteSchedule(ctx context.Context, req *mcp.CallToolRequest, input DeleteScheduleToolInput) (*mcp.CallToolResult, DeleteScheduleToolOutput, error) {
+	if s.scheduleUseCase == nil {
+		return nil, DeleteScheduleToolOutput{}, fmt.Errorf("schedule tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, DeleteScheduleToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.ScheduleID == "" {
+		return nil, DeleteScheduleToolOutput{}, fmt.Errorf("schedule_id is required")
+	}
+
+	if err := s.scheduleUseCase.DeleteSchedule(ctx, input.ScheduleID, s.authenticatedUserID, s.authenticatedTeams); err != nil {
+		return nil, DeleteScheduleToolOutput{}, fmt.Errorf("failed to delete schedule: %w", err)
+	}
+
+	return nil, DeleteScheduleToolOutput{
+		Message:    "Schedule deleted successfully",
+		ScheduleID: input.ScheduleID,
+	}, nil
+}

--- a/internal/interfaces/mcp/server.go
+++ b/internal/interfaces/mcp/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	mcpusecases "github.com/takutakahashi/agentapi-proxy/internal/usecases/mcp"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
 )
 
 // MCPServer wraps the MCP server and use cases
@@ -14,6 +15,9 @@ type MCPServer struct {
 	useCase                  *mcpusecases.MCPSessionToolsUseCase
 	taskUseCase              *mcpusecases.MCPTaskToolsUseCase
 	memoryUseCase            *mcpusecases.MCPMemoryToolsUseCase
+	scheduleUseCase          *mcpusecases.MCPScheduleToolsUseCase
+	webhookUseCase           *mcpusecases.MCPWebhookToolsUseCase
+	slackBotUseCase          *mcpusecases.MCPSlackBotToolsUseCase
 	authenticatedUserID      string
 	authenticatedTeams       []string // GitHub team slugs (e.g., ["org/team-a"])
 	authenticatedGithubToken string   // GitHub token from Authorization header
@@ -21,7 +25,7 @@ type MCPServer struct {
 }
 
 // NewMCPServer creates a new MCP server instance
-func NewMCPServer(sessionManager repositories.SessionManager, shareRepo repositories.ShareRepository, taskRepo repositories.TaskRepository, taskGroupRepo repositories.TaskGroupRepository, memoryRepo repositories.MemoryRepository, authenticatedUserID string, authenticatedTeams []string, authenticatedGithubToken string, sessionID string, opts *mcp.ServerOptions) *MCPServer {
+func NewMCPServer(sessionManager repositories.SessionManager, shareRepo repositories.ShareRepository, taskRepo repositories.TaskRepository, taskGroupRepo repositories.TaskGroupRepository, memoryRepo repositories.MemoryRepository, webhookRepo repositories.WebhookRepository, slackBotRepo repositories.SlackBotRepository, scheduleManager schedule.Manager, authenticatedUserID string, authenticatedTeams []string, authenticatedGithubToken string, sessionID string, opts *mcp.ServerOptions) *MCPServer {
 	// Create session use case with actual dependencies
 	useCase := mcpusecases.NewMCPSessionToolsUseCase(sessionManager, shareRepo, taskRepo)
 
@@ -37,6 +41,24 @@ func NewMCPServer(sessionManager repositories.SessionManager, shareRepo reposito
 		memoryUseCase = mcpusecases.NewMCPMemoryToolsUseCase(memoryRepo)
 	}
 
+	// Create schedule use case (may be nil if manager is not configured)
+	var scheduleUseCase *mcpusecases.MCPScheduleToolsUseCase
+	if scheduleManager != nil {
+		scheduleUseCase = mcpusecases.NewMCPScheduleToolsUseCase(scheduleManager)
+	}
+
+	// Create webhook use case (may be nil if repo is not configured)
+	var webhookUseCase *mcpusecases.MCPWebhookToolsUseCase
+	if webhookRepo != nil {
+		webhookUseCase = mcpusecases.NewMCPWebhookToolsUseCase(webhookRepo)
+	}
+
+	// Create slackbot use case (may be nil if repo is not configured)
+	var slackBotUseCase *mcpusecases.MCPSlackBotToolsUseCase
+	if slackBotRepo != nil {
+		slackBotUseCase = mcpusecases.NewMCPSlackBotToolsUseCase(slackBotRepo)
+	}
+
 	// Create MCP server
 	impl := &mcp.Implementation{
 		Name:    "agentapi-proxy-mcp",
@@ -50,6 +72,9 @@ func NewMCPServer(sessionManager repositories.SessionManager, shareRepo reposito
 		useCase:                  useCase,
 		taskUseCase:              taskUseCase,
 		memoryUseCase:            memoryUseCase,
+		scheduleUseCase:          scheduleUseCase,
+		webhookUseCase:           webhookUseCase,
+		slackBotUseCase:          slackBotUseCase,
 		authenticatedUserID:      authenticatedUserID,
 		authenticatedTeams:       authenticatedTeams,
 		authenticatedGithubToken: authenticatedGithubToken,
@@ -70,6 +95,21 @@ func (s *MCPServer) RegisterTools() {
 	// Register memory tools if available
 	if s.memoryUseCase != nil {
 		s.registerMemoryTools()
+	}
+
+	// Register schedule tools if available
+	if s.scheduleUseCase != nil {
+		s.registerScheduleTools()
+	}
+
+	// Register webhook tools if available
+	if s.webhookUseCase != nil {
+		s.registerWebhookTools()
+	}
+
+	// Register slackbot tools if available
+	if s.slackBotUseCase != nil {
+		s.registerSlackBotTools()
 	}
 }
 
@@ -219,6 +259,36 @@ func (s *MCPServer) registerMemoryTools() {
 	mcp.AddTool(s.server, deleteMemoryTool, s.handleDeleteMemory)
 
 	slog.Info("[MCP] Registered 5 memory tools: list_memories, get_memory, create_memory, update_memory, delete_memory")
+}
+
+// registerScheduleTools registers schedule management MCP tools
+func (s *MCPServer) registerScheduleTools() {
+	mcp.AddTool(s.server, &mcp.Tool{Name: "list_schedules", Description: "List schedules with optional filters (scope, team_id, status)"}, s.handleListSchedules)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "get_schedule", Description: "Get details of a specific schedule by ID"}, s.handleGetSchedule)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "create_schedule", Description: "Create a new schedule. Requires either cron_expr (recurring) or scheduled_at (one-time). scope must be 'user' or 'team'."}, s.handleCreateSchedule)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "update_schedule", Description: "Update an existing schedule. Only provided fields are updated."}, s.handleUpdateSchedule)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "delete_schedule", Description: "Delete a schedule by ID"}, s.handleDeleteSchedule)
+	slog.Info("[MCP] Registered 5 schedule tools: list_schedules, get_schedule, create_schedule, update_schedule, delete_schedule")
+}
+
+// registerWebhookTools registers webhook management MCP tools
+func (s *MCPServer) registerWebhookTools() {
+	mcp.AddTool(s.server, &mcp.Tool{Name: "list_webhooks", Description: "List webhooks with optional filters (scope, team_id, status, type)"}, s.handleListWebhooks)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "get_webhook", Description: "Get details of a specific webhook by ID"}, s.handleGetWebhook)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "create_webhook", Description: "Create a new webhook. type must be 'github' or 'custom'. At least one trigger is required."}, s.handleCreateWebhook)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "update_webhook", Description: "Update an existing webhook. Only provided fields are updated."}, s.handleUpdateWebhook)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "delete_webhook", Description: "Delete a webhook by ID"}, s.handleDeleteWebhook)
+	slog.Info("[MCP] Registered 5 webhook tools: list_webhooks, get_webhook, create_webhook, update_webhook, delete_webhook")
+}
+
+// registerSlackBotTools registers SlackBot management MCP tools
+func (s *MCPServer) registerSlackBotTools() {
+	mcp.AddTool(s.server, &mcp.Tool{Name: "list_slackbots", Description: "List SlackBots with optional filters (scope, team_id, status)"}, s.handleListSlackBots)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "get_slackbot", Description: "Get details of a specific SlackBot by ID"}, s.handleGetSlackBot)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "create_slackbot", Description: "Create a new SlackBot configuration. scope must be 'user' or 'team'."}, s.handleCreateSlackBot)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "update_slackbot", Description: "Update an existing SlackBot. Only provided fields are updated."}, s.handleUpdateSlackBot)
+	mcp.AddTool(s.server, &mcp.Tool{Name: "delete_slackbot", Description: "Delete a SlackBot by ID"}, s.handleDeleteSlackBot)
+	slog.Info("[MCP] Registered 5 slackbot tools: list_slackbots, get_slackbot, create_slackbot, update_slackbot, delete_slackbot")
 }
 
 // GetServer returns the underlying MCP server

--- a/internal/interfaces/mcp/slackbot_tools.go
+++ b/internal/interfaces/mcp/slackbot_tools.go
@@ -1,0 +1,309 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpusecases "github.com/takutakahashi/agentapi-proxy/internal/usecases/mcp"
+)
+
+// --- SlackBot Tool Input/Output types ---
+
+type ListSlackBotsToolInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type SlackBotSessionParamsOutput struct {
+	Message      string `json:"message,omitempty"`
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+type SlackBotSessionConfigOutput struct {
+	Environment            map[string]string            `json:"environment,omitempty"`
+	Tags                   map[string]string            `json:"tags,omitempty"`
+	InitialMessageTemplate string                       `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                       `json:"reuse_message_template,omitempty"`
+	Params                 *SlackBotSessionParamsOutput `json:"params,omitempty"`
+	MemoryKey              map[string]string            `json:"memory_key,omitempty"`
+	ReuseSession           bool                         `json:"reuse_session,omitempty"`
+	MountPayload           bool                         `json:"mount_payload,omitempty"`
+}
+
+type SlackBotOutput struct {
+	ID                     string                       `json:"id"`
+	Name                   string                       `json:"name"`
+	UserID                 string                       `json:"user_id"`
+	Scope                  string                       `json:"scope,omitempty"`
+	TeamID                 string                       `json:"team_id,omitempty"`
+	Teams                  []string                     `json:"teams,omitempty"`
+	Status                 string                       `json:"status"`
+	BotTokenSecretName     string                       `json:"bot_token_secret_name,omitempty"`
+	AllowedEventTypes      []string                     `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string                     `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                     `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SlackBotSessionConfigOutput `json:"session_config,omitempty"`
+	MaxSessions            int                          `json:"max_sessions"`
+	NotifyOnSessionCreated bool                         `json:"notify_on_session_created"`
+	AllowBotMessages       bool                         `json:"allow_bot_messages"`
+	CreatedAt              time.Time                    `json:"created_at"`
+	UpdatedAt              time.Time                    `json:"updated_at"`
+}
+
+type ListSlackBotsToolOutput struct {
+	SlackBots []SlackBotOutput `json:"slackbots"`
+	Total     int              `json:"total"`
+}
+
+type GetSlackBotToolInput struct {
+	SlackBotID string `json:"slackbot_id"`
+}
+
+type GetSlackBotToolOutput struct {
+	SlackBot SlackBotOutput `json:"slackbot"`
+}
+
+type CreateSlackBotToolInput struct {
+	Name                   string                       `json:"name"`
+	Scope                  string                       `json:"scope,omitempty"`
+	TeamID                 string                       `json:"team_id,omitempty"`
+	BotTokenSecretName     string                       `json:"bot_token_secret_name,omitempty"`
+	AllowedEventTypes      []string                     `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string                     `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                     `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SlackBotSessionConfigOutput `json:"session_config,omitempty"`
+	MaxSessions            int                          `json:"max_sessions,omitempty"`
+	NotifyOnSessionCreated *bool                        `json:"notify_on_session_created,omitempty"`
+	AllowBotMessages       *bool                        `json:"allow_bot_messages,omitempty"`
+}
+
+type CreateSlackBotToolOutput struct {
+	SlackBot SlackBotOutput `json:"slackbot"`
+}
+
+type UpdateSlackBotToolInput struct {
+	SlackBotID             string                       `json:"slackbot_id"`
+	Name                   *string                      `json:"name,omitempty"`
+	Status                 *string                      `json:"status,omitempty"`
+	BotTokenSecretName     *string                      `json:"bot_token_secret_name,omitempty"`
+	AllowedEventTypes      []string                     `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string                     `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                     `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SlackBotSessionConfigOutput `json:"session_config,omitempty"`
+	MaxSessions            *int                         `json:"max_sessions,omitempty"`
+	NotifyOnSessionCreated *bool                        `json:"notify_on_session_created,omitempty"`
+	AllowBotMessages       *bool                        `json:"allow_bot_messages,omitempty"`
+}
+
+type UpdateSlackBotToolOutput struct {
+	SlackBot SlackBotOutput `json:"slackbot"`
+}
+
+type DeleteSlackBotToolInput struct {
+	SlackBotID string `json:"slackbot_id"`
+}
+
+type DeleteSlackBotToolOutput struct {
+	Message    string `json:"message"`
+	SlackBotID string `json:"slackbot_id"`
+}
+
+// --- Conversion helpers ---
+
+func toSlackBotOutput(info mcpusecases.SlackBotInfo) SlackBotOutput {
+	out := SlackBotOutput{
+		ID:                     info.ID,
+		Name:                   info.Name,
+		UserID:                 info.UserID,
+		Scope:                  info.Scope,
+		TeamID:                 info.TeamID,
+		Teams:                  info.Teams,
+		Status:                 info.Status,
+		BotTokenSecretName:     info.BotTokenSecretName,
+		AllowedEventTypes:      info.AllowedEventTypes,
+		AllowedChannelNames:    info.AllowedChannelNames,
+		AllowedUserIDs:         info.AllowedUserIDs,
+		MaxSessions:            info.MaxSessions,
+		NotifyOnSessionCreated: info.NotifyOnSessionCreated,
+		AllowBotMessages:       info.AllowBotMessages,
+		CreatedAt:              info.CreatedAt,
+		UpdatedAt:              info.UpdatedAt,
+	}
+	if info.SessionConfig != nil {
+		cfg := SlackBotSessionConfigOutput{
+			Environment:            info.SessionConfig.Environment,
+			Tags:                   info.SessionConfig.Tags,
+			InitialMessageTemplate: info.SessionConfig.InitialMessageTemplate,
+			ReuseMessageTemplate:   info.SessionConfig.ReuseMessageTemplate,
+			MemoryKey:              info.SessionConfig.MemoryKey,
+			ReuseSession:           info.SessionConfig.ReuseSession,
+			MountPayload:           info.SessionConfig.MountPayload,
+		}
+		if info.SessionConfig.Params != nil {
+			cfg.Params = &SlackBotSessionParamsOutput{
+				Message:      info.SessionConfig.Params.Message,
+				AgentType:    info.SessionConfig.Params.AgentType,
+				Oneshot:      info.SessionConfig.Params.Oneshot,
+				RepoFullName: info.SessionConfig.Params.RepoFullName,
+			}
+		}
+		out.SessionConfig = &cfg
+	}
+	return out
+}
+
+func fromSlackBotSessionConfigOutput(out *SlackBotSessionConfigOutput) *mcpusecases.SlackBotSessionConfigInfo {
+	if out == nil {
+		return nil
+	}
+	info := &mcpusecases.SlackBotSessionConfigInfo{
+		Environment:            out.Environment,
+		Tags:                   out.Tags,
+		InitialMessageTemplate: out.InitialMessageTemplate,
+		ReuseMessageTemplate:   out.ReuseMessageTemplate,
+		MemoryKey:              out.MemoryKey,
+		ReuseSession:           out.ReuseSession,
+		MountPayload:           out.MountPayload,
+	}
+	if out.Params != nil {
+		info.Params = &mcpusecases.SlackBotSessionParams{
+			Message:      out.Params.Message,
+			AgentType:    out.Params.AgentType,
+			Oneshot:      out.Params.Oneshot,
+			RepoFullName: out.Params.RepoFullName,
+		}
+	}
+	return info
+}
+
+// --- SlackBot Tool Handlers ---
+
+func (s *MCPServer) handleListSlackBots(ctx context.Context, req *mcp.CallToolRequest, input ListSlackBotsToolInput) (*mcp.CallToolResult, ListSlackBotsToolOutput, error) {
+	if s.slackBotUseCase == nil {
+		return nil, ListSlackBotsToolOutput{}, fmt.Errorf("slackbot tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, ListSlackBotsToolOutput{}, fmt.Errorf("authentication required")
+	}
+
+	bots, err := s.slackBotUseCase.ListSlackBots(ctx, mcpusecases.ListSlackBotsInput{
+		Scope:  input.Scope,
+		TeamID: input.TeamID,
+		Status: input.Status,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, ListSlackBotsToolOutput{}, fmt.Errorf("failed to list slackbots: %w", err)
+	}
+
+	out := ListSlackBotsToolOutput{
+		SlackBots: make([]SlackBotOutput, 0, len(bots)),
+		Total:     len(bots),
+	}
+	for _, b := range bots {
+		out.SlackBots = append(out.SlackBots, toSlackBotOutput(b))
+	}
+	return nil, out, nil
+}
+
+func (s *MCPServer) handleGetSlackBot(ctx context.Context, req *mcp.CallToolRequest, input GetSlackBotToolInput) (*mcp.CallToolResult, GetSlackBotToolOutput, error) {
+	if s.slackBotUseCase == nil {
+		return nil, GetSlackBotToolOutput{}, fmt.Errorf("slackbot tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, GetSlackBotToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.SlackBotID == "" {
+		return nil, GetSlackBotToolOutput{}, fmt.Errorf("slackbot_id is required")
+	}
+
+	info, err := s.slackBotUseCase.GetSlackBot(ctx, input.SlackBotID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, GetSlackBotToolOutput{}, fmt.Errorf("failed to get slackbot: %w", err)
+	}
+
+	return nil, GetSlackBotToolOutput{SlackBot: toSlackBotOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleCreateSlackBot(ctx context.Context, req *mcp.CallToolRequest, input CreateSlackBotToolInput) (*mcp.CallToolResult, CreateSlackBotToolOutput, error) {
+	if s.slackBotUseCase == nil {
+		return nil, CreateSlackBotToolOutput{}, fmt.Errorf("slackbot tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, CreateSlackBotToolOutput{}, fmt.Errorf("authentication required")
+	}
+
+	info, err := s.slackBotUseCase.CreateSlackBot(ctx, mcpusecases.CreateSlackBotInput{
+		Name:                   input.Name,
+		Scope:                  input.Scope,
+		TeamID:                 input.TeamID,
+		BotTokenSecretName:     input.BotTokenSecretName,
+		AllowedEventTypes:      input.AllowedEventTypes,
+		AllowedChannelNames:    input.AllowedChannelNames,
+		AllowedUserIDs:         input.AllowedUserIDs,
+		SessionConfig:          fromSlackBotSessionConfigOutput(input.SessionConfig),
+		MaxSessions:            input.MaxSessions,
+		NotifyOnSessionCreated: input.NotifyOnSessionCreated,
+		AllowBotMessages:       input.AllowBotMessages,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, CreateSlackBotToolOutput{}, fmt.Errorf("failed to create slackbot: %w", err)
+	}
+
+	return nil, CreateSlackBotToolOutput{SlackBot: toSlackBotOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleUpdateSlackBot(ctx context.Context, req *mcp.CallToolRequest, input UpdateSlackBotToolInput) (*mcp.CallToolResult, UpdateSlackBotToolOutput, error) {
+	if s.slackBotUseCase == nil {
+		return nil, UpdateSlackBotToolOutput{}, fmt.Errorf("slackbot tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, UpdateSlackBotToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.SlackBotID == "" {
+		return nil, UpdateSlackBotToolOutput{}, fmt.Errorf("slackbot_id is required")
+	}
+
+	info, err := s.slackBotUseCase.UpdateSlackBot(ctx, input.SlackBotID, mcpusecases.UpdateSlackBotInput{
+		Name:                   input.Name,
+		Status:                 input.Status,
+		BotTokenSecretName:     input.BotTokenSecretName,
+		AllowedEventTypes:      input.AllowedEventTypes,
+		AllowedChannelNames:    input.AllowedChannelNames,
+		AllowedUserIDs:         input.AllowedUserIDs,
+		SessionConfig:          fromSlackBotSessionConfigOutput(input.SessionConfig),
+		MaxSessions:            input.MaxSessions,
+		NotifyOnSessionCreated: input.NotifyOnSessionCreated,
+		AllowBotMessages:       input.AllowBotMessages,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, UpdateSlackBotToolOutput{}, fmt.Errorf("failed to update slackbot: %w", err)
+	}
+
+	return nil, UpdateSlackBotToolOutput{SlackBot: toSlackBotOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleDeleteSlackBot(ctx context.Context, req *mcp.CallToolRequest, input DeleteSlackBotToolInput) (*mcp.CallToolResult, DeleteSlackBotToolOutput, error) {
+	if s.slackBotUseCase == nil {
+		return nil, DeleteSlackBotToolOutput{}, fmt.Errorf("slackbot tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, DeleteSlackBotToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.SlackBotID == "" {
+		return nil, DeleteSlackBotToolOutput{}, fmt.Errorf("slackbot_id is required")
+	}
+
+	if err := s.slackBotUseCase.DeleteSlackBot(ctx, input.SlackBotID, s.authenticatedUserID, s.authenticatedTeams); err != nil {
+		return nil, DeleteSlackBotToolOutput{}, fmt.Errorf("failed to delete slackbot: %w", err)
+	}
+
+	return nil, DeleteSlackBotToolOutput{
+		Message:    "SlackBot deleted successfully",
+		SlackBotID: input.SlackBotID,
+	}, nil
+}

--- a/internal/interfaces/mcp/webhook_tools.go
+++ b/internal/interfaces/mcp/webhook_tools.go
@@ -1,0 +1,453 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpusecases "github.com/takutakahashi/agentapi-proxy/internal/usecases/mcp"
+)
+
+// --- Webhook Tool Input/Output types ---
+
+type ListWebhooksToolInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+type WebhookSessionParamsOutput struct {
+	Message      string `json:"message,omitempty"`
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+type WebhookSessionConfigOutput struct {
+	Environment            map[string]string           `json:"environment,omitempty"`
+	Tags                   map[string]string           `json:"tags,omitempty"`
+	InitialMessageTemplate string                      `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                      `json:"reuse_message_template,omitempty"`
+	Params                 *WebhookSessionParamsOutput `json:"params,omitempty"`
+	ReuseSession           bool                        `json:"reuse_session,omitempty"`
+	MountPayload           bool                        `json:"mount_payload,omitempty"`
+	MemoryKey              map[string]string           `json:"memory_key,omitempty"`
+}
+
+type WebhookGitHubConfigOutput struct {
+	EnterpriseURL       string   `json:"enterprise_url,omitempty"`
+	AllowedEvents       []string `json:"allowed_events,omitempty"`
+	AllowedRepositories []string `json:"allowed_repositories,omitempty"`
+}
+
+type WebhookGitHubConditionsOutput struct {
+	Events       []string `json:"events,omitempty"`
+	Actions      []string `json:"actions,omitempty"`
+	Branches     []string `json:"branches,omitempty"`
+	Repositories []string `json:"repositories,omitempty"`
+	Labels       []string `json:"labels,omitempty"`
+	Paths        []string `json:"paths,omitempty"`
+	BaseBranches []string `json:"base_branches,omitempty"`
+	Draft        *bool    `json:"draft,omitempty"`
+	Sender       []string `json:"sender,omitempty"`
+}
+
+type WebhookTriggerConditionsOutput struct {
+	GitHub     *WebhookGitHubConditionsOutput `json:"github,omitempty"`
+	GoTemplate string                         `json:"go_template,omitempty"`
+}
+
+type WebhookTriggerOutput struct {
+	ID            string                         `json:"id"`
+	Name          string                         `json:"name"`
+	Priority      int                            `json:"priority"`
+	Enabled       bool                           `json:"enabled"`
+	Conditions    WebhookTriggerConditionsOutput `json:"conditions"`
+	SessionConfig *WebhookSessionConfigOutput    `json:"session_config,omitempty"`
+	StopOnMatch   bool                           `json:"stop_on_match"`
+}
+
+type WebhookDeliveryOutput struct {
+	ID             string    `json:"id"`
+	ReceivedAt     time.Time `json:"received_at"`
+	Status         string    `json:"status"`
+	MatchedTrigger string    `json:"matched_trigger,omitempty"`
+	SessionID      string    `json:"session_id,omitempty"`
+	ErrorMessage   string    `json:"error_message,omitempty"`
+	SessionReused  bool      `json:"session_reused,omitempty"`
+}
+
+type WebhookOutput struct {
+	ID              string                      `json:"id"`
+	Name            string                      `json:"name"`
+	UserID          string                      `json:"user_id"`
+	Scope           string                      `json:"scope,omitempty"`
+	TeamID          string                      `json:"team_id,omitempty"`
+	Status          string                      `json:"status"`
+	Type            string                      `json:"type"`
+	SignatureHeader string                      `json:"signature_header,omitempty"`
+	SignatureType   string                      `json:"signature_type,omitempty"`
+	GitHub          *WebhookGitHubConfigOutput  `json:"github,omitempty"`
+	Triggers        []WebhookTriggerOutput      `json:"triggers"`
+	SessionConfig   *WebhookSessionConfigOutput `json:"session_config,omitempty"`
+	MaxSessions     int                         `json:"max_sessions"`
+	DeliveryCount   int64                       `json:"delivery_count"`
+	LastDelivery    *WebhookDeliveryOutput      `json:"last_delivery,omitempty"`
+	CreatedAt       time.Time                   `json:"created_at"`
+	UpdatedAt       time.Time                   `json:"updated_at"`
+}
+
+type ListWebhooksToolOutput struct {
+	Webhooks []WebhookOutput `json:"webhooks"`
+	Total    int             `json:"total"`
+}
+
+type GetWebhookToolInput struct {
+	WebhookID string `json:"webhook_id"`
+}
+
+type GetWebhookToolOutput struct {
+	Webhook WebhookOutput `json:"webhook"`
+}
+
+type CreateWebhookToolInput struct {
+	Name            string                      `json:"name"`
+	Scope           string                      `json:"scope,omitempty"`
+	TeamID          string                      `json:"team_id,omitempty"`
+	Type            string                      `json:"type"`
+	Secret          string                      `json:"secret,omitempty"`
+	SignatureHeader string                      `json:"signature_header,omitempty"`
+	SignatureType   string                      `json:"signature_type,omitempty"`
+	GitHub          *WebhookGitHubConfigOutput  `json:"github,omitempty"`
+	Triggers        []WebhookTriggerOutput      `json:"triggers"`
+	SessionConfig   *WebhookSessionConfigOutput `json:"session_config,omitempty"`
+	MaxSessions     int                         `json:"max_sessions,omitempty"`
+}
+
+type CreateWebhookToolOutput struct {
+	Webhook WebhookOutput `json:"webhook"`
+}
+
+type UpdateWebhookToolInput struct {
+	WebhookID     string                      `json:"webhook_id"`
+	Name          *string                     `json:"name,omitempty"`
+	Status        *string                     `json:"status,omitempty"`
+	Secret        *string                     `json:"secret,omitempty"`
+	GitHub        *WebhookGitHubConfigOutput  `json:"github,omitempty"`
+	Triggers      []WebhookTriggerOutput      `json:"triggers,omitempty"`
+	SessionConfig *WebhookSessionConfigOutput `json:"session_config,omitempty"`
+	MaxSessions   *int                        `json:"max_sessions,omitempty"`
+}
+
+type UpdateWebhookToolOutput struct {
+	Webhook WebhookOutput `json:"webhook"`
+}
+
+type DeleteWebhookToolInput struct {
+	WebhookID string `json:"webhook_id"`
+}
+
+type DeleteWebhookToolOutput struct {
+	Message   string `json:"message"`
+	WebhookID string `json:"webhook_id"`
+}
+
+// --- Conversion helpers ---
+
+func toWebhookOutput(info mcpusecases.WebhookInfo) WebhookOutput {
+	out := WebhookOutput{
+		ID:              info.ID,
+		Name:            info.Name,
+		UserID:          info.UserID,
+		Scope:           info.Scope,
+		TeamID:          info.TeamID,
+		Status:          info.Status,
+		Type:            info.Type,
+		SignatureHeader: info.SignatureHeader,
+		SignatureType:   info.SignatureType,
+		MaxSessions:     info.MaxSessions,
+		DeliveryCount:   info.DeliveryCount,
+		CreatedAt:       info.CreatedAt,
+		UpdatedAt:       info.UpdatedAt,
+	}
+
+	if info.GitHub != nil {
+		out.GitHub = &WebhookGitHubConfigOutput{
+			EnterpriseURL:       info.GitHub.EnterpriseURL,
+			AllowedEvents:       info.GitHub.AllowedEvents,
+			AllowedRepositories: info.GitHub.AllowedRepositories,
+		}
+	}
+
+	out.Triggers = make([]WebhookTriggerOutput, 0, len(info.Triggers))
+	for _, t := range info.Triggers {
+		out.Triggers = append(out.Triggers, toWebhookTriggerOutput(t))
+	}
+
+	if info.SessionConfig != nil {
+		cfg := toWebhookSessionConfigOutput(*info.SessionConfig)
+		out.SessionConfig = &cfg
+	}
+
+	if info.LastDelivery != nil {
+		d := WebhookDeliveryOutput{
+			ID:             info.LastDelivery.ID,
+			ReceivedAt:     info.LastDelivery.ReceivedAt,
+			Status:         info.LastDelivery.Status,
+			MatchedTrigger: info.LastDelivery.MatchedTrigger,
+			SessionID:      info.LastDelivery.SessionID,
+			ErrorMessage:   info.LastDelivery.ErrorMessage,
+			SessionReused:  info.LastDelivery.SessionReused,
+		}
+		out.LastDelivery = &d
+	}
+
+	return out
+}
+
+func toWebhookTriggerOutput(t mcpusecases.WebhookTriggerInfo) WebhookTriggerOutput {
+	out := WebhookTriggerOutput{
+		ID:          t.ID,
+		Name:        t.Name,
+		Priority:    t.Priority,
+		Enabled:     t.Enabled,
+		StopOnMatch: t.StopOnMatch,
+		Conditions:  WebhookTriggerConditionsOutput{GoTemplate: t.Conditions.GoTemplate},
+	}
+	if t.Conditions.GitHub != nil {
+		out.Conditions.GitHub = &WebhookGitHubConditionsOutput{
+			Events:       t.Conditions.GitHub.Events,
+			Actions:      t.Conditions.GitHub.Actions,
+			Branches:     t.Conditions.GitHub.Branches,
+			Repositories: t.Conditions.GitHub.Repositories,
+			Labels:       t.Conditions.GitHub.Labels,
+			Paths:        t.Conditions.GitHub.Paths,
+			BaseBranches: t.Conditions.GitHub.BaseBranches,
+			Draft:        t.Conditions.GitHub.Draft,
+			Sender:       t.Conditions.GitHub.Sender,
+		}
+	}
+	if t.SessionConfig != nil {
+		cfg := toWebhookSessionConfigOutput(*t.SessionConfig)
+		out.SessionConfig = &cfg
+	}
+	return out
+}
+
+func toWebhookSessionConfigOutput(info mcpusecases.WebhookSessionConfigInfo) WebhookSessionConfigOutput {
+	out := WebhookSessionConfigOutput{
+		Environment:            info.Environment,
+		Tags:                   info.Tags,
+		InitialMessageTemplate: info.InitialMessageTemplate,
+		ReuseMessageTemplate:   info.ReuseMessageTemplate,
+		ReuseSession:           info.ReuseSession,
+		MountPayload:           info.MountPayload,
+		MemoryKey:              info.MemoryKey,
+	}
+	if info.Params != nil {
+		out.Params = &WebhookSessionParamsOutput{
+			Message:      info.Params.Message,
+			AgentType:    info.Params.AgentType,
+			Oneshot:      info.Params.Oneshot,
+			RepoFullName: info.Params.RepoFullName,
+		}
+	}
+	return out
+}
+
+func fromWebhookSessionConfigOutput(out *WebhookSessionConfigOutput) *mcpusecases.WebhookSessionConfigInfo {
+	if out == nil {
+		return nil
+	}
+	info := &mcpusecases.WebhookSessionConfigInfo{
+		Environment:            out.Environment,
+		Tags:                   out.Tags,
+		InitialMessageTemplate: out.InitialMessageTemplate,
+		ReuseMessageTemplate:   out.ReuseMessageTemplate,
+		ReuseSession:           out.ReuseSession,
+		MountPayload:           out.MountPayload,
+		MemoryKey:              out.MemoryKey,
+	}
+	if out.Params != nil {
+		info.Params = &mcpusecases.WebhookSessionParams{
+			Message:      out.Params.Message,
+			AgentType:    out.Params.AgentType,
+			Oneshot:      out.Params.Oneshot,
+			RepoFullName: out.Params.RepoFullName,
+		}
+	}
+	return info
+}
+
+func fromWebhookGitHubConfigOutput(out *WebhookGitHubConfigOutput) *mcpusecases.WebhookGitHubConfigInfo {
+	if out == nil {
+		return nil
+	}
+	return &mcpusecases.WebhookGitHubConfigInfo{
+		EnterpriseURL:       out.EnterpriseURL,
+		AllowedEvents:       out.AllowedEvents,
+		AllowedRepositories: out.AllowedRepositories,
+	}
+}
+
+func fromWebhookTriggerOutputs(triggers []WebhookTriggerOutput) []mcpusecases.WebhookTriggerInfo {
+	result := make([]mcpusecases.WebhookTriggerInfo, 0, len(triggers))
+	for _, t := range triggers {
+		info := mcpusecases.WebhookTriggerInfo{
+			ID:          t.ID,
+			Name:        t.Name,
+			Priority:    t.Priority,
+			Enabled:     t.Enabled,
+			StopOnMatch: t.StopOnMatch,
+			Conditions:  mcpusecases.WebhookTriggerConditionsInfo{GoTemplate: t.Conditions.GoTemplate},
+		}
+		if t.Conditions.GitHub != nil {
+			info.Conditions.GitHub = &mcpusecases.WebhookGitHubConditionsInfo{
+				Events:       t.Conditions.GitHub.Events,
+				Actions:      t.Conditions.GitHub.Actions,
+				Branches:     t.Conditions.GitHub.Branches,
+				Repositories: t.Conditions.GitHub.Repositories,
+				Labels:       t.Conditions.GitHub.Labels,
+				Paths:        t.Conditions.GitHub.Paths,
+				BaseBranches: t.Conditions.GitHub.BaseBranches,
+				Draft:        t.Conditions.GitHub.Draft,
+				Sender:       t.Conditions.GitHub.Sender,
+			}
+		}
+		info.SessionConfig = fromWebhookSessionConfigOutput(t.SessionConfig)
+		result = append(result, info)
+	}
+	return result
+}
+
+// --- Webhook Tool Handlers ---
+
+func (s *MCPServer) handleListWebhooks(ctx context.Context, req *mcp.CallToolRequest, input ListWebhooksToolInput) (*mcp.CallToolResult, ListWebhooksToolOutput, error) {
+	if s.webhookUseCase == nil {
+		return nil, ListWebhooksToolOutput{}, fmt.Errorf("webhook tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, ListWebhooksToolOutput{}, fmt.Errorf("authentication required")
+	}
+
+	webhooks, err := s.webhookUseCase.ListWebhooks(ctx, mcpusecases.ListWebhooksInput{
+		Scope:  input.Scope,
+		TeamID: input.TeamID,
+		Status: input.Status,
+		Type:   input.Type,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, ListWebhooksToolOutput{}, fmt.Errorf("failed to list webhooks: %w", err)
+	}
+
+	out := ListWebhooksToolOutput{
+		Webhooks: make([]WebhookOutput, 0, len(webhooks)),
+		Total:    len(webhooks),
+	}
+	for _, w := range webhooks {
+		out.Webhooks = append(out.Webhooks, toWebhookOutput(w))
+	}
+	return nil, out, nil
+}
+
+func (s *MCPServer) handleGetWebhook(ctx context.Context, req *mcp.CallToolRequest, input GetWebhookToolInput) (*mcp.CallToolResult, GetWebhookToolOutput, error) {
+	if s.webhookUseCase == nil {
+		return nil, GetWebhookToolOutput{}, fmt.Errorf("webhook tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, GetWebhookToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.WebhookID == "" {
+		return nil, GetWebhookToolOutput{}, fmt.Errorf("webhook_id is required")
+	}
+
+	info, err := s.webhookUseCase.GetWebhook(ctx, input.WebhookID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, GetWebhookToolOutput{}, fmt.Errorf("failed to get webhook: %w", err)
+	}
+
+	return nil, GetWebhookToolOutput{Webhook: toWebhookOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleCreateWebhook(ctx context.Context, req *mcp.CallToolRequest, input CreateWebhookToolInput) (*mcp.CallToolResult, CreateWebhookToolOutput, error) {
+	if s.webhookUseCase == nil {
+		return nil, CreateWebhookToolOutput{}, fmt.Errorf("webhook tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, CreateWebhookToolOutput{}, fmt.Errorf("authentication required")
+	}
+
+	info, err := s.webhookUseCase.CreateWebhook(ctx, mcpusecases.CreateWebhookInput{
+		Name:            input.Name,
+		Scope:           input.Scope,
+		TeamID:          input.TeamID,
+		Type:            input.Type,
+		Secret:          input.Secret,
+		SignatureHeader: input.SignatureHeader,
+		SignatureType:   input.SignatureType,
+		GitHub:          fromWebhookGitHubConfigOutput(input.GitHub),
+		Triggers:        fromWebhookTriggerOutputs(input.Triggers),
+		SessionConfig:   fromWebhookSessionConfigOutput(input.SessionConfig),
+		MaxSessions:     input.MaxSessions,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, CreateWebhookToolOutput{}, fmt.Errorf("failed to create webhook: %w", err)
+	}
+
+	return nil, CreateWebhookToolOutput{Webhook: toWebhookOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleUpdateWebhook(ctx context.Context, req *mcp.CallToolRequest, input UpdateWebhookToolInput) (*mcp.CallToolResult, UpdateWebhookToolOutput, error) {
+	if s.webhookUseCase == nil {
+		return nil, UpdateWebhookToolOutput{}, fmt.Errorf("webhook tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, UpdateWebhookToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.WebhookID == "" {
+		return nil, UpdateWebhookToolOutput{}, fmt.Errorf("webhook_id is required")
+	}
+
+	var triggers []mcpusecases.WebhookTriggerInfo
+	if input.Triggers != nil {
+		triggers = fromWebhookTriggerOutputs(input.Triggers)
+	}
+
+	info, err := s.webhookUseCase.UpdateWebhook(ctx, input.WebhookID, mcpusecases.UpdateWebhookInput{
+		Name:          input.Name,
+		Status:        input.Status,
+		Secret:        input.Secret,
+		GitHub:        fromWebhookGitHubConfigOutput(input.GitHub),
+		Triggers:      triggers,
+		SessionConfig: fromWebhookSessionConfigOutput(input.SessionConfig),
+		MaxSessions:   input.MaxSessions,
+	}, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, UpdateWebhookToolOutput{}, fmt.Errorf("failed to update webhook: %w", err)
+	}
+
+	return nil, UpdateWebhookToolOutput{Webhook: toWebhookOutput(*info)}, nil
+}
+
+func (s *MCPServer) handleDeleteWebhook(ctx context.Context, req *mcp.CallToolRequest, input DeleteWebhookToolInput) (*mcp.CallToolResult, DeleteWebhookToolOutput, error) {
+	if s.webhookUseCase == nil {
+		return nil, DeleteWebhookToolOutput{}, fmt.Errorf("webhook tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return nil, DeleteWebhookToolOutput{}, fmt.Errorf("authentication required")
+	}
+	if input.WebhookID == "" {
+		return nil, DeleteWebhookToolOutput{}, fmt.Errorf("webhook_id is required")
+	}
+
+	if err := s.webhookUseCase.DeleteWebhook(ctx, input.WebhookID, s.authenticatedUserID, s.authenticatedTeams); err != nil {
+		return nil, DeleteWebhookToolOutput{}, fmt.Errorf("failed to delete webhook: %w", err)
+	}
+
+	return nil, DeleteWebhookToolOutput{
+		Message:   "Webhook deleted successfully",
+		WebhookID: input.WebhookID,
+	}, nil
+}

--- a/internal/usecases/mcp/schedule_tools.go
+++ b/internal/usecases/mcp/schedule_tools.go
@@ -1,0 +1,381 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
+)
+
+// MCPScheduleToolsUseCase provides use cases for MCP schedule tools
+type MCPScheduleToolsUseCase struct {
+	scheduleManager schedule.Manager
+}
+
+// NewMCPScheduleToolsUseCase creates a new MCPScheduleToolsUseCase
+func NewMCPScheduleToolsUseCase(mgr schedule.Manager) *MCPScheduleToolsUseCase {
+	return &MCPScheduleToolsUseCase{scheduleManager: mgr}
+}
+
+// ScheduleSessionConfigInfo represents session configuration for a schedule
+type ScheduleSessionConfigInfo struct {
+	Environment  map[string]string      `json:"environment,omitempty"`
+	Tags         map[string]string      `json:"tags,omitempty"`
+	Params       *ScheduleSessionParams `json:"params,omitempty"`
+	MemoryKey    map[string]string      `json:"memory_key,omitempty"`
+	ReuseSession bool                   `json:"reuse_session,omitempty"`
+	ReuseMessage string                 `json:"reuse_message,omitempty"`
+}
+
+// ScheduleSessionParams represents session params for a schedule
+type ScheduleSessionParams struct {
+	Message      string `json:"message,omitempty"`
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+// ScheduleExecutionInfo represents a single execution record
+type ScheduleExecutionInfo struct {
+	ExecutedAt    time.Time `json:"executed_at"`
+	SessionID     string    `json:"session_id,omitempty"`
+	Status        string    `json:"status"`
+	Error         string    `json:"error,omitempty"`
+	SessionReused bool      `json:"session_reused,omitempty"`
+}
+
+// ScheduleInfo represents schedule information returned by MCP tools
+type ScheduleInfo struct {
+	ID              string                    `json:"id"`
+	Name            string                    `json:"name"`
+	UserID          string                    `json:"user_id"`
+	Scope           string                    `json:"scope"`
+	TeamID          string                    `json:"team_id,omitempty"`
+	Status          string                    `json:"status"`
+	ScheduledAt     *time.Time                `json:"scheduled_at,omitempty"`
+	CronExpr        string                    `json:"cron_expr,omitempty"`
+	Timezone        string                    `json:"timezone,omitempty"`
+	SessionConfig   ScheduleSessionConfigInfo `json:"session_config"`
+	LastExecution   *ScheduleExecutionInfo    `json:"last_execution,omitempty"`
+	NextExecutionAt *time.Time                `json:"next_execution_at,omitempty"`
+	ExecutionCount  int                       `json:"execution_count"`
+	CreatedAt       time.Time                 `json:"created_at"`
+	UpdatedAt       time.Time                 `json:"updated_at"`
+}
+
+// ListSchedulesInput represents input for listing schedules
+type ListSchedulesInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// CreateScheduleInput represents input for creating a schedule
+type CreateScheduleInput struct {
+	Name          string                    `json:"name"`
+	Scope         string                    `json:"scope,omitempty"`
+	TeamID        string                    `json:"team_id,omitempty"`
+	ScheduledAt   *time.Time                `json:"scheduled_at,omitempty"`
+	CronExpr      string                    `json:"cron_expr,omitempty"`
+	Timezone      string                    `json:"timezone,omitempty"`
+	SessionConfig ScheduleSessionConfigInfo `json:"session_config"`
+}
+
+// UpdateScheduleInput represents input for updating a schedule
+type UpdateScheduleInput struct {
+	Name          *string                    `json:"name,omitempty"`
+	Status        *string                    `json:"status,omitempty"`
+	ScheduledAt   *time.Time                 `json:"scheduled_at,omitempty"`
+	CronExpr      *string                    `json:"cron_expr,omitempty"`
+	Timezone      *string                    `json:"timezone,omitempty"`
+	SessionConfig *ScheduleSessionConfigInfo `json:"session_config,omitempty"`
+}
+
+func toScheduleInfo(s *schedule.Schedule) ScheduleInfo {
+	info := ScheduleInfo{
+		ID:              s.ID,
+		Name:            s.Name,
+		UserID:          s.UserID,
+		Scope:           string(s.Scope),
+		TeamID:          s.TeamID,
+		Status:          string(s.Status),
+		ScheduledAt:     s.ScheduledAt,
+		CronExpr:        s.CronExpr,
+		Timezone:        s.Timezone,
+		ExecutionCount:  s.ExecutionCount,
+		NextExecutionAt: s.NextExecutionAt,
+		CreatedAt:       s.CreatedAt,
+		UpdatedAt:       s.UpdatedAt,
+		SessionConfig:   toScheduleSessionConfigInfo(s.SessionConfig),
+	}
+	if s.LastExecution != nil {
+		exec := toScheduleExecutionInfo(*s.LastExecution)
+		info.LastExecution = &exec
+	}
+	return info
+}
+
+func toScheduleSessionConfigInfo(sc schedule.SessionConfig) ScheduleSessionConfigInfo {
+	info := ScheduleSessionConfigInfo{
+		Environment:  sc.Environment,
+		Tags:         sc.Tags,
+		MemoryKey:    sc.MemoryKey,
+		ReuseSession: sc.ReuseSession,
+		ReuseMessage: sc.ReuseMessage,
+	}
+	if sc.Params != nil {
+		info.Params = &ScheduleSessionParams{
+			Message:      sc.Params.Message,
+			AgentType:    sc.Params.AgentType,
+			Oneshot:      sc.Params.Oneshot,
+			RepoFullName: sc.Params.RepoFullName,
+		}
+	}
+	return info
+}
+
+func toScheduleExecutionInfo(e schedule.ExecutionRecord) ScheduleExecutionInfo {
+	return ScheduleExecutionInfo{
+		ExecutedAt:    e.ExecutedAt,
+		SessionID:     e.SessionID,
+		Status:        e.Status,
+		Error:         e.Error,
+		SessionReused: e.SessionReused,
+	}
+}
+
+func fromScheduleSessionConfigInfo(info ScheduleSessionConfigInfo) schedule.SessionConfig {
+	sc := schedule.SessionConfig{
+		Environment:  info.Environment,
+		Tags:         info.Tags,
+		MemoryKey:    info.MemoryKey,
+		ReuseSession: info.ReuseSession,
+		ReuseMessage: info.ReuseMessage,
+	}
+	if info.Params != nil {
+		sc.Params = &entities.SessionParams{
+			Message:      info.Params.Message,
+			AgentType:    info.Params.AgentType,
+			Oneshot:      info.Params.Oneshot,
+			RepoFullName: info.Params.RepoFullName,
+		}
+	}
+	return sc
+}
+
+func canAccessSchedule(s *schedule.Schedule, requestingUserID string, teamIDs []string) bool {
+	switch s.Scope {
+	case entities.ScopeUser:
+		return s.UserID == requestingUserID
+	case entities.ScopeTeam:
+		return containsTeam(teamIDs, s.TeamID)
+	default:
+		return false
+	}
+}
+
+// ListSchedules lists schedules for the requesting user
+func (uc *MCPScheduleToolsUseCase) ListSchedules(ctx context.Context, input ListSchedulesInput, requestingUserID string, teamIDs []string) ([]ScheduleInfo, error) {
+	if uc.scheduleManager == nil {
+		return nil, fmt.Errorf("schedule manager not available")
+	}
+
+	var schedules []*schedule.Schedule
+
+	switch entities.ResourceScope(input.Scope) {
+	case entities.ScopeUser:
+		result, err := uc.scheduleManager.List(ctx, schedule.ScheduleFilter{
+			UserID: requestingUserID,
+			Scope:  entities.ScopeUser,
+			Status: schedule.ScheduleStatus(input.Status),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list schedules: %w", err)
+		}
+		schedules = result
+
+	case entities.ScopeTeam:
+		if input.TeamID == "" {
+			return nil, fmt.Errorf("team_id is required when scope is 'team'")
+		}
+		if !containsTeam(teamIDs, input.TeamID) {
+			return nil, fmt.Errorf("access denied: not a member of the specified team")
+		}
+		result, err := uc.scheduleManager.List(ctx, schedule.ScheduleFilter{
+			Scope:  entities.ScopeTeam,
+			TeamID: input.TeamID,
+			Status: schedule.ScheduleStatus(input.Status),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list schedules: %w", err)
+		}
+		schedules = result
+
+	default:
+		userResult, err := uc.scheduleManager.List(ctx, schedule.ScheduleFilter{
+			UserID: requestingUserID,
+			Scope:  entities.ScopeUser,
+			Status: schedule.ScheduleStatus(input.Status),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list user schedules: %w", err)
+		}
+		var teamResult []*schedule.Schedule
+		if len(teamIDs) > 0 {
+			teamResult, err = uc.scheduleManager.List(ctx, schedule.ScheduleFilter{
+				TeamIDs: teamIDs,
+				Scope:   entities.ScopeTeam,
+				Status:  schedule.ScheduleStatus(input.Status),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list team schedules: %w", err)
+			}
+		}
+		schedules = append(userResult, teamResult...)
+	}
+
+	result := make([]ScheduleInfo, 0, len(schedules))
+	for _, s := range schedules {
+		result = append(result, toScheduleInfo(s))
+	}
+	return result, nil
+}
+
+// GetSchedule retrieves a schedule by ID
+func (uc *MCPScheduleToolsUseCase) GetSchedule(ctx context.Context, scheduleID, requestingUserID string, teamIDs []string) (*ScheduleInfo, error) {
+	if uc.scheduleManager == nil {
+		return nil, fmt.Errorf("schedule manager not available")
+	}
+
+	s, err := uc.scheduleManager.Get(ctx, scheduleID)
+	if err != nil {
+		return nil, fmt.Errorf("schedule not found: %w", err)
+	}
+
+	if !canAccessSchedule(s, requestingUserID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	info := toScheduleInfo(s)
+	return &info, nil
+}
+
+// CreateSchedule creates a new schedule
+func (uc *MCPScheduleToolsUseCase) CreateSchedule(ctx context.Context, input CreateScheduleInput, requestingUserID string, teamIDs []string) (*ScheduleInfo, error) {
+	if uc.scheduleManager == nil {
+		return nil, fmt.Errorf("schedule manager not available")
+	}
+
+	if input.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if input.CronExpr == "" && input.ScheduledAt == nil {
+		return nil, fmt.Errorf("either cron_expr or scheduled_at is required")
+	}
+
+	scope := entities.ResourceScope(input.Scope)
+	if scope == "" {
+		scope = entities.ScopeUser
+	}
+	if scope != entities.ScopeUser && scope != entities.ScopeTeam {
+		return nil, fmt.Errorf("scope must be 'user' or 'team'")
+	}
+	if scope == entities.ScopeTeam {
+		if input.TeamID == "" {
+			return nil, fmt.Errorf("team_id is required when scope is 'team'")
+		}
+		if !containsTeam(teamIDs, input.TeamID) {
+			return nil, fmt.Errorf("access denied: not a member of the specified team")
+		}
+	}
+
+	s := &schedule.Schedule{
+		ID:            uuid.New().String(),
+		Name:          input.Name,
+		UserID:        requestingUserID,
+		Scope:         scope,
+		TeamID:        input.TeamID,
+		Status:        schedule.ScheduleStatusActive,
+		ScheduledAt:   input.ScheduledAt,
+		CronExpr:      input.CronExpr,
+		Timezone:      input.Timezone,
+		SessionConfig: fromScheduleSessionConfigInfo(input.SessionConfig),
+		UserTeams:     teamIDs,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+
+	if err := uc.scheduleManager.Create(ctx, s); err != nil {
+		return nil, fmt.Errorf("failed to create schedule: %w", err)
+	}
+
+	info := toScheduleInfo(s)
+	return &info, nil
+}
+
+// UpdateSchedule updates an existing schedule
+func (uc *MCPScheduleToolsUseCase) UpdateSchedule(ctx context.Context, scheduleID string, input UpdateScheduleInput, requestingUserID string, teamIDs []string) (*ScheduleInfo, error) {
+	if uc.scheduleManager == nil {
+		return nil, fmt.Errorf("schedule manager not available")
+	}
+
+	s, err := uc.scheduleManager.Get(ctx, scheduleID)
+	if err != nil {
+		return nil, fmt.Errorf("schedule not found: %w", err)
+	}
+
+	if !canAccessSchedule(s, requestingUserID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	if input.Name != nil {
+		if *input.Name == "" {
+			return nil, fmt.Errorf("name cannot be empty")
+		}
+		s.Name = *input.Name
+	}
+	if input.Status != nil {
+		s.Status = schedule.ScheduleStatus(*input.Status)
+	}
+	if input.ScheduledAt != nil {
+		s.ScheduledAt = input.ScheduledAt
+	}
+	if input.CronExpr != nil {
+		s.CronExpr = *input.CronExpr
+	}
+	if input.Timezone != nil {
+		s.Timezone = *input.Timezone
+	}
+	if input.SessionConfig != nil {
+		s.SessionConfig = fromScheduleSessionConfigInfo(*input.SessionConfig)
+	}
+	s.UpdatedAt = time.Now()
+
+	if err := uc.scheduleManager.Update(ctx, s); err != nil {
+		return nil, fmt.Errorf("failed to update schedule: %w", err)
+	}
+
+	info := toScheduleInfo(s)
+	return &info, nil
+}
+
+// DeleteSchedule deletes a schedule
+func (uc *MCPScheduleToolsUseCase) DeleteSchedule(ctx context.Context, scheduleID, requestingUserID string, teamIDs []string) error {
+	if uc.scheduleManager == nil {
+		return fmt.Errorf("schedule manager not available")
+	}
+
+	s, err := uc.scheduleManager.Get(ctx, scheduleID)
+	if err != nil {
+		return fmt.Errorf("schedule not found: %w", err)
+	}
+
+	if !canAccessSchedule(s, requestingUserID, teamIDs) {
+		return fmt.Errorf("access denied")
+	}
+
+	return uc.scheduleManager.Delete(ctx, scheduleID)
+}

--- a/internal/usecases/mcp/slackbot_tools.go
+++ b/internal/usecases/mcp/slackbot_tools.go
@@ -1,0 +1,409 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+// MCPSlackBotToolsUseCase provides use cases for MCP SlackBot tools
+type MCPSlackBotToolsUseCase struct {
+	slackBotRepo portrepos.SlackBotRepository
+}
+
+// NewMCPSlackBotToolsUseCase creates a new MCPSlackBotToolsUseCase
+func NewMCPSlackBotToolsUseCase(repo portrepos.SlackBotRepository) *MCPSlackBotToolsUseCase {
+	return &MCPSlackBotToolsUseCase{slackBotRepo: repo}
+}
+
+// SlackBotSessionConfigInfo represents session configuration for a SlackBot
+type SlackBotSessionConfigInfo struct {
+	Environment            map[string]string      `json:"environment,omitempty"`
+	Tags                   map[string]string      `json:"tags,omitempty"`
+	InitialMessageTemplate string                 `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                 `json:"reuse_message_template,omitempty"`
+	Params                 *SlackBotSessionParams `json:"params,omitempty"`
+	MemoryKey              map[string]string      `json:"memory_key,omitempty"`
+	ReuseSession           bool                   `json:"reuse_session,omitempty"`
+	MountPayload           bool                   `json:"mount_payload,omitempty"`
+}
+
+// SlackBotSessionParams represents session params for a SlackBot
+type SlackBotSessionParams struct {
+	Message      string `json:"message,omitempty"`
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+// SlackBotInfo represents SlackBot information returned by MCP tools
+type SlackBotInfo struct {
+	ID                     string                     `json:"id"`
+	Name                   string                     `json:"name"`
+	UserID                 string                     `json:"user_id"`
+	Scope                  string                     `json:"scope,omitempty"`
+	TeamID                 string                     `json:"team_id,omitempty"`
+	Teams                  []string                   `json:"teams,omitempty"`
+	Status                 string                     `json:"status"`
+	BotTokenSecretName     string                     `json:"bot_token_secret_name,omitempty"`
+	AllowedEventTypes      []string                   `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string                   `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                   `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SlackBotSessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions            int                        `json:"max_sessions"`
+	NotifyOnSessionCreated bool                       `json:"notify_on_session_created"`
+	AllowBotMessages       bool                       `json:"allow_bot_messages"`
+	CreatedAt              time.Time                  `json:"created_at"`
+	UpdatedAt              time.Time                  `json:"updated_at"`
+}
+
+// ListSlackBotsInput represents input for listing SlackBots
+type ListSlackBotsInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// CreateSlackBotInput represents input for creating a SlackBot
+type CreateSlackBotInput struct {
+	Name                   string                     `json:"name"`
+	Scope                  string                     `json:"scope,omitempty"`
+	TeamID                 string                     `json:"team_id,omitempty"`
+	BotTokenSecretName     string                     `json:"bot_token_secret_name,omitempty"`
+	AllowedEventTypes      []string                   `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string                   `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                   `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SlackBotSessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions            int                        `json:"max_sessions,omitempty"`
+	NotifyOnSessionCreated *bool                      `json:"notify_on_session_created,omitempty"`
+	AllowBotMessages       *bool                      `json:"allow_bot_messages,omitempty"`
+}
+
+// UpdateSlackBotInput represents input for updating a SlackBot
+type UpdateSlackBotInput struct {
+	Name                   *string                    `json:"name,omitempty"`
+	Status                 *string                    `json:"status,omitempty"`
+	BotTokenSecretName     *string                    `json:"bot_token_secret_name,omitempty"`
+	AllowedEventTypes      []string                   `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string                   `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string                   `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SlackBotSessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions            *int                       `json:"max_sessions,omitempty"`
+	NotifyOnSessionCreated *bool                      `json:"notify_on_session_created,omitempty"`
+	AllowBotMessages       *bool                      `json:"allow_bot_messages,omitempty"`
+}
+
+func toSlackBotInfo(s *entities.SlackBot) SlackBotInfo {
+	info := SlackBotInfo{
+		ID:                     s.ID(),
+		Name:                   s.Name(),
+		UserID:                 s.UserID(),
+		Scope:                  string(s.Scope()),
+		TeamID:                 s.TeamID(),
+		Teams:                  s.Teams(),
+		Status:                 string(s.Status()),
+		BotTokenSecretName:     s.BotTokenSecretName(),
+		AllowedEventTypes:      s.AllowedEventTypes(),
+		AllowedChannelNames:    s.AllowedChannelNames(),
+		AllowedUserIDs:         s.AllowedUserIDs(),
+		MaxSessions:            s.MaxSessions(),
+		NotifyOnSessionCreated: s.NotifyOnSessionCreated(),
+		AllowBotMessages:       s.AllowBotMessages(),
+		CreatedAt:              s.CreatedAt(),
+		UpdatedAt:              s.UpdatedAt(),
+	}
+
+	if sc := s.SessionConfig(); sc != nil {
+		cfg := SlackBotSessionConfigInfo{
+			Environment:            sc.Environment(),
+			Tags:                   sc.Tags(),
+			InitialMessageTemplate: sc.InitialMessageTemplate(),
+			ReuseMessageTemplate:   sc.ReuseMessageTemplate(),
+			MemoryKey:              sc.MemoryKey(),
+			ReuseSession:           sc.ReuseSession(),
+			MountPayload:           sc.MountPayload(),
+		}
+		if p := sc.Params(); p != nil {
+			cfg.Params = &SlackBotSessionParams{
+				Message:      p.Message,
+				AgentType:    p.AgentType,
+				Oneshot:      p.Oneshot,
+				RepoFullName: p.RepoFullName,
+			}
+		}
+		info.SessionConfig = &cfg
+	}
+
+	return info
+}
+
+func canAccessSlackBot(s *entities.SlackBot, requestingUserID string, teamIDs []string) bool {
+	switch s.Scope() {
+	case entities.ScopeUser:
+		return s.UserID() == requestingUserID
+	case entities.ScopeTeam:
+		return containsTeam(teamIDs, s.TeamID())
+	default:
+		return false
+	}
+}
+
+// ListSlackBots lists SlackBots for the requesting user
+func (uc *MCPSlackBotToolsUseCase) ListSlackBots(ctx context.Context, input ListSlackBotsInput, requestingUserID string, teamIDs []string) ([]SlackBotInfo, error) {
+	if uc.slackBotRepo == nil {
+		return nil, fmt.Errorf("slackbot repository not available")
+	}
+
+	var bots []*entities.SlackBot
+
+	switch entities.ResourceScope(input.Scope) {
+	case entities.ScopeUser:
+		result, err := uc.slackBotRepo.List(ctx, portrepos.SlackBotFilter{
+			UserID: requestingUserID,
+			Scope:  entities.ScopeUser,
+			Status: entities.SlackBotStatus(input.Status),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list slackbots: %w", err)
+		}
+		bots = result
+
+	case entities.ScopeTeam:
+		if input.TeamID == "" {
+			return nil, fmt.Errorf("team_id is required when scope is 'team'")
+		}
+		if !containsTeam(teamIDs, input.TeamID) {
+			return nil, fmt.Errorf("access denied: not a member of the specified team")
+		}
+		result, err := uc.slackBotRepo.List(ctx, portrepos.SlackBotFilter{
+			Scope:  entities.ScopeTeam,
+			TeamID: input.TeamID,
+			Status: entities.SlackBotStatus(input.Status),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list slackbots: %w", err)
+		}
+		bots = result
+
+	default:
+		userResult, err := uc.slackBotRepo.List(ctx, portrepos.SlackBotFilter{
+			UserID: requestingUserID,
+			Scope:  entities.ScopeUser,
+			Status: entities.SlackBotStatus(input.Status),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list user slackbots: %w", err)
+		}
+		var teamResult []*entities.SlackBot
+		if len(teamIDs) > 0 {
+			teamResult, err = uc.slackBotRepo.List(ctx, portrepos.SlackBotFilter{
+				TeamIDs: teamIDs,
+				Scope:   entities.ScopeTeam,
+				Status:  entities.SlackBotStatus(input.Status),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list team slackbots: %w", err)
+			}
+		}
+		bots = append(userResult, teamResult...)
+	}
+
+	result := make([]SlackBotInfo, 0, len(bots))
+	for _, b := range bots {
+		result = append(result, toSlackBotInfo(b))
+	}
+	return result, nil
+}
+
+// GetSlackBot retrieves a SlackBot by ID
+func (uc *MCPSlackBotToolsUseCase) GetSlackBot(ctx context.Context, slackBotID, requestingUserID string, teamIDs []string) (*SlackBotInfo, error) {
+	if uc.slackBotRepo == nil {
+		return nil, fmt.Errorf("slackbot repository not available")
+	}
+
+	b, err := uc.slackBotRepo.Get(ctx, slackBotID)
+	if err != nil {
+		return nil, fmt.Errorf("slackbot not found: %w", err)
+	}
+
+	if !canAccessSlackBot(b, requestingUserID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	info := toSlackBotInfo(b)
+	return &info, nil
+}
+
+// CreateSlackBot creates a new SlackBot
+func (uc *MCPSlackBotToolsUseCase) CreateSlackBot(ctx context.Context, input CreateSlackBotInput, requestingUserID string, teamIDs []string) (*SlackBotInfo, error) {
+	if uc.slackBotRepo == nil {
+		return nil, fmt.Errorf("slackbot repository not available")
+	}
+
+	if input.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	scope := entities.ResourceScope(input.Scope)
+	if scope == "" {
+		scope = entities.ScopeUser
+	}
+	if scope != entities.ScopeUser && scope != entities.ScopeTeam {
+		return nil, fmt.Errorf("scope must be 'user' or 'team'")
+	}
+	if scope == entities.ScopeTeam {
+		if input.TeamID == "" {
+			return nil, fmt.Errorf("team_id is required when scope is 'team'")
+		}
+		if !containsTeam(teamIDs, input.TeamID) {
+			return nil, fmt.Errorf("access denied: not a member of the specified team")
+		}
+	}
+
+	b := entities.NewSlackBot(uuid.New().String(), input.Name, requestingUserID)
+	b.SetScope(scope)
+	b.SetTeamID(input.TeamID)
+	b.SetTeams(teamIDs)
+	if input.BotTokenSecretName != "" {
+		b.SetBotTokenSecretName(input.BotTokenSecretName)
+	}
+	if len(input.AllowedEventTypes) > 0 {
+		b.SetAllowedEventTypes(input.AllowedEventTypes)
+	}
+	if len(input.AllowedChannelNames) > 0 {
+		b.SetAllowedChannelNames(input.AllowedChannelNames)
+	}
+	if len(input.AllowedUserIDs) > 0 {
+		b.SetAllowedUserIDs(input.AllowedUserIDs)
+	}
+	if input.MaxSessions > 0 {
+		b.SetMaxSessions(input.MaxSessions)
+	}
+	b.SetNotifyOnSessionCreated(input.NotifyOnSessionCreated)
+	b.SetAllowBotMessages(input.AllowBotMessages)
+	b.SetCreatedAt(time.Now())
+	b.SetUpdatedAt(time.Now())
+
+	if input.SessionConfig != nil {
+		sc := entities.NewWebhookSessionConfig()
+		sc.SetEnvironment(input.SessionConfig.Environment)
+		sc.SetTags(input.SessionConfig.Tags)
+		sc.SetInitialMessageTemplate(input.SessionConfig.InitialMessageTemplate)
+		sc.SetReuseMessageTemplate(input.SessionConfig.ReuseMessageTemplate)
+		sc.SetMemoryKey(input.SessionConfig.MemoryKey)
+		sc.SetReuseSession(input.SessionConfig.ReuseSession)
+		sc.SetMountPayload(input.SessionConfig.MountPayload)
+		if input.SessionConfig.Params != nil {
+			sc.SetParams(&entities.SessionParams{
+				Message:      input.SessionConfig.Params.Message,
+				AgentType:    input.SessionConfig.Params.AgentType,
+				Oneshot:      input.SessionConfig.Params.Oneshot,
+				RepoFullName: input.SessionConfig.Params.RepoFullName,
+			})
+		}
+		b.SetSessionConfig(sc)
+	}
+
+	if err := uc.slackBotRepo.Create(ctx, b); err != nil {
+		return nil, fmt.Errorf("failed to create slackbot: %w", err)
+	}
+
+	info := toSlackBotInfo(b)
+	return &info, nil
+}
+
+// UpdateSlackBot updates an existing SlackBot
+func (uc *MCPSlackBotToolsUseCase) UpdateSlackBot(ctx context.Context, slackBotID string, input UpdateSlackBotInput, requestingUserID string, teamIDs []string) (*SlackBotInfo, error) {
+	if uc.slackBotRepo == nil {
+		return nil, fmt.Errorf("slackbot repository not available")
+	}
+
+	b, err := uc.slackBotRepo.Get(ctx, slackBotID)
+	if err != nil {
+		return nil, fmt.Errorf("slackbot not found: %w", err)
+	}
+
+	if !canAccessSlackBot(b, requestingUserID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	if input.Name != nil {
+		if *input.Name == "" {
+			return nil, fmt.Errorf("name cannot be empty")
+		}
+		b.SetName(*input.Name)
+	}
+	if input.Status != nil {
+		b.SetStatus(entities.SlackBotStatus(*input.Status))
+	}
+	if input.BotTokenSecretName != nil {
+		b.SetBotTokenSecretName(*input.BotTokenSecretName)
+	}
+	if input.AllowedEventTypes != nil {
+		b.SetAllowedEventTypes(input.AllowedEventTypes)
+	}
+	if input.AllowedChannelNames != nil {
+		b.SetAllowedChannelNames(input.AllowedChannelNames)
+	}
+	if input.AllowedUserIDs != nil {
+		b.SetAllowedUserIDs(input.AllowedUserIDs)
+	}
+	if input.MaxSessions != nil {
+		b.SetMaxSessions(*input.MaxSessions)
+	}
+	if input.NotifyOnSessionCreated != nil {
+		b.SetNotifyOnSessionCreated(input.NotifyOnSessionCreated)
+	}
+	if input.AllowBotMessages != nil {
+		b.SetAllowBotMessages(input.AllowBotMessages)
+	}
+	if input.SessionConfig != nil {
+		sc := entities.NewWebhookSessionConfig()
+		sc.SetEnvironment(input.SessionConfig.Environment)
+		sc.SetTags(input.SessionConfig.Tags)
+		sc.SetInitialMessageTemplate(input.SessionConfig.InitialMessageTemplate)
+		sc.SetReuseMessageTemplate(input.SessionConfig.ReuseMessageTemplate)
+		sc.SetMemoryKey(input.SessionConfig.MemoryKey)
+		sc.SetReuseSession(input.SessionConfig.ReuseSession)
+		sc.SetMountPayload(input.SessionConfig.MountPayload)
+		if input.SessionConfig.Params != nil {
+			sc.SetParams(&entities.SessionParams{
+				Message:      input.SessionConfig.Params.Message,
+				AgentType:    input.SessionConfig.Params.AgentType,
+				Oneshot:      input.SessionConfig.Params.Oneshot,
+				RepoFullName: input.SessionConfig.Params.RepoFullName,
+			})
+		}
+		b.SetSessionConfig(sc)
+	}
+	b.SetUpdatedAt(time.Now())
+
+	if err := uc.slackBotRepo.Update(ctx, b); err != nil {
+		return nil, fmt.Errorf("failed to update slackbot: %w", err)
+	}
+
+	info := toSlackBotInfo(b)
+	return &info, nil
+}
+
+// DeleteSlackBot deletes a SlackBot
+func (uc *MCPSlackBotToolsUseCase) DeleteSlackBot(ctx context.Context, slackBotID, requestingUserID string, teamIDs []string) error {
+	if uc.slackBotRepo == nil {
+		return fmt.Errorf("slackbot repository not available")
+	}
+
+	b, err := uc.slackBotRepo.Get(ctx, slackBotID)
+	if err != nil {
+		return fmt.Errorf("slackbot not found: %w", err)
+	}
+
+	if !canAccessSlackBot(b, requestingUserID, teamIDs) {
+		return fmt.Errorf("access denied")
+	}
+
+	return uc.slackBotRepo.Delete(ctx, slackBotID)
+}

--- a/internal/usecases/mcp/webhook_tools.go
+++ b/internal/usecases/mcp/webhook_tools.go
@@ -1,0 +1,556 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+// MCPWebhookToolsUseCase provides use cases for MCP webhook tools
+type MCPWebhookToolsUseCase struct {
+	webhookRepo portrepos.WebhookRepository
+}
+
+// NewMCPWebhookToolsUseCase creates a new MCPWebhookToolsUseCase
+func NewMCPWebhookToolsUseCase(repo portrepos.WebhookRepository) *MCPWebhookToolsUseCase {
+	return &MCPWebhookToolsUseCase{webhookRepo: repo}
+}
+
+// WebhookSessionConfigInfo represents session configuration for a webhook
+type WebhookSessionConfigInfo struct {
+	Environment            map[string]string     `json:"environment,omitempty"`
+	Tags                   map[string]string     `json:"tags,omitempty"`
+	InitialMessageTemplate string                `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                `json:"reuse_message_template,omitempty"`
+	Params                 *WebhookSessionParams `json:"params,omitempty"`
+	ReuseSession           bool                  `json:"reuse_session,omitempty"`
+	MountPayload           bool                  `json:"mount_payload,omitempty"`
+	MemoryKey              map[string]string     `json:"memory_key,omitempty"`
+}
+
+// WebhookSessionParams represents session params for a webhook
+type WebhookSessionParams struct {
+	Message      string `json:"message,omitempty"`
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+// WebhookGitHubConfigInfo represents GitHub-specific webhook configuration
+type WebhookGitHubConfigInfo struct {
+	EnterpriseURL       string   `json:"enterprise_url,omitempty"`
+	AllowedEvents       []string `json:"allowed_events,omitempty"`
+	AllowedRepositories []string `json:"allowed_repositories,omitempty"`
+}
+
+// WebhookGitHubConditionsInfo represents GitHub trigger conditions
+type WebhookGitHubConditionsInfo struct {
+	Events       []string `json:"events,omitempty"`
+	Actions      []string `json:"actions,omitempty"`
+	Branches     []string `json:"branches,omitempty"`
+	Repositories []string `json:"repositories,omitempty"`
+	Labels       []string `json:"labels,omitempty"`
+	Paths        []string `json:"paths,omitempty"`
+	BaseBranches []string `json:"base_branches,omitempty"`
+	Draft        *bool    `json:"draft,omitempty"`
+	Sender       []string `json:"sender,omitempty"`
+}
+
+// WebhookTriggerConditionsInfo represents trigger conditions
+type WebhookTriggerConditionsInfo struct {
+	GitHub     *WebhookGitHubConditionsInfo `json:"github,omitempty"`
+	GoTemplate string                       `json:"go_template,omitempty"`
+}
+
+// WebhookTriggerInfo represents a webhook trigger
+type WebhookTriggerInfo struct {
+	ID            string                       `json:"id"`
+	Name          string                       `json:"name"`
+	Priority      int                          `json:"priority"`
+	Enabled       bool                         `json:"enabled"`
+	Conditions    WebhookTriggerConditionsInfo `json:"conditions"`
+	SessionConfig *WebhookSessionConfigInfo    `json:"session_config,omitempty"`
+	StopOnMatch   bool                         `json:"stop_on_match"`
+}
+
+// WebhookDeliveryInfo represents a delivery record
+type WebhookDeliveryInfo struct {
+	ID             string    `json:"id"`
+	ReceivedAt     time.Time `json:"received_at"`
+	Status         string    `json:"status"`
+	MatchedTrigger string    `json:"matched_trigger,omitempty"`
+	SessionID      string    `json:"session_id,omitempty"`
+	ErrorMessage   string    `json:"error_message,omitempty"`
+	SessionReused  bool      `json:"session_reused,omitempty"`
+}
+
+// WebhookInfo represents webhook information returned by MCP tools
+type WebhookInfo struct {
+	ID              string                    `json:"id"`
+	Name            string                    `json:"name"`
+	UserID          string                    `json:"user_id"`
+	Scope           string                    `json:"scope,omitempty"`
+	TeamID          string                    `json:"team_id,omitempty"`
+	Status          string                    `json:"status"`
+	Type            string                    `json:"type"`
+	SignatureHeader string                    `json:"signature_header,omitempty"`
+	SignatureType   string                    `json:"signature_type,omitempty"`
+	GitHub          *WebhookGitHubConfigInfo  `json:"github,omitempty"`
+	Triggers        []WebhookTriggerInfo      `json:"triggers"`
+	SessionConfig   *WebhookSessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions     int                       `json:"max_sessions"`
+	DeliveryCount   int64                     `json:"delivery_count"`
+	LastDelivery    *WebhookDeliveryInfo      `json:"last_delivery,omitempty"`
+	CreatedAt       time.Time                 `json:"created_at"`
+	UpdatedAt       time.Time                 `json:"updated_at"`
+}
+
+// ListWebhooksInput represents input for listing webhooks
+type ListWebhooksInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+// CreateWebhookInput represents input for creating a webhook
+type CreateWebhookInput struct {
+	Name            string                    `json:"name"`
+	Scope           string                    `json:"scope,omitempty"`
+	TeamID          string                    `json:"team_id,omitempty"`
+	Type            string                    `json:"type"`
+	Secret          string                    `json:"secret,omitempty"`
+	SignatureHeader string                    `json:"signature_header,omitempty"`
+	SignatureType   string                    `json:"signature_type,omitempty"`
+	GitHub          *WebhookGitHubConfigInfo  `json:"github,omitempty"`
+	Triggers        []WebhookTriggerInfo      `json:"triggers"`
+	SessionConfig   *WebhookSessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions     int                       `json:"max_sessions,omitempty"`
+}
+
+// UpdateWebhookInput represents input for updating a webhook
+type UpdateWebhookInput struct {
+	Name          *string                   `json:"name,omitempty"`
+	Status        *string                   `json:"status,omitempty"`
+	Secret        *string                   `json:"secret,omitempty"`
+	GitHub        *WebhookGitHubConfigInfo  `json:"github,omitempty"`
+	Triggers      []WebhookTriggerInfo      `json:"triggers,omitempty"`
+	SessionConfig *WebhookSessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions   *int                      `json:"max_sessions,omitempty"`
+}
+
+func toWebhookInfo(w *entities.Webhook) WebhookInfo {
+	info := WebhookInfo{
+		ID:              w.ID(),
+		Name:            w.Name(),
+		UserID:          w.UserID(),
+		Scope:           string(w.Scope()),
+		TeamID:          w.TeamID(),
+		Status:          string(w.Status()),
+		Type:            string(w.WebhookType()),
+		SignatureHeader: w.SignatureHeader(),
+		SignatureType:   string(w.SignatureType()),
+		MaxSessions:     w.MaxSessions(),
+		DeliveryCount:   w.DeliveryCount(),
+		CreatedAt:       w.CreatedAt(),
+		UpdatedAt:       w.UpdatedAt(),
+	}
+
+	if gh := w.GitHub(); gh != nil {
+		info.GitHub = &WebhookGitHubConfigInfo{
+			EnterpriseURL:       gh.EnterpriseURL(),
+			AllowedEvents:       gh.AllowedEvents(),
+			AllowedRepositories: gh.AllowedRepositories(),
+		}
+	}
+
+	for _, t := range w.Triggers() {
+		info.Triggers = append(info.Triggers, toWebhookTriggerInfo(t))
+	}
+	if info.Triggers == nil {
+		info.Triggers = []WebhookTriggerInfo{}
+	}
+
+	if sc := w.SessionConfig(); sc != nil {
+		cfg := toWebhookSessionConfigInfo(sc)
+		info.SessionConfig = &cfg
+	}
+
+	if d := w.LastDelivery(); d != nil {
+		delivery := WebhookDeliveryInfo{
+			ID:             d.ID(),
+			ReceivedAt:     d.ReceivedAt(),
+			Status:         string(d.Status()),
+			MatchedTrigger: d.MatchedTrigger(),
+			SessionID:      d.SessionID(),
+			ErrorMessage:   d.Error(),
+			SessionReused:  d.SessionReused(),
+		}
+		info.LastDelivery = &delivery
+	}
+
+	return info
+}
+
+func toWebhookTriggerInfo(t entities.WebhookTrigger) WebhookTriggerInfo {
+	info := WebhookTriggerInfo{
+		ID:          t.ID(),
+		Name:        t.Name(),
+		Priority:    t.Priority(),
+		Enabled:     t.Enabled(),
+		StopOnMatch: t.StopOnMatch(),
+		Conditions:  WebhookTriggerConditionsInfo{GoTemplate: t.Conditions().GoTemplate()},
+	}
+
+	if gh := t.Conditions().GitHub(); gh != nil {
+		info.Conditions.GitHub = &WebhookGitHubConditionsInfo{
+			Events:       gh.Events(),
+			Actions:      gh.Actions(),
+			Branches:     gh.Branches(),
+			Repositories: gh.Repositories(),
+			Labels:       gh.Labels(),
+			Paths:        gh.Paths(),
+			BaseBranches: gh.BaseBranches(),
+			Draft:        gh.Draft(),
+			Sender:       gh.Sender(),
+		}
+	}
+
+	if sc := t.SessionConfig(); sc != nil {
+		cfg := toWebhookSessionConfigInfo(sc)
+		info.SessionConfig = &cfg
+	}
+
+	return info
+}
+
+func toWebhookSessionConfigInfo(sc *entities.WebhookSessionConfig) WebhookSessionConfigInfo {
+	info := WebhookSessionConfigInfo{
+		Environment:            sc.Environment(),
+		Tags:                   sc.Tags(),
+		InitialMessageTemplate: sc.InitialMessageTemplate(),
+		ReuseMessageTemplate:   sc.ReuseMessageTemplate(),
+		ReuseSession:           sc.ReuseSession(),
+		MountPayload:           sc.MountPayload(),
+		MemoryKey:              sc.MemoryKey(),
+	}
+	if p := sc.Params(); p != nil {
+		info.Params = &WebhookSessionParams{
+			Message:      p.Message,
+			AgentType:    p.AgentType,
+			Oneshot:      p.Oneshot,
+			RepoFullName: p.RepoFullName,
+		}
+	}
+	return info
+}
+
+func fromWebhookSessionConfigInfo(info *WebhookSessionConfigInfo) *entities.WebhookSessionConfig {
+	if info == nil {
+		return nil
+	}
+	sc := entities.NewWebhookSessionConfig()
+	sc.SetEnvironment(info.Environment)
+	sc.SetTags(info.Tags)
+	sc.SetInitialMessageTemplate(info.InitialMessageTemplate)
+	sc.SetReuseMessageTemplate(info.ReuseMessageTemplate)
+	sc.SetReuseSession(info.ReuseSession)
+	sc.SetMountPayload(info.MountPayload)
+	sc.SetMemoryKey(info.MemoryKey)
+	if info.Params != nil {
+		sc.SetParams(&entities.SessionParams{
+			Message:      info.Params.Message,
+			AgentType:    info.Params.AgentType,
+			Oneshot:      info.Params.Oneshot,
+			RepoFullName: info.Params.RepoFullName,
+		})
+	}
+	return sc
+}
+
+func fromWebhookTriggerInfo(t WebhookTriggerInfo) entities.WebhookTrigger {
+	id := t.ID
+	if id == "" {
+		id = uuid.New().String()
+	}
+
+	trigger := entities.NewWebhookTrigger(id, t.Name)
+	trigger.SetPriority(t.Priority)
+	trigger.SetEnabled(t.Enabled)
+	trigger.SetStopOnMatch(t.StopOnMatch)
+
+	var conditions entities.WebhookTriggerConditions
+	conditions.SetGoTemplate(t.Conditions.GoTemplate)
+	if t.Conditions.GitHub != nil {
+		gh := entities.NewWebhookGitHubConditions()
+		gh.SetEvents(t.Conditions.GitHub.Events)
+		gh.SetActions(t.Conditions.GitHub.Actions)
+		gh.SetBranches(t.Conditions.GitHub.Branches)
+		gh.SetRepositories(t.Conditions.GitHub.Repositories)
+		gh.SetLabels(t.Conditions.GitHub.Labels)
+		gh.SetPaths(t.Conditions.GitHub.Paths)
+		gh.SetBaseBranches(t.Conditions.GitHub.BaseBranches)
+		gh.SetDraft(t.Conditions.GitHub.Draft)
+		gh.SetSender(t.Conditions.GitHub.Sender)
+		conditions.SetGitHub(gh)
+	}
+	trigger.SetConditions(conditions)
+
+	if t.SessionConfig != nil {
+		trigger.SetSessionConfig(fromWebhookSessionConfigInfo(t.SessionConfig))
+	}
+	return trigger
+}
+
+func canAccessWebhook(w *entities.Webhook, requestingUserID string, teamIDs []string) bool {
+	switch w.Scope() {
+	case entities.ScopeUser:
+		return w.UserID() == requestingUserID
+	case entities.ScopeTeam:
+		return containsTeam(teamIDs, w.TeamID())
+	default:
+		return false
+	}
+}
+
+// ListWebhooks lists webhooks for the requesting user
+func (uc *MCPWebhookToolsUseCase) ListWebhooks(ctx context.Context, input ListWebhooksInput, requestingUserID string, teamIDs []string) ([]WebhookInfo, error) {
+	if uc.webhookRepo == nil {
+		return nil, fmt.Errorf("webhook repository not available")
+	}
+
+	var webhooks []*entities.Webhook
+
+	switch entities.ResourceScope(input.Scope) {
+	case entities.ScopeUser:
+		result, err := uc.webhookRepo.List(ctx, portrepos.WebhookFilter{
+			UserID: requestingUserID,
+			Scope:  entities.ScopeUser,
+			Status: entities.WebhookStatus(input.Status),
+			Type:   entities.WebhookType(input.Type),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list webhooks: %w", err)
+		}
+		webhooks = result
+
+	case entities.ScopeTeam:
+		if input.TeamID == "" {
+			return nil, fmt.Errorf("team_id is required when scope is 'team'")
+		}
+		if !containsTeam(teamIDs, input.TeamID) {
+			return nil, fmt.Errorf("access denied: not a member of the specified team")
+		}
+		result, err := uc.webhookRepo.List(ctx, portrepos.WebhookFilter{
+			Scope:  entities.ScopeTeam,
+			TeamID: input.TeamID,
+			Status: entities.WebhookStatus(input.Status),
+			Type:   entities.WebhookType(input.Type),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list webhooks: %w", err)
+		}
+		webhooks = result
+
+	default:
+		userResult, err := uc.webhookRepo.List(ctx, portrepos.WebhookFilter{
+			UserID: requestingUserID,
+			Scope:  entities.ScopeUser,
+			Status: entities.WebhookStatus(input.Status),
+			Type:   entities.WebhookType(input.Type),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list user webhooks: %w", err)
+		}
+		var teamResult []*entities.Webhook
+		if len(teamIDs) > 0 {
+			teamResult, err = uc.webhookRepo.List(ctx, portrepos.WebhookFilter{
+				TeamIDs: teamIDs,
+				Scope:   entities.ScopeTeam,
+				Status:  entities.WebhookStatus(input.Status),
+				Type:    entities.WebhookType(input.Type),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to list team webhooks: %w", err)
+			}
+		}
+		webhooks = append(userResult, teamResult...)
+	}
+
+	result := make([]WebhookInfo, 0, len(webhooks))
+	for _, w := range webhooks {
+		result = append(result, toWebhookInfo(w))
+	}
+	return result, nil
+}
+
+// GetWebhook retrieves a webhook by ID
+func (uc *MCPWebhookToolsUseCase) GetWebhook(ctx context.Context, webhookID, requestingUserID string, teamIDs []string) (*WebhookInfo, error) {
+	if uc.webhookRepo == nil {
+		return nil, fmt.Errorf("webhook repository not available")
+	}
+
+	w, err := uc.webhookRepo.Get(ctx, webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("webhook not found: %w", err)
+	}
+
+	if !canAccessWebhook(w, requestingUserID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	info := toWebhookInfo(w)
+	return &info, nil
+}
+
+// CreateWebhook creates a new webhook
+func (uc *MCPWebhookToolsUseCase) CreateWebhook(ctx context.Context, input CreateWebhookInput, requestingUserID string, teamIDs []string) (*WebhookInfo, error) {
+	if uc.webhookRepo == nil {
+		return nil, fmt.Errorf("webhook repository not available")
+	}
+
+	if input.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if input.Type != string(entities.WebhookTypeGitHub) && input.Type != string(entities.WebhookTypeCustom) {
+		return nil, fmt.Errorf("type must be 'github' or 'custom'")
+	}
+	if len(input.Triggers) == 0 {
+		return nil, fmt.Errorf("at least one trigger is required")
+	}
+
+	scope := entities.ResourceScope(input.Scope)
+	if scope == "" {
+		scope = entities.ScopeUser
+	}
+	if scope == entities.ScopeTeam {
+		if input.TeamID == "" {
+			return nil, fmt.Errorf("team_id is required when scope is 'team'")
+		}
+		if !containsTeam(teamIDs, input.TeamID) {
+			return nil, fmt.Errorf("access denied: not a member of the specified team")
+		}
+	}
+
+	w := entities.NewWebhook(uuid.New().String(), input.Name, requestingUserID, entities.WebhookType(input.Type))
+	w.SetScope(scope)
+	w.SetTeamID(input.TeamID)
+	if input.Secret != "" {
+		w.SetSecret(input.Secret)
+	}
+	if input.SignatureHeader != "" {
+		w.SetSignatureHeader(input.SignatureHeader)
+	}
+	if input.SignatureType != "" {
+		w.SetSignatureType(entities.WebhookSignatureType(input.SignatureType))
+	}
+	if input.MaxSessions > 0 {
+		w.SetMaxSessions(input.MaxSessions)
+	}
+	if scope != entities.ScopeTeam {
+		w.SetUserTeams(teamIDs)
+	}
+	if input.GitHub != nil {
+		gh := entities.NewWebhookGitHubConfig()
+		gh.SetEnterpriseURL(input.GitHub.EnterpriseURL)
+		gh.SetAllowedEvents(input.GitHub.AllowedEvents)
+		gh.SetAllowedRepositories(input.GitHub.AllowedRepositories)
+		w.SetGitHub(gh)
+	}
+
+	triggers := make([]entities.WebhookTrigger, 0, len(input.Triggers))
+	for _, t := range input.Triggers {
+		triggers = append(triggers, fromWebhookTriggerInfo(t))
+	}
+	w.SetTriggers(triggers)
+
+	if input.SessionConfig != nil {
+		w.SetSessionConfig(fromWebhookSessionConfigInfo(input.SessionConfig))
+	}
+
+	if err := uc.webhookRepo.Create(ctx, w); err != nil {
+		return nil, fmt.Errorf("failed to create webhook: %w", err)
+	}
+
+	info := toWebhookInfo(w)
+	return &info, nil
+}
+
+// UpdateWebhook updates an existing webhook
+func (uc *MCPWebhookToolsUseCase) UpdateWebhook(ctx context.Context, webhookID string, input UpdateWebhookInput, requestingUserID string, teamIDs []string) (*WebhookInfo, error) {
+	if uc.webhookRepo == nil {
+		return nil, fmt.Errorf("webhook repository not available")
+	}
+
+	w, err := uc.webhookRepo.Get(ctx, webhookID)
+	if err != nil {
+		return nil, fmt.Errorf("webhook not found: %w", err)
+	}
+
+	if !canAccessWebhook(w, requestingUserID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	if input.Name != nil {
+		if *input.Name == "" {
+			return nil, fmt.Errorf("name cannot be empty")
+		}
+		w.SetName(*input.Name)
+	}
+	if input.Status != nil {
+		w.SetStatus(entities.WebhookStatus(*input.Status))
+	}
+	if input.Secret != nil {
+		w.SetSecret(*input.Secret)
+	}
+	if input.GitHub != nil {
+		gh := entities.NewWebhookGitHubConfig()
+		gh.SetEnterpriseURL(input.GitHub.EnterpriseURL)
+		gh.SetAllowedEvents(input.GitHub.AllowedEvents)
+		gh.SetAllowedRepositories(input.GitHub.AllowedRepositories)
+		w.SetGitHub(gh)
+	}
+	if input.Triggers != nil {
+		triggers := make([]entities.WebhookTrigger, 0, len(input.Triggers))
+		for _, t := range input.Triggers {
+			triggers = append(triggers, fromWebhookTriggerInfo(t))
+		}
+		w.SetTriggers(triggers)
+	}
+	if input.SessionConfig != nil {
+		w.SetSessionConfig(fromWebhookSessionConfigInfo(input.SessionConfig))
+	}
+	if input.MaxSessions != nil {
+		w.SetMaxSessions(*input.MaxSessions)
+	}
+	w.SetUpdatedAt(time.Now())
+
+	if err := uc.webhookRepo.Update(ctx, w); err != nil {
+		return nil, fmt.Errorf("failed to update webhook: %w", err)
+	}
+
+	info := toWebhookInfo(w)
+	return &info, nil
+}
+
+// DeleteWebhook deletes a webhook
+func (uc *MCPWebhookToolsUseCase) DeleteWebhook(ctx context.Context, webhookID, requestingUserID string, teamIDs []string) error {
+	if uc.webhookRepo == nil {
+		return fmt.Errorf("webhook repository not available")
+	}
+
+	w, err := uc.webhookRepo.Get(ctx, webhookID)
+	if err != nil {
+		return fmt.Errorf("webhook not found: %w", err)
+	}
+
+	if !canAccessWebhook(w, requestingUserID, teamIDs) {
+		return fmt.Errorf("access denied")
+	}
+
+	return uc.webhookRepo.Delete(ctx, webhookID)
+}


### PR DESCRIPTION
## Summary

- Adds 15 new MCP tools (5 CRUD each) for Schedule, Webhook, and SlackBot
- MCP の `/mcp` エンドポイントから schedule/webhook/slackbot の管理が可能になります
- `pkg/schedule` → `internal/app` の既存インポートサイクルを回避するため、`schedule.Manager` は `app.Server` には保持せず `cmd/server.go` で直接スレッドします

## New MCP Tools

| Category | Tools |
|---|---|
| **Schedule (5)** | `list_schedules`, `get_schedule`, `create_schedule`, `update_schedule`, `delete_schedule` |
| **Webhook (5)** | `list_webhooks`, `get_webhook`, `create_webhook`, `update_webhook`, `delete_webhook` |
| **SlackBot (5)** | `list_slackbots`, `get_slackbot`, `create_slackbot`, `update_slackbot`, `delete_slackbot` |

## Architecture

既存の memory/task ツールと同じ4層パターンに準拠:
- `internal/usecases/mcp/{schedule,webhook,slackbot}_tools.go` — ビジネスロジック・アクセス制御
- `internal/interfaces/mcp/{schedule,webhook,slackbot}_tools.go` — MCP ハンドラ・型定義
- `app.Server` に `webhookRepo`/`slackBotRepo` フィールド追加
- `schedule.Manager` は `registerScheduleHandlers` から返値として受け渡し

## Test plan

- [x] `make build` passes
- [x] `CGO_ENABLED=0 go test ./...` passes
- [x] `make lint` passes

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)