### PR TITLE
feat: add Codex OAuth device authorization flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,14 @@ ENV PATH="/opt/claude/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/h
 RUN bun install -g @takutakahashi/claude-agentapi
 
 # Install codex CLI
-RUN bun install -g @openai/codex
+RUN /home/agentapi/.bun/bin/bun install -g @openai/codex
+
+# Create a codex wrapper in /opt/claude/bin (first in PATH) that uses the real bun binary.
+# The installed codex script has "#!/usr/bin/env node" as shebang, but /usr/local/bin/node
+# is a claude wrapper. This explicit wrapper bypasses that and runs codex with the real bun.
+RUN printf '#!/bin/bash\nexec /home/agentapi/.bun/bin/bun /home/agentapi/.bun/bin/codex "$@"\n' | \
+    sudo tee /opt/claude/bin/codex > /dev/null && \
+    sudo chmod +x /opt/claude/bin/codex
 
 # Install claude-agent-sdk CLI and create arch-agnostic symlink
 RUN bun install -g @anthropic-ai/claude-agent-sdk && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -157,13 +157,12 @@ ENV PATH="/opt/claude/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/h
 # install claude-agentapi
 RUN bun install -g @takutakahashi/claude-agentapi
 
-# Install codex CLI
-RUN /home/agentapi/.bun/bin/bun install -g @openai/codex
-
-# Create a codex wrapper in /opt/claude/bin (first in PATH) that uses the real bun binary.
-# The installed codex script has "#!/usr/bin/env node" as shebang, but /usr/local/bin/node
-# is a claude wrapper. This explicit wrapper bypasses that and runs codex with the real bun.
-RUN printf '#!/bin/bash\nexec /home/agentapi/.bun/bin/bun /home/agentapi/.bun/bin/codex "$@"\n' | \
+# Install codex CLI and place a wrapper in /opt/claude/bin (first in PATH).
+# The bun-installed codex script uses "#!/usr/bin/env node", but /usr/local/bin/node is a
+# claude wrapper. The wrapper here explicitly invokes bun so codex works reliably in the proxy.
+# Uses the absolute path to the codex script so it works even when HOME is overridden.
+RUN bun install -g @openai/codex && \
+    printf '#!/bin/bash\nexec bun /home/agentapi/.bun/bin/codex "$@"\n' | \
     sudo tee /opt/claude/bin/codex > /dev/null && \
     sudo chmod +x /opt/claude/bin/codex
 

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/personal_api_key"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/spec"
 )
 
@@ -23,21 +24,22 @@ type Router struct {
 
 // HandlerRegistry contains all handlers
 type HandlerRegistry struct {
-	notificationHandlers     *controllers.NotificationHandlers
-	healthController         *controllers.HealthController
-	sessionController        *controllers.SessionController
-	acpController            *controllers.ACPController
-	settingsController       *controllers.SettingsController
-	credentialsController    *controllers.CredentialsController
-	userController           *controllers.UserController
-	shareController          *controllers.ShareController
-	personalAPIKeyController *controllers.PersonalAPIKeyController
-	memoryController         *controllers.MemoryController
-	taskController           *controllers.TaskController
-	taskGroupController      *controllers.TaskGroupController
-	fileController           *controllers.FileController
-	sessionProfileController *controllers.SessionProfileController
-	customHandlers           []CustomHandler
+	notificationHandlers      *controllers.NotificationHandlers
+	healthController          *controllers.HealthController
+	sessionController         *controllers.SessionController
+	acpController             *controllers.ACPController
+	settingsController        *controllers.SettingsController
+	credentialsController     *controllers.CredentialsController
+	codexDeviceAuthController *controllers.CodexDeviceAuthController
+	userController            *controllers.UserController
+	shareController           *controllers.ShareController
+	personalAPIKeyController  *controllers.PersonalAPIKeyController
+	memoryController          *controllers.MemoryController
+	taskController            *controllers.TaskController
+	taskGroupController       *controllers.TaskGroupController
+	fileController            *controllers.FileController
+	sessionProfileController  *controllers.SessionProfileController
+	customHandlers            []CustomHandler
 }
 
 // CustomHandler interface for adding custom routes
@@ -61,6 +63,18 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 	if server.credentialsRepo != nil {
 		credentialsController = controllers.NewCredentialsController(server.credentialsRepo)
 		log.Printf("[ROUTER] Credentials controller initialized")
+	}
+
+	// Create Codex device auth controller (requires credentials repo + config)
+	var codexDeviceAuthController *controllers.CodexDeviceAuthController
+	if server.credentialsRepo != nil {
+		cfg := server.GetConfig()
+		var codexCfg *config.CodexAuthConfig
+		if cfg != nil {
+			codexCfg = &cfg.CodexAuth
+		}
+		codexDeviceAuthController = controllers.NewCodexDeviceAuthController(codexCfg, server.credentialsRepo)
+		log.Printf("[ROUTER] Codex device auth controller initialized")
 	}
 
 	// Create session controller with proper dependencies
@@ -145,21 +159,22 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		echo:   e,
 		server: server,
 		handlers: &HandlerRegistry{
-			notificationHandlers:     controllers.NewNotificationHandlers(server.notificationSvc, server.sessionManager),
-			healthController:         controllers.NewHealthController(),
-			sessionController:        sessionController,
-			acpController:            acpController,
-			settingsController:       settingsController,
-			credentialsController:    credentialsController,
-			userController:           controllers.NewUserController(),
-			shareController:          shareController,
-			personalAPIKeyController: personalAPIKeyController,
-			memoryController:         memoryController,
-			taskController:           taskController,
-			taskGroupController:      taskGroupController,
-			fileController:           fileController,
-			sessionProfileController: sessionProfileController,
-			customHandlers:           make([]CustomHandler, 0),
+			notificationHandlers:      controllers.NewNotificationHandlers(server.notificationSvc, server.sessionManager),
+			healthController:          controllers.NewHealthController(),
+			sessionController:         sessionController,
+			acpController:             acpController,
+			settingsController:        settingsController,
+			credentialsController:     credentialsController,
+			codexDeviceAuthController: codexDeviceAuthController,
+			userController:            controllers.NewUserController(),
+			shareController:           shareController,
+			personalAPIKeyController:  personalAPIKeyController,
+			memoryController:          memoryController,
+			taskController:            taskController,
+			taskGroupController:       taskGroupController,
+			fileController:            fileController,
+			sessionProfileController:  sessionProfileController,
+			customHandlers:            make([]CustomHandler, 0),
 		},
 	}
 }
@@ -323,6 +338,15 @@ func (r *Router) registerConditionalRoutes() error {
 		log.Printf("[ROUTES] Credentials endpoints registered")
 	} else {
 		log.Printf("[ROUTES] Credentials repository not available, skipping credentials routes")
+	}
+
+	// Add Codex device auth routes (requires credentials repo)
+	if r.handlers.codexDeviceAuthController != nil {
+		log.Printf("[ROUTES] Registering Codex device auth endpoints...")
+		r.echo.GET("/codex/device-auth/config", r.handlers.codexDeviceAuthController.GetConfig, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.POST("/codex/device-auth", r.handlers.codexDeviceAuthController.StartDeviceAuth, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.POST("/codex/device-auth/token", r.handlers.codexDeviceAuthController.PollDeviceAuth, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		log.Printf("[ROUTES] Codex device auth endpoints registered")
 	}
 
 	// Add personal API key routes if controller is available (Kubernetes mode only)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -11,7 +11,6 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/personal_api_key"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
-	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/spec"
 )
 
@@ -65,15 +64,10 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] Credentials controller initialized")
 	}
 
-	// Create Codex device auth controller (requires credentials repo + config)
+	// Create Codex device auth controller (requires credentials repo)
 	var codexDeviceAuthController *controllers.CodexDeviceAuthController
 	if server.credentialsRepo != nil {
-		cfg := server.GetConfig()
-		var codexCfg *config.CodexAuthConfig
-		if cfg != nil {
-			codexCfg = &cfg.CodexAuth
-		}
-		codexDeviceAuthController = controllers.NewCodexDeviceAuthController(codexCfg, server.credentialsRepo)
+		codexDeviceAuthController = controllers.NewCodexDeviceAuthController(server.credentialsRepo)
 		log.Printf("[ROUTER] Codex device auth controller initialized")
 	}
 

--- a/internal/interfaces/controllers/codex_device_auth_controller.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller.go
@@ -26,7 +26,8 @@ import (
 var (
 	ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 	urlRegex  = regexp.MustCompile(`https://[^\s]+`)
-	codeRegex = regexp.MustCompile(`\b[A-Z0-9]{4}-[A-Z0-9]{4}\b`)
+	// codex device codes are formatted as XXXX-XXXXX (4 chars, dash, 4–8 chars).
+	codeRegex = regexp.MustCompile(`\b[A-Z0-9]{4}-[A-Z0-9]{4,8}\b`)
 )
 
 // authSession tracks an in-progress codex login --device-auth subprocess.
@@ -100,8 +101,17 @@ func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 	// Cancel any existing session for this user before starting a new one.
 	c.cancelSession(userID)
 
-	// Use a temporary HOME so each user's auth.json is isolated.
-	tmpHome, err := os.MkdirTemp("", "codex-auth-*")
+	// Use a per-session HOME under the proxy user's home dir (not /tmp) so that
+	// codex does not warn about "refusing to create helper binaries under /tmp".
+	homeDir := os.Getenv("HOME")
+	if homeDir == "" {
+		homeDir = "/home/agentapi"
+	}
+	tmpBase := filepath.Join(homeDir, ".codex-sessions")
+	if err := os.MkdirAll(tmpBase, 0700); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create temp directory")
+	}
+	tmpHome, err := os.MkdirTemp(tmpBase, "")
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create temp directory")
 	}

--- a/internal/interfaces/controllers/codex_device_auth_controller.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller.go
@@ -141,6 +141,7 @@ func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 
 	session := &authSession{cmd: cmd, tmpHome: tmpHome, status: "pending"}
 	c.sessions.Store(userID, session)
+	log.Printf("[CODEX_AUTH] Session tmpHome for user=%s: %s", userID, tmpHome)
 
 	// exitErrCh receives the process exit status once.
 	exitErrCh := make(chan error, 1)
@@ -163,6 +164,7 @@ func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 		scanner := bufio.NewScanner(pr)
 		for scanner.Scan() {
 			line := ansiRegex.ReplaceAllString(scanner.Text(), "")
+			log.Printf("[CODEX_AUTH] stdout: %s", line)
 			if verifyURI == "" {
 				if m := urlRegex.FindString(line); m != "" {
 					verifyURI = strings.TrimSpace(m)
@@ -175,8 +177,9 @@ func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 			}
 			if userCode != "" && verifyURI != "" {
 				parseCh <- parseResult{userCode: userCode, verifyURI: verifyURI}
-				// Drain remaining output so the process isn't blocked.
+				// Log remaining output so we can see codex's completion/error messages.
 				for scanner.Scan() {
+					log.Printf("[CODEX_AUTH] stdout(post): %s", ansiRegex.ReplaceAllString(scanner.Text(), ""))
 				}
 				return
 			}
@@ -255,13 +258,20 @@ func (c *CodexDeviceAuthController) watchCompletion(userID string, session *auth
 		return
 	}
 
+	log.Printf("[CODEX_AUTH] Process exited successfully for user=%s, scanning tmpHome=%s", userID, session.tmpHome)
+	// Log directory tree for debugging.
+	if entries, walkErr := listDir(session.tmpHome); walkErr == nil {
+		log.Printf("[CODEX_AUTH] Files in tmpHome: %v", entries)
+	}
+
 	authJSONPath := filepath.Join(session.tmpHome, ".codex", "auth.json")
 	data, err := os.ReadFile(authJSONPath)
 	if err != nil {
-		log.Printf("[CODEX_AUTH] Failed to read auth.json for user=%s: %v", userID, err)
+		log.Printf("[CODEX_AUTH] Failed to read auth.json at %s for user=%s: %v", authJSONPath, userID, err)
 		session.status = "denied"
 		return
 	}
+	log.Printf("[CODEX_AUTH] auth.json found (%d bytes) for user=%s", len(data), userID)
 
 	creds := entities.NewCredentials(userID, json.RawMessage(data))
 	creds.SetFileType(sessionsettings.FileTypeCodexAuth)
@@ -274,6 +284,20 @@ func (c *CodexDeviceAuthController) watchCompletion(userID string, session *auth
 
 	session.status = "authorized"
 	log.Printf("[CODEX_AUTH] Auth completed and credentials saved for user=%s", userID)
+}
+
+// listDir returns relative paths of all files under root (best-effort).
+func listDir(root string) ([]string, error) {
+	var paths []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		paths = append(paths, rel)
+		return nil
+	})
+	return paths, err
 }
 
 // cancelSession kills any running auth subprocess for the given user.

--- a/internal/interfaces/controllers/codex_device_auth_controller.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller.go
@@ -1,31 +1,52 @@
 package controllers
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
-	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
-	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
-// CodexDeviceAuthController handles Codex OAuth device authorization flow.
+var (
+	ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+	urlRegex  = regexp.MustCompile(`https://[^\s]+`)
+	codeRegex = regexp.MustCompile(`\b[A-Z0-9]{4}-[A-Z0-9]{4}\b`)
+)
+
+// authSession tracks an in-progress codex login --device-auth subprocess.
+type authSession struct {
+	cmd     *exec.Cmd
+	tmpHome string
+	mu      sync.Mutex
+	status  string // "pending", "authorized", "denied"
+}
+
+// CodexDeviceAuthController runs `codex login --device-auth` and proxies
+// the result to the credentials store. No OAuth app registration required.
 type CodexDeviceAuthController struct {
-	cfg  *config.CodexAuthConfig
-	repo repositories.CredentialsRepository
+	repo     repositories.CredentialsRepository
+	sessions sync.Map // userID -> *authSession
 }
 
 // NewCodexDeviceAuthController creates a new CodexDeviceAuthController.
-func NewCodexDeviceAuthController(cfg *config.CodexAuthConfig, repo repositories.CredentialsRepository) *CodexDeviceAuthController {
-	return &CodexDeviceAuthController{cfg: cfg, repo: repo}
+func NewCodexDeviceAuthController(repo repositories.CredentialsRepository) *CodexDeviceAuthController {
+	return &CodexDeviceAuthController{repo: repo}
 }
 
 // GetName returns the controller name for logging.
@@ -33,173 +54,228 @@ func (c *CodexDeviceAuthController) GetName() string {
 	return "CodexDeviceAuthController"
 }
 
-// StartDeviceAuthResponse is returned when the device auth flow is initiated.
+// StartDeviceAuthResponse is returned by POST /codex/device-auth.
 type StartDeviceAuthResponse struct {
-	DeviceCode              string `json:"device_code"`
-	UserCode                string `json:"user_code"`
-	VerificationURI         string `json:"verification_uri"`
-	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
-	ExpiresIn               int    `json:"expires_in"`
-	Interval                int    `json:"interval"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
 }
 
-// PollDeviceAuthRequest is the request body for polling the device auth token.
-type PollDeviceAuthRequest struct {
-	DeviceCode string `json:"device_code"`
-}
-
-// PollDeviceAuthResponse is returned when polling for the device auth token.
+// PollDeviceAuthResponse is returned by POST /codex/device-auth/token.
 type PollDeviceAuthResponse struct {
-	// Status is one of "pending", "authorized", "expired", "denied".
+	// Status is one of "pending", "authorized", "denied".
 	Status string `json:"status"`
 }
 
-// CodexAuthConfigResponse is returned by the GET /codex/device-auth/config endpoint.
+// CodexAuthConfigResponse is returned by GET /codex/device-auth/config.
 type CodexAuthConfigResponse struct {
 	Configured bool `json:"configured"`
 }
 
-// GetConfig handles GET /codex/device-auth/config
-// Returns whether device auth is configured on this proxy instance.
+// GetConfig handles GET /codex/device-auth/config.
+// Returns whether the codex CLI is available for device auth.
 func (c *CodexDeviceAuthController) GetConfig(ctx echo.Context) error {
 	user := auth.GetUserFromContext(ctx)
 	if user == nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
-	configured := c.cfg != nil && c.cfg.DeviceAuthURL != "" && c.cfg.TokenURL != "" && c.cfg.ClientID != ""
-	return ctx.JSON(http.StatusOK, CodexAuthConfigResponse{Configured: configured})
+	_, err := exec.LookPath("codex")
+	return ctx.JSON(http.StatusOK, CodexAuthConfigResponse{Configured: err == nil})
 }
 
-// StartDeviceAuth handles POST /codex/device-auth
-// Initiates the OAuth 2.0 device authorization flow by calling the configured
-// device authorization endpoint and returning the user code / verification URI.
+// StartDeviceAuth handles POST /codex/device-auth.
+// Runs `codex login --device-auth` and returns the user_code and verification_uri.
 func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 	user := auth.GetUserFromContext(ctx)
 	if user == nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	if c.cfg == nil || c.cfg.DeviceAuthURL == "" || c.cfg.ClientID == "" {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, "Codex device auth not configured: set AGENTAPI_CODEX_AUTH_DEVICE_AUTH_URL, AGENTAPI_CODEX_AUTH_TOKEN_URL, and AGENTAPI_CODEX_AUTH_CLIENT_ID")
-	}
+	userID := string(user.ID())
 
-	scope := c.cfg.Scope
-	if scope == "" {
-		scope = "openid email profile offline_access"
-	}
-
-	params := url.Values{}
-	params.Set("client_id", c.cfg.ClientID)
-	params.Set("scope", scope)
-
-	resp, err := http.PostForm(c.cfg.DeviceAuthURL, params)
+	codexPath, err := exec.LookPath("codex")
 	if err != nil {
-		log.Printf("[CODEX_AUTH] Device auth request failed: %v", err)
-		return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Device auth request failed: %v", err))
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "codex CLI not found in PATH")
 	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	// Cancel any existing session for this user before starting a new one.
+	c.cancelSession(userID)
+
+	// Use a temporary HOME so each user's auth.json is isolated.
+	tmpHome, err := os.MkdirTemp("", "codex-auth-*")
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadGateway, "Failed to read device auth response")
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create temp directory")
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		log.Printf("[CODEX_AUTH] Device auth endpoint returned %d: %s", resp.StatusCode, string(body))
-		return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Device auth endpoint returned %d", resp.StatusCode))
+	// Inherit env but override HOME.
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "HOME=") {
+			env = append(env, e)
+		}
+	}
+	env = append(env, "HOME="+tmpHome)
+
+	// Merge stdout+stderr into a single pipe for parsing.
+	pr, pw := io.Pipe()
+	cmd := exec.Command(codexPath, "login", "--device-auth")
+	cmd.Env = env
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+
+	if err := cmd.Start(); err != nil {
+		_ = pw.Close()
+		_ = pr.Close()
+		_ = os.RemoveAll(tmpHome)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to start codex: %v", err))
 	}
 
-	var result StartDeviceAuthResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		log.Printf("[CODEX_AUTH] Failed to parse device auth response: %v", err)
-		return echo.NewHTTPError(http.StatusBadGateway, "Failed to parse device auth response")
-	}
+	session := &authSession{cmd: cmd, tmpHome: tmpHome, status: "pending"}
+	c.sessions.Store(userID, session)
 
-	log.Printf("[CODEX_AUTH] Device auth started for user=%s, user_code=%s", user.ID(), result.UserCode)
-	return ctx.JSON(http.StatusOK, result)
+	// exitErrCh receives the process exit status once.
+	exitErrCh := make(chan error, 1)
+	go func() {
+		err := cmd.Wait()
+		_ = pw.Close()
+		exitErrCh <- err
+	}()
+
+	// parseCh receives the URL+code pair extracted from stdout.
+	type parseResult struct {
+		userCode  string
+		verifyURI string
+		err       error
+	}
+	parseCh := make(chan parseResult, 1)
+
+	go func() {
+		var userCode, verifyURI string
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			line := ansiRegex.ReplaceAllString(scanner.Text(), "")
+			if verifyURI == "" {
+				if m := urlRegex.FindString(line); m != "" {
+					verifyURI = strings.TrimSpace(m)
+				}
+			}
+			if userCode == "" {
+				if m := codeRegex.FindString(line); m != "" {
+					userCode = m
+				}
+			}
+			if userCode != "" && verifyURI != "" {
+				parseCh <- parseResult{userCode: userCode, verifyURI: verifyURI}
+				// Drain remaining output so the process isn't blocked.
+				for scanner.Scan() {
+				}
+				return
+			}
+		}
+		parseCh <- parseResult{err: fmt.Errorf("auth flow ended before providing user code")}
+	}()
+
+	// Wait for URL+code to appear, or timeout.
+	select {
+	case r := <-parseCh:
+		if r.err != nil {
+			c.cancelSession(userID)
+			return echo.NewHTTPError(http.StatusInternalServerError, r.err.Error())
+		}
+		log.Printf("[CODEX_AUTH] Device auth started for user=%s code=%s", userID, r.userCode)
+		go c.watchCompletion(userID, session, exitErrCh)
+		return ctx.JSON(http.StatusOK, StartDeviceAuthResponse{
+			UserCode:        r.userCode,
+			VerificationURI: r.verifyURI,
+		})
+
+	case exitErr := <-exitErrCh:
+		c.cancelSession(userID)
+		msg := "codex auth process exited unexpectedly"
+		if exitErr != nil {
+			msg = fmt.Sprintf("codex auth failed: %v", exitErr)
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, msg)
+
+	case <-time.After(30 * time.Second):
+		c.cancelSession(userID)
+		return echo.NewHTTPError(http.StatusGatewayTimeout, "Timeout waiting for auth flow to start")
+	}
 }
 
-// PollDeviceAuth handles POST /codex/device-auth/token
-// Polls the OAuth 2.0 token endpoint for the device auth result.
-// On success, the token is persisted to the user's Codex credentials.
+// PollDeviceAuth handles POST /codex/device-auth/token.
+// Returns the current status for the calling user's in-progress auth session.
 func (c *CodexDeviceAuthController) PollDeviceAuth(ctx echo.Context) error {
 	user := auth.GetUserFromContext(ctx)
 	if user == nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
 	}
 
-	if c.cfg == nil || c.cfg.TokenURL == "" || c.cfg.ClientID == "" {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, "Codex device auth not configured")
+	userID := string(user.ID())
+	val, ok := c.sessions.Load(userID)
+	if !ok {
+		return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "pending"})
 	}
 
-	var req PollDeviceAuthRequest
-	if err := ctx.Bind(&req); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
-	}
-	if req.DeviceCode == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "device_code is required")
+	s := val.(*authSession)
+	s.mu.Lock()
+	status := s.status
+	s.mu.Unlock()
+
+	return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: status})
+}
+
+// watchCompletion waits for the auth subprocess to exit, then reads the generated
+// auth.json and persists it to the credentials repository.
+func (c *CodexDeviceAuthController) watchCompletion(userID string, session *authSession, exitErrCh <-chan error) {
+	exitErr := <-exitErrCh
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	defer func() {
+		go func() {
+			time.Sleep(10 * time.Second)
+			_ = os.RemoveAll(session.tmpHome)
+		}()
+	}()
+
+	if exitErr != nil {
+		log.Printf("[CODEX_AUTH] Auth process failed for user=%s: %v", userID, exitErr)
+		session.status = "denied"
+		return
 	}
 
-	params := url.Values{}
-	params.Set("client_id", c.cfg.ClientID)
-	params.Set("device_code", req.DeviceCode)
-	params.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
-
-	resp, err := http.PostForm(c.cfg.TokenURL, params)
+	authJSONPath := filepath.Join(session.tmpHome, ".codex", "auth.json")
+	data, err := os.ReadFile(authJSONPath)
 	if err != nil {
-		log.Printf("[CODEX_AUTH] Token poll request failed: %v", err)
-		return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Token request failed: %v", err))
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadGateway, "Failed to read token response")
+		log.Printf("[CODEX_AUTH] Failed to read auth.json for user=%s: %v", userID, err)
+		session.status = "denied"
+		return
 	}
 
-	var tokenResp map[string]interface{}
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		log.Printf("[CODEX_AUTH] Failed to parse token response: %v", err)
-		return echo.NewHTTPError(http.StatusBadGateway, "Failed to parse token response")
-	}
-
-	// Handle OAuth error responses
-	if errCode, ok := tokenResp["error"].(string); ok {
-		switch errCode {
-		case "authorization_pending", "slow_down":
-			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "pending"})
-		case "expired_token":
-			log.Printf("[CODEX_AUTH] Device code expired for user=%s", user.ID())
-			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "expired"})
-		case "access_denied", "authorization_declined":
-			log.Printf("[CODEX_AUTH] Device auth denied for user=%s", user.ID())
-			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "denied"})
-		default:
-			log.Printf("[CODEX_AUTH] Token endpoint error=%s for user=%s", errCode, user.ID())
-			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "denied"})
-		}
-	}
-
-	// Token received — convert expires_in to absolute expires_at and persist
-	if expiresIn, ok := tokenResp["expires_in"].(float64); ok {
-		tokenResp["expires_at"] = time.Now().Add(time.Duration(expiresIn) * time.Second).Unix()
-		delete(tokenResp, "expires_in")
-	}
-
-	tokenJSON, err := json.Marshal(tokenResp)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to serialize token")
-	}
-
-	userName := string(user.ID())
-	creds := entities.NewCredentials(userName, json.RawMessage(tokenJSON))
+	creds := entities.NewCredentials(userID, json.RawMessage(data))
 	creds.SetFileType(sessionsettings.FileTypeCodexAuth)
 
-	if err := c.repo.Save(ctx.Request().Context(), creds); err != nil {
-		log.Printf("[CODEX_AUTH] Failed to save credentials for user=%s: %v", user.ID(), err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to save credentials")
+	if err := c.repo.Save(context.Background(), creds); err != nil {
+		log.Printf("[CODEX_AUTH] Failed to save credentials for user=%s: %v", userID, err)
+		session.status = "denied"
+		return
 	}
 
-	log.Printf("[CODEX_AUTH] Device auth completed and credentials saved for user=%s", user.ID())
-	return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "authorized"})
+	session.status = "authorized"
+	log.Printf("[CODEX_AUTH] Auth completed and credentials saved for user=%s", userID)
+}
+
+// cancelSession kills any running auth subprocess for the given user.
+func (c *CodexDeviceAuthController) cancelSession(userID string) {
+	if val, ok := c.sessions.LoadAndDelete(userID); ok {
+		s := val.(*authSession)
+		if s.cmd != nil && s.cmd.Process != nil {
+			_ = s.cmd.Process.Kill()
+		}
+		go func() {
+			time.Sleep(time.Second)
+			_ = os.RemoveAll(s.tmpHome)
+		}()
+	}
 }

--- a/internal/interfaces/controllers/codex_device_auth_controller.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller.go
@@ -1,0 +1,205 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
+)
+
+// CodexDeviceAuthController handles Codex OAuth device authorization flow.
+type CodexDeviceAuthController struct {
+	cfg  *config.CodexAuthConfig
+	repo repositories.CredentialsRepository
+}
+
+// NewCodexDeviceAuthController creates a new CodexDeviceAuthController.
+func NewCodexDeviceAuthController(cfg *config.CodexAuthConfig, repo repositories.CredentialsRepository) *CodexDeviceAuthController {
+	return &CodexDeviceAuthController{cfg: cfg, repo: repo}
+}
+
+// GetName returns the controller name for logging.
+func (c *CodexDeviceAuthController) GetName() string {
+	return "CodexDeviceAuthController"
+}
+
+// StartDeviceAuthResponse is returned when the device auth flow is initiated.
+type StartDeviceAuthResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// PollDeviceAuthRequest is the request body for polling the device auth token.
+type PollDeviceAuthRequest struct {
+	DeviceCode string `json:"device_code"`
+}
+
+// PollDeviceAuthResponse is returned when polling for the device auth token.
+type PollDeviceAuthResponse struct {
+	// Status is one of "pending", "authorized", "expired", "denied".
+	Status string `json:"status"`
+}
+
+// CodexAuthConfigResponse is returned by the GET /codex/device-auth/config endpoint.
+type CodexAuthConfigResponse struct {
+	Configured bool `json:"configured"`
+}
+
+// GetConfig handles GET /codex/device-auth/config
+// Returns whether device auth is configured on this proxy instance.
+func (c *CodexDeviceAuthController) GetConfig(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+	configured := c.cfg != nil && c.cfg.DeviceAuthURL != "" && c.cfg.TokenURL != "" && c.cfg.ClientID != ""
+	return ctx.JSON(http.StatusOK, CodexAuthConfigResponse{Configured: configured})
+}
+
+// StartDeviceAuth handles POST /codex/device-auth
+// Initiates the OAuth 2.0 device authorization flow by calling the configured
+// device authorization endpoint and returning the user code / verification URI.
+func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	if c.cfg == nil || c.cfg.DeviceAuthURL == "" || c.cfg.ClientID == "" {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Codex device auth not configured: set AGENTAPI_CODEX_AUTH_DEVICE_AUTH_URL, AGENTAPI_CODEX_AUTH_TOKEN_URL, and AGENTAPI_CODEX_AUTH_CLIENT_ID")
+	}
+
+	scope := c.cfg.Scope
+	if scope == "" {
+		scope = "openid email profile offline_access"
+	}
+
+	params := url.Values{}
+	params.Set("client_id", c.cfg.ClientID)
+	params.Set("scope", scope)
+
+	resp, err := http.PostForm(c.cfg.DeviceAuthURL, params)
+	if err != nil {
+		log.Printf("[CODEX_AUTH] Device auth request failed: %v", err)
+		return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Device auth request failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, "Failed to read device auth response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Printf("[CODEX_AUTH] Device auth endpoint returned %d: %s", resp.StatusCode, string(body))
+		return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Device auth endpoint returned %d", resp.StatusCode))
+	}
+
+	var result StartDeviceAuthResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		log.Printf("[CODEX_AUTH] Failed to parse device auth response: %v", err)
+		return echo.NewHTTPError(http.StatusBadGateway, "Failed to parse device auth response")
+	}
+
+	log.Printf("[CODEX_AUTH] Device auth started for user=%s, user_code=%s", user.ID(), result.UserCode)
+	return ctx.JSON(http.StatusOK, result)
+}
+
+// PollDeviceAuth handles POST /codex/device-auth/token
+// Polls the OAuth 2.0 token endpoint for the device auth result.
+// On success, the token is persisted to the user's Codex credentials.
+func (c *CodexDeviceAuthController) PollDeviceAuth(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	if c.cfg == nil || c.cfg.TokenURL == "" || c.cfg.ClientID == "" {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Codex device auth not configured")
+	}
+
+	var req PollDeviceAuthRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+	if req.DeviceCode == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "device_code is required")
+	}
+
+	params := url.Values{}
+	params.Set("client_id", c.cfg.ClientID)
+	params.Set("device_code", req.DeviceCode)
+	params.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+
+	resp, err := http.PostForm(c.cfg.TokenURL, params)
+	if err != nil {
+		log.Printf("[CODEX_AUTH] Token poll request failed: %v", err)
+		return echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("Token request failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, "Failed to read token response")
+	}
+
+	var tokenResp map[string]interface{}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		log.Printf("[CODEX_AUTH] Failed to parse token response: %v", err)
+		return echo.NewHTTPError(http.StatusBadGateway, "Failed to parse token response")
+	}
+
+	// Handle OAuth error responses
+	if errCode, ok := tokenResp["error"].(string); ok {
+		switch errCode {
+		case "authorization_pending", "slow_down":
+			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "pending"})
+		case "expired_token":
+			log.Printf("[CODEX_AUTH] Device code expired for user=%s", user.ID())
+			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "expired"})
+		case "access_denied", "authorization_declined":
+			log.Printf("[CODEX_AUTH] Device auth denied for user=%s", user.ID())
+			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "denied"})
+		default:
+			log.Printf("[CODEX_AUTH] Token endpoint error=%s for user=%s", errCode, user.ID())
+			return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "denied"})
+		}
+	}
+
+	// Token received — convert expires_in to absolute expires_at and persist
+	if expiresIn, ok := tokenResp["expires_in"].(float64); ok {
+		tokenResp["expires_at"] = time.Now().Add(time.Duration(expiresIn) * time.Second).Unix()
+		delete(tokenResp, "expires_in")
+	}
+
+	tokenJSON, err := json.Marshal(tokenResp)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to serialize token")
+	}
+
+	userName := string(user.ID())
+	creds := entities.NewCredentials(userName, json.RawMessage(tokenJSON))
+	creds.SetFileType(sessionsettings.FileTypeCodexAuth)
+
+	if err := c.repo.Save(ctx.Request().Context(), creds); err != nil {
+		log.Printf("[CODEX_AUTH] Failed to save credentials for user=%s: %v", user.ID(), err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to save credentials")
+	}
+
+	log.Printf("[CODEX_AUTH] Device auth completed and credentials saved for user=%s", user.ID())
+	return ctx.JSON(http.StatusOK, PollDeviceAuthResponse{Status: "authorized"})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -418,8 +418,6 @@ type Config struct {
 	Redis RedisConfig `json:"redis" mapstructure:"redis"`
 	// GitSync holds proxy-level GitHub sync settings (e.g. KMS encryption key).
 	GitSync GitSyncProxyConfig `json:"git_sync" mapstructure:"git_sync"`
-	// CodexAuth holds configuration for Codex OAuth device authentication.
-	CodexAuth CodexAuthConfig `json:"codex_auth" mapstructure:"codex_auth"`
 }
 
 // GitSyncEncryptionProxyConfig holds proxy-level AWS KMS settings for GitHub sync.
@@ -459,23 +457,6 @@ type GitSyncProxyConfig struct {
 	RenewDeadline string `json:"renew_deadline" mapstructure:"renew_deadline"`
 	// RetryPeriod is the duration the LeaderElector clients should wait between tries of actions.
 	RetryPeriod string `json:"retry_period" mapstructure:"retry_period"`
-}
-
-// CodexAuthConfig holds configuration for Codex OAuth device authentication.
-// When DeviceAuthURL and TokenURL are configured, users can initiate the OAuth
-// device authorization flow from the UI settings page.
-type CodexAuthConfig struct {
-	// DeviceAuthURL is the OAuth 2.0 device authorization endpoint URL.
-	// Example: https://auth0.openai.com/oauth/device/code
-	DeviceAuthURL string `json:"device_auth_url" mapstructure:"device_auth_url"`
-	// TokenURL is the OAuth 2.0 token endpoint URL.
-	// Example: https://auth0.openai.com/oauth/token
-	TokenURL string `json:"token_url" mapstructure:"token_url"`
-	// ClientID is the OAuth 2.0 client ID for the Codex application.
-	ClientID string `json:"client_id" mapstructure:"client_id"`
-	// Scope is the OAuth 2.0 scope string.
-	// Default: "openid email profile offline_access"
-	Scope string `json:"scope" mapstructure:"scope"`
 }
 
 // SlackConfig represents Slack bot (Socket Mode) configuration
@@ -860,11 +841,6 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("git_sync.renew_deadline", "AGENTAPI_GIT_SYNC_RENEW_DEADLINE")
 	_ = v.BindEnv("git_sync.retry_period", "AGENTAPI_GIT_SYNC_RETRY_PERIOD")
 
-	// Codex device auth configuration
-	_ = v.BindEnv("codex_auth.device_auth_url", "AGENTAPI_CODEX_AUTH_DEVICE_AUTH_URL")
-	_ = v.BindEnv("codex_auth.token_url", "AGENTAPI_CODEX_AUTH_TOKEN_URL")
-	_ = v.BindEnv("codex_auth.client_id", "AGENTAPI_CODEX_AUTH_CLIENT_ID")
-	_ = v.BindEnv("codex_auth.scope", "AGENTAPI_CODEX_AUTH_SCOPE")
 }
 
 // setDefaults sets default values for viper configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -418,6 +418,8 @@ type Config struct {
 	Redis RedisConfig `json:"redis" mapstructure:"redis"`
 	// GitSync holds proxy-level GitHub sync settings (e.g. KMS encryption key).
 	GitSync GitSyncProxyConfig `json:"git_sync" mapstructure:"git_sync"`
+	// CodexAuth holds configuration for Codex OAuth device authentication.
+	CodexAuth CodexAuthConfig `json:"codex_auth" mapstructure:"codex_auth"`
 }
 
 // GitSyncEncryptionProxyConfig holds proxy-level AWS KMS settings for GitHub sync.
@@ -457,6 +459,23 @@ type GitSyncProxyConfig struct {
 	RenewDeadline string `json:"renew_deadline" mapstructure:"renew_deadline"`
 	// RetryPeriod is the duration the LeaderElector clients should wait between tries of actions.
 	RetryPeriod string `json:"retry_period" mapstructure:"retry_period"`
+}
+
+// CodexAuthConfig holds configuration for Codex OAuth device authentication.
+// When DeviceAuthURL and TokenURL are configured, users can initiate the OAuth
+// device authorization flow from the UI settings page.
+type CodexAuthConfig struct {
+	// DeviceAuthURL is the OAuth 2.0 device authorization endpoint URL.
+	// Example: https://auth0.openai.com/oauth/device/code
+	DeviceAuthURL string `json:"device_auth_url" mapstructure:"device_auth_url"`
+	// TokenURL is the OAuth 2.0 token endpoint URL.
+	// Example: https://auth0.openai.com/oauth/token
+	TokenURL string `json:"token_url" mapstructure:"token_url"`
+	// ClientID is the OAuth 2.0 client ID for the Codex application.
+	ClientID string `json:"client_id" mapstructure:"client_id"`
+	// Scope is the OAuth 2.0 scope string.
+	// Default: "openid email profile offline_access"
+	Scope string `json:"scope" mapstructure:"scope"`
 }
 
 // SlackConfig represents Slack bot (Socket Mode) configuration
@@ -840,6 +859,12 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("git_sync.lease_duration", "AGENTAPI_GIT_SYNC_LEASE_DURATION")
 	_ = v.BindEnv("git_sync.renew_deadline", "AGENTAPI_GIT_SYNC_RENEW_DEADLINE")
 	_ = v.BindEnv("git_sync.retry_period", "AGENTAPI_GIT_SYNC_RETRY_PERIOD")
+
+	// Codex device auth configuration
+	_ = v.BindEnv("codex_auth.device_auth_url", "AGENTAPI_CODEX_AUTH_DEVICE_AUTH_URL")
+	_ = v.BindEnv("codex_auth.token_url", "AGENTAPI_CODEX_AUTH_TOKEN_URL")
+	_ = v.BindEnv("codex_auth.client_id", "AGENTAPI_CODEX_AUTH_CLIENT_ID")
+	_ = v.BindEnv("codex_auth.scope", "AGENTAPI_CODEX_AUTH_SCOPE")
 }
 
 // setDefaults sets default values for viper configuration

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4252,7 +4252,7 @@
     "/codex/device-auth": {
       "post": {
         "summary": "Start Codex device authorization flow",
-        "description": "Initiates the OAuth 2.0 Device Authorization Grant flow for Codex authentication. Returns a user code and verification URI that the user must visit to complete authentication.",
+        "description": "Runs `codex login --device-auth` and returns the user code and verification URI for the user to complete authentication in their browser.",
         "operationId": "startCodexDeviceAuth",
         "tags": [
           "Codex"
@@ -4273,10 +4273,6 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "device_code": {
-                      "type": "string",
-                      "description": "Device code for polling"
-                    },
                     "user_code": {
                       "type": "string",
                       "description": "Code the user must enter at the verification URI"
@@ -4284,26 +4280,11 @@
                     "verification_uri": {
                       "type": "string",
                       "description": "URL the user must visit to authenticate"
-                    },
-                    "verification_uri_complete": {
-                      "type": "string",
-                      "description": "Verification URI with user code pre-filled"
-                    },
-                    "expires_in": {
-                      "type": "integer",
-                      "description": "Seconds until the device code expires"
-                    },
-                    "interval": {
-                      "type": "integer",
-                      "description": "Minimum polling interval in seconds"
                     }
                   },
                   "required": [
-                    "device_code",
                     "user_code",
-                    "verification_uri",
-                    "expires_in",
-                    "interval"
+                    "verification_uri"
                   ]
                 }
               }
@@ -4313,15 +4294,15 @@
             "description": "Unauthorized"
           },
           "503": {
-            "description": "Device auth not configured"
+            "description": "codex CLI not found in PATH"
           }
         }
       }
     },
     "/codex/device-auth/token": {
       "post": {
-        "summary": "Poll Codex device auth token",
-        "description": "Polls the OAuth 2.0 token endpoint to check if the user has completed authentication. On success, the token is saved as Codex credentials.",
+        "summary": "Poll Codex device auth status",
+        "description": "Returns the current status of the caller's in-progress device auth session. The session is identified by the caller's authentication token.",
         "operationId": "pollCodexDeviceAuth",
         "tags": [
           "Codex"
@@ -4334,25 +4315,6 @@
             "ApiKeyAuth": []
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "device_code": {
-                    "type": "string",
-                    "description": "Device code received from startCodexDeviceAuth"
-                  }
-                },
-                "required": [
-                  "device_code"
-                ]
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Poll result",
@@ -4366,7 +4328,6 @@
                       "enum": [
                         "pending",
                         "authorized",
-                        "expired",
                         "denied"
                       ],
                       "description": "Current authorization status"
@@ -4379,14 +4340,8 @@
               }
             }
           },
-          "400": {
-            "description": "Missing device_code"
-          },
           "401": {
             "description": "Unauthorized"
-          },
-          "503": {
-            "description": "Device auth not configured"
           }
         }
       }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -328,7 +328,9 @@
                           "maxItems": 0
                         }
                       },
-                      "required": ["events"]
+                      "required": [
+                        "events"
+                      ]
                     }
                   ]
                 }
@@ -395,7 +397,9 @@
                       "properties": {
                         "updated": {
                           "type": "boolean",
-                          "enum": [true]
+                          "enum": [
+                            true
+                          ]
                         },
                         "session_id": {
                           "type": "string"
@@ -405,7 +409,11 @@
                           "format": "date-time"
                         }
                       },
-                      "required": ["updated", "session_id", "timestamp"]
+                      "required": [
+                        "updated",
+                        "session_id",
+                        "timestamp"
+                      ]
                     },
                     {
                       "type": "object",
@@ -413,10 +421,14 @@
                       "properties": {
                         "updated": {
                           "type": "boolean",
-                          "enum": [false]
+                          "enum": [
+                            false
+                          ]
                         }
                       },
-                      "required": ["updated"]
+                      "required": [
+                        "updated"
+                      ]
                     }
                   ]
                 }
@@ -3939,36 +3951,58 @@
       "delete": {
         "summary": "Delete GitHub sync configuration",
         "description": "Removes the GitHub sync configuration from the specified settings. The sync config can also be set via PUT /settings/{name} with a git_sync field.",
-        "tags": ["GitHubSync"],
+        "tags": [
+          "GitHubSync"
+        ],
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Deleted successfully" },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "404": { "description": "Not found" },
-          "500": { "description": "Internal server error" }
+          "200": {
+            "description": "Deleted successfully"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
-        "security": [{ "bearerAuth": [] }]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/settings/{name}/sync/push": {
       "post": {
         "summary": "Push resources to GitHub",
         "description": "Exports all resources (memories, tasks, schedules, webhooks, settings, etc.) and commits them to the configured GitHub repository. Sensitive fields are encrypted with AES-256-GCM using an AWS KMS-managed DEK.",
-        "tags": ["GitHubSync"],
+        "tags": [
+          "GitHubSync"
+        ],
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -3977,7 +4011,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "commit_message": { "type": "string", "description": "Override the default commit message" }
+                  "commit_message": {
+                    "type": "string",
+                    "description": "Override the default commit message"
+                  }
                 }
               }
             }
@@ -3988,28 +4025,44 @@
             "description": "Push succeeded",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PushResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/PushResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
-        "security": [{ "bearerAuth": [] }]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/settings/{name}/sync/pull": {
       "post": {
         "summary": "Pull resources from GitHub",
         "description": "Downloads resources from the configured GitHub repository and imports them into the local store. Encrypted fields are decrypted using the stored DEK.",
-        "tags": ["GitHubSync"],
+        "tags": [
+          "GitHubSync"
+        ],
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4018,7 +4071,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "delete_orphans": { "type": "boolean", "description": "Remove local resources that no longer exist in GitHub" }
+                  "delete_orphans": {
+                    "type": "boolean",
+                    "description": "Remove local resources that no longer exist in GitHub"
+                  }
                 }
               }
             }
@@ -4029,28 +4085,44 @@
             "description": "Pull succeeded",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PullResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/PullResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
-        "security": [{ "bearerAuth": [] }]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/settings/{name}/sync/rotate-key": {
       "post": {
         "summary": "Rotate the sync encryption key",
         "description": "Generates a new DEK via AWS KMS, re-encrypts all values in the GitHub repository with the new DEK, and commits atomically. The old encryptedDEK is replaced in Settings.",
-        "tags": ["GitHubSync"],
+        "tags": [
+          "GitHubSync"
+        ],
         "parameters": [
           {
             "name": "name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4058,22 +4130,36 @@
             "description": "Key rotated successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RotateKeyResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/RotateKeyResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
-        "security": [{ "bearerAuth": [] }]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/settings/sync/all": {
       "post": {
         "summary": "Sync all tenants",
         "description": "Syncs GitHub for every settings tenant that has sync enabled. Only accessible by admin users. The direction (push/pull) is determined automatically per tenant by comparing the remote .sync-meta.yaml syncedAt timestamp against the local LastPushedAt: if GitHub is newer the tenant is pulled, otherwise pushed. Push is idempotent: no commit is created when file contents are unchanged.",
-        "tags": ["GitHubSync"],
+        "tags": [
+          "GitHubSync"
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -4098,15 +4184,211 @@
             "description": "Sync completed (individual tenant errors are captured in results[].error)",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SyncAllResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SyncAllResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized" },
-          "403": { "description": "Forbidden — admin permission required" },
-          "500": { "description": "Internal server error" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden — admin permission required"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
         },
-        "security": [{ "bearerAuth": [] }]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/codex/device-auth/config": {
+      "get": {
+        "summary": "Get Codex device auth configuration status",
+        "description": "Returns whether Codex device authentication is configured on this proxy instance.",
+        "operationId": "getCodexDeviceAuthConfig",
+        "tags": [
+          "Codex"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Configuration status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "configured": {
+                      "type": "boolean",
+                      "description": "Whether device auth is configured"
+                    }
+                  },
+                  "required": [
+                    "configured"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/codex/device-auth": {
+      "post": {
+        "summary": "Start Codex device authorization flow",
+        "description": "Initiates the OAuth 2.0 Device Authorization Grant flow for Codex authentication. Returns a user code and verification URI that the user must visit to complete authentication.",
+        "operationId": "startCodexDeviceAuth",
+        "tags": [
+          "Codex"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Device authorization started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "device_code": {
+                      "type": "string",
+                      "description": "Device code for polling"
+                    },
+                    "user_code": {
+                      "type": "string",
+                      "description": "Code the user must enter at the verification URI"
+                    },
+                    "verification_uri": {
+                      "type": "string",
+                      "description": "URL the user must visit to authenticate"
+                    },
+                    "verification_uri_complete": {
+                      "type": "string",
+                      "description": "Verification URI with user code pre-filled"
+                    },
+                    "expires_in": {
+                      "type": "integer",
+                      "description": "Seconds until the device code expires"
+                    },
+                    "interval": {
+                      "type": "integer",
+                      "description": "Minimum polling interval in seconds"
+                    }
+                  },
+                  "required": [
+                    "device_code",
+                    "user_code",
+                    "verification_uri",
+                    "expires_in",
+                    "interval"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "503": {
+            "description": "Device auth not configured"
+          }
+        }
+      }
+    },
+    "/codex/device-auth/token": {
+      "post": {
+        "summary": "Poll Codex device auth token",
+        "description": "Polls the OAuth 2.0 token endpoint to check if the user has completed authentication. On success, the token is saved as Codex credentials.",
+        "operationId": "pollCodexDeviceAuth",
+        "tags": [
+          "Codex"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "device_code": {
+                    "type": "string",
+                    "description": "Device code received from startCodexDeviceAuth"
+                  }
+                },
+                "required": [
+                  "device_code"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Poll result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "authorized",
+                        "expired",
+                        "denied"
+                      ],
+                      "description": "Current authorization status"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing device_code"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "503": {
+            "description": "Device auth not configured"
+          }
+        }
       }
     }
   },
@@ -4116,83 +4398,172 @@
         "type": "object",
         "description": "Public view of GitHub sync configuration (token redacted)",
         "properties": {
-          "enabled": { "type": "boolean" },
-          "repo_full_name": { "type": "string", "example": "owner/repo" },
-          "branch": { "type": "string", "example": "main" },
-          "root_path": { "type": "string", "example": "agentapi-config/" },
-          "auto_push": { "type": "boolean" },
-          "has_github_token": { "type": "boolean", "description": "true when a GitHub token is configured" },
-          "encryption": { "$ref": "#/components/schemas/SyncEncryptionResponse" }
+          "enabled": {
+            "type": "boolean"
+          },
+          "repo_full_name": {
+            "type": "string",
+            "example": "owner/repo"
+          },
+          "branch": {
+            "type": "string",
+            "example": "main"
+          },
+          "root_path": {
+            "type": "string",
+            "example": "agentapi-config/"
+          },
+          "auto_push": {
+            "type": "boolean"
+          },
+          "has_github_token": {
+            "type": "boolean",
+            "description": "true when a GitHub token is configured"
+          },
+          "encryption": {
+            "$ref": "#/components/schemas/SyncEncryptionResponse"
+          }
         }
       },
       "GitSyncConfigRequest": {
         "type": "object",
         "description": "GitHub sync configuration. Encryption settings (KMS key ARN, AWS region) are set at the proxy level.",
-        "required": ["repo_full_name"],
+        "required": [
+          "repo_full_name"
+        ],
         "properties": {
-          "enabled": { "type": "boolean" },
-          "repo_full_name": { "type": "string", "example": "owner/repo" },
-          "branch": { "type": "string", "example": "main", "description": "Defaults to 'main' if omitted" },
-          "root_path": { "type": "string", "example": "agentapi-config/", "description": "Defaults to 'agentapi-config/' if omitted" },
-          "auto_push": { "type": "boolean" },
-          "github_token": { "type": "string", "description": "GitHub PAT (write-only, not returned). Existing token is preserved if omitted." }
+          "enabled": {
+            "type": "boolean"
+          },
+          "repo_full_name": {
+            "type": "string",
+            "example": "owner/repo"
+          },
+          "branch": {
+            "type": "string",
+            "example": "main",
+            "description": "Defaults to 'main' if omitted"
+          },
+          "root_path": {
+            "type": "string",
+            "example": "agentapi-config/",
+            "description": "Defaults to 'agentapi-config/' if omitted"
+          },
+          "auto_push": {
+            "type": "boolean"
+          },
+          "github_token": {
+            "type": "string",
+            "description": "GitHub PAT (write-only, not returned). Existing token is preserved if omitted."
+          }
         }
       },
       "SyncEncryptionResponse": {
         "type": "object",
         "description": "Public encryption info (no secrets)",
         "properties": {
-          "dek_version": { "type": "integer" },
-          "dek_ready": { "type": "boolean", "description": "true when a DEK has been generated and stored" }
+          "dek_version": {
+            "type": "integer"
+          },
+          "dek_ready": {
+            "type": "boolean",
+            "description": "true when a DEK has been generated and stored"
+          }
         }
       },
       "PushResponse": {
         "type": "object",
         "properties": {
-          "commit_sha": { "type": "string" },
-          "pushed_at": { "type": "string", "format": "date-time" },
-          "summary": { "$ref": "#/components/schemas/SyncSummary" }
+          "commit_sha": {
+            "type": "string"
+          },
+          "pushed_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/SyncSummary"
+          }
         }
       },
       "PullResponse": {
         "type": "object",
         "properties": {
-          "pulled_at": { "type": "string", "format": "date-time" },
-          "summary": { "$ref": "#/components/schemas/SyncSummary" }
+          "pulled_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/SyncSummary"
+          }
         }
       },
       "RotateKeyResponse": {
         "type": "object",
         "properties": {
-          "commit_sha": { "type": "string" },
-          "rotated_at": { "type": "string", "format": "date-time" },
-          "dek_version": { "type": "integer" }
+          "commit_sha": {
+            "type": "string"
+          },
+          "rotated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dek_version": {
+            "type": "integer"
+          }
         }
       },
       "SyncSummary": {
         "type": "object",
         "properties": {
-          "files_written": { "type": "integer" },
-          "files_deleted": { "type": "integer" }
+          "files_written": {
+            "type": "integer"
+          },
+          "files_deleted": {
+            "type": "integer"
+          }
         }
       },
       "SyncAllResult": {
         "type": "object",
         "properties": {
-          "settings_name": { "type": "string", "description": "Settings name (user ID or team name)" },
-          "direction": { "type": "string", "enum": ["push", "pull", "unknown"], "description": "Automatically determined sync direction" },
-          "push": { "$ref": "#/components/schemas/PushResponse" },
-          "pull": { "$ref": "#/components/schemas/PullResponse" },
-          "error": { "type": "string", "description": "Error message if sync failed for this tenant" }
+          "settings_name": {
+            "type": "string",
+            "description": "Settings name (user ID or team name)"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "push",
+              "pull",
+              "unknown"
+            ],
+            "description": "Automatically determined sync direction"
+          },
+          "push": {
+            "$ref": "#/components/schemas/PushResponse"
+          },
+          "pull": {
+            "$ref": "#/components/schemas/PullResponse"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message if sync failed for this tenant"
+          }
         }
       },
       "SyncAllResponse": {
         "type": "object",
         "properties": {
-          "synced_at": { "type": "string", "format": "date-time" },
+          "synced_at": {
+            "type": "string",
+            "format": "date-time"
+          },
           "results": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/SyncAllResult" }
+            "items": {
+              "$ref": "#/components/schemas/SyncAllResult"
+            }
           }
         }
       },
@@ -4795,15 +5166,25 @@
           },
           "allowed_domains": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "Allowlist mode: only listed domains are permitted; all others are blocked. Supports wildcard prefixes (e.g. '*.example.com'). Takes precedence over denied_domains when set.",
-            "example": ["api.example.com", "*.trusted.com"]
+            "example": [
+              "api.example.com",
+              "*.trusted.com"
+            ]
           },
           "denied_domains": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "Denylist mode: listed domains are blocked, all others are allowed. Used only when allowed_domains is empty. Supports wildcard prefixes (e.g. '*.example.com').",
-            "example": ["example.com", "*.evil.com"]
+            "example": [
+              "example.com",
+              "*.evil.com"
+            ]
           }
         }
       },
@@ -4913,7 +5294,11 @@
             "description": "When the status change was detected by the proxy"
           }
         },
-        "required": ["session_id", "status", "timestamp"]
+        "required": [
+          "session_id",
+          "status",
+          "timestamp"
+        ]
       },
       "CreateScheduleRequest": {
         "type": "object",


### PR DESCRIPTION
## Summary

- OAuth 2.0 Device Authorization Grant (RFC 8628) を Codex 認証として実装
- 設定画面からデバイス認証フローを開始できる新しい API エンドポイントを追加
- 認証成功時にトークンを credentials リポジトリ (codex_auth) へ自動保存

## 変更内容

### 新規 API エンドポイント

| Method | Path | 説明 |
|--------|------|------|
| `GET` | `/codex/device-auth/config` | デバイス認証が設定済みか確認 |
| `POST` | `/codex/device-auth` | デバイス認証フロー開始 |
| `POST` | `/codex/device-auth/token` | トークンポーリング・認証完了 |

### 設定 (環境変数)

```bash
AGENTAPI_CODEX_AUTH_DEVICE_AUTH_URL=https://auth0.openai.com/oauth/device/code
AGENTAPI_CODEX_AUTH_TOKEN_URL=https://auth0.openai.com/oauth/token
AGENTAPI_CODEX_AUTH_CLIENT_ID=<client_id>
AGENTAPI_CODEX_AUTH_SCOPE=openid email profile offline_access  # optional
```

### フロー概要

1. `POST /codex/device-auth` → OAuth プロバイダーのデバイスコードエンドポイントを呼び出し
2. `device_code`, `user_code`, `verification_uri` を UI に返す
3. UI がユーザーに `user_code` と `verification_uri` を表示
4. `POST /codex/device-auth/token` でポーリング (status: pending/authorized/expired/denied)
5. 認証成功時にトークンを `codex_auth` credentials として保存 (`~/.codex/auth.json` に反映)

### 変更ファイル

- `pkg/config/config.go` — `CodexAuthConfig` 構造体と `Config.CodexAuth` フィールド追加
- `internal/interfaces/controllers/codex_device_auth_controller.go` — 新規コントローラー
- `internal/app/router.go` — ルート登録
- `spec/openapi.json` — Codex タグの新規エンドポイント追加

## Test plan

- [ ] `make test` — 全テスト通過確認
- [ ] `make lint` — lint 通過確認
- [ ] `AGENTAPI_CODEX_AUTH_*` 環境変数なしの場合: `/codex/device-auth/config` が `{"configured": false}` を返すことを確認
- [ ] 環境変数設定済みの場合: デバイス認証フローが正常に動作することを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)