### PR TITLE
fix(sandbox): empty allowlist denies all, empty denylist allows all

### DIFF
--- a/cmd/network_filter.go
+++ b/cmd/network_filter.go
@@ -68,9 +68,12 @@ A single listener on port 3128 handles three types of connections:
 		if len(allowedDomains) > 0 {
 			log.Printf("[network-filter] Starting proxy on 0.0.0.0:%d (allowlist: %v)", networkfilter.ProxyPort, allowedDomains)
 			filter = networkfilter.NewAllowlistFilter(allowedDomains)
-		} else {
+		} else if len(deniedDomains) > 0 {
 			log.Printf("[network-filter] Starting proxy on 0.0.0.0:%d (denylist: %v)", networkfilter.ProxyPort, deniedDomains)
 			filter = networkfilter.NewFilter(deniedDomains)
+		} else {
+			log.Printf("[network-filter] Starting proxy on 0.0.0.0:%d (deny-all: no domains specified)", networkfilter.ProxyPort)
+			filter = networkfilter.NewAllowlistFilter(nil)
 		}
 
 		proxy := networkfilter.NewProxy(filter)

--- a/pkg/networkfilter/filter.go
+++ b/pkg/networkfilter/filter.go
@@ -38,12 +38,15 @@ var bypassDomains = normalize([]string{
 })
 
 // Filter decides whether a given host should be blocked.
-// When allowedDomains is non-empty, only those domains pass (allowlist mode).
-// Otherwise, deniedDomains are blocked (denylist mode).
+// In allowlist mode (created via NewAllowlistFilter), only listed domains pass;
+// an empty allowlist blocks everything.
+// In denylist mode (created via NewFilter), listed domains are blocked;
+// an empty denylist allows everything.
 // bypassDomains are always allowed regardless of mode.
 type Filter struct {
 	deniedDomains  []string
 	allowedDomains []string
+	allowlistMode  bool
 }
 
 func normalize(domains []string) []string {
@@ -63,8 +66,9 @@ func NewFilter(deniedDomains []string) *Filter {
 }
 
 // NewAllowlistFilter creates an allowlist filter: only listed domains are permitted.
+// An empty allowedDomains list blocks all traffic (nothing is allowed).
 func NewAllowlistFilter(allowedDomains []string) *Filter {
-	return &Filter{allowedDomains: normalize(allowedDomains)}
+	return &Filter{allowedDomains: normalize(allowedDomains), allowlistMode: true}
 }
 
 // FilterResult describes the outcome of a filter check.
@@ -107,7 +111,8 @@ func (f *Filter) Check(host string) FilterResult {
 	}
 
 	// Allowlist mode: deny everything NOT in the allowed list.
-	if len(f.allowedDomains) > 0 {
+	// An empty allowlist blocks all traffic.
+	if f.allowlistMode {
 		for _, allowed := range f.allowedDomains {
 			if matchDomain(h, allowed) {
 				return FilterResultAllowed
@@ -117,6 +122,7 @@ func (f *Filter) Check(host string) FilterResult {
 	}
 
 	// Denylist mode: deny only matched domains.
+	// An empty denylist allows all traffic.
 	for _, denied := range f.deniedDomains {
 		if matchDomain(h, denied) {
 			return FilterResultBlocked

--- a/pkg/networkfilter/filter_test.go
+++ b/pkg/networkfilter/filter_test.go
@@ -52,6 +52,26 @@ func TestMatchDomainMiddleWildcard(t *testing.T) {
 	}
 }
 
+func TestAllowlistFilterEmptyDeniesAll(t *testing.T) {
+	f := NewAllowlistFilter(nil)
+	cases := []string{"example.com", "good.com", "anything.io", "sub.example.com"}
+	for _, host := range cases {
+		if r := f.Check(host); r != FilterResultBlocked {
+			t.Errorf("NewAllowlistFilter(nil).Check(%q) = %v, want blocked", host, r)
+		}
+	}
+}
+
+func TestDenylistFilterEmptyAllowsAll(t *testing.T) {
+	f := NewFilter(nil)
+	cases := []string{"example.com", "anything.io", "sub.example.com"}
+	for _, host := range cases {
+		if r := f.Check(host); r != FilterResultAllowed {
+			t.Errorf("NewFilter(nil).Check(%q) = %v, want allowed", host, r)
+		}
+	}
+}
+
 func TestBypassDomains(t *testing.T) {
 	f := NewAllowlistFilter([]string{"example.com"})
 	bypassed := []string{


### PR DESCRIPTION
## Summary

- `NewAllowlistFilter([])` が空リストで全許可になっていたバグを修正
- `Filter` 構造体に `allowlistMode bool` フィールドを追加し、モードを明示的に追跡
- allowlist モード (空リスト含む) → 全拒否
- denylist モード (空リスト) → 全許可 (既存動作、変更なし)
- allowlist/denylist どちらも未指定の場合 → deny-all をデフォルトに変更

## 変更内容

- `pkg/networkfilter/filter.go`: `allowlistMode bool` フィールド追加、`Check()` のモード判定を `len(allowedDomains) > 0` から `allowlistMode` に変更
- `cmd/network_filter.go`: allowlist/denylist どちらも未指定の場合は `NewAllowlistFilter(nil)` (deny-all) を使用
- `pkg/networkfilter/filter_test.go`: 空 allowlist が全拒否、空 denylist が全許可になることのテストを追加

## Test plan

- [x] `TestAllowlistFilterEmptyDeniesAll`: 空の allowlist が全ドメインをブロックすることを確認
- [x] `TestDenylistFilterEmptyAllowsAll`: 空の denylist が全ドメインを許可することを確認
- [x] 既存テスト全通過
- [x] `golangci-lint` 0 issues

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)