### PR TITLE
Increase network filter sidecar resources

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -207,13 +207,13 @@ spec:
             - name: AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME
               value: {{ printf "%s-sandbox-iptables" (include "agentapi-proxy.fullname" .) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
-              value: {{ dig "networkFilter" "resources" "requests" "cpu" "100m" .Values.kubernetesSession | quote }}
+              value: {{ dig "networkFilter" "resources" "requests" "cpu" "250m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT
-              value: {{ dig "networkFilter" "resources" "limits" "cpu" "500m" .Values.kubernetesSession | quote }}
+              value: {{ dig "networkFilter" "resources" "limits" "cpu" "1000m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_REQUEST
-              value: {{ dig "networkFilter" "resources" "requests" "memory" "64Mi" .Values.kubernetesSession | quote }}
+              value: {{ dig "networkFilter" "resources" "requests" "memory" "256Mi" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_LIMIT
-              value: {{ dig "networkFilter" "resources" "limits" "memory" "256Mi" .Values.kubernetesSession | quote }}
+              value: {{ dig "networkFilter" "resources" "limits" "memory" "512Mi" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_REQUEST
               value: {{ dig "networkFilter" "initResources" "requests" "cpu" "50m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_INIT_CPU_LIMIT

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -348,11 +348,11 @@ kubernetesSession:
     # Resources for the network-filter forward proxy sidecar container
     resources:
       requests:
-        cpu: "100m"
-        memory: "64Mi"
-      limits:
-        cpu: "500m"
+        cpu: "250m"
         memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "512Mi"
     # Resources for the network-filter-setup init container
     initResources:
       requests:
@@ -627,4 +627,3 @@ externalRedis:
   dialTimeout: "5s"
   readTimeout: "3s"
   writeTimeout: "3s"
-

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -887,6 +887,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
+	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
+	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
+	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")
+	v.SetDefault("kubernetes_session.network_filter_memory_limit", "512Mi")
 	v.SetDefault("kubernetes_session.github_secret_name", "")
 
 	// Settings base secret default (single base Secret shared by all sessions,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -434,6 +434,20 @@ func TestLoadConfigWithEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestLoadConfigNetworkFilterResourceDefaults(t *testing.T) {
+	clearAGENTAPIEnvVars(t)
+
+	loadedConfig, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	assert.Equal(t, "250m", loadedConfig.KubernetesSession.NetworkFilterCPURequest)
+	assert.Equal(t, "1000m", loadedConfig.KubernetesSession.NetworkFilterCPULimit)
+	assert.Equal(t, "256Mi", loadedConfig.KubernetesSession.NetworkFilterMemoryRequest)
+	assert.Equal(t, "512Mi", loadedConfig.KubernetesSession.NetworkFilterMemoryLimit)
+}
+
 func TestInitializeConfigStructsFromEnv_StaticAuth(t *testing.T) {
 	// Set up test environment variables for static auth
 	_ = os.Setenv("AGENTAPI_AUTH_STATIC_ENABLED", "true")


### PR DESCRIPTION
## Summary
- increase Helm defaults for the network-filter forward proxy sidecar resources
- keep Helm deployment fallback values aligned with values.yaml
- add Go config defaults for non-Helm startup paths and cover them with a config test

## Tests
- mise exec -- go test ./pkg/config ./internal/infrastructure/services
- mise exec -- helm template test ./helm/agentapi-proxy
- git diff --check