### PR TITLE
feat: change default slackbot agent type to claude-acp

### DIFF
--- a/internal/interfaces/controllers/slackbot_event_handler.go
+++ b/internal/interfaces/controllers/slackbot_event_handler.go
@@ -292,8 +292,8 @@ func (h *SlackBotEventHandler) ProcessEvent(ctx context.Context, botID string, p
 	//   initial_message_template: "{{ .thread_messages }}\n---\n{{ .event.text }}"
 	initialMessage := h.buildMessage(bot, payloadMap, event.Text, false)
 
-	// Determine agent type: default to "claude-agentapi"; bot session_config may override.
-	agentType := "claude-agentapi"
+	// Determine agent type: default to "claude-acp"; bot session_config may override.
+	agentType := "claude-acp"
 	if bot != nil && bot.SessionConfig() != nil && bot.SessionConfig().Params() != nil {
 		if bot.SessionConfig().Params().AgentType != "" {
 			agentType = bot.SessionConfig().Params().AgentType


### PR DESCRIPTION
## Summary
- `SlackBotEventHandler` のデフォルト `agentType` を `claude-agentapi` から `claude-acp` に変更

## Test plan
- [ ] `go vet` と `go build` が通ることを確認済み
- [ ] `TestSlackBot*` テスト群が PASS することを確認済み
- [ ] 既存の明示的な `AgentType: "claude-agentapi"` 設定は引き続き動作する

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)