### PR TITLE
feat: network-filter deferred policy activation and remove github/docker bypass domains

### DIFF
--- a/cmd/network_filter.go
+++ b/cmd/network_filter.go
@@ -46,10 +46,15 @@ Allowlist takes precedence when both are specified.
 A single listener on port 3128 handles three types of connections:
   - HTTP CONNECT tunnels (proxy-aware HTTPS clients via HTTP_PROXY/HTTPS_PROXY env vars)
   - HTTP forward proxy requests (proxy-aware HTTP clients)
-  - Transparent TLS (iptables-redirected port-443 traffic, SNI-filtered)`,
+  - Transparent TLS (iptables-redirected port-443 traffic, SNI-filtered)
+
+When --deferred-policy is set, the proxy starts in passthrough mode (all traffic allowed)
+and the configured policy is activated only after sending POST /enable-policy to the
+control server on port 3129 (localhost only).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		allowedDomainsFlag, _ := cmd.Flags().GetStringSlice("allowed-domains")
 		deniedDomainsFlag, _ := cmd.Flags().GetStringSlice("denied-domains")
+		deferredPolicy, _ := cmd.Flags().GetBool("deferred-policy")
 
 		parseDomains := func(envKey string, flagVals []string) []string {
 			var out []string
@@ -76,7 +81,22 @@ A single listener on port 3128 handles three types of connections:
 			filter = networkfilter.NewAllowlistFilter(nil)
 		}
 
-		proxy := networkfilter.NewProxy(filter)
+		if deferredPolicy {
+			log.Printf("[network-filter] deferred-policy mode: policy inactive until POST /enable-policy on port %d", networkfilter.ControlPort)
+		}
+
+		proxy := networkfilter.NewProxy(filter, !deferredPolicy)
+
+		controlAddr := fmt.Sprintf("127.0.0.1:%d", networkfilter.ControlPort)
+		controlLis, err := net.Listen("tcp", controlAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", controlAddr, err)
+		}
+		go func() {
+			if err := networkfilter.NewControlServer(proxy).Run(controlLis); err != nil {
+				log.Printf("[network-filter] control server error: %v", err)
+			}
+		}()
 
 		addr := fmt.Sprintf("0.0.0.0:%d", networkfilter.ProxyPort)
 		lis, err := net.Listen("tcp", addr)
@@ -93,6 +113,8 @@ func init() {
 		"Domains to allow (allowlist mode). All others blocked. Overrides denied-domains when set. Also via NETWORK_FILTER_ALLOWED_DOMAINS.")
 	networkFilterProxyCmd.Flags().StringSlice("denied-domains", nil,
 		"Domains to block (denylist mode). Also via NETWORK_FILTER_DENIED_DOMAINS.")
+	networkFilterProxyCmd.Flags().Bool("deferred-policy", false,
+		"Start in passthrough mode (all traffic allowed). Activate the policy later via POST /enable-policy on the control server (port 3129).")
 
 	NetworkFilterCmd.AddCommand(networkFilterSetupCmd)
 	NetworkFilterCmd.AddCommand(networkFilterProxyCmd)

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2040,7 +2040,7 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 		Name:            "network-filter",
 		Image:           m.k8sConfig.Image,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"agentapi-proxy", "network-filter", "proxy"},
+		Command:         []string{"agentapi-proxy", "network-filter", "proxy", "--deferred-policy"},
 		Env:             filterEnvVars,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &rootUID,

--- a/pkg/networkfilter/control.go
+++ b/pkg/networkfilter/control.go
@@ -1,0 +1,34 @@
+package networkfilter
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+)
+
+// ControlServer exposes a minimal HTTP API for managing the proxy at runtime.
+// It listens on ControlPort (localhost only) and accepts:
+//
+//   - POST /enable-policy  — activate the configured filter (idempotent)
+type ControlServer struct {
+	proxy *Proxy
+}
+
+// NewControlServer creates a ControlServer that operates on the given proxy.
+func NewControlServer(proxy *Proxy) *ControlServer {
+	return &ControlServer{proxy: proxy}
+}
+
+// Run starts the HTTP control server on lis and blocks until lis is closed.
+func (c *ControlServer) Run(lis net.Listener) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /enable-policy", func(w http.ResponseWriter, _ *http.Request) {
+		c.proxy.EnablePolicy()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "policy enabled")
+	})
+	srv := &http.Server{Handler: mux}
+	log.Printf("[network-filter] control server listening on %s", lis.Addr())
+	return srv.Serve(lis)
+}

--- a/pkg/networkfilter/filter.go
+++ b/pkg/networkfilter/filter.go
@@ -8,11 +8,8 @@ import (
 // These are required for Claude Code sessions to function correctly:
 // - anthropic.com: Claude API
 // - svc.cluster.local: Kubernetes internal services (stop hooks, health checks)
-// - github.com / githubusercontent.com: GitHub auth, raw content, API
 // - storage.googleapis.com: tool downloads via GCS
 // - sentry.io: error reporting
-// - npmjs.org: npm package registry (tool installation)
-// - docker.io / docker.com: Docker Hub image pulls
 // - openai.com: codex-acp OpenAI backend
 // - bedrock.*.amazonaws.com: AWS Bedrock legacy InvokeModel/Converse API (region-scoped endpoints)
 // - bedrock-mantle.*.api.aws: AWS Bedrock new Messages API (Anthropic-compatible SSE endpoint)
@@ -20,15 +17,9 @@ var bypassDomains = normalize([]string{
 	"*.anthropic.com",
 	"anthropic.com",
 	"*.svc.cluster.local",
-	"github.com",
-	"*.github.com",
-	"*.githubusercontent.com",
 	"storage.googleapis.com",
 	"sentry.io",
 	"*.sentry.io",
-	"registry.npmjs.org",
-	"*.docker.io",
-	"*.docker.com",
 	"api.openai.com",
 	"bedrock.*.amazonaws.com",
 	"bedrock-runtime.*.amazonaws.com",

--- a/pkg/networkfilter/filter_test.go
+++ b/pkg/networkfilter/filter_test.go
@@ -81,13 +81,27 @@ func TestBypassDomains(t *testing.T) {
 		"bedrock-runtime.ap-northeast-1.amazonaws.com",
 		"bedrock-mantle.us-east-1.api.aws",
 		"bedrock-mantle.ap-northeast-1.api.aws",
-		"api.github.com",
-		"raw.githubusercontent.com",
-		"registry.npmjs.org",
 	}
 	for _, host := range bypassed {
 		if r := f.Check(host); r != FilterResultBypassed {
 			t.Errorf("Check(%q) = %v, want bypassed", host, r)
+		}
+	}
+}
+
+func TestFormerBypassDomainsNowBlocked(t *testing.T) {
+	f := NewAllowlistFilter([]string{"example.com"})
+	blocked := []string{
+		"github.com",
+		"api.github.com",
+		"raw.githubusercontent.com",
+		"registry.npmjs.org",
+		"registry-1.docker.io",
+		"hub.docker.com",
+	}
+	for _, host := range blocked {
+		if r := f.Check(host); r == FilterResultBypassed {
+			t.Errorf("Check(%q) = bypassed, want blocked or allowed-by-policy", host)
 		}
 	}
 }

--- a/pkg/networkfilter/proxy.go
+++ b/pkg/networkfilter/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -17,8 +18,15 @@ const (
 	// Transparent iptables-redirected connections (port 80/443) are also accepted here.
 	ProxyPort = 3128
 
+	// ControlPort is the port the control server listens on (localhost only).
+	// Used to enable the policy after startup via POST /enable-policy.
+	ControlPort = 3129
+
 	dialTimeout = 10 * time.Second
 )
+
+// passthroughFilter allows all traffic (empty denylist, no allowlist).
+var passthroughFilter = &Filter{}
 
 // Proxy is a forward proxy that enforces a domain deny-list.
 // It handles three types of incoming connections on a single port:
@@ -28,13 +36,39 @@ const (
 //  3. Transparent TCP        — redirected by iptables from port 80/443
 //     - port 80:  parsed as an HTTP request (Host header)
 //     - port 443: TLS ClientHello SNI peek
+//
+// When created with active=false (deferred mode), all traffic is allowed until
+// EnablePolicy is called.
 type Proxy struct {
-	filter *Filter
+	configuredFilter *Filter
+	activeFilter     atomic.Pointer[Filter]
 }
 
-// NewProxy creates a Proxy with the given deny-list filter.
-func NewProxy(filter *Filter) *Proxy {
-	return &Proxy{filter: filter}
+// NewProxy creates a Proxy with the given filter.
+// When active is true, the policy is enforced immediately.
+// When active is false, all traffic is allowed until EnablePolicy is called.
+func NewProxy(filter *Filter, active bool) *Proxy {
+	p := &Proxy{configuredFilter: filter}
+	if active {
+		p.activeFilter.Store(filter)
+	}
+	return p
+}
+
+// EnablePolicy activates the configured filter. After this call, all connections
+// are subject to domain filtering. Safe to call concurrently.
+func (p *Proxy) EnablePolicy() {
+	p.activeFilter.Store(p.configuredFilter)
+	log.Printf("[network-filter] policy enabled")
+}
+
+// effectiveFilter returns the active filter, or the passthrough filter if the policy
+// has not yet been enabled.
+func (p *Proxy) effectiveFilter() *Filter {
+	if f := p.activeFilter.Load(); f != nil {
+		return f
+	}
+	return passthroughFilter
 }
 
 // Run starts the proxy on the given listener.
@@ -92,7 +126,7 @@ func (p *Proxy) handleCONNECT(conn net.Conn, req *http.Request) {
 		host = req.Host
 	}
 
-	result := p.filter.Check(host)
+	result := p.effectiveFilter().Check(host)
 	log.Printf("[network-filter] CONNECT %s: %s", result, req.Host)
 
 	if result == FilterResultBlocked {
@@ -120,7 +154,7 @@ func (p *Proxy) handleHTTP(conn net.Conn, br *bufio.Reader, req *http.Request) {
 		host = req.URL.Host
 	}
 
-	result := p.filter.Check(host)
+	result := p.effectiveFilter().Check(host)
 	log.Printf("[network-filter] HTTP %s: %s", result, host)
 
 	if result == FilterResultBlocked {
@@ -182,7 +216,7 @@ func (p *Proxy) handleTransparentTLS(conn net.Conn, br *bufio.Reader) {
 		return
 	}
 
-	result := p.filter.Check(sni)
+	result := p.effectiveFilter().Check(sni)
 	log.Printf("[network-filter] TLS %s: %s", result, sni)
 
 	if result == FilterResultBlocked {

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -181,6 +181,11 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}
 	log.Printf("[PROVISIONER] agentapi is ready")
 
+	// Enable the network-filter policy now that the agent is fully started.
+	// This is a best-effort call; if there is no sandbox sidecar the request
+	// simply fails and is ignored.
+	enableNetworkFilterPolicy()
+
 	// ── Step 9: send initial message ─────────────────────────────────────────
 	if settings.InitialMessage != "" {
 		log.Printf("[PROVISIONER] Sending initial message")
@@ -1203,3 +1208,18 @@ func mergeEnv(base []string, overlay map[string]string) []string {
 	sort.Strings(result)
 	return result
 }
+
+// enableNetworkFilterPolicy calls POST /enable-policy on the network-filter
+// control server (localhost:3129) so that the sandbox policy takes effect after
+// the agent has fully started. The call is best-effort: if there is no sandbox
+// sidecar the connection is refused and the error is silently ignored.
+func enableNetworkFilterPolicy() {
+	resp, err := http.Post("http://127.0.0.1:3129/enable-policy", "", nil)
+	if err != nil {
+		log.Printf("[PROVISIONER] network-filter enable-policy: %v (no sandbox sidecar?)", err)
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	log.Printf("[PROVISIONER] network-filter policy enabled (status %s)", resp.Status)
+}
+


### PR DESCRIPTION
## Summary

- **Deferred policy mode**: `network-filter proxy --deferred-policy` で起動すると、プロキシはポリシーを適用せず全トラフィックを通過させる。その後 `POST http://127.0.0.1:3129/enable-policy` を送信することでポリシーが有効化される（エージェント初期化後にサンドボックスを有効化するユースケース向け）
- **コントロールサーバー**: `pkg/networkfilter/control.go` を新規追加。ポート 3129 (localhost only) で HTTP サーバーを起動し `POST /enable-policy` エンドポイントを提供
- **スレッドセーフな切り替え**: `Proxy` 内のフィルターを `atomic.Pointer[Filter]` で管理し、`EnablePolicy()` による並行安全な有効化を実現
- **bypass ドメインの削減**: `github.com` / `githubusercontent.com` / `docker.io` / `docker.com` / `npmjs.org` をデフォルト bypass リストから削除。これらはポリシーの対象となる

## Usage

```bash
# 遅延モードで起動（ポリシー無効）
network-filter proxy --deferred-policy --allowed-domains example.com

# エージェント初期化完了後にポリシーを有効化
curl -X POST http://127.0.0.1:3129/enable-policy
```

## Test plan

- [ ] `make test` がすべて通ること
- [ ] `--deferred-policy` なしで起動した場合は従来通りポリシーが即時有効
- [ ] `--deferred-policy` で起動後、`/enable-policy` 前は github.com 等にアクセス可能
- [ ] `/enable-policy` 後は allowlist/denylist が正しく機能すること
- [ ] github.com / docker.io がデフォルト bypass でなくなったこと

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)