### PR TITLE
feat: git sync automatically uses Helm-configured GitHub App and Enterprise settings

### DIFF
--- a/pkg/github_sync/github_client.go
+++ b/pkg/github_sync/github_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/google/go-github/v57/github"
@@ -19,6 +20,9 @@ type GitHubSyncClient struct {
 
 // NewGitHubSyncClient creates a client authenticated with the given PAT.
 // repoFullName must be "owner/repo".
+// When the GITHUB_API environment variable is set, an Enterprise client is created
+// using that URL so that operators who configure GitHub Enterprise in Helm do not
+// need separate git-sync settings.
 func NewGitHubSyncClient(ctx context.Context, token, repoFullName string) (*GitHubSyncClient, error) {
 	parts := strings.SplitN(repoFullName, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -27,8 +31,23 @@ func NewGitHubSyncClient(ctx context.Context, token, repoFullName string) (*GitH
 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(ctx, ts)
+
+	var ghClient *github.Client
+	if enterpriseURL := os.Getenv("GITHUB_API"); enterpriseURL != "" {
+		if !strings.HasSuffix(enterpriseURL, "/") {
+			enterpriseURL += "/"
+		}
+		var err error
+		ghClient, err = github.NewClient(tc).WithEnterpriseURLs(enterpriseURL, enterpriseURL)
+		if err != nil {
+			return nil, fmt.Errorf("create enterprise GitHub client for %s: %w", enterpriseURL, err)
+		}
+	} else {
+		ghClient = github.NewClient(tc)
+	}
+
 	return &GitHubSyncClient{
-		client: github.NewClient(tc),
+		client: ghClient,
 		owner:  parts[0],
 		repo:   parts[1],
 	}, nil

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -74,24 +74,33 @@ func isPersonalSync(settingsName, userID string) bool {
 // resolveToken returns the GitHub token to use for sync operations.
 // If personalToken is non-empty it is returned directly.
 // Otherwise a short-lived GitHub App installation token is generated using
-// GITHUB_APP_ID / GITHUB_APP_PEM env vars and the proxy-configured installation ID.
+// GITHUB_APP_ID / GITHUB_APP_PEM env vars and the installation ID resolved as follows:
+//  1. The proxy-level git_sync.github_app.installation_id config value
+//  2. The GITHUB_INSTALLATION_ID environment variable (set by Helm from github.app.installationId)
 func (s *Syncer) resolveToken(personalToken string) (string, error) {
 	if personalToken != "" {
 		return personalToken, nil
 	}
-	if s.githubAppInstallID == "" {
-		return "", fmt.Errorf("github_token is not configured and no GitHub App fallback is set (git_sync.github_app.installation_id)")
+
+	// Resolve installation ID: explicit config → GITHUB_INSTALLATION_ID env var (Helm-injected)
+	installID := s.githubAppInstallID
+	if installID == "" {
+		installID = os.Getenv("GITHUB_INSTALLATION_ID")
 	}
+	if installID == "" {
+		return "", fmt.Errorf("github_token is not configured and no GitHub App fallback is set (git_sync.github_app.installation_id or GITHUB_INSTALLATION_ID)")
+	}
+
 	appID := os.Getenv("GITHUB_APP_ID")
 	if appID == "" {
 		return "", fmt.Errorf("github_token is not configured and GITHUB_APP_ID env var is not set")
 	}
 	pemPath := os.Getenv("GITHUB_APP_PEM_PATH")
-	token, err := startup.GenerateGitHubAppToken(appID, s.githubAppInstallID, pemPath)
+	token, err := startup.GenerateGitHubAppToken(appID, installID, pemPath)
 	if err != nil {
 		return "", fmt.Errorf("github_token is not configured; GitHub App token generation failed: %w", err)
 	}
-	log.Printf("[SYNC] Using GitHub App installation token (installation_id=%s)", s.githubAppInstallID)
+	log.Printf("[SYNC] Using GitHub App installation token (installation_id=%s)", installID)
 	return token, nil
 }
 


### PR DESCRIPTION
## Summary

- `GITHUB_INSTALLATION_ID` 環境変数（Helm の `github.app.installationId` から注入）を `git_sync.github_app.installation_id` のフォールバックとして使用するようにした
- `GITHUB_API` 環境変数（Helm の `github.enterprise.apiUrl` から注入）が設定されている場合、git sync が自動的に GitHub Enterprise クライアントを使用するようにした

これにより、Helm で GitHub App や Enterprise を設定済みの環境では、git sync 用に同じ設定を二重に書く必要がなくなる。

## 変更詳細

**`pkg/github_sync/syncer.go`**
- `resolveToken` で、`githubAppInstallID` が空の場合に `GITHUB_INSTALLATION_ID` 環境変数にフォールバック

**`pkg/github_sync/github_client.go`**
- `NewGitHubSyncClient` で `GITHUB_API` 環境変数が設定されている場合は `WithEnterpriseURLs` を使って Enterprise クライアントを生成

## Test plan

- [ ] lint (`make lint`) 通過確認 ✅
- [ ] ビルド (`go build ./...`) 通過確認 ✅
- [ ] Helm で `github.app.installationId` 設定済みの環境で `AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID` を未設定のまま git sync が動作することを確認
- [ ] `github.enterprise.apiUrl` 設定済みの環境で git sync が Enterprise エンドポイントを使用することを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)