### PR TITLE
feat: replace claude-posts with acp-posts for Slack integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,10 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # sessions have no such mount at pod creation time.
 RUN mkdir -p /opt/webhook && chown agentapi:agentapi /opt/webhook
 
+# Pre-create /opt/acp-posts so that the acp-server bridge (running as agentapi)
+# can write the conversation history file for acp-posts Slack integration.
+RUN mkdir -p /opt/acp-posts && chown agentapi:agentapi /opt/acp-posts
+
 # Switch to non-root user
 USER agentapi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,17 +66,17 @@ COPY --from=agentapi-builder /agentapi /usr/local/bin/agentapi
 # Copy github-mcp-server binary from official image
 COPY --from=ghcr.io/github/github-mcp-server:v0.26.3 /server/github-mcp-server /usr/local/bin/
 
-# Download claude-posts binary for Slack integration subprocess
-ARG CLAUDE_POSTS_VERSION=v0.4.0
+# Download acp-posts binary for Slack integration subprocess
+ARG ACP_POSTS_VERSION=v0.1.0
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
-      amd64) CLAUDE_POSTS_ARCH="linux-amd64" ;; \
-      arm64) CLAUDE_POSTS_ARCH="linux-arm64" ;; \
+      amd64) ACP_POSTS_ARCH="linux-amd64" ;; \
+      arm64) ACP_POSTS_ARCH="linux-arm64" ;; \
       *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    curl -fsSL "https://github.com/takutakahashi/claude-posts/releases/download/${CLAUDE_POSTS_VERSION}/claude-posts-${CLAUDE_POSTS_ARCH}" \
-      -o /usr/local/bin/claude-posts && \
-    chmod +x /usr/local/bin/claude-posts
+    curl -fsSL "https://github.com/takutakahashi/acp-posts/releases/download/${ACP_POSTS_VERSION}/acp-posts-${ACP_POSTS_ARCH}" \
+      -o /usr/local/bin/acp-posts && \
+    chmod +x /usr/local/bin/acp-posts
 
 # Download otelcol-contrib binary for in-process OpenTelemetry Collector support.
 # Used when OtelCollectorInProcess=true (e.g. when stock inventory is enabled) so

--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -21,6 +21,7 @@ var (
 	acpCwd         string
 	acpSessionID   string
 	acpSessionFile string
+	acpOutputFile  string
 	acpVerbose     bool
 )
 
@@ -54,6 +55,7 @@ func init() {
 	AcpServerCmd.Flags().StringVar(&acpCwd, "cwd", "", "Working directory for the ACP session (defaults to current directory)")
 	AcpServerCmd.Flags().StringVar(&acpSessionID, "session-id", "", "Session ID to use (defaults to auto-generated)")
 	AcpServerCmd.Flags().StringVar(&acpSessionFile, "session-file", "", "File to persist ACP session ID for reuse across restarts (defaults to {cwd}/.acp-session-id)")
+	AcpServerCmd.Flags().StringVar(&acpOutputFile, "output-file", "", "File to append conversation history in acp-posts JSONL format (for Slack integration)")
 	AcpServerCmd.Flags().BoolVarP(&acpVerbose, "verbose", "v", false, "Enable verbose logging")
 }
 
@@ -156,7 +158,7 @@ func runAcpServer(cmd *cobra.Command, args []string) error {
 	log.Printf("[acp-server] ACP session ready (session=%s)", acpClient.SessionID())
 
 	// Create the bridge and start its event loop.
-	b := bridge.New(acpClient, acpClient.SessionID(), acpVerbose)
+	b := bridge.New(acpClient, acpClient.SessionID(), acpVerbose, acpOutputFile)
 	go b.Run(ctx)
 
 	// Start the HTTP server.

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1320,54 +1320,97 @@ func (m *KubernetesSessionManager) Shutdown(timeout time.Duration) error {
 	return nil
 }
 
-// SendMessage sends a message to an existing session
+// SendMessage sends a message to an existing session.
+// For ACP sessions (claude-acp, codex-acp) it uses the ACP JSON-RPC 2.0
+// POST /rpc endpoint with session/prompt; for standard agentapi sessions it
+// uses the agentapi-compatible POST /message endpoint.
 func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, message string) error {
-	// Get session
 	session := m.GetSession(id)
 	if session == nil {
 		return fmt.Errorf("session not found: %s", id)
 	}
 
-	// Check session status
 	status := session.Status()
 	if status != "active" && status != "starting" {
 		return fmt.Errorf("session is not active: status=%s", status)
 	}
 
-	// Build service name and endpoint URL
 	serviceName := fmt.Sprintf("agentapi-session-%s-svc", id)
-	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/message",
+	baseURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
 		serviceName,
 		m.namespace,
 		m.k8sConfig.BasePort,
 	)
 
-	// Create payload
-	payload := map[string]interface{}{
-		"content": message,
-		"type":    "user",
+	agentType := ""
+	if ks, ok := session.(*KubernetesSession); ok {
+		if req := ks.Request(); req != nil {
+			agentType = req.AgentType
+		}
 	}
 
-	// Marshal JSON
-	jsonData, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to marshal message payload: %w", err)
+	isACP := agentType == "claude-acp" || agentType == "codex-acp"
+
+	var jsonData []byte
+	var postURL string
+	if isACP {
+		// Fetch the ACP session ID from GET /session.
+		acpSessionID, err := m.getACPSessionIDFromPod(ctx, baseURL)
+		if err != nil {
+			return fmt.Errorf("failed to get ACP session ID: %w", err)
+		}
+		type contentBlock struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		type promptParams struct {
+			SessionId string         `json:"sessionId"`
+			Prompt    []contentBlock `json:"prompt"`
+		}
+		type rpcRequest struct {
+			JSONRPC string       `json:"jsonrpc"`
+			ID      int          `json:"id"`
+			Method  string       `json:"method"`
+			Params  promptParams `json:"params"`
+		}
+		payload := rpcRequest{
+			JSONRPC: "2.0",
+			ID:      1,
+			Method:  "session/prompt",
+			Params: promptParams{
+				SessionId: acpSessionID,
+				Prompt:    []contentBlock{{Type: "text", Text: message}},
+			},
+		}
+		jsonData, err = json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal ACP payload: %w", err)
+		}
+		postURL = baseURL + "/rpc"
+	} else {
+		payload := map[string]interface{}{
+			"content": message,
+			"type":    "user",
+		}
+		var err error
+		jsonData, err = json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal message payload: %w", err)
+		}
+		postURL = baseURL + "/message"
 	}
 
-	// Create HTTP request
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
-	if err != nil {
-		return fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	// Send request with retry logic
 	var lastErr error
 	for i := 0; i < 3; i++ {
+		req, err := http.NewRequestWithContext(ctx, "POST", postURL, bytes.NewBuffer(jsonData))
+		if err != nil {
+			return fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
 		resp, err := http.DefaultClient.Do(req)
-		if err == nil && resp.StatusCode == 200 {
+		if err == nil && (resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted) {
 			_ = resp.Body.Close()
-			// Update last-message-at in memory and on the Kubernetes Service annotation.
 			now := time.Now()
 			if ks, ok := session.(*KubernetesSession); ok {
 				ks.SetLastMessageAt(now)
@@ -1376,7 +1419,7 @@ func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, m
 			if patchErr := m.patchLastMessageAt(context.Background(), svcName, now); patchErr != nil {
 				log.Printf("[K8S_SESSION] Failed to update last-message-at for session %s: %v", id, patchErr)
 			}
-			log.Printf("[K8S_SESSION] Successfully sent message to session %s", id)
+			log.Printf("[K8S_SESSION] Successfully sent message to session %s (agentType=%q)", id, agentType)
 			return nil
 		}
 		if err != nil {
@@ -1391,6 +1434,30 @@ func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, m
 	}
 
 	return fmt.Errorf("failed to send message after 3 retries: %w", lastErr)
+}
+
+// getACPSessionIDFromPod fetches the ACP session ID from the pod's GET /session endpoint.
+func (m *KubernetesSessionManager) getACPSessionIDFromPod(ctx context.Context, baseURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/session", nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var body struct {
+		SessionId string `json:"sessionId"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.SessionId == "" {
+		return "", fmt.Errorf("empty sessionId from /session")
+	}
+	return body.SessionId, nil
 }
 
 // StopAgent sends a stop_agent action to the running agent in the session via the

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -58,10 +60,11 @@ type subscriber struct {
 // It does not translate ACP semantics – it reconstructs JSON-RPC envelopes from
 // the parsed events that acp.Client exposes and broadcasts them to subscribers.
 type Bridge struct {
-	acp       *acp.Client
-	sessionId string
-	verbose   bool
-	serverCtx context.Context
+	acp        *acp.Client
+	sessionId  string
+	verbose    bool
+	serverCtx  context.Context
+	outputFile string // path to append conversation history in acp-posts format
 
 	subsMu sync.Mutex
 	subs   []*subscriber
@@ -99,13 +102,64 @@ type statusSubscriber struct {
 
 // New creates a Bridge backed by the given ACP client.
 // sessionId must be the id returned by acp.Client.SessionID() after session/new.
-func New(client *acp.Client, sessionId string, verbose bool) *Bridge {
+// outputFile, when non-empty, is a path where completed agent messages are appended
+// in acp-posts JSONL format for consumption by the acp-posts Slack integration.
+func New(client *acp.Client, sessionId string, verbose bool, outputFile string) *Bridge {
 	return &Bridge{
 		acp:            client,
 		sessionId:      sessionId,
 		verbose:        verbose,
+		outputFile:     outputFile,
 		pendingReplies: make(map[int64]chan json.RawMessage),
 		currentStatus:  "stable",
+	}
+}
+
+// acpPostsEnvelope is the JSONL envelope written to the output file for acp-posts.
+type acpPostsEnvelope struct {
+	Type      string          `json:"type"`
+	Message   acpPostsMessage `json:"message"`
+	SessionID string          `json:"sessionId"`
+}
+
+type acpPostsMessage struct {
+	Content []acpPostsContent `json:"content"`
+}
+
+type acpPostsContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// appendToOutputFile writes a completed agent message to b.outputFile in acp-posts format.
+func (b *Bridge) appendToOutputFile(text string) {
+	if b.outputFile == "" || text == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(b.outputFile), 0o755); err != nil {
+		log.Printf("[bridge] failed to create output dir for %s: %v", b.outputFile, err)
+		return
+	}
+	envelope := acpPostsEnvelope{
+		Type: "assistant",
+		Message: acpPostsMessage{
+			Content: []acpPostsContent{{Type: "text", Text: text}},
+		},
+		SessionID: b.sessionId,
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		log.Printf("[bridge] failed to marshal acp-posts envelope: %v", err)
+		return
+	}
+	f, err := os.OpenFile(b.outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		log.Printf("[bridge] failed to open output file %s: %v", b.outputFile, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := fmt.Fprintf(f, "%s\n", data); err != nil {
+		log.Printf("[bridge] failed to write to output file %s: %v", b.outputFile, err)
 	}
 }
 
@@ -280,6 +334,10 @@ func (b *Bridge) flushChunkBufferLocked() {
 	// broadcast without holding chunkMu to avoid lock-order inversion.
 	b.chunkMu.Unlock()
 	b.broadcast(msg)
+	// Persist completed agent messages to the output file for acp-posts consumption.
+	if kind == acp.SessionUpdateKindAgentMessageChunk {
+		b.appendToOutputFile(text)
+	}
 	b.chunkMu.Lock()
 }
 

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync/atomic"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -25,6 +26,7 @@ type Server struct {
 	bridge  *Bridge
 	echo    *echo.Echo
 	verbose bool
+	msgSeq  atomic.Int64 // used to generate unique JSON-RPC IDs for POST /message
 }
 
 // NewServer creates a new HTTP transport server backed by the given Bridge.
@@ -160,7 +162,8 @@ func (s *Server) handleMessage(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "content is required"})
 	}
 	log.Printf("[acp-server] POST /message content=%q (remoteAddr=%s)", payload.Content, c.RealIP())
-	idRaw := json.RawMessage(`0`)
+	id := s.msgSeq.Add(1)
+	idRaw, _ := json.Marshal(id)
 	if err := s.bridge.SendPrompt(idRaw, payload.Content); err != nil {
 		log.Printf("[acp-server] POST /message SendPrompt error: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -64,6 +64,10 @@ func (s *Server) registerRoutes() {
 	// they missed while disconnected from the SSE stream.
 	s.echo.GET("/messages", s.handleGetMessages)
 	s.echo.POST("/rpc", s.handleRPC)
+	// /message is the agentapi-compatible endpoint used by the proxy and SlackBot
+	// to send follow-up user messages to an active session (multi-turn support).
+	// Accepts {"content": "...", "type": "user"} and forwards the text to the agent.
+	s.echo.POST("/message", s.handleMessage)
 	s.echo.GET("/sse", s.handleSSE)
 	// /events is the agentapi-compatible SSE endpoint consumed by the proxy's
 	// watchAgentAPIStatus goroutine.  It emits status_change events whenever
@@ -136,6 +140,32 @@ func (s *Server) handleGetSession(c echo.Context) error {
 		"sessionId": sessionId,
 		"status":    "ready",
 	})
+}
+
+// POST /message
+//
+// agentapi-compatible endpoint for sending a user message to the active session.
+// Used by the proxy and SlackBot for multi-turn conversations.
+// Accepts {"content": "...", "type": "user"} and forwards the text to the ACP agent.
+func (s *Server) handleMessage(c echo.Context) error {
+	var payload struct {
+		Content string `json:"content"`
+		Type    string `json:"type"`
+	}
+	if err := c.Bind(&payload); err != nil {
+		log.Printf("[acp-server] POST /message parse error (remoteAddr=%s): %v", c.RealIP(), err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
+	}
+	if payload.Content == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "content is required"})
+	}
+	log.Printf("[acp-server] POST /message content=%q (remoteAddr=%s)", payload.Content, c.RealIP())
+	idRaw := json.RawMessage(`0`)
+	if err := s.bridge.SendPrompt(idRaw, payload.Content); err != nil {
+		log.Printf("[acp-server] POST /message SendPrompt error: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // rpcEnvelope is the JSON-RPC 2.0 message envelope received on POST /rpc.

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -26,7 +25,6 @@ type Server struct {
 	bridge  *Bridge
 	echo    *echo.Echo
 	verbose bool
-	msgSeq  atomic.Int64 // used to generate unique JSON-RPC IDs for POST /message
 }
 
 // NewServer creates a new HTTP transport server backed by the given Bridge.
@@ -66,10 +64,6 @@ func (s *Server) registerRoutes() {
 	// they missed while disconnected from the SSE stream.
 	s.echo.GET("/messages", s.handleGetMessages)
 	s.echo.POST("/rpc", s.handleRPC)
-	// /message is the agentapi-compatible endpoint used by the proxy and SlackBot
-	// to send follow-up user messages to an active session (multi-turn support).
-	// Accepts {"content": "...", "type": "user"} and forwards the text to the agent.
-	s.echo.POST("/message", s.handleMessage)
 	s.echo.GET("/sse", s.handleSSE)
 	// /events is the agentapi-compatible SSE endpoint consumed by the proxy's
 	// watchAgentAPIStatus goroutine.  It emits status_change events whenever
@@ -142,33 +136,6 @@ func (s *Server) handleGetSession(c echo.Context) error {
 		"sessionId": sessionId,
 		"status":    "ready",
 	})
-}
-
-// POST /message
-//
-// agentapi-compatible endpoint for sending a user message to the active session.
-// Used by the proxy and SlackBot for multi-turn conversations.
-// Accepts {"content": "...", "type": "user"} and forwards the text to the ACP agent.
-func (s *Server) handleMessage(c echo.Context) error {
-	var payload struct {
-		Content string `json:"content"`
-		Type    string `json:"type"`
-	}
-	if err := c.Bind(&payload); err != nil {
-		log.Printf("[acp-server] POST /message parse error (remoteAddr=%s): %v", c.RealIP(), err)
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request"})
-	}
-	if payload.Content == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "content is required"})
-	}
-	log.Printf("[acp-server] POST /message content=%q (remoteAddr=%s)", payload.Content, c.RealIP())
-	id := s.msgSeq.Add(1)
-	idRaw, _ := json.Marshal(id)
-	if err := s.bridge.SendPrompt(idRaw, payload.Content); err != nil {
-		log.Printf("[acp-server] POST /message SendPrompt error: %v", err)
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
-	}
-	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // rpcEnvelope is the JSON-RPC 2.0 message envelope received on POST /rpc.

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -184,9 +184,9 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	// ── Step 10: mark ready and supervise ────────────────────────────────────
 	s.setStatus(StatusReady, "")
 
-	// ── Step 11: launch claude-posts subprocess if SlackParams provided ───────
+	// ── Step 11: launch acp-posts subprocess if SlackParams provided ─────────
 	if settings.SlackParams != nil && settings.SlackParams.Channel != "" {
-		go s.runClaudePosts(ctx, settings.SlackParams)
+		go s.runAcpPosts(ctx, settings.SlackParams, settings.Session.AgentType)
 	}
 
 	// ── Step 12: start files sync goroutine ───────────────────────────────────
@@ -205,19 +205,26 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}()
 }
 
-// runClaudePosts starts the claude-posts binary as a subprocess, forwarding
+// runAcpPosts starts the acp-posts binary as a subprocess, forwarding
 // agent output (history.jsonl) to Slack. It waits for the history file to
-// appear before launching, mirroring the sidecar's shell loop.
+// appear before launching. The history file path depends on the agent type:
+//   - claude-acp: /opt/acp-posts/history.jsonl (written by the acp-server bridge)
+//   - others:     /opt/claude-agentapi/history.jsonl (written by claude-agentapi)
+//
 // The subprocess is tied to ctx: when ctx is cancelled the goroutine exits.
-func (s *Server) runClaudePosts(ctx context.Context, params *sessionsettings.SlackParams) {
-	const historyFile = "/opt/claude-agentapi/history.jsonl"
-	const claudePostsBin = "/usr/local/bin/claude-posts"
+func (s *Server) runAcpPosts(ctx context.Context, params *sessionsettings.SlackParams, agentType string) {
+	const acpPostsBin = "/usr/local/bin/acp-posts"
 
-	log.Printf("[CLAUDE_POSTS] Waiting for history file %s", historyFile)
+	historyFile := "/opt/claude-agentapi/history.jsonl"
+	if agentType == "claude-acp" {
+		historyFile = "/opt/acp-posts/history.jsonl"
+	}
+
+	log.Printf("[ACP_POSTS] Waiting for history file %s", historyFile)
 	for {
 		select {
 		case <-ctx.Done():
-			log.Printf("[CLAUDE_POSTS] Context cancelled while waiting for history file")
+			log.Printf("[ACP_POSTS] Context cancelled while waiting for history file")
 			return
 		case <-time.After(time.Second):
 		}
@@ -225,9 +232,9 @@ func (s *Server) runClaudePosts(ctx context.Context, params *sessionsettings.Sla
 			break
 		}
 	}
-	log.Printf("[CLAUDE_POSTS] History file found, starting claude-posts")
+	log.Printf("[ACP_POSTS] History file found, starting acp-posts")
 
-	cmd := exec.CommandContext(ctx, claudePostsBin, "--file", historyFile)
+	cmd := exec.CommandContext(ctx, acpPostsBin, "--file", historyFile)
 	cmd.Env = append(os.Environ(),
 		"SLACK_BOT_TOKEN="+params.BotToken,
 		"SLACK_CHANNEL_ID="+params.Channel,
@@ -239,12 +246,12 @@ func (s *Server) runClaudePosts(ctx context.Context, params *sessionsettings.Sla
 	if err := cmd.Run(); err != nil {
 		// ctx cancellation causes an expected error; don't log it as fatal.
 		if ctx.Err() != nil {
-			log.Printf("[CLAUDE_POSTS] Exited due to context cancellation")
+			log.Printf("[ACP_POSTS] Exited due to context cancellation")
 		} else {
-			log.Printf("[CLAUDE_POSTS] Exited with error: %v", err)
+			log.Printf("[ACP_POSTS] Exited with error: %v", err)
 		}
 	} else {
-		log.Printf("[CLAUDE_POSTS] Exited normally")
+		log.Printf("[ACP_POSTS] Exited normally")
 	}
 }
 
@@ -591,11 +598,13 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	case "claude-acp":
 		// Start the acp-server bridge that wraps claude-agent-acp (ACP agent) via stdio.
 		// The bridge exposes an agentapi-compatible HTTP server on AGENTAPI_PORT.
+		// --output-file writes conversation history in acp-posts JSONL format for Slack integration.
 		// claude-agent-acp is the official ACP adapter for the Claude Agent SDK:
 		// https://github.com/agentclientprotocol/claude-agent-acp
 		return "agentapi-proxy", []string{
 			"acp-server",
 			"--port", agentapiPort,
+			"--output-file", "/opt/acp-posts/history.jsonl",
 			"--",
 			"bunx", "@agentclientprotocol/claude-agent-acp",
 		}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -121,7 +121,7 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	log.Printf("[PROVISIONER] Loaded %d env vars from session env file", len(envMap))
 
 	// ── Step 4: fetch memory from proxy → inject into CLAUDE.md ──────────────
-	s.fetchAndInjectMemory()
+	s.fetchAndInjectMemory(envMap)
 
 	// ── Step 5: cd into cloned repo ───────────────────────────────────────────
 	if _, err := os.Stat(workdirRepoPath); err == nil {
@@ -1025,21 +1025,29 @@ func countNonEmptyMessages(client *http.Client, agentapiURL string) int {
 
 // fetchAndInjectMemory fetches session memory from the proxy and appends it to
 // CLAUDE.md, replicating the bash memory injection in buildClaudeStartCommand.
-func (s *Server) fetchAndInjectMemory() {
-	memoryKeyFlags := os.Getenv("MEMORY_KEY_FLAGS")
+// getEnv returns the value of key from envMap if present, falling back to os.Getenv.
+func getEnv(envMap map[string]string, key string) string {
+	if v, ok := envMap[key]; ok {
+		return v
+	}
+	return os.Getenv(key)
+}
+
+func (s *Server) fetchAndInjectMemory(envMap map[string]string) {
+	memoryKeyFlags := getEnv(envMap, "MEMORY_KEY_FLAGS")
 	if memoryKeyFlags == "" {
 		return
 	}
 
-	proxyHost := os.Getenv("AGENTAPI_PROXY_SERVICE_HOST")
-	proxyPort := os.Getenv("AGENTAPI_PROXY_SERVICE_PORT_HTTP")
+	proxyHost := getEnv(envMap, "AGENTAPI_PROXY_SERVICE_HOST")
+	proxyPort := getEnv(envMap, "AGENTAPI_PROXY_SERVICE_PORT_HTTP")
 	if proxyHost == "" || proxyPort == "" {
 		log.Printf("[PROVISIONER] AGENTAPI_PROXY_SERVICE_HOST or PORT not set, skipping memory fetch")
 		return
 	}
 	proxyEndpoint := fmt.Sprintf("http://%s:%s", proxyHost, proxyPort)
 
-	scope := os.Getenv("AGENTAPI_SCOPE")
+	scope := getEnv(envMap, "AGENTAPI_SCOPE")
 	if scope == "" {
 		scope = "user"
 	}
@@ -1056,7 +1064,7 @@ func (s *Server) fetchAndInjectMemory() {
 	args = append(args, strings.Fields(memoryKeyFlags)...)
 
 	if scope == "team" {
-		if teamID := os.Getenv("AGENTAPI_TEAM_ID"); teamID != "" {
+		if teamID := getEnv(envMap, "AGENTAPI_TEAM_ID"); teamID != "" {
 			args = append(args, "--team-id", teamID)
 		}
 	}

--- a/pkg/urlutil/urlutil_test.go
+++ b/pkg/urlutil/urlutil_test.go
@@ -8,9 +8,9 @@ import (
 
 func TestRewriteEncodedSlashes(t *testing.T) {
 	tests := []struct {
-		rawPath  string
-		want     string
-		wantOK   bool
+		rawPath string
+		want    string
+		wantOK  bool
 	}{
 		{"/settings/our%2Fcc-users/sync/push", "/settings/our\x01cc-users/sync/push", true},
 		{"/settings/our%2fcc-users/sync/push", "/settings/our\x01cc-users/sync/push", true},


### PR DESCRIPTION
## Summary

- Replace `claude-posts` binary with `acp-posts` (v0.1.0) in Dockerfile
- Add `--output-file` flag to `acp-server` command to write conversation history in acp-posts JSONL format
- Bridge writes completed `agent_message_chunk` events to the output file so `acp-posts` can read them and post to Slack
- Rename `runClaudePosts` → `runAcpPosts` in provisioner; route to correct history file based on agent type
  - `claude-acp` agent type: `/opt/acp-posts/history.jsonl` (written by the bridge)
  - other types: `/opt/claude-agentapi/history.jsonl` (written by claude-agentapi, same format acp-posts supports)
- Pass `--output-file /opt/acp-posts/history.jsonl` when starting `acp-server` for `claude-acp` agent type

## Details

### How it works for `claude-acp`

1. `acp-server` starts with `--output-file /opt/acp-posts/history.jsonl`
2. The ACP bridge accumulates agent message chunks and flushes them as complete messages
3. When an `agent_message_chunk` is flushed, the bridge appends to the output file in acp-posts JSONL format:
   ```json
   {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]},"sessionId":"..."}
   ```
4. `acp-posts` watches the file and posts new entries to Slack

### acp-posts compatibility

`acp-posts` uses the same JSONL format as `claude-agentapi`'s history output, so it's a drop-in replacement for `claude-posts` for all agent types.

## Test plan

- [x] `go build` and `go vet` pass
- [x] `golangci-lint` passes with 0 issues
- [x] Dev image built and deployed to `agentapi-ui-dev`
- [ ] Create `claude-acp` session with Slack params and verify messages post to Slack

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)