### PR TITLE
feat: add resources.limits/requests to network-filter sidecar and initContainer

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -207,21 +207,21 @@ spec:
             - name: AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME
               value: {{ printf "%s-sandbox-iptables" (include "agentapi-proxy.fullname" .) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
-              value: {{ .Values.kubernetesSession.networkFilter.resources.requests.cpu | quote }}
+              value: {{ dig "networkFilter" "resources" "requests" "cpu" "100m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT
-              value: {{ .Values.kubernetesSession.networkFilter.resources.limits.cpu | quote }}
+              value: {{ dig "networkFilter" "resources" "limits" "cpu" "500m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_REQUEST
-              value: {{ .Values.kubernetesSession.networkFilter.resources.requests.memory | quote }}
+              value: {{ dig "networkFilter" "resources" "requests" "memory" "64Mi" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_LIMIT
-              value: {{ .Values.kubernetesSession.networkFilter.resources.limits.memory | quote }}
+              value: {{ dig "networkFilter" "resources" "limits" "memory" "256Mi" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_REQUEST
-              value: {{ .Values.kubernetesSession.networkFilter.initResources.requests.cpu | quote }}
+              value: {{ dig "networkFilter" "initResources" "requests" "cpu" "50m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_LIMIT
-              value: {{ .Values.kubernetesSession.networkFilter.initResources.limits.cpu | quote }}
+              value: {{ dig "networkFilter" "initResources" "limits" "cpu" "100m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_MEMORY_REQUEST
-              value: {{ .Values.kubernetesSession.networkFilter.initResources.requests.memory | quote }}
+              value: {{ dig "networkFilter" "initResources" "requests" "memory" "32Mi" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_MEMORY_LIMIT
-              value: {{ .Values.kubernetesSession.networkFilter.initResources.limits.memory | quote }}
+              value: {{ dig "networkFilter" "initResources" "limits" "memory" "64Mi" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -206,6 +206,22 @@ spec:
             {{- end }}
             - name: AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME
               value: {{ printf "%s-sandbox-iptables" (include "agentapi-proxy.fullname" .) | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
+              value: {{ .Values.kubernetesSession.networkFilter.resources.requests.cpu | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT
+              value: {{ .Values.kubernetesSession.networkFilter.resources.limits.cpu | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_REQUEST
+              value: {{ .Values.kubernetesSession.networkFilter.resources.requests.memory | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_LIMIT
+              value: {{ .Values.kubernetesSession.networkFilter.resources.limits.memory | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_REQUEST
+              value: {{ .Values.kubernetesSession.networkFilter.initResources.requests.cpu | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_LIMIT
+              value: {{ .Values.kubernetesSession.networkFilter.initResources.limits.cpu | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_MEMORY_REQUEST
+              value: {{ .Values.kubernetesSession.networkFilter.initResources.requests.memory | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_MEMORY_LIMIT
+              value: {{ .Values.kubernetesSession.networkFilter.initResources.limits.memory | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE_PULL_POLICY
               value: {{ .Values.kubernetesSession.imagePullPolicy | quote }}
             - name: AGENTAPI_K8S_SESSION_SERVICE_ACCOUNT

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -343,6 +343,25 @@ kubernetesSession:
   # If empty, falls back to the session image (image field above, or proxy image).
   sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"
 
+  # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)
+  networkFilter:
+    # Resources for the network-filter forward proxy sidecar container
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+    # Resources for the network-filter-setup init container
+    initResources:
+      requests:
+        cpu: "50m"
+        memory: "32Mi"
+      limits:
+        cpu: "100m"
+        memory: "64Mi"
+
   # Image pull policy for session pods
   imagePullPolicy: "IfNotPresent"
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2050,6 +2050,7 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},
 		},
+		Resources: buildResourceRequirements(m.k8sConfig.NetworkFilterInitCPURequest, m.k8sConfig.NetworkFilterInitCPULimit, m.k8sConfig.NetworkFilterInitMemoryRequest, m.k8sConfig.NetworkFilterInitMemoryLimit),
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "sandbox-iptables",
@@ -2072,6 +2073,7 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 			RunAsNonRoot:             &falseVal,
 			AllowPrivilegeEscalation: &falseVal,
 		},
+		Resources: buildResourceRequirements(m.k8sConfig.NetworkFilterCPURequest, m.k8sConfig.NetworkFilterCPULimit, m.k8sConfig.NetworkFilterMemoryRequest, m.k8sConfig.NetworkFilterMemoryLimit),
 		Ports: []corev1.ContainerPort{
 			{Name: "proxy", ContainerPort: int32(networkfilter.ProxyPort), Protocol: corev1.ProtocolTCP},
 		},
@@ -2094,6 +2096,26 @@ func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServe
 	}
 
 	return []corev1.Container{initContainer}, &sidecar, proxyEnvVars
+}
+
+// buildResourceRequirements constructs a corev1.ResourceRequirements from string quantities.
+// Any empty string is silently omitted, allowing partial specification.
+func buildResourceRequirements(cpuReq, cpuLim, memReq, memLim string) corev1.ResourceRequirements {
+	requests := corev1.ResourceList{}
+	limits := corev1.ResourceList{}
+	if cpuReq != "" {
+		requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
+	}
+	if memReq != "" {
+		requests[corev1.ResourceMemory] = resource.MustParse(memReq)
+	}
+	if cpuLim != "" {
+		limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
+	}
+	if memLim != "" {
+		limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	}
+	return corev1.ResourceRequirements{Requests: requests, Limits: limits}
 }
 
 // buildVolumes builds the volume configuration for the session pod

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -312,6 +312,18 @@ type KubernetesSessionConfig struct {
 	// The ConfigMap is mounted at /etc/iptables/ inside the init container.
 	// Defaults to "{release-name}-sandbox-iptables" (created by the Helm chart).
 	SandboxIptablesConfigMapName string `json:"sandbox_iptables_configmap_name" mapstructure:"sandbox_iptables_configmap_name"`
+
+	// Network filter sidecar resource configuration
+	NetworkFilterCPURequest    string `json:"network_filter_cpu_request" mapstructure:"network_filter_cpu_request"`
+	NetworkFilterCPULimit      string `json:"network_filter_cpu_limit" mapstructure:"network_filter_cpu_limit"`
+	NetworkFilterMemoryRequest string `json:"network_filter_memory_request" mapstructure:"network_filter_memory_request"`
+	NetworkFilterMemoryLimit   string `json:"network_filter_memory_limit" mapstructure:"network_filter_memory_limit"`
+
+	// Network filter init container resource configuration
+	NetworkFilterInitCPURequest    string `json:"network_filter_init_cpu_request" mapstructure:"network_filter_init_cpu_request"`
+	NetworkFilterInitCPULimit      string `json:"network_filter_init_cpu_limit" mapstructure:"network_filter_init_cpu_limit"`
+	NetworkFilterInitMemoryRequest string `json:"network_filter_init_memory_request" mapstructure:"network_filter_init_memory_request"`
+	NetworkFilterInitMemoryLimit   string `json:"network_filter_init_memory_limit" mapstructure:"network_filter_init_memory_limit"`
 }
 
 // MemoryConfig represents memory backend configuration
@@ -718,6 +730,14 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.init_container_image", "AGENTAPI_K8S_SESSION_INIT_CONTAINER_IMAGE")
 	_ = v.BindEnv("kubernetes_session.sandbox_init_image", "AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE")
 	_ = v.BindEnv("kubernetes_session.sandbox_iptables_configmap_name", "AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME")
+	_ = v.BindEnv("kubernetes_session.network_filter_cpu_request", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST")
+	_ = v.BindEnv("kubernetes_session.network_filter_cpu_limit", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT")
+	_ = v.BindEnv("kubernetes_session.network_filter_memory_request", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_REQUEST")
+	_ = v.BindEnv("kubernetes_session.network_filter_memory_limit", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_LIMIT")
+	_ = v.BindEnv("kubernetes_session.network_filter_init_cpu_request", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_REQUEST")
+	_ = v.BindEnv("kubernetes_session.network_filter_init_cpu_limit", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_LIMIT")
+	_ = v.BindEnv("kubernetes_session.network_filter_init_memory_request", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_MEMORY_REQUEST")
+	_ = v.BindEnv("kubernetes_session.network_filter_init_memory_limit", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_MEMORY_LIMIT")
 	_ = v.BindEnv("kubernetes_session.github_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")


### PR DESCRIPTION
## Summary

- `network-filter` sidecar コンテナに `resources.requests/limits` を追加（デフォルト: CPU 100m/500m, Memory 64Mi/256Mi）
- `network-filter-setup` initContainer に `resources.requests/limits` を追加（デフォルト: CPU 50m/100m, Memory 32Mi/64Mi）
- `buildResourceRequirements` ヘルパー関数を追加し、空文字列を無視して安全にパースする

## Changes

- `helm/agentapi-proxy/values.yaml`: `kubernetesSession.networkFilter.resources` および `initResources` セクションを追加
- `helm/agentapi-proxy/templates/deployment.yaml`: 8つの新しい env vars を追加
- `pkg/config/config.go`: `KubernetesSessionConfig` に8フィールドと `BindEnv` を追加
- `internal/infrastructure/services/kubernetes_session_manager.go`: `buildSandboxContainers` でリソースを適用、`buildResourceRequirements` ヘルパーを追加

## Test plan

- [ ] `make lint` 通過を確認（✅ 済み）
- [ ] `go build ./...` 成功を確認（✅ 済み）
- [ ] sandbox 有効なセッションを起動し、`kubectl describe pod` で network-filter コンテナと initContainer にリソース設定が入っていることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)