### PR TITLE
fix: handle %2F encoded slashes in settings name path parameter

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
 	"github.com/takutakahashi/agentapi-proxy/pkg/notification"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
+	"github.com/takutakahashi/agentapi-proxy/pkg/urlutil"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -67,6 +68,21 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 
 	// Disable Echo's default logger and use custom logging
 	e.Logger.SetOutput(io.Discard)
+
+	// Rewrite %2F in URL paths before route matching so that settings names
+	// containing slashes (e.g. "org/team-slug") are routed correctly.
+	e.Pre(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			rawPath := c.Request().URL.RawPath
+			if rawPath != "" {
+				if rewritten, ok := urlutil.RewriteEncodedSlashes(rawPath); ok {
+					c.Request().URL.Path = rewritten
+					c.Request().URL.RawPath = rewritten
+				}
+			}
+			return next(c)
+		}
+	})
 
 	// Add recovery middleware
 	e.Use(middleware.Recover())

--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 	"github.com/takutakahashi/agentapi-proxy/pkg/notification"
+	"github.com/takutakahashi/agentapi-proxy/pkg/urlutil"
 )
 
 // BaseSettingsName is the reserved name for global base settings (admin-only)
@@ -243,7 +244,7 @@ func (c *SettingsController) GetSettings(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	name := ctx.Param("name")
+	name := urlutil.DecodeSlashParam(ctx.Param("name"))
 	if name == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "Name is required")
 	}
@@ -271,7 +272,7 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	name := ctx.Param("name")
+	name := urlutil.DecodeSlashParam(ctx.Param("name"))
 	if name == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "Name is required")
 	}
@@ -565,7 +566,7 @@ func (c *SettingsController) DeleteGitSync(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	name := ctx.Param("name")
+	name := urlutil.DecodeSlashParam(ctx.Param("name"))
 	if name == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "Name is required")
 	}
@@ -597,7 +598,7 @@ func (c *SettingsController) DeleteSettings(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	name := ctx.Param("name")
+	name := urlutil.DecodeSlashParam(ctx.Param("name"))
 	if name == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "Name is required")
 	}

--- a/pkg/github_sync/handlers.go
+++ b/pkg/github_sync/handlers.go
@@ -11,6 +11,7 @@ import (
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
+	"github.com/takutakahashi/agentapi-proxy/pkg/urlutil"
 )
 
 // Handlers implements app.CustomHandler for GitHub sync endpoints.
@@ -63,7 +64,7 @@ func (h *Handlers) Push(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
 	}
 
-	name := c.Param("name")
+	name := urlutil.DecodeSlashParam(c.Param("name"))
 	if !h.canModifySettings(user, name) {
 		return echo.NewHTTPError(http.StatusForbidden, "access denied")
 	}
@@ -87,7 +88,7 @@ func (h *Handlers) Pull(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
 	}
 
-	name := c.Param("name")
+	name := urlutil.DecodeSlashParam(c.Param("name"))
 	if !h.canModifySettings(user, name) {
 		return echo.NewHTTPError(http.StatusForbidden, "access denied")
 	}
@@ -134,7 +135,7 @@ func (h *Handlers) RotateKey(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
 	}
 
-	name := c.Param("name")
+	name := urlutil.DecodeSlashParam(c.Param("name"))
 	if !h.canModifySettings(user, name) {
 		return echo.NewHTTPError(http.StatusForbidden, "access denied")
 	}

--- a/pkg/urlutil/urlutil.go
+++ b/pkg/urlutil/urlutil.go
@@ -1,0 +1,28 @@
+package urlutil
+
+import "strings"
+
+// slashPlaceholder replaces %2F (percent-encoded slash) in URL paths before
+// Echo route matching. Go's net/http decodes %2F → / before routing, so a
+// settings name like "org/team-slug" sent as "org%2Fteam-slug" would be split
+// into two path segments, causing a 404 on routes like /settings/:name/sync/push.
+const slashPlaceholder = "\x01"
+
+// RewriteEncodedSlashes replaces %2F occurrences in rawPath with a placeholder
+// and returns the rewritten path. The second return value is true when a
+// substitution was made. If rawPath contains no encoded slashes the first
+// return value equals rawPath and ok is false.
+func RewriteEncodedSlashes(rawPath string) (rewritten string, ok bool) {
+	normalized := strings.ReplaceAll(rawPath, "%2f", "%2F")
+	if !strings.Contains(normalized, "%2F") {
+		return rawPath, false
+	}
+	return strings.ReplaceAll(normalized, "%2F", slashPlaceholder), true
+}
+
+// DecodeSlashParam restores the placeholder back to / in a path parameter
+// value. Use this instead of c.Param() for any route parameter that may
+// contain a slash (e.g. settings name = "org/team-slug").
+func DecodeSlashParam(param string) string {
+	return strings.ReplaceAll(param, slashPlaceholder, "/")
+}

--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -1,0 +1,47 @@
+package urlutil_test
+
+import (
+	"testing"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/urlutil"
+)
+
+func TestRewriteEncodedSlashes(t *testing.T) {
+	tests := []struct {
+		rawPath  string
+		want     string
+		wantOK   bool
+	}{
+		{"/settings/our%2Fcc-users/sync/push", "/settings/our\x01cc-users/sync/push", true},
+		{"/settings/our%2fcc-users/sync/push", "/settings/our\x01cc-users/sync/push", true},
+		{"/settings/a%2Fb%2Fc/sync/push", "/settings/a\x01b\x01c/sync/push", true},
+		{"/settings/simple-name/sync/push", "/settings/simple-name/sync/push", false},
+		{"", "", false},
+		{"/settings/no-slash", "/settings/no-slash", false},
+	}
+	for _, tc := range tests {
+		got, ok := urlutil.RewriteEncodedSlashes(tc.rawPath)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("RewriteEncodedSlashes(%q) = (%q, %v), want (%q, %v)",
+				tc.rawPath, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+func TestDecodeSlashParam(t *testing.T) {
+	tests := []struct {
+		param string
+		want  string
+	}{
+		{"our\x01cc-users", "our/cc-users"},
+		{"a\x01b\x01c", "a/b/c"},
+		{"simple-name", "simple-name"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := urlutil.DecodeSlashParam(tc.param)
+		if got != tc.want {
+			t.Errorf("DecodeSlashParam(%q) = %q, want %q", tc.param, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Go の `net/http` はルーティング前に `%2F` を `/` にデコードするため、`/settings/our%2Fcc-users/sync/push` が `/settings/our/cc-users/sync/push` と解釈されてルートにマッチせず 404 になっていた
- `e.Pre()` ミドルウェアでルーティング前に `%2F` を `\x01` プレースホルダーに置換し、ハンドラ側で `/` に戻す方式で修正
- `pkg/urlutil` パッケージを新設し `RewriteEncodedSlashes` / `DecodeSlashParam` を提供
- `settings_controller.go` と `github_sync/handlers.go` の `:name` パラメータ取得箇所をすべて更新

## Test plan

- [x] `go build ./...` が通ること
- [x] `go test ./...` が全 Pass すること
- [x] `pkg/urlutil` のユニットテストを追加（`TestRewriteEncodedSlashes`, `TestDecodeSlashParam`）

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)