### PR TITLE
fix: encrypt github_token in schedule SessionParams during git sync

### DIFF
--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1164,6 +1164,13 @@ func encryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 			return err
 		}
 		sc.EnvironmentEncrypted = nil
+		if p := sc.Params; p != nil && p.GitHubToken != "" && !IsEncrypted(p.GitHubToken) {
+			enc, err := EncryptField(dek, p.GitHubToken)
+			if err != nil {
+				return fmt.Errorf("encrypt schedule github_token: %w", err)
+			}
+			p.GitHubToken = enc
+		}
 	}
 
 	for i := range r.Webhooks {
@@ -1251,8 +1258,16 @@ func decryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 	}
 
 	for i := range r.Schedules {
-		if err := decryptMapValues(r.Schedules[i].SessionConfig.Environment, "schedule env"); err != nil {
+		sc := &r.Schedules[i].SessionConfig
+		if err := decryptMapValues(sc.Environment, "schedule env"); err != nil {
 			return err
+		}
+		if p := sc.Params; p != nil && IsEncrypted(p.GitHubToken) {
+			plain, err := DecryptField(dek, p.GitHubToken)
+			if err != nil {
+				return fmt.Errorf("decrypt schedule github_token: %w", err)
+			}
+			p.GitHubToken = plain
 		}
 	}
 

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1219,6 +1219,13 @@ func encryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 				b.SecretAccessKey = enc
 			}
 			b.SecretAccessKeyEncrypted = nil
+			if b.AccessKeyID != "" && !IsEncrypted(b.AccessKeyID) {
+				enc, err := EncryptField(dek, b.AccessKeyID)
+				if err != nil {
+					return fmt.Errorf("encrypt bedrock access_key_id: %w", err)
+				}
+				b.AccessKeyID = enc
+			}
 			b.AccessKeyIDEncrypted = nil
 		}
 
@@ -1309,6 +1316,13 @@ func decryptTeamResourcesFields(r *importexport.TeamResources, dek []byte) error
 					return fmt.Errorf("decrypt bedrock secret key: %w", err)
 				}
 				b.SecretAccessKey = plain
+			}
+			if IsEncrypted(b.AccessKeyID) {
+				plain, err := DecryptField(dek, b.AccessKeyID)
+				if err != nil {
+					return fmt.Errorf("decrypt bedrock access_key_id: %w", err)
+				}
+				b.AccessKeyID = plain
 			}
 		}
 		for _, mcp := range s.MCPServers {

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -951,15 +951,16 @@ func (s *Syncer) importUserWebhookFile(ctx context.Context, data []byte, userID 
 	if err := yaml.Unmarshal(data, &wi); err != nil {
 		return fmt.Errorf("unmarshal webhook: %w", err)
 	}
-	// Decrypt secret field inline (ScopeUser — cannot use generic Importer which hardcodes ScopeTeam).
-	if IsEncrypted(wi.Secret) {
-		plain, err := DecryptField(dek, wi.Secret)
-		if err != nil {
-			return fmt.Errorf("decrypt webhook secret: %w", err)
-		}
-		wi.Secret = plain
+	// Decrypt all sensitive fields (Secret, Environment maps) via the shared helper.
+	// Cannot use the generic Importer here because it hardcodes ScopeTeam.
+	wrapper := &importexport.TeamResources{
+		Metadata: importexport.ResourceMetadata{TeamID: userID},
+		Webhooks: []importexport.WebhookImport{wi},
 	}
-	return s.upsertUserWebhook(ctx, wi, userID)
+	if err := decryptTeamResourcesFields(wrapper, dek); err != nil {
+		return fmt.Errorf("decrypt webhook: %w", err)
+	}
+	return s.upsertUserWebhook(ctx, wrapper.Webhooks[0], userID)
 }
 
 // upsertUserWebhook creates or updates a personal (ScopeUser) webhook from a WebhookImport.


### PR DESCRIPTION
## Summary

git sync で GitHub にプッシュされる YAML ファイルへの機密情報漏洩と、pull 時の復号漏れを修正。

### 修正した問題

**1. スケジュールの `github_token` が平文プッシュ** (PR #752 の副作用)
- `scheduleToImport()` が `GithubToken` をエクスポートするようになったが `encryptTeamResourcesFields()` 側が未対応
- → スケジュール `SessionConfig.Params.GitHubToken` を DEK で暗号化するよう追加

**2. Bedrock `access_key_id` が平文プッシュ**
- `encryptTeamResourcesFields()` が `AccessKeyIDEncrypted` をクリアするだけで、平文フィールド自体を暗号化していなかった
- → `SecretAccessKey` と同様に DEK で暗号化・復号するよう追加

**3. ユーザー webhook の環境変数が pull 時に復号されない**
- `importUserWebhookFile()` が `Secret` だけ個別に復号し、`SessionConfig.Environment` と `Triggers[].SessionConfig.Environment` を復号していなかった
- → `decryptTeamResourcesFields()` ラッパーパターンに統一し全フィールドを復号するよう修正

### 対応不要と判断したもの

- SlackBot の `BotTokenSecretName` / `BotTokenSecretKey` / `AppTokenSecretKey`: K8s Secret の**参照名**であり実際のトークン値ではない

## Test plan

- [ ] git sync push 後、schedule YAML の `github_token` が `enc:v1:...` 形式になっていることを確認
- [ ] git sync push 後、settings YAML の `access_key_id` が `enc:v1:...` 形式になっていることを確認
- [ ] git sync pull 後、ユーザー webhook の環境変数が正しく復号されて保存されていることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)