### PR TITLE
feat: add bedrock-mantle.*.api.aws to sandbox bypass domains

### DIFF
--- a/pkg/networkfilter/filter.go
+++ b/pkg/networkfilter/filter.go
@@ -14,7 +14,8 @@ import (
 // - npmjs.org: npm package registry (tool installation)
 // - docker.io / docker.com: Docker Hub image pulls
 // - openai.com: codex-acp OpenAI backend
-// - bedrock.*.amazonaws.com: AWS Bedrock (region-scoped endpoints)
+// - bedrock.*.amazonaws.com: AWS Bedrock legacy InvokeModel/Converse API (region-scoped endpoints)
+// - bedrock-mantle.*.api.aws: AWS Bedrock new Messages API (Anthropic-compatible SSE endpoint)
 var bypassDomains = normalize([]string{
 	"*.anthropic.com",
 	"anthropic.com",
@@ -33,6 +34,7 @@ var bypassDomains = normalize([]string{
 	"bedrock-runtime.*.amazonaws.com",
 	"bedrock-agent.*.amazonaws.com",
 	"bedrock-agent-runtime.*.amazonaws.com",
+	"bedrock-mantle.*.api.aws",
 })
 
 // Filter decides whether a given host should be blocked.

--- a/pkg/networkfilter/filter_test.go
+++ b/pkg/networkfilter/filter_test.go
@@ -39,6 +39,10 @@ func TestMatchDomainMiddleWildcard(t *testing.T) {
 		{"bedrock-agent.eu-west-1.amazonaws.com", "bedrock-agent.*.amazonaws.com", true},
 		{"s3.us-east-1.amazonaws.com", "bedrock.*.amazonaws.com", false},
 		{"notbedrock.us-east-1.amazonaws.com", "bedrock.*.amazonaws.com", false},
+		{"bedrock-mantle.us-east-1.api.aws", "bedrock-mantle.*.api.aws", true},
+		{"bedrock-mantle.ap-northeast-1.api.aws", "bedrock-mantle.*.api.aws", true},
+		{"bedrock-mantle.eu-west-1.api.aws", "bedrock-mantle.*.api.aws", true},
+		{"other.us-east-1.api.aws", "bedrock-mantle.*.api.aws", false},
 	}
 	for _, c := range cases {
 		got := matchDomain(c.host, c.pattern)
@@ -55,6 +59,8 @@ func TestBypassDomains(t *testing.T) {
 		"api.openai.com",
 		"bedrock.us-east-1.amazonaws.com",
 		"bedrock-runtime.ap-northeast-1.amazonaws.com",
+		"bedrock-mantle.us-east-1.api.aws",
+		"bedrock-mantle.ap-northeast-1.api.aws",
 		"api.github.com",
 		"raw.githubusercontent.com",
 		"registry.npmjs.org",


### PR DESCRIPTION
## Summary

- AWS Bedrock の新しい Messages API (`bedrock-mantle.{region}.api.aws`) を sandbox のネットワークフィルタ bypass domains に追加
- 旧 InvokeModel/Converse API (`bedrock-runtime.*.amazonaws.com` など) は既に bypass 対象だったが、新エンドポイントが未対応だった
- `matchDomain` の中間ワイルドカード (`prefix.*.suffix`) パターンを利用して `bedrock-mantle.*.api.aws` を追加

## 背景

AWS Bedrock の新 Messages API エンドポイントは `https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages` 形式で、Anthropic の直接 API と同じリクエストボディ形式・SSE ストリーミングをサポートする。sandbox モードでアクセスするためには bypass domains への追加が必要。

## Test plan

- [x] `TestMatchDomainMiddleWildcard` に `bedrock-mantle.*.api.aws` パターンのテストケースを追加
- [x] `TestBypassDomains` に `bedrock-mantle.us-east-1.api.aws` / `bedrock-mantle.ap-northeast-1.api.aws` を追加
- [x] `pkg/networkfilter` テスト全通過確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)