### PR TITLE
feat: change default agent type to claude-acp for webhooks and schedules

### DIFF
--- a/internal/interfaces/controllers/webhook_custom_controller.go
+++ b/internal/interfaces/controllers/webhook_custom_controller.go
@@ -271,12 +271,15 @@ Raw payload (first 500 chars):
 Please ensure the webhook payload is valid JSON.
 `, wh.Name(), parseErr.Error(), truncateString(string(rawBody), 500))
 
-	var githubToken, agentType string
+	agentType := "claude-acp"
+	var githubToken string
 	var oneshot bool
 	if sessionConfig != nil && sessionConfig.Params() != nil {
 		params := sessionConfig.Params()
 		githubToken = params.GithubToken
-		agentType = params.AgentType
+		if params.AgentType != "" {
+			agentType = params.AgentType
+		}
 		oneshot = params.Oneshot
 	}
 

--- a/internal/interfaces/controllers/webhook_session_service.go
+++ b/internal/interfaces/controllers/webhook_session_service.go
@@ -86,11 +86,14 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 	}
 
 	// Determine session params fields from rendered params
-	var githubToken, agentType string
+	agentType := "claude-acp"
+	var githubToken string
 	var oneshot bool
 	if renderedParams != nil {
 		githubToken = renderedParams.GithubToken
-		agentType = renderedParams.AgentType
+		if renderedParams.AgentType != "" {
+			agentType = renderedParams.AgentType
+		}
 		oneshot = renderedParams.Oneshot
 	}
 

--- a/pkg/schedule/handlers.go
+++ b/pkg/schedule/handlers.go
@@ -513,7 +513,8 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 	tags["schedule_id"] = schedule.ID
 	tags["schedule_name"] = schedule.Name
 
-	var initialMessage, githubToken, agentType string
+	agentType := "claude-acp"
+	var initialMessage, githubToken string
 	var slackParams *entities.SlackParams
 	var oneshot bool
 	if schedule.SessionConfig.Params != nil {
@@ -522,7 +523,9 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 		if scheduleScope != entities.ScopeTeam {
 			githubToken = schedule.SessionConfig.Params.GithubToken
 		}
-		agentType = schedule.SessionConfig.Params.AgentType
+		if schedule.SessionConfig.Params.AgentType != "" {
+			agentType = schedule.SessionConfig.Params.AgentType
+		}
 		slackParams = schedule.SessionConfig.Params.Slack
 		oneshot = schedule.SessionConfig.Params.Oneshot
 	}

--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -243,7 +243,8 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 	tags["schedule_id"] = schedule.ID
 	tags["schedule_name"] = schedule.Name
 
-	var initialMessage, githubToken, agentType string
+	agentType := "claude-acp"
+	var initialMessage, githubToken string
 	var slackParams *entities.SlackParams
 	var oneshot bool
 	if schedule.SessionConfig.Params != nil {
@@ -252,7 +253,9 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 		if scheduleScope != entities.ScopeTeam {
 			githubToken = schedule.SessionConfig.Params.GithubToken
 		}
-		agentType = schedule.SessionConfig.Params.AgentType
+		if schedule.SessionConfig.Params.AgentType != "" {
+			agentType = schedule.SessionConfig.Params.AgentType
+		}
 		slackParams = schedule.SessionConfig.Params.Slack
 		oneshot = schedule.SessionConfig.Params.Oneshot
 	}


### PR DESCRIPTION
## Summary

- Webhook (`WebhookSessionService.CreateSessionFromWebhook`) のデフォルト agent type を `claude-acp` に変更
- Schedule worker (`buildLaunchRequest`) のデフォルト agent type を `claude-acp` に変更
- SlackBot は #755 で既に `claude-acp` がデフォルトになっており、今回の変更で全てのイベント駆動セッション作成が統一されました
- 設定で `agent_type` が明示的に指定されている場合は引き続きその値が優先されます

## Test plan

- [ ] lint: `make lint` → 0 issues
- [ ] build: `make build` → 正常終了
- [ ] webhook からセッションを作成して agent_type が `claude-acp` になることを確認
- [ ] schedule からセッションを作成して agent_type が `claude-acp` になることを確認
- [ ] `agent_type` を明示指定した場合に上書きされることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)