### PR TITLE
fix: export GoTemplate and GithubToken fields in git sync

### DIFF
--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -932,7 +932,8 @@ func (s *Syncer) importUserScheduleFile(ctx context.Context, data []byte, userID
 	}
 	if si.SessionConfig.Params != nil {
 		sc.SessionConfig.Params = &entities.SessionParams{
-			Message: si.SessionConfig.Params.InitialMessage,
+			Message:     si.SessionConfig.Params.InitialMessage,
+			GithubToken: si.SessionConfig.Params.GitHubToken,
 		}
 	}
 
@@ -1382,6 +1383,7 @@ func scheduleToImport(sc *schedule.Schedule) importexport.ScheduleImport {
 	if sc.SessionConfig.Params != nil {
 		si.SessionConfig.Params = &importexport.SessionParamsImport{
 			InitialMessage: sc.SessionConfig.Params.Message,
+			GitHubToken:    sc.SessionConfig.Params.GithubToken,
 		}
 	}
 	return si
@@ -1436,6 +1438,9 @@ func webhookToImport(wh *entities.Webhook) importexport.WebhookImport {
 				Draft:        gh.Draft(),
 				Sender:       gh.Sender(),
 			}
+		}
+		if cond.GoTemplate() != "" {
+			ti.Conditions.GoTemplate = cond.GoTemplate()
 		}
 		if tsc := t.SessionConfig(); tsc != nil {
 			ti.SessionConfig = &importexport.SessionConfigImport{


### PR DESCRIPTION
## Summary

- `webhookToImport` でトリガー条件の `GoTemplate` フィールドが push 時に欠落しており、Go テンプレートフィルタを使う webhook の round-trip sync が壊れていた
- `scheduleToImport` / `importUserScheduleFile` でも `SessionParams.GithubToken` が export/import されていなかった

## Root cause

`pkg/github_sync/syncer.go` の sync 専用変換関数が、`pkg/import/exporter.go` の汎用エクスポーターに比べてフィールドマッピングが不完全だった。

| 関数 | 欠落フィールド |
|---|---|
| `webhookToImport` | `Conditions.GoTemplate` |
| `scheduleToImport` | `SessionConfig.Params.GithubToken` |
| `importUserScheduleFile` | `SessionConfig.Params.GithubToken` |

## Test plan

- [ ] `go build ./...` 成功を確認
- [ ] `go test ./pkg/import/...` パス
- [ ] GoTemplate 条件を持つ webhook を push → pull して条件が保持されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)