### PR TITLE
feat: network sandbox sidecar proxy for session isolation (#762)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex && \
 FROM ubuntu:24.04
 
 # Install essential packages: ca-certificates, curl, bash, git, make, sudo, jq, procps, and GitHub CLI
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata && \
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/cmd/network_filter.go
+++ b/cmd/network_filter.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/takutakahashi/agentapi-proxy/pkg/networkfilter"
+)
+
+// NetworkFilterCmd is the root command for network-filter subcommands.
+var NetworkFilterCmd = &cobra.Command{
+	Use:   "network-filter",
+	Short: "Network filter proxy for session sandbox",
+}
+
+var networkFilterSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Configure iptables rules for transparent proxy redirect (requires CAP_NET_ADMIN)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Println("[network-filter] Setting up iptables rules...")
+		if err := networkfilter.SetupIPTables(); err != nil {
+			return fmt.Errorf("iptables setup failed: %w", err)
+		}
+		log.Println("[network-filter] iptables rules configured successfully")
+		return nil
+	},
+}
+
+var networkFilterProxyCmd = &cobra.Command{
+	Use:   "proxy",
+	Short: "Run the transparent HTTP/HTTPS proxy sidecar",
+	Long: `Runs the transparent proxy sidecar that enforces the denied-domains list.
+
+Denied domains are read from the NETWORK_FILTER_DENIED_DOMAINS environment
+variable (comma-separated hostnames) or from the --denied-domains flag.
+
+HTTP traffic (port 3128): filtered by Host header.
+HTTPS traffic (port 3129): filtered by TLS SNI (no decryption).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		deniedDomainsFlag, _ := cmd.Flags().GetStringSlice("denied-domains")
+
+		// Merge flag values with the environment variable.
+		envVal := os.Getenv("NETWORK_FILTER_DENIED_DOMAINS")
+		var allDomains []string
+		if envVal != "" {
+			for _, d := range strings.Split(envVal, ",") {
+				allDomains = append(allDomains, strings.TrimSpace(d))
+			}
+		}
+		allDomains = append(allDomains, deniedDomainsFlag...)
+
+		filter := networkfilter.NewFilter(allDomains)
+		proxy := networkfilter.NewProxy(filter)
+
+		httpAddr := fmt.Sprintf("0.0.0.0:%d", networkfilter.HTTPProxyPort)
+		httpsAddr := fmt.Sprintf("0.0.0.0:%d", networkfilter.HTTPSProxyPort)
+
+		httpLis, err := net.Listen("tcp", httpAddr)
+		if err != nil {
+			return fmt.Errorf("listen HTTP %s: %w", httpAddr, err)
+		}
+		httpsLis, err := net.Listen("tcp", httpsAddr)
+		if err != nil {
+			return fmt.Errorf("listen HTTPS %s: %w", httpsAddr, err)
+		}
+
+		log.Printf("[network-filter] Starting proxy (denied domains: %v)", allDomains)
+
+		errCh := make(chan error, 2)
+		go func() { errCh <- proxy.RunHTTP(httpLis) }()
+		go func() { errCh <- proxy.RunHTTPS(httpsLis) }()
+
+		return <-errCh
+	},
+}
+
+func init() {
+	networkFilterProxyCmd.Flags().StringSlice("denied-domains", nil,
+		"Comma-separated list of domains to block (can also be set via NETWORK_FILTER_DENIED_DOMAINS env var)")
+
+	NetworkFilterCmd.AddCommand(networkFilterSetupCmd)
+	NetworkFilterCmd.AddCommand(networkFilterProxyCmd)
+}

--- a/cmd/network_filter.go
+++ b/cmd/network_filter.go
@@ -32,14 +32,16 @@ var networkFilterSetupCmd = &cobra.Command{
 
 var networkFilterProxyCmd = &cobra.Command{
 	Use:   "proxy",
-	Short: "Run the transparent HTTP/HTTPS proxy sidecar",
-	Long: `Runs the transparent proxy sidecar that enforces the denied-domains list.
+	Short: "Run the forward proxy sidecar",
+	Long: `Runs the forward proxy sidecar that enforces the denied-domains list.
 
 Denied domains are read from the NETWORK_FILTER_DENIED_DOMAINS environment
 variable (comma-separated hostnames) or from the --denied-domains flag.
 
-HTTP traffic (port 3128): filtered by Host header.
-HTTPS traffic (port 3129): filtered by TLS SNI (no decryption).`,
+A single listener on port 3128 handles three types of connections:
+  - HTTP CONNECT tunnels (proxy-aware HTTPS clients via HTTP_PROXY/HTTPS_PROXY env vars)
+  - HTTP forward proxy requests (proxy-aware HTTP clients)
+  - Transparent TLS (iptables-redirected port-443 traffic, SNI-filtered)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		deniedDomainsFlag, _ := cmd.Flags().GetStringSlice("denied-domains")
 
@@ -56,25 +58,14 @@ HTTPS traffic (port 3129): filtered by TLS SNI (no decryption).`,
 		filter := networkfilter.NewFilter(allDomains)
 		proxy := networkfilter.NewProxy(filter)
 
-		httpAddr := fmt.Sprintf("0.0.0.0:%d", networkfilter.HTTPProxyPort)
-		httpsAddr := fmt.Sprintf("0.0.0.0:%d", networkfilter.HTTPSProxyPort)
-
-		httpLis, err := net.Listen("tcp", httpAddr)
+		addr := fmt.Sprintf("0.0.0.0:%d", networkfilter.ProxyPort)
+		lis, err := net.Listen("tcp", addr)
 		if err != nil {
-			return fmt.Errorf("listen HTTP %s: %w", httpAddr, err)
-		}
-		httpsLis, err := net.Listen("tcp", httpsAddr)
-		if err != nil {
-			return fmt.Errorf("listen HTTPS %s: %w", httpsAddr, err)
+			return fmt.Errorf("listen %s: %w", addr, err)
 		}
 
-		log.Printf("[network-filter] Starting proxy (denied domains: %v)", allDomains)
-
-		errCh := make(chan error, 2)
-		go func() { errCh <- proxy.RunHTTP(httpLis) }()
-		go func() { errCh <- proxy.RunHTTPS(httpsLis) }()
-
-		return <-errCh
+		log.Printf("[network-filter] Starting proxy on %s (denied domains: %v)", addr, allDomains)
+		return proxy.Run(lis)
 	},
 }
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -622,6 +622,12 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		cycleMaxCount = startReq.Params.CycleMaxCount
 	}
 
+	// Determine sandbox params from Params.Sandbox
+	var sandbox *entities.SandboxParams
+	if startReq.Params != nil && startReq.Params.Sandbox != nil {
+		sandbox = startReq.Params.Sandbox
+	}
+
 	// Build run server request
 	req := &entities.RunServerRequest{
 		UserID:                   userID,
@@ -640,6 +646,7 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		MemoryKey:                startReq.MemoryKey,
 		CycleMessage:             cycleMessage,
 		CycleMaxCount:            cycleMaxCount,
+		Sandbox:                  sandbox,
 	}
 
 	// Delegate to session manager

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -542,14 +542,19 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		return s.createRemoteSession(context.Background(), sessionID, startReq, userID, teams)
 	}
 
-	// If no ManagerID is specified, check for a default external session manager
-	if defaultESM, err := s.findDefaultESM(context.Background(), userID, teams); err == nil && defaultESM != nil {
-		log.Printf("[SESSION] Using default external session manager %s (%s) for session %s", defaultESM.Name, defaultESM.ID, sessionID)
-		if startReq.Params == nil {
-			startReq.Params = &entities.SessionParams{}
+	// If no ManagerID is specified, check for a default external session manager.
+	// Skip ESM forwarding when sandbox is requested: the remote proxy may not support
+	// sandbox, and sandbox requires local Kubernetes deployment to add init containers.
+	sandboxRequested := startReq.Params != nil && startReq.Params.Sandbox != nil && startReq.Params.Sandbox.Enabled
+	if !sandboxRequested {
+		if defaultESM, err := s.findDefaultESM(context.Background(), userID, teams); err == nil && defaultESM != nil {
+			log.Printf("[SESSION] Using default external session manager %s (%s) for session %s", defaultESM.Name, defaultESM.ID, sessionID)
+			if startReq.Params == nil {
+				startReq.Params = &entities.SessionParams{}
+			}
+			startReq.Params.ManagerID = defaultESM.ID
+			return s.createRemoteSession(context.Background(), sessionID, startReq, userID, teams)
 		}
-		startReq.Params.ManagerID = defaultESM.ID
-		return s.createRemoteSession(context.Background(), sessionID, startReq, userID, teams)
 	}
 
 	// Get auth team env file from user context if available

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -30,6 +30,15 @@ type SlackParams struct {
 	BotTokenSecretKey string `json:"bot_token_secret_key,omitempty"`
 }
 
+// SandboxParams holds network sandbox configuration requested at session creation.
+type SandboxParams struct {
+	// Enabled activates the network filter sidecar (iptables redirect + transparent proxy).
+	Enabled bool `json:"enabled,omitempty"`
+	// DeniedDomains is the list of hostnames whose traffic should be blocked.
+	// HTTP connections are matched by Host header; HTTPS by SNI.
+	DeniedDomains []string `json:"denied_domains,omitempty"`
+}
+
 // SessionParams represents session parameters for agentapi server
 type SessionParams struct {
 	// Message is the initial message to send to the agent after session starts
@@ -62,6 +71,8 @@ type SessionParams struct {
 	// environment so the repository is cloned at session startup.
 	// For SlackBot sessions, this takes priority over any repository auto-detected from the message text.
 	RepoFullName string `json:"repo_full_name,omitempty"`
+	// Sandbox configures network isolation for the session via a sidecar transparent proxy.
+	Sandbox *SandboxParams `json:"sandbox,omitempty"`
 }
 
 // StartRequest represents the request body for starting a new agentapi server
@@ -104,6 +115,8 @@ type RunServerRequest struct {
 	MemoryKey                map[string]string // Tag map to identify memories; nil means use Tags
 	CycleMessage             string            // Message to send to session after each Claude stop event (injects Stop hook)
 	CycleMaxCount            int               // Maximum number of cycles (0 = unlimited); requires CycleMessage
+	// Sandbox configures network isolation for the session.
+	Sandbox *SandboxParams
 	// ProvisionSettings, when non-nil, is used directly as the provision payload
 	// instead of building it from the other request fields.
 	// Used by the session manager forwarding path (small-cluster mode).

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1609,7 +1609,13 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 	memoryRequest := resource.MustParse(m.k8sConfig.MemoryRequest)
 	memoryLimit := resource.MustParse(m.k8sConfig.MemoryLimit)
 
-	// No init containers — setup is performed by the main container on startup
+	// Build init containers and sandbox sidecar if network sandbox is enabled.
+	sandboxEnabled := req.Sandbox != nil && req.Sandbox.Enabled
+	var initContainers []corev1.Container
+	var sandboxSidecar *corev1.Container
+	if sandboxEnabled {
+		initContainers, sandboxSidecar = m.buildSandboxContainers(req)
+	}
 
 	// Determine working directory
 	// Always use /home/agentapi/workdir as base; clone-repo will create /home/agentapi/workdir/repo
@@ -1730,11 +1736,14 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 	// Build volumes
 	volumes := m.buildVolumes(session)
 
-	// Build containers list (main container only)
+	// Build containers list.
 	// Note: credentials-sync is now handled as a goroutine inside agent-provisioner
 	// (pkg/provisioner/provision.go) after user context is established, so the
 	// UserID is always set correctly even for stock pool pods.
 	containers := []corev1.Container{container}
+	if sandboxSidecar != nil {
+		containers = append(containers, *sandboxSidecar)
+	}
 
 	// Note: Initial message is now sent by agent-provisioner internally after agentapi
 	// becomes ready. The initial-message-sender sidecar has been removed.
@@ -1803,10 +1812,11 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 						RunAsUser:  int64Ptr(999),
 						RunAsGroup: int64Ptr(999),
 					},
-					Containers:   containers,
-					Volumes:      volumes,
-					NodeSelector: m.k8sConfig.NodeSelector,
-					Tolerations:  tolerations,
+					InitContainers: initContainers,
+					Containers:     containers,
+					Volumes:        volumes,
+					NodeSelector:   m.k8sConfig.NodeSelector,
+					Tolerations:    tolerations,
 				},
 			},
 		},
@@ -1982,6 +1992,55 @@ func (m *KubernetesSessionManager) createOneshotSettingsSecret(
 
 	log.Printf("[K8S_SESSION] Created oneshot settings Secret %s for session %s", secretName, session.id)
 	return nil
+}
+
+// buildSandboxContainers returns the init container (iptables setup) and sidecar
+// (network-filter proxy) needed for session network sandboxing.
+// The sidecar runs as UID 0 (root) so that iptables rules can skip its traffic
+// via the "--uid-owner 0" match, preventing redirect loops.
+func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServerRequest) ([]corev1.Container, *corev1.Container) {
+	deniedDomains := ""
+	if req.Sandbox != nil && len(req.Sandbox.DeniedDomains) > 0 {
+		deniedDomains = strings.Join(req.Sandbox.DeniedDomains, ",")
+	}
+
+	rootUID := int64(0)
+	falseVal := false
+
+	initContainer := corev1.Container{
+		Name:            "network-filter-setup",
+		Image:           m.k8sConfig.Image,
+		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
+		Command:         []string{"agentapi-proxy", "network-filter", "setup"},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:    &rootUID,
+			RunAsNonRoot: &falseVal,
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN"},
+			},
+		},
+	}
+
+	sidecar := corev1.Container{
+		Name:            "network-filter",
+		Image:           m.k8sConfig.Image,
+		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
+		Command:         []string{"agentapi-proxy", "network-filter", "proxy"},
+		Env: []corev1.EnvVar{
+			{Name: "NETWORK_FILTER_DENIED_DOMAINS", Value: deniedDomains},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &rootUID,
+			RunAsNonRoot:             &falseVal,
+			AllowPrivilegeEscalation: &falseVal,
+		},
+		Ports: []corev1.ContainerPort{
+			{Name: "http-proxy", ContainerPort: 3128, Protocol: corev1.ProtocolTCP},
+			{Name: "https-proxy", ContainerPort: 3129, Protocol: corev1.ProtocolTCP},
+		},
+	}
+
+	return []corev1.Container{initContainer}, &sidecar
 }
 
 // buildVolumes builds the volume configuration for the session pod
@@ -3967,6 +4026,15 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			Content: req.CycleMessage,
 		})
 		log.Printf("[K8S_SESSION] Injected CYCLE_ENABLED file (with message) for session %s", session.id)
+	}
+
+	// Embed sandbox configuration when enabled.
+	if req.Sandbox != nil && req.Sandbox.Enabled {
+		settings.Sandbox = &sessionsettings.SandboxConfig{
+			Enabled:       true,
+			DeniedDomains: req.Sandbox.DeniedDomains,
+		}
+		log.Printf("[K8S_SESSION] Network sandbox enabled for session %s (denied domains: %v)", session.id, req.Sandbox.DeniedDomains)
 	}
 
 	return settings

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -311,15 +311,20 @@ func (m *KubernetesSessionManager) StopStatusSubscriber() {
 // If no stock is available, a new session is created from scratch.
 func (m *KubernetesSessionManager) CreateSession(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error) {
 	// Attempt to adopt a stock session before creating a new one.
-	if stockSvc, err := m.findStockSession(ctx); err != nil {
-		log.Printf("[K8S_SESSION] Warning: failed to search for stock sessions: %v", err)
-	} else if stockSvc != nil {
-		claimedSvc, claimErr := m.claimStockService(ctx, stockSvc)
-		if claimErr != nil {
-			log.Printf("[K8S_SESSION] Stock session claim failed (concurrent claim?), falling back to new session creation: %v", claimErr)
-		} else {
-			log.Printf("[K8S_SESSION] Found stock session %s, adopting for new request", claimedSvc.Labels["agentapi.proxy/session-id"])
-			return m.adoptStockSession(ctx, req, webhookPayload, claimedSvc)
+	// Skip stock adoption when sandbox is enabled: stock pods lack the init container
+	// and network-filter sidecar, so they cannot enforce network isolation.
+	sandboxRequested := req.Sandbox != nil && req.Sandbox.Enabled
+	if !sandboxRequested {
+		if stockSvc, err := m.findStockSession(ctx); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to search for stock sessions: %v", err)
+		} else if stockSvc != nil {
+			claimedSvc, claimErr := m.claimStockService(ctx, stockSvc)
+			if claimErr != nil {
+				log.Printf("[K8S_SESSION] Stock session claim failed (concurrent claim?), falling back to new session creation: %v", claimErr)
+			} else {
+				log.Printf("[K8S_SESSION] Found stock session %s, adopting for new request", claimedSvc.Labels["agentapi.proxy/session-id"])
+				return m.adoptStockSession(ctx, req, webhookPayload, claimedSvc)
+			}
 		}
 	}
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -34,6 +34,7 @@ import (
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+	"github.com/takutakahashi/agentapi-proxy/pkg/networkfilter"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 	"github.com/takutakahashi/agentapi-proxy/pkg/settingspatch"
 )
@@ -1613,8 +1614,9 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 	sandboxEnabled := req.Sandbox != nil && req.Sandbox.Enabled
 	var initContainers []corev1.Container
 	var sandboxSidecar *corev1.Container
+	var sandboxEnvVars []corev1.EnvVar
 	if sandboxEnabled {
-		initContainers, sandboxSidecar = m.buildSandboxContainers(req)
+		initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(req)
 	}
 
 	// Determine working directory
@@ -1691,7 +1693,7 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env:     envVars,
+		Env:     append(envVars, sandboxEnvVars...),
 		EnvFrom: envFrom,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -1998,7 +2000,7 @@ func (m *KubernetesSessionManager) createOneshotSettingsSecret(
 // (network-filter proxy) needed for session network sandboxing.
 // The sidecar runs as UID 0 (root) so that iptables rules can skip its traffic
 // via the "--uid-owner 0" match, preventing redirect loops.
-func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServerRequest) ([]corev1.Container, *corev1.Container) {
+func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServerRequest) ([]corev1.Container, *corev1.Container, []corev1.EnvVar) {
 	deniedDomains := ""
 	if req.Sandbox != nil && len(req.Sandbox.DeniedDomains) > 0 {
 		deniedDomains = strings.Join(req.Sandbox.DeniedDomains, ",")
@@ -2021,6 +2023,8 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 		},
 	}
 
+	proxyAddr := fmt.Sprintf("http://127.0.0.1:%d", networkfilter.ProxyPort)
+
 	sidecar := corev1.Container{
 		Name:            "network-filter",
 		Image:           m.k8sConfig.Image,
@@ -2035,12 +2039,24 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 			AllowPrivilegeEscalation: &falseVal,
 		},
 		Ports: []corev1.ContainerPort{
-			{Name: "http-proxy", ContainerPort: 3128, Protocol: corev1.ProtocolTCP},
-			{Name: "https-proxy", ContainerPort: 3129, Protocol: corev1.ProtocolTCP},
+			{Name: "proxy", ContainerPort: int32(networkfilter.ProxyPort), Protocol: corev1.ProtocolTCP},
 		},
 	}
 
-	return []corev1.Container{initContainer}, &sidecar
+	// Inject HTTP_PROXY / HTTPS_PROXY env vars into the main container so that
+	// proxy-aware clients (curl, Go's http.Client, pip, npm, etc.) route all
+	// HTTP and HTTPS traffic through the sidecar via CONNECT tunnels.
+	// This covers non-standard ports and avoids SNI-peeking for HTTPS.
+	proxyEnvVars := []corev1.EnvVar{
+		{Name: "HTTP_PROXY", Value: proxyAddr},
+		{Name: "HTTPS_PROXY", Value: proxyAddr},
+		{Name: "http_proxy", Value: proxyAddr},
+		{Name: "https_proxy", Value: proxyAddr},
+		{Name: "NO_PROXY", Value: "127.0.0.1,localhost"},
+		{Name: "no_proxy", Value: "127.0.0.1,localhost"},
+	}
+
+	return []corev1.Container{initContainer}, &sidecar, proxyEnvVars
 }
 
 // buildVolumes builds the volume configuration for the session pod

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func init() {
 	rootCmd.AddCommand(cmd.AgentProvisionerCmd)
 	rootCmd.AddCommand(cmd.OneshotCmd)
 	rootCmd.AddCommand(cmd.AcpServerCmd)
+	rootCmd.AddCommand(cmd.NetworkFilterCmd)
 }
 
 func main() {

--- a/pkg/networkfilter/filter.go
+++ b/pkg/networkfilter/filter.go
@@ -1,0 +1,53 @@
+package networkfilter
+
+import (
+	"strings"
+)
+
+// Filter decides whether a given host should be blocked based on the denied domain list.
+type Filter struct {
+	deniedDomains []string
+}
+
+// NewFilter creates a new Filter with the given list of denied domains.
+// Each entry may be an exact hostname or a wildcard prefix (e.g. "*.example.com").
+func NewFilter(deniedDomains []string) *Filter {
+	normalized := make([]string, 0, len(deniedDomains))
+	for _, d := range deniedDomains {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d != "" {
+			normalized = append(normalized, d)
+		}
+	}
+	return &Filter{deniedDomains: normalized}
+}
+
+// IsDenied returns true when host matches a denied domain.
+// host may include a port suffix (host:port); it is stripped before matching.
+func (f *Filter) IsDenied(host string) bool {
+	h := strings.ToLower(host)
+	// Strip port if present.
+	if idx := strings.LastIndex(h, ":"); idx != -1 {
+		// Make sure it's not an IPv6 bracket address without port.
+		if strings.Contains(h[idx:], ":") || !strings.Contains(h, "[") {
+			h = h[:idx]
+		}
+	}
+	h = strings.TrimSuffix(h, ".")
+	for _, denied := range f.deniedDomains {
+		if matchDomain(h, denied) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchDomain checks whether host matches the pattern.
+// pattern may start with "*." for wildcard subdomain matching.
+func matchDomain(host, pattern string) bool {
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[1:] // ".example.com"
+		return host == pattern[2:] || strings.HasSuffix(host, suffix)
+	}
+	return host == pattern
+}

--- a/pkg/networkfilter/filter_test.go
+++ b/pkg/networkfilter/filter_test.go
@@ -1,0 +1,28 @@
+package networkfilter
+
+import "testing"
+
+func TestFilterIsDenied(t *testing.T) {
+	f := NewFilter([]string{"bad.com", "*.evil.org", "exact.io"})
+
+	cases := []struct {
+		host    string
+		blocked bool
+	}{
+		{"bad.com", true},
+		{"bad.com:80", true},
+		{"good.com", false},
+		{"sub.evil.org", true},
+		{"evil.org", true},
+		{"notevil.org", false},
+		{"exact.io", true},
+		{"sub.exact.io", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := f.IsDenied(c.host)
+		if got != c.blocked {
+			t.Errorf("IsDenied(%q) = %v, want %v", c.host, got, c.blocked)
+		}
+	}
+}

--- a/pkg/networkfilter/proxy.go
+++ b/pkg/networkfilter/proxy.go
@@ -2,7 +2,6 @@ package networkfilter
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -13,15 +12,22 @@ import (
 )
 
 const (
-	// HTTPProxyPort is the port the transparent HTTP proxy listens on.
-	HTTPProxyPort = 3128
-	// HTTPSProxyPort is the port the transparent HTTPS (SNI) proxy listens on.
-	HTTPSProxyPort = 3129
+	// ProxyPort is the port the forward proxy listens on.
+	// It serves both HTTP forward proxy requests and HTTP CONNECT tunnels.
+	// Transparent iptables-redirected connections (port 80/443) are also accepted here.
+	ProxyPort = 3128
 
 	dialTimeout = 10 * time.Second
 )
 
-// Proxy is a transparent HTTP/HTTPS proxy that enforces a domain deny-list.
+// Proxy is a forward proxy that enforces a domain deny-list.
+// It handles three types of incoming connections on a single port:
+//
+//  1. HTTP CONNECT tunnels   — sent by proxy-aware HTTPS clients (via HTTP_PROXY env var)
+//  2. HTTP forward requests  — sent by proxy-aware HTTP clients  (via HTTP_PROXY env var)
+//  3. Transparent TCP        — redirected by iptables from port 80/443
+//     - port 80:  parsed as an HTTP request (Host header)
+//     - port 443: TLS ClientHello SNI peek
 type Proxy struct {
 	filter *Filter
 }
@@ -31,46 +37,87 @@ func NewProxy(filter *Filter) *Proxy {
 	return &Proxy{filter: filter}
 }
 
-// RunHTTP starts the transparent HTTP proxy on the given listener.
+// Run starts the proxy on the given listener.
 // It blocks until lis is closed.
-func (p *Proxy) RunHTTP(lis net.Listener) error {
-	log.Printf("[network-filter] HTTP proxy listening on %s", lis.Addr())
+func (p *Proxy) Run(lis net.Listener) error {
+	log.Printf("[network-filter] proxy listening on %s", lis.Addr())
 	for {
 		conn, err := lis.Accept()
 		if err != nil {
 			return err
 		}
-		go p.handleHTTP(conn)
+		go p.handle(conn)
 	}
 }
 
-// RunHTTPS starts the transparent HTTPS (SNI-based) proxy on the given listener.
-// It blocks until lis is closed.
-func (p *Proxy) RunHTTPS(lis net.Listener) error {
-	log.Printf("[network-filter] HTTPS proxy listening on %s", lis.Addr())
-	for {
-		conn, err := lis.Accept()
-		if err != nil {
-			return err
-		}
-		go p.handleHTTPS(conn)
-	}
-}
-
-// handleHTTP reads one HTTP request, checks the Host header, and either blocks or forwards.
-func (p *Proxy) handleHTTP(conn net.Conn) {
+// handle dispatches an incoming connection by inspecting the first bytes.
+func (p *Proxy) handle(conn net.Conn) {
 	defer conn.Close()
 
-	br := bufio.NewReader(conn)
+	br := bufio.NewReaderSize(conn, 4096)
+
+	// Peek at the first byte to decide the protocol.
+	first, err := br.Peek(1)
+	if err != nil {
+		return
+	}
+
+	// TLS ClientHello starts with 0x16 (TLS record type: handshake).
+	// These arrive when iptables redirects port-443 traffic transparently.
+	if first[0] == 0x16 {
+		p.handleTransparentTLS(conn, br)
+		return
+	}
+
+	// Everything else is treated as an HTTP request (forward proxy or transparent HTTP).
 	req, err := http.ReadRequest(br)
 	if err != nil {
 		return
 	}
+
+	if req.Method == http.MethodConnect {
+		p.handleCONNECT(conn, req)
+	} else {
+		p.handleHTTP(conn, br, req)
+	}
+}
+
+// handleCONNECT processes HTTP CONNECT tunnel requests.
+// This is the standard way proxy-aware clients (curl, browsers, Go's http.Client)
+// establish HTTPS connections through a forward proxy.
+// The target hostname is taken directly from the CONNECT request line — no SNI peeking needed.
+func (p *Proxy) handleCONNECT(conn net.Conn, req *http.Request) {
+	host, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		// No port in CONNECT target — use as-is for domain matching.
+		host = req.Host
+	}
+
+	if p.filter.IsDenied(host) {
+		log.Printf("[network-filter] CONNECT blocked: %s", req.Host)
+		_, _ = fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\nblocked by network filter\n")
+		return
+	}
+
+	upConn, err := net.DialTimeout("tcp", req.Host, dialTimeout)
+	if err != nil {
+		log.Printf("[network-filter] CONNECT dial error %s: %v", req.Host, err)
+		_, _ = fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\n\r\n%v\n", err)
+		return
+	}
+	defer upConn.Close()
+
+	_, _ = fmt.Fprint(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+	pipe(conn, upConn)
+}
+
+// handleHTTP processes a direct HTTP forward proxy request or an iptables-redirected
+// HTTP connection (port 80 → 3128). The host is taken from the Host header.
+func (p *Proxy) handleHTTP(conn net.Conn, br *bufio.Reader, req *http.Request) {
 	host := req.Host
 	if host == "" {
 		host = req.URL.Host
 	}
-
 	if p.filter.IsDenied(host) {
 		log.Printf("[network-filter] HTTP blocked: %s", host)
 		resp := &http.Response{
@@ -79,15 +126,17 @@ func (p *Proxy) handleHTTP(conn net.Conn) {
 			Proto:      "HTTP/1.1",
 			ProtoMajor: 1,
 			ProtoMinor: 1,
-			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Header:     http.Header{"Content-Type": []string{"text/plain"}, "Connection": []string{"close"}},
 			Body:       io.NopCloser(strings.NewReader("blocked by network filter\n")),
 		}
 		_ = resp.Write(conn)
 		return
 	}
 
-	// Determine upstream address.
-	upstream := host
+	upstream := req.Host
+	if upstream == "" {
+		upstream = req.URL.Host
+	}
 	if !strings.Contains(upstream, ":") {
 		upstream = net.JoinHostPort(upstream, "80")
 	}
@@ -108,82 +157,70 @@ func (p *Proxy) handleHTTP(conn net.Conn) {
 	}
 	defer upConn.Close()
 
-	// Forward original request.
+	// Re-write the request in origin server format (strip absolute URL).
+	req.RequestURI = req.URL.RequestURI()
 	if err := req.Write(upConn); err != nil {
 		return
 	}
-	// Drain any buffered bytes from br back into the pipe.
-	if br.Buffered() > 0 {
-		buf := make([]byte, br.Buffered())
-		_, _ = br.Read(buf)
-		_, _ = upConn.Write(buf)
-	}
-
-	// Bi-directional copy.
-	done := make(chan struct{}, 2)
-	go func() { _, _ = io.Copy(upConn, conn); done <- struct{}{} }()
-	go func() { _, _ = io.Copy(conn, upConn); done <- struct{}{} }()
-	<-done
+	pipe(conn, upConn)
 }
 
-// handleHTTPS peeks at the TLS ClientHello to extract the SNI hostname,
-// checks it against the deny-list, and either closes the connection or
-// pipes it through transparently (without decryption).
-func (p *Proxy) handleHTTPS(conn net.Conn) {
-	defer conn.Close()
-
-	br := bufio.NewReader(conn)
+// handleTransparentTLS handles TLS connections redirected transparently by iptables
+// (port 443 → 3128).  It peeks at the TLS ClientHello to extract the SNI hostname
+// without decrypting the traffic, then either closes the connection (denied) or
+// pipes it through to the real upstream.
+func (p *Proxy) handleTransparentTLS(conn net.Conn, br *bufio.Reader) {
 	sni, raw, err := PeekSNI(br)
 	if err != nil {
-		// Could not parse SNI — let traffic through (fail-open for non-TLS or unusual clients).
-		log.Printf("[network-filter] HTTPS: SNI parse error (fail-open): %v", err)
-		p.pipeHTTPS(conn, br, raw, conn.RemoteAddr().String())
+		// Cannot determine hostname — fail-open to avoid blocking legitimate traffic.
+		log.Printf("[network-filter] TLS: SNI parse error (fail-open): %v", err)
+		// Without knowing the destination we can't forward; just close.
 		return
 	}
 
 	if p.filter.IsDenied(sni) {
-		log.Printf("[network-filter] HTTPS blocked: %s", sni)
-		return // close connection — sends TCP RST / FIN
+		log.Printf("[network-filter] TLS blocked: %s", sni)
+		return
 	}
 
 	upstream := net.JoinHostPort(sni, "443")
-	p.pipeHTTPS(conn, br, raw, upstream)
-}
-
-// pipeHTTPS replays raw (already-read bytes) followed by the rest of conn to upstream.
-func (p *Proxy) pipeHTTPS(conn net.Conn, br *bufio.Reader, raw []byte, upstream string) {
 	upConn, err := net.DialTimeout("tcp", upstream, dialTimeout)
 	if err != nil {
-		log.Printf("[network-filter] HTTPS dial error %s: %v", upstream, err)
+		log.Printf("[network-filter] TLS dial error %s: %v", upstream, err)
 		return
 	}
 	defer upConn.Close()
 
-	// Replay the already-read bytes (TLS record).
-	if len(raw) > 0 {
-		if _, err := upConn.Write(raw); err != nil {
-			return
-		}
+	// Replay the already-peeked bytes before piping.
+	if _, err := upConn.Write(raw); err != nil {
+		return
 	}
-	// Forward any additional buffered bytes.
-	if br.Buffered() > 0 {
-		buf := make([]byte, br.Buffered())
-		n, _ := br.Read(buf)
-		if n > 0 {
-			if _, err := upConn.Write(buf[:n]); err != nil {
-				return
+	pipe(io.MultiReader(br, conn), upConn, conn)
+}
+
+// pipe copies bytes bidirectionally between two connections until either side closes.
+// Optional extra writers receive the same bytes as the second connection sends back.
+func pipe(a, b interface{ Read([]byte) (int, error) }, extras ...io.Writer) {
+	aConn, aOK := a.(net.Conn)
+	bConn, bOK := b.(net.Conn)
+	if !aOK || !bOK {
+		// Fallback for non-Conn readers (e.g. io.MultiReader).
+		done := make(chan struct{}, 2)
+		go func() { _, _ = io.Copy(b.(io.Writer), a.(io.Reader)); done <- struct{}{} }()
+		go func() {
+			if len(extras) > 0 {
+				_, _ = io.Copy(io.MultiWriter(append(extras, a.(io.Writer))...), b.(io.Reader))
+			} else {
+				_, _ = io.Copy(a.(io.Writer), b.(io.Reader))
 			}
-		}
+			done <- struct{}{}
+		}()
+		<-done
+		return
 	}
 
 	done := make(chan struct{}, 2)
-	go func() {
-		_, _ = io.Copy(upConn, io.MultiReader(bytes.NewReader(nil), conn))
-		done <- struct{}{}
-	}()
-	go func() {
-		_, _ = io.Copy(conn, upConn)
-		done <- struct{}{}
-	}()
+	go func() { _, _ = io.Copy(bConn, aConn); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(aConn, bConn); done <- struct{}{} }()
 	<-done
 }

--- a/pkg/networkfilter/proxy.go
+++ b/pkg/networkfilter/proxy.go
@@ -52,7 +52,7 @@ func (p *Proxy) Run(lis net.Listener) error {
 
 // handle dispatches an incoming connection by inspecting the first bytes.
 func (p *Proxy) handle(conn net.Conn) {
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck
 
 	br := bufio.NewReaderSize(conn, 4096)
 
@@ -105,7 +105,7 @@ func (p *Proxy) handleCONNECT(conn net.Conn, req *http.Request) {
 		_, _ = fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\n\r\n%v\n", err)
 		return
 	}
-	defer upConn.Close()
+	defer upConn.Close() //nolint:errcheck
 
 	_, _ = fmt.Fprint(conn, "HTTP/1.1 200 Connection Established\r\n\r\n")
 	pipe(conn, upConn)
@@ -155,7 +155,7 @@ func (p *Proxy) handleHTTP(conn net.Conn, br *bufio.Reader, req *http.Request) {
 		_ = resp.Write(conn)
 		return
 	}
-	defer upConn.Close()
+	defer upConn.Close() //nolint:errcheck
 
 	// Re-write the request in origin server format (strip absolute URL).
 	req.RequestURI = req.URL.RequestURI()
@@ -189,7 +189,7 @@ func (p *Proxy) handleTransparentTLS(conn net.Conn, br *bufio.Reader) {
 		log.Printf("[network-filter] TLS dial error %s: %v", upstream, err)
 		return
 	}
-	defer upConn.Close()
+	defer upConn.Close() //nolint:errcheck
 
 	// Replay the already-peeked bytes before piping.
 	if _, err := upConn.Write(raw); err != nil {

--- a/pkg/networkfilter/proxy.go
+++ b/pkg/networkfilter/proxy.go
@@ -209,7 +209,7 @@ func pipe(a, b interface{ Read([]byte) (int, error) }, extras ...io.Writer) {
 		go func() { _, _ = io.Copy(b.(io.Writer), a.(io.Reader)); done <- struct{}{} }()
 		go func() {
 			if len(extras) > 0 {
-				_, _ = io.Copy(io.MultiWriter(append(extras, a.(io.Writer))...), b.(io.Reader))
+				_, _ = io.Copy(io.MultiWriter(extras...), b.(io.Reader))
 			} else {
 				_, _ = io.Copy(a.(io.Writer), b.(io.Reader))
 			}

--- a/pkg/networkfilter/proxy.go
+++ b/pkg/networkfilter/proxy.go
@@ -1,0 +1,189 @@
+package networkfilter
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// HTTPProxyPort is the port the transparent HTTP proxy listens on.
+	HTTPProxyPort = 3128
+	// HTTPSProxyPort is the port the transparent HTTPS (SNI) proxy listens on.
+	HTTPSProxyPort = 3129
+
+	dialTimeout = 10 * time.Second
+)
+
+// Proxy is a transparent HTTP/HTTPS proxy that enforces a domain deny-list.
+type Proxy struct {
+	filter *Filter
+}
+
+// NewProxy creates a Proxy with the given deny-list filter.
+func NewProxy(filter *Filter) *Proxy {
+	return &Proxy{filter: filter}
+}
+
+// RunHTTP starts the transparent HTTP proxy on the given listener.
+// It blocks until lis is closed.
+func (p *Proxy) RunHTTP(lis net.Listener) error {
+	log.Printf("[network-filter] HTTP proxy listening on %s", lis.Addr())
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			return err
+		}
+		go p.handleHTTP(conn)
+	}
+}
+
+// RunHTTPS starts the transparent HTTPS (SNI-based) proxy on the given listener.
+// It blocks until lis is closed.
+func (p *Proxy) RunHTTPS(lis net.Listener) error {
+	log.Printf("[network-filter] HTTPS proxy listening on %s", lis.Addr())
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			return err
+		}
+		go p.handleHTTPS(conn)
+	}
+}
+
+// handleHTTP reads one HTTP request, checks the Host header, and either blocks or forwards.
+func (p *Proxy) handleHTTP(conn net.Conn) {
+	defer conn.Close()
+
+	br := bufio.NewReader(conn)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		return
+	}
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+
+	if p.filter.IsDenied(host) {
+		log.Printf("[network-filter] HTTP blocked: %s", host)
+		resp := &http.Response{
+			Status:     "403 Forbidden",
+			StatusCode: http.StatusForbidden,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     http.Header{"Content-Type": []string{"text/plain"}},
+			Body:       io.NopCloser(strings.NewReader("blocked by network filter\n")),
+		}
+		_ = resp.Write(conn)
+		return
+	}
+
+	// Determine upstream address.
+	upstream := host
+	if !strings.Contains(upstream, ":") {
+		upstream = net.JoinHostPort(upstream, "80")
+	}
+
+	upConn, err := net.DialTimeout("tcp", upstream, dialTimeout)
+	if err != nil {
+		log.Printf("[network-filter] HTTP dial error %s: %v", upstream, err)
+		resp := &http.Response{
+			Status:     "502 Bad Gateway",
+			StatusCode: http.StatusBadGateway,
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Body:       io.NopCloser(strings.NewReader(fmt.Sprintf("dial error: %v\n", err))),
+		}
+		_ = resp.Write(conn)
+		return
+	}
+	defer upConn.Close()
+
+	// Forward original request.
+	if err := req.Write(upConn); err != nil {
+		return
+	}
+	// Drain any buffered bytes from br back into the pipe.
+	if br.Buffered() > 0 {
+		buf := make([]byte, br.Buffered())
+		_, _ = br.Read(buf)
+		_, _ = upConn.Write(buf)
+	}
+
+	// Bi-directional copy.
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(upConn, conn); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(conn, upConn); done <- struct{}{} }()
+	<-done
+}
+
+// handleHTTPS peeks at the TLS ClientHello to extract the SNI hostname,
+// checks it against the deny-list, and either closes the connection or
+// pipes it through transparently (without decryption).
+func (p *Proxy) handleHTTPS(conn net.Conn) {
+	defer conn.Close()
+
+	br := bufio.NewReader(conn)
+	sni, raw, err := PeekSNI(br)
+	if err != nil {
+		// Could not parse SNI — let traffic through (fail-open for non-TLS or unusual clients).
+		log.Printf("[network-filter] HTTPS: SNI parse error (fail-open): %v", err)
+		p.pipeHTTPS(conn, br, raw, conn.RemoteAddr().String())
+		return
+	}
+
+	if p.filter.IsDenied(sni) {
+		log.Printf("[network-filter] HTTPS blocked: %s", sni)
+		return // close connection — sends TCP RST / FIN
+	}
+
+	upstream := net.JoinHostPort(sni, "443")
+	p.pipeHTTPS(conn, br, raw, upstream)
+}
+
+// pipeHTTPS replays raw (already-read bytes) followed by the rest of conn to upstream.
+func (p *Proxy) pipeHTTPS(conn net.Conn, br *bufio.Reader, raw []byte, upstream string) {
+	upConn, err := net.DialTimeout("tcp", upstream, dialTimeout)
+	if err != nil {
+		log.Printf("[network-filter] HTTPS dial error %s: %v", upstream, err)
+		return
+	}
+	defer upConn.Close()
+
+	// Replay the already-read bytes (TLS record).
+	if len(raw) > 0 {
+		if _, err := upConn.Write(raw); err != nil {
+			return
+		}
+	}
+	// Forward any additional buffered bytes.
+	if br.Buffered() > 0 {
+		buf := make([]byte, br.Buffered())
+		n, _ := br.Read(buf)
+		if n > 0 {
+			if _, err := upConn.Write(buf[:n]); err != nil {
+				return
+			}
+		}
+	}
+
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(upConn, io.MultiReader(bytes.NewReader(nil), conn))
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(conn, upConn)
+		done <- struct{}{}
+	}()
+	<-done
+}

--- a/pkg/networkfilter/setup.go
+++ b/pkg/networkfilter/setup.go
@@ -6,22 +6,32 @@ import (
 )
 
 // SidecarUID is the UID the network-filter sidecar container runs as.
-// iptables rules skip packets from this UID to avoid redirect loops.
+// iptables OUTPUT rules skip packets from this UID to prevent redirect loops:
+// the sidecar connects to real upstreams and those packets must not be re-intercepted.
 const SidecarUID = 0
 
-// SetupIPTables configures iptables rules to redirect outbound HTTP/HTTPS
-// traffic through the network-filter transparent proxy.
-// Must be called with CAP_NET_ADMIN (typically from an init container).
+// SetupIPTables configures iptables NAT OUTPUT rules so that outbound HTTP and
+// HTTPS traffic from the main container is redirected to the network-filter sidecar.
+//
+// Primary filtering mechanism: HTTP_PROXY / HTTPS_PROXY env vars (injected by the
+// session manager) make proxy-aware clients use CONNECT tunnels so the sidecar sees
+// the target hostname directly — no TLS decryption required.
+//
+// This iptables redirect is a belt-and-suspenders fallback for clients that do not
+// respect HTTP_PROXY (e.g. programs that open raw TCP sockets to port 80/443).
+//
+// Must be called with CAP_NET_ADMIN — typically from an init container.
 func SetupIPTables() error {
 	rules := [][]string{
-		// Skip loopback traffic.
+		// Skip loopback — keeps localhost communication intact.
 		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-d", "127.0.0.1", "-j", "RETURN"},
-		// Skip traffic from the sidecar itself (runs as UID 0) to avoid redirect loops.
+		// Skip traffic from the sidecar itself (UID 0) to avoid redirect loops.
 		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-m", "owner", "--uid-owner", fmt.Sprintf("%d", SidecarUID), "-j", "RETURN"},
-		// Redirect HTTP (port 80) to transparent proxy.
-		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", HTTPProxyPort)},
-		// Redirect HTTPS (port 443) to SNI proxy.
-		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", HTTPSProxyPort)},
+		// Redirect outbound HTTP (port 80) to the forward proxy.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", ProxyPort)},
+		// Redirect outbound HTTPS (port 443) to the forward proxy.
+		// The proxy peeks at the TLS ClientHello SNI for clients that bypass HTTP_PROXY.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", ProxyPort)},
 	}
 	for _, rule := range rules {
 		cmd := exec.Command("iptables", rule...)

--- a/pkg/networkfilter/setup.go
+++ b/pkg/networkfilter/setup.go
@@ -6,33 +6,67 @@ import (
 )
 
 // SidecarUID is the UID the network-filter sidecar container runs as.
-// iptables OUTPUT rules skip packets from this UID to prevent redirect loops:
-// the sidecar connects to real upstreams and those packets must not be re-intercepted.
+// filter OUTPUT rules accept all traffic from this UID unconditionally so the
+// sidecar can reach real upstreams without being self-blocked.
 const SidecarUID = 0
 
-// SetupIPTables configures iptables NAT OUTPUT rules so that outbound HTTP and
-// HTTPS traffic from the main container is redirected to the network-filter sidecar.
+// SetupIPTables configures iptables rules to enforce network isolation for the
+// session Pod, following the same strategy as NemoClaw / NVIDIA OpenShell:
 //
-// Primary filtering mechanism: HTTP_PROXY / HTTPS_PROXY env vars (injected by the
-// session manager) make proxy-aware clients use CONNECT tunnels so the sidecar sees
-// the target hostname directly — no TLS decryption required.
+//   - All outbound TCP is REJECT-ed by default.
+//   - Traffic from the network-filter sidecar (UID 0) is exempted so it can
+//     reach real upstreams without looping back through itself.
+//   - The proxy port (127.0.0.1:3128) is explicitly allowed for the main
+//     container to reach the sidecar.
+//   - Established / related packets (TCP replies, ICMP unreachables) are let
+//     through so the proxy's upstream connections work normally.
+//   - UDP is left unrestricted to avoid breaking DNS and other infrastructure;
+//     add explicit UDP rules here if stricter UDP isolation is required.
 //
-// This iptables redirect is a belt-and-suspenders fallback for clients that do not
-// respect HTTP_PROXY (e.g. programs that open raw TCP sockets to port 80/443).
+// Primary mechanism: HTTP_PROXY / HTTPS_PROXY environment variables (injected
+// by the session manager) make proxy-aware clients (curl, Go http.Client, npm,
+// pip, etc.) use CONNECT tunnels for ALL ports, not just 80/443. The REJECT
+// rules below ensure non-proxy-aware direct TCP connections are also blocked.
 //
-// Must be called with CAP_NET_ADMIN — typically from an init container.
+// Must be called with CAP_NET_ADMIN — from the network-filter-setup init container.
 func SetupIPTables() error {
+	proxyPort := fmt.Sprintf("%d", ProxyPort)
+	sidecarUID := fmt.Sprintf("%d", SidecarUID)
+
 	rules := [][]string{
-		// Skip loopback — keeps localhost communication intact.
+		// ── filter OUTPUT (primary enforcement) ────────────────────────────────
+
+		// Allow loopback.
+		{"-t", "filter", "-A", "OUTPUT", "-o", "lo", "-j", "ACCEPT"},
+
+		// Allow all traffic from the sidecar (UID 0) so it can reach upstreams.
+		{"-t", "filter", "-A", "OUTPUT", "-m", "owner", "--uid-owner", sidecarUID, "-j", "ACCEPT"},
+
+		// Allow main container to reach the local proxy sidecar.
+		{"-t", "filter", "-A", "OUTPUT", "-p", "tcp", "-d", "127.0.0.1", "--dport", proxyPort, "-j", "ACCEPT"},
+
+		// Allow established / related packets (responses from sidecar's upstream connections).
+		{"-t", "filter", "-A", "OUTPUT", "-m", "state", "--state", "ESTABLISHED,RELATED", "-j", "ACCEPT"},
+
+		// REJECT all other outbound TCP with a TCP RST (fast fail for the client).
+		{"-t", "filter", "-A", "OUTPUT", "-p", "tcp", "-j", "REJECT", "--reject-with", "tcp-reset"},
+
+		// ── nat OUTPUT (transparent interception fallback) ─────────────────────
+		// Redirect port 80/443 to the sidecar for clients that ignore HTTP_PROXY
+		// and open a direct TCP connection. These connections would be blocked by
+		// the filter REJECT above, but redirecting them first lets the sidecar
+		// serve an informative 403 instead of a bare RST.
+
+		// Skip loopback in NAT (after filter rules; order matters less here).
 		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-d", "127.0.0.1", "-j", "RETURN"},
-		// Skip traffic from the sidecar itself (UID 0) to avoid redirect loops.
-		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-m", "owner", "--uid-owner", fmt.Sprintf("%d", SidecarUID), "-j", "RETURN"},
-		// Redirect outbound HTTP (port 80) to the forward proxy.
-		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", ProxyPort)},
-		// Redirect outbound HTTPS (port 443) to the forward proxy.
-		// The proxy peeks at the TLS ClientHello SNI for clients that bypass HTTP_PROXY.
-		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", ProxyPort)},
+		// Skip sidecar traffic in NAT to avoid loops.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-m", "owner", "--uid-owner", sidecarUID, "-j", "RETURN"},
+		// Redirect HTTP.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", proxyPort},
+		// Redirect HTTPS.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", proxyPort},
 	}
+
 	for _, rule := range rules {
 		cmd := exec.Command("iptables", rule...)
 		if out, err := cmd.CombinedOutput(); err != nil {

--- a/pkg/networkfilter/setup.go
+++ b/pkg/networkfilter/setup.go
@@ -1,0 +1,33 @@
+package networkfilter
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// SidecarUID is the UID the network-filter sidecar container runs as.
+// iptables rules skip packets from this UID to avoid redirect loops.
+const SidecarUID = 0
+
+// SetupIPTables configures iptables rules to redirect outbound HTTP/HTTPS
+// traffic through the network-filter transparent proxy.
+// Must be called with CAP_NET_ADMIN (typically from an init container).
+func SetupIPTables() error {
+	rules := [][]string{
+		// Skip loopback traffic.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-d", "127.0.0.1", "-j", "RETURN"},
+		// Skip traffic from the sidecar itself (runs as UID 0) to avoid redirect loops.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-m", "owner", "--uid-owner", fmt.Sprintf("%d", SidecarUID), "-j", "RETURN"},
+		// Redirect HTTP (port 80) to transparent proxy.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "80", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", HTTPProxyPort)},
+		// Redirect HTTPS (port 443) to SNI proxy.
+		{"-t", "nat", "-A", "OUTPUT", "-p", "tcp", "--dport", "443", "-j", "REDIRECT", "--to-port", fmt.Sprintf("%d", HTTPSProxyPort)},
+	}
+	for _, rule := range rules {
+		cmd := exec.Command("iptables", rule...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("iptables %v: %w\noutput: %s", rule, err, out)
+		}
+	}
+	return nil
+}

--- a/pkg/networkfilter/sni.go
+++ b/pkg/networkfilter/sni.go
@@ -1,0 +1,125 @@
+package networkfilter
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// PeekSNI reads a TLS ClientHello from r and returns the SNI hostname.
+// It does not consume bytes beyond what it reads; use a bufio.Reader or
+// bytes.Buffer so the caller can replay the bytes to the upstream connection.
+// Returns an error if the record is not a valid TLS ClientHello or has no SNI.
+func PeekSNI(r io.Reader) (string, []byte, error) {
+	// Read the TLS record header (5 bytes).
+	header := make([]byte, 5)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return "", nil, fmt.Errorf("reading TLS header: %w", err)
+	}
+	// record type 0x16 = handshake
+	if header[0] != 0x16 {
+		return "", header, fmt.Errorf("not a TLS handshake record (type=%02x)", header[0])
+	}
+	recordLen := int(binary.BigEndian.Uint16(header[3:5]))
+	if recordLen > 16384 {
+		return "", header, fmt.Errorf("TLS record too large (%d)", recordLen)
+	}
+	body := make([]byte, recordLen)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return "", header, fmt.Errorf("reading TLS record body: %w", err)
+	}
+	raw := append(header, body...)
+
+	sni, err := extractSNI(body)
+	if err != nil {
+		return "", raw, err
+	}
+	return sni, raw, nil
+}
+
+// extractSNI parses a TLS ClientHello handshake message body and extracts the SNI.
+func extractSNI(data []byte) (string, error) {
+	if len(data) < 4 {
+		return "", fmt.Errorf("handshake record too short")
+	}
+	// Handshake type must be ClientHello (1).
+	if data[0] != 0x01 {
+		return "", fmt.Errorf("not a ClientHello (type=%02x)", data[0])
+	}
+	// Handshake length (3 bytes big-endian).
+	hsLen := int(data[1])<<16 | int(data[2])<<8 | int(data[3])
+	if 4+hsLen > len(data) {
+		return "", fmt.Errorf("ClientHello truncated")
+	}
+	hello := data[4 : 4+hsLen]
+
+	// ClientHello: client_version(2) + random(32) + session_id_len(1) + ...
+	if len(hello) < 35 {
+		return "", fmt.Errorf("ClientHello too short")
+	}
+	pos := 34 // skip version(2) + random(32)
+	sessionIDLen := int(hello[pos])
+	pos++
+	pos += sessionIDLen
+	if pos+2 > len(hello) {
+		return "", fmt.Errorf("ClientHello truncated at cipher suites")
+	}
+	cipherSuitesLen := int(binary.BigEndian.Uint16(hello[pos : pos+2]))
+	pos += 2 + cipherSuitesLen
+	if pos+1 > len(hello) {
+		return "", fmt.Errorf("ClientHello truncated at compression methods")
+	}
+	compressionLen := int(hello[pos])
+	pos++
+	pos += compressionLen
+	if pos+2 > len(hello) {
+		// No extensions.
+		return "", fmt.Errorf("no extensions in ClientHello")
+	}
+	extLen := int(binary.BigEndian.Uint16(hello[pos : pos+2]))
+	pos += 2
+	extEnd := pos + extLen
+	if extEnd > len(hello) {
+		return "", fmt.Errorf("extensions length overflow")
+	}
+	for pos+4 <= extEnd {
+		extType := binary.BigEndian.Uint16(hello[pos : pos+2])
+		extDataLen := int(binary.BigEndian.Uint16(hello[pos+2 : pos+4]))
+		pos += 4
+		if extType == 0x0000 { // SNI extension
+			sni, err := parseSNIExtension(hello[pos : pos+extDataLen])
+			if err != nil {
+				return "", err
+			}
+			return sni, nil
+		}
+		pos += extDataLen
+	}
+	return "", fmt.Errorf("SNI extension not found")
+}
+
+// parseSNIExtension parses the SNI extension data and returns the first hostname.
+func parseSNIExtension(data []byte) (string, error) {
+	if len(data) < 2 {
+		return "", fmt.Errorf("SNI extension too short")
+	}
+	listLen := int(binary.BigEndian.Uint16(data[0:2]))
+	data = data[2:]
+	if listLen > len(data) {
+		return "", fmt.Errorf("SNI list length overflow")
+	}
+	pos := 0
+	for pos+3 <= listLen {
+		nameType := data[pos]
+		nameLen := int(binary.BigEndian.Uint16(data[pos+1 : pos+3]))
+		pos += 3
+		if nameType == 0x00 { // host_name
+			if pos+nameLen > len(data) {
+				return "", fmt.Errorf("SNI hostname truncated")
+			}
+			return string(data[pos : pos+nameLen]), nil
+		}
+		pos += nameLen
+	}
+	return "", fmt.Errorf("no host_name in SNI list")
+}

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -113,6 +113,14 @@ func parseFileSecretKey(k string) (int, bool) {
 	return idx, true
 }
 
+// SandboxConfig holds network sandbox configuration for a session Pod.
+// When Enabled is true, an init container sets up iptables rules and a sidecar
+// acts as a transparent HTTP/HTTPS proxy that enforces DeniedDomains.
+type SandboxConfig struct {
+	Enabled       bool     `yaml:"enabled"                  json:"enabled"`
+	DeniedDomains []string `yaml:"denied_domains,omitempty" json:"denied_domains,omitempty"`
+}
+
 // SessionSettings is the top-level unified settings YAML structure.
 // It consolidates all configuration needed for a session Pod.
 type SessionSettings struct {
@@ -126,6 +134,7 @@ type SessionSettings struct {
 	Github         *GithubConfig        `yaml:"github,omitempty"          json:"github,omitempty"`
 	SlackParams    *SlackParams         `yaml:"slack_params,omitempty"    json:"slack_params,omitempty"`
 	OtelCollector  *OtelCollectorConfig `yaml:"otel_collector,omitempty"  json:"otel_collector,omitempty"`
+	Sandbox        *SandboxConfig       `yaml:"sandbox,omitempty"         json:"sandbox,omitempty"`
 	// Files holds the managed files to be restored at session startup.
 	// They are read from the agentapi-agent-files-{userID} Secret at session creation
 	// time and written to their respective paths by the provisioner.

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4568,6 +4568,26 @@
             "description": "Maximum number of cycles to run. 0 means unlimited. Requires cycle_message to be set. The current count is tracked in /tmp/check/CYCLE_COUNT inside the session.",
             "default": 10,
             "example": 10
+          },
+          "sandbox": {
+            "$ref": "#/components/schemas/SandboxParams"
+          }
+        }
+      },
+      "SandboxParams": {
+        "type": "object",
+        "description": "Network sandbox configuration for the session. When enabled, outbound HTTP/HTTPS traffic is routed through a transparent proxy sidecar that enforces the denied-domains list.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "When true, the network-filter init container and sidecar are injected into the session Pod. The init container configures iptables to redirect HTTP/HTTPS traffic through the sidecar.",
+            "default": false
+          },
+          "denied_domains": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of hostnames to block. HTTP traffic is matched by Host header; HTTPS by TLS SNI (no decryption). Supports wildcard prefixes (e.g. '*.example.com').",
+            "example": ["example.com", "*.evil.com"]
           }
         }
       },


### PR DESCRIPTION
## Summary

- Implements Issue #762: NemoClaw-inspired sidecar transparent proxy for session network isolation
- Adds params.sandbox to POST /start API so callers can enable sandboxing and specify denied_domains
- Adds network-filter setup (init container, iptables) and network-filter proxy (sidecar) subcommands to the agentapi-proxy binary, reusing the existing image with no new Docker image needed

## Architecture

```
[agentapi コンテナ (UID 999)]
    HTTP port 80 / HTTPS port 443
    ↓
[iptables NAT OUTPUT — set by init container network-filter-setup]
    ↓
[network-filter sidecar (UID 0, excluded from iptables redirect)]
    HTTP  port 3128 → Host header filter
    HTTPS port 3129 → TLS SNI filter (no decryption)
    ├─ denied → 403 / TCP close
    └─ allowed → upstream
```

## New files

- pkg/networkfilter/filter.go — Domain matching with wildcard support
- pkg/networkfilter/sni.go — TLS ClientHello SNI extraction
- pkg/networkfilter/proxy.go — Transparent HTTP/HTTPS proxy
- pkg/networkfilter/setup.go — iptables rule setup
- cmd/network_filter.go — network-filter {setup,proxy} cobra commands

## Changes to existing code

- pkg/sessionsettings/types.go — add SandboxConfig struct + SessionSettings.Sandbox
- internal/domain/entities/session.go — add SandboxParams + SessionParams.Sandbox + RunServerRequest.Sandbox
- internal/app/server.go — map params.sandbox to RunServerRequest.Sandbox
- internal/infrastructure/services/kubernetes_session_manager.go — inject init container + sidecar when sandbox enabled; store sandbox config in SessionSettings
- main.go — register NetworkFilterCmd
- spec/openapi.json — add SandboxParams schema

## Test plan

- [ ] Unit tests pass: go test ./pkg/networkfilter/ -v
- [ ] Build succeeds: go build ./...
- [ ] Integration: create session with params.sandbox.enabled=true, denied_domains=["example.com"] and verify curl http://example.com returns 403
- [ ] Verify non-denied domains are reachable through the sidecar

Closes #762

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)