### PR TITLE
feat(helm): add config.gitSync.githubApp.installationId value

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
             - name: GITHUB_INSTALLATION_ID
               value: {{ .Values.github.app.installationId | quote }}
             {{- end }}
+            {{- if .Values.config.gitSync.githubApp.installationId }}
+            - name: AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID
+              value: {{ .Values.config.gitSync.githubApp.installationId | quote }}
+            {{- end }}
             {{- if and .Values.github.app.privateKey.secretName .Values.github.app.privateKey.key }}
             - name: GITHUB_APP_PEM
               valueFrom:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -188,6 +188,14 @@ config:
     # 設定しない場合は暗号化なし (Noop) になります
     key: ""
 
+  # Git Sync 設定
+  gitSync:
+    githubApp:
+      # git sync 専用の GitHub App Installation ID
+      # github.app.installationId と異なる installation ID を git sync に使いたい場合に設定する
+      # 設定しない場合は github.app.installationId (GITHUB_INSTALLATION_ID) にフォールバック
+      installationId: ""
+
 # Environment variables
 env: []
 # - name: GITHUB_TOKEN


### PR DESCRIPTION
## Summary

- `config.gitSync.githubApp.installationId` を Helm values に追加
- `AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID` 環境変数としてプロキシ Pod に渡す

## 背景

`github.app.installationId` はセッション Pod (`github-session-secret`) にも `GITHUB_INSTALLATION_ID` として渡されるため、チームセッションのリポジトリクローンに影響が出ることがある。

git sync だけ別の installation ID を使いたい場合、`AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID` を設定する必要があるが、Helm chart に対応するフィールドがなかった。

## 使い方

```yaml
config:
  gitSync:
    githubApp:
      installationId: "12345678"  # git sync 専用の Installation ID
```

`github.app.installationId` は空のままにすることでセッションへの影響を避けられる。

## Test plan

- [ ] `helm lint` 通過確認 ✅
- [ ] `helm template` で `AGENTAPI_GIT_SYNC_GITHUB_APP_INSTALLATION_ID` が正しくレンダリングされることを確認 ✅

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)