### PR TITLE
feat: add sandboxInitImage for network-filter init container

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -200,6 +200,8 @@ spec:
               value: {{ .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
+            - name: AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE
+              value: {{ .Values.kubernetesSession.sandboxInitImage | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -204,6 +204,8 @@ spec:
             - name: AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE
               value: {{ .Values.kubernetesSession.sandboxInitImage | quote }}
             {{- end }}
+            - name: AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME
+              value: {{ printf "%s-sandbox-iptables" (include "agentapi-proxy.fullname" .) | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -200,8 +200,10 @@ spec:
               value: {{ .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
+            {{- if .Values.kubernetesSession.sandboxInitImage }}
             - name: AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE
               value: {{ .Values.kubernetesSession.sandboxInitImage | quote }}
+            {{- end }}
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT

--- a/helm/agentapi-proxy/templates/sandbox-iptables-configmap.yaml
+++ b/helm/agentapi-proxy/templates/sandbox-iptables-configmap.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.kubernetesSession.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-sandbox-iptables
+  namespace: {{ .Values.kubernetesSession.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+data:
+  rules.v4: |
+    *filter
+    :INPUT ACCEPT [0:0]
+    :FORWARD ACCEPT [0:0]
+    :OUTPUT ACCEPT [0:0]
+    -A OUTPUT -o lo -j ACCEPT
+    -A OUTPUT -m owner --uid-owner 0 -j ACCEPT
+    -A OUTPUT -p tcp -d 127.0.0.1 --dport 3128 -j ACCEPT
+    -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+    -A OUTPUT -p tcp -d 10.0.0.0/8 -j ACCEPT
+    -A OUTPUT -p tcp -d 172.16.0.0/12 -j ACCEPT
+    -A OUTPUT -p tcp -d 192.168.0.0/16 -j ACCEPT
+    -A OUTPUT -p tcp -j REJECT --reject-with tcp-reset
+    COMMIT
+    *nat
+    :PREROUTING ACCEPT [0:0]
+    :INPUT ACCEPT [0:0]
+    :OUTPUT ACCEPT [0:0]
+    :POSTROUTING ACCEPT [0:0]
+    -A OUTPUT -p tcp -d 127.0.0.1 -j RETURN
+    -A OUTPUT -p tcp -m owner --uid-owner 0 -j RETURN
+    -A OUTPUT -p tcp -d 10.0.0.0/8 -j RETURN
+    -A OUTPUT -p tcp -d 172.16.0.0/12 -j RETURN
+    -A OUTPUT -p tcp -d 192.168.0.0/16 -j RETURN
+    -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-port 3128
+    -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-port 3128
+    COMMIT
+{{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -337,6 +337,12 @@ kubernetesSession:
   # If empty, uses the same image as the proxy
   image: ""
 
+  # Container image for the network-filter-setup init container (sandbox feature).
+  # This init container only needs sh and iptables, so a small image can be used
+  # instead of the full session image — useful in environments with image allowlists.
+  # If empty, falls back to the session image (image field above, or proxy image).
+  sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"
+
   # Image pull policy for session pods
   imagePullPolicy: "IfNotPresent"
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2020,11 +2020,35 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 	rootUID := int64(0)
 	falseVal := false
 
+	sandboxInitImage := m.k8sConfig.SandboxInitImage
+	if sandboxInitImage == "" {
+		sandboxInitImage = m.k8sConfig.Image
+	}
+
+	iptablesScript := fmt.Sprintf(`set -e
+iptables -t filter -A OUTPUT -o lo -j ACCEPT
+iptables -t filter -A OUTPUT -m owner --uid-owner %d -j ACCEPT
+iptables -t filter -A OUTPUT -p tcp -d 127.0.0.1 --dport %d -j ACCEPT
+iptables -t filter -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables -t filter -A OUTPUT -p tcp -d 10.0.0.0/8 -j ACCEPT
+iptables -t filter -A OUTPUT -p tcp -d 172.16.0.0/12 -j ACCEPT
+iptables -t filter -A OUTPUT -p tcp -d 192.168.0.0/16 -j ACCEPT
+iptables -t filter -A OUTPUT -p tcp -j REJECT --reject-with tcp-reset
+iptables -t nat -A OUTPUT -p tcp -d 127.0.0.1 -j RETURN
+iptables -t nat -A OUTPUT -p tcp -m owner --uid-owner %d -j RETURN
+iptables -t nat -A OUTPUT -p tcp -d 10.0.0.0/8 -j RETURN
+iptables -t nat -A OUTPUT -p tcp -d 172.16.0.0/12 -j RETURN
+iptables -t nat -A OUTPUT -p tcp -d 192.168.0.0/16 -j RETURN
+iptables -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-port %d
+iptables -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-port %d
+`, networkfilter.SidecarUID, networkfilter.ProxyPort, networkfilter.SidecarUID, networkfilter.ProxyPort, networkfilter.ProxyPort)
+
 	initContainer := corev1.Container{
 		Name:            "network-filter-setup",
-		Image:           m.k8sConfig.Image,
+		Image:           sandboxInitImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"agentapi-proxy", "network-filter", "setup"},
+		Command:         []string{"sh", "-c"},
+		Args:            []string{iptablesScript},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    &rootUID,
 			RunAsNonRoot: &falseVal,

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1742,6 +1742,18 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 
 	// Build volumes
 	volumes := m.buildVolumes(session)
+	if sandboxEnabled && m.k8sConfig.SandboxIptablesConfigMapName != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "sandbox-iptables",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: m.k8sConfig.SandboxIptablesConfigMapName,
+					},
+				},
+			},
+		})
+	}
 
 	// Build containers list.
 	// Note: credentials-sync is now handled as a goroutine inside agent-provisioner
@@ -2025,35 +2037,24 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 		sandboxInitImage = m.k8sConfig.Image
 	}
 
-	iptablesScript := fmt.Sprintf(`set -e
-iptables -t filter -A OUTPUT -o lo -j ACCEPT
-iptables -t filter -A OUTPUT -m owner --uid-owner %d -j ACCEPT
-iptables -t filter -A OUTPUT -p tcp -d 127.0.0.1 --dport %d -j ACCEPT
-iptables -t filter -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -t filter -A OUTPUT -p tcp -d 10.0.0.0/8 -j ACCEPT
-iptables -t filter -A OUTPUT -p tcp -d 172.16.0.0/12 -j ACCEPT
-iptables -t filter -A OUTPUT -p tcp -d 192.168.0.0/16 -j ACCEPT
-iptables -t filter -A OUTPUT -p tcp -j REJECT --reject-with tcp-reset
-iptables -t nat -A OUTPUT -p tcp -d 127.0.0.1 -j RETURN
-iptables -t nat -A OUTPUT -p tcp -m owner --uid-owner %d -j RETURN
-iptables -t nat -A OUTPUT -p tcp -d 10.0.0.0/8 -j RETURN
-iptables -t nat -A OUTPUT -p tcp -d 172.16.0.0/12 -j RETURN
-iptables -t nat -A OUTPUT -p tcp -d 192.168.0.0/16 -j RETURN
-iptables -t nat -A OUTPUT -p tcp --dport 80 -j REDIRECT --to-port %d
-iptables -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-port %d
-`, networkfilter.SidecarUID, networkfilter.ProxyPort, networkfilter.SidecarUID, networkfilter.ProxyPort, networkfilter.ProxyPort)
-
 	initContainer := corev1.Container{
 		Name:            "network-filter-setup",
 		Image:           sandboxInitImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"sh", "-c"},
-		Args:            []string{iptablesScript},
+		Command:         []string{"iptables-restore"},
+		Args:            []string{"/etc/iptables/rules.v4"},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    &rootUID,
 			RunAsNonRoot: &falseVal,
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "sandbox-iptables",
+				MountPath: "/etc/iptables",
+				ReadOnly:  true,
 			},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -300,6 +300,13 @@ type KubernetesSessionConfig struct {
 	// session pods so that hooks are treated as managed (auto-trusted) by codex_core.
 	// Typically created by the Helm chart. When empty, no managed hooks are mounted.
 	CodexRequirementsConfigMapName string `json:"codex_requirements_configmap_name" mapstructure:"codex_requirements_configmap_name"`
+
+	// SandboxInitImage is the container image used for the network-filter-setup init container
+	// that configures iptables rules for session network sandboxing.
+	// If empty, falls back to Image (the session pod image).
+	// Use a small iptables-capable image (e.g. alpine with iptables) to avoid pulling
+	// the full session image just for init container use in restricted environments.
+	SandboxInitImage string `json:"sandbox_init_image" mapstructure:"sandbox_init_image"`
 }
 
 // MemoryConfig represents memory backend configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -304,9 +304,14 @@ type KubernetesSessionConfig struct {
 	// SandboxInitImage is the container image used for the network-filter-setup init container
 	// that configures iptables rules for session network sandboxing.
 	// If empty, falls back to Image (the session pod image).
-	// Use a small iptables-capable image (e.g. alpine with iptables) to avoid pulling
-	// the full session image just for init container use in restricted environments.
+	// The image must provide iptables-restore. A shell is not required.
 	SandboxInitImage string `json:"sandbox_init_image" mapstructure:"sandbox_init_image"`
+
+	// SandboxIptablesConfigMapName is the name of the ConfigMap containing iptables-restore
+	// rules (key: rules.v4) for the network-filter-setup init container.
+	// The ConfigMap is mounted at /etc/iptables/ inside the init container.
+	// Defaults to "{release-name}-sandbox-iptables" (created by the Helm chart).
+	SandboxIptablesConfigMapName string `json:"sandbox_iptables_configmap_name" mapstructure:"sandbox_iptables_configmap_name"`
 }
 
 // MemoryConfig represents memory backend configuration
@@ -712,6 +717,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.claude_config_user_configmap_prefix", "AGENTAPI_K8S_SESSION_CLAUDE_CONFIG_USER_CONFIGMAP_PREFIX")
 	_ = v.BindEnv("kubernetes_session.init_container_image", "AGENTAPI_K8S_SESSION_INIT_CONTAINER_IMAGE")
 	_ = v.BindEnv("kubernetes_session.sandbox_init_image", "AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE")
+	_ = v.BindEnv("kubernetes_session.sandbox_iptables_configmap_name", "AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME")
 	_ = v.BindEnv("kubernetes_session.github_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")
@@ -859,6 +865,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.claude_config_user_configmap_prefix", "claude-config")
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
+	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
 	v.SetDefault("kubernetes_session.github_secret_name", "")
 
 	// Settings base secret default (single base Secret shared by all sessions,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -711,6 +711,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.pod_stop_timeout", "AGENTAPI_K8S_SESSION_POD_STOP_TIMEOUT")
 	_ = v.BindEnv("kubernetes_session.claude_config_user_configmap_prefix", "AGENTAPI_K8S_SESSION_CLAUDE_CONFIG_USER_CONFIGMAP_PREFIX")
 	_ = v.BindEnv("kubernetes_session.init_container_image", "AGENTAPI_K8S_SESSION_INIT_CONTAINER_IMAGE")
+	_ = v.BindEnv("kubernetes_session.sandbox_init_image", "AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE")
 	_ = v.BindEnv("kubernetes_session.github_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")
@@ -857,6 +858,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.pod_stop_timeout", 30)
 	v.SetDefault("kubernetes_session.claude_config_user_configmap_prefix", "claude-config")
 	v.SetDefault("kubernetes_session.init_container_image", "")
+	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.github_secret_name", "")
 
 	// Settings base secret default (single base Secret shared by all sessions,


### PR DESCRIPTION
## Summary

- `kubernetesSession.sandboxInitImage` を values.yaml に追加し、sandbox の init container に使うイメージを指定可能にした
- デフォルトは `gcr.io/istio-release/iptables@sha256:88626c33...`（digest ピン）
- init container のコマンドを `agentapi-proxy network-filter setup` から sh スクリプトによる直接 iptables 呼び出しに変更
- Gatekeeper 等のイメージ allowlist がある環境でフルサイズのセッションイメージを pull せずに済む

## Test plan

- [ ] `make lint` / `make test` 通過確認（済）
- [ ] sandbox 有効なセッションを起動して network-filter-setup init container が正常に完了することを確認
- [ ] `kubernetesSession.sandboxInitImage` をカスタム値で上書きした場合も正しいイメージが使われることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)