### PR TITLE
fix(oauth): use API host for token revocation on logout

### DIFF
--- a/internal/app/auth_test.go
+++ b/internal/app/auth_test.go
@@ -40,6 +40,12 @@ func setupTestServerWithOAuth(t *testing.T) (*Server, *httptest.Server) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`[{"login":"test-org","id":789}]`))
+		case "/applications/test-client-id/token":
+			if r.Method == http.MethodDelete {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -277,11 +277,31 @@ func (p *GitHubOAuthProvider) getOAuthHost() string {
 	return baseURL
 }
 
+// getAPIHost returns the GitHub REST API base URL for API calls (e.g. token revocation).
+// Unlike getOAuthHost (which returns github.com for OAuth flows), this returns the API
+// host (api.github.com or the GHE /api/v3 base).
+func (p *GitHubOAuthProvider) getAPIHost() string {
+	// Prefer the GitHub auth provider's base URL — it is already the API URL.
+	if p.githubProvider != nil && p.githubProvider.config != nil && p.githubProvider.config.BaseURL != "" {
+		return strings.TrimSuffix(p.githubProvider.config.BaseURL, "/")
+	}
+
+	baseURL := p.config.BaseURL
+	if baseURL == "" || baseURL == "https://github.com" {
+		return "https://api.github.com"
+	}
+	if strings.Contains(baseURL, "api.github.com") {
+		return "https://api.github.com"
+	}
+	// GitHub Enterprise or custom host — use as-is
+	return strings.TrimSuffix(baseURL, "/")
+}
+
 // RevokeToken revokes a GitHub access token
 func (p *GitHubOAuthProvider) RevokeToken(ctx context.Context, token string) error {
-	oauthHost := p.getOAuthHost()
+	apiHost := p.getAPIHost()
 	revokeURL := fmt.Sprintf("%s/applications/%s/token",
-		strings.TrimSuffix(oauthHost, "/"),
+		strings.TrimSuffix(apiHost, "/"),
 		p.config.ClientID)
 
 	req, err := http.NewRequestWithContext(ctx, "DELETE", revokeURL, nil)

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -65,6 +67,12 @@ func TestGitHubOAuthProvider_ExchangeCode(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`[{"login":"test-org","id":789}]`))
+		case "/applications/test-client-id/token":
+			if r.Method == http.MethodDelete {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -206,4 +214,74 @@ func TestGitHubOAuthProvider_cleanupExpiredStates(t *testing.T) {
 	_, expiredExists, _ := provider.stateStore.Load(ctx, expiredState)
 	assert.True(t, validExists)
 	assert.False(t, expiredExists)
+}
+
+func TestGitHubOAuthProvider_RevokeToken(t *testing.T) {
+	var capturedMethod, capturedPath, capturedToken string
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		if r.Method == http.MethodDelete {
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]string
+			_ = json.Unmarshal(body, &payload)
+			capturedToken = payload["access_token"]
+			w.WriteHeader(http.StatusNoContent)
+		} else {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer mockServer.Close()
+
+	cfg := &config.GitHubOAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		BaseURL:      "https://github.com",
+	}
+	githubCfg := &config.GitHubAuthConfig{
+		Enabled:     true,
+		BaseURL:     mockServer.URL,
+		TokenHeader: "Authorization",
+	}
+
+	provider := NewGitHubOAuthProvider(cfg, NewGitHubAuthProvider(githubCfg))
+
+	err := provider.RevokeToken(context.Background(), "gho_test_token")
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, capturedMethod)
+	assert.Equal(t, "/applications/test-client-id/token", capturedPath)
+	assert.Equal(t, "gho_test_token", capturedToken)
+}
+
+func TestGitHubOAuthProvider_RevokeToken_APIURLUsed(t *testing.T) {
+	// Verify that RevokeToken uses the API host (api.github.com), not the OAuth host (github.com).
+	// With GitHubOAuthConfig.BaseURL="https://github.com" and GitHubAuthConfig.BaseURL="https://api.github.com",
+	// the revoke request must go to api.github.com.
+	var capturedHost string
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHost = r.Host
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer mockServer.Close()
+
+	cfg := &config.GitHubOAuthConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		BaseURL:      "https://github.com",
+	}
+	githubCfg := &config.GitHubAuthConfig{
+		Enabled:     true,
+		BaseURL:     mockServer.URL,
+		TokenHeader: "Authorization",
+	}
+
+	provider := NewGitHubOAuthProvider(cfg, NewGitHubAuthProvider(githubCfg))
+	err := provider.RevokeToken(context.Background(), "gho_token")
+
+	assert.NoError(t, err)
+	// The request must have gone to the mock server (the API host), not to github.com
+	assert.NotEmpty(t, capturedHost)
 }


### PR DESCRIPTION
## Summary

- `RevokeToken` was constructing the URL with `getOAuthHost()` which returns `https://github.com` (the OAuth login host). GitHub's token revocation endpoint is `DELETE https://api.github.com/applications/{client_id}/token`, so the request was being sent to the wrong host and silently failing on every logout.
- Added `getAPIHost()` method that correctly returns `api.github.com` (or the GHE `/api/v3` base URL) by preferring `GitHubAuthProvider.config.BaseURL`, which is already the API URL.
- Updated `RevokeToken` to use `getAPIHost()` instead of `getOAuthHost()`.

## Test plan

- [ ] `TestGitHubOAuthProvider_RevokeToken` — verifies `DELETE /applications/{client_id}/token` is called with the correct token body
- [ ] `TestGitHubOAuthProvider_RevokeToken_APIURLUsed` — verifies the request goes to the API host (mock server), not `github.com`
- [ ] Mock servers in `internal/app/auth_test.go` and `pkg/auth/oauth_test.go` updated to handle `DELETE /applications/{client_id}/token` returning 204
- [ ] All existing tests continue to pass

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)