### PR TITLE
fix: load newly created personal API keys into auth service immediately

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -446,6 +446,9 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 				if err := services.BootstrapPersonalAPIKeys(ctx, simpleAuth, personalAPIKeyRepo); err != nil {
 					log.Printf("[SERVER] Warning: failed to bootstrap personal API keys: %v", err)
 				}
+				// Wire up the auth service as the personal API key loader so keys
+				// created on-the-fly (for new users) are immediately authenticatable.
+				k8sSessionManager.SetPersonalAPIKeyLoader(simpleAuth)
 			}
 		}
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -55,6 +55,13 @@ type ServiceAccountEnsurer interface {
 	EnsureServiceAccount(ctx context.Context, teamID string) error
 }
 
+// PersonalAPIKeyLoader registers a newly-created personal API key in the
+// authentication layer so it can be used immediately without a proxy restart.
+// Implementations must be safe to call concurrently.
+type PersonalAPIKeyLoader interface {
+	LoadPersonalAPIKey(ctx context.Context, apiKey *entities.PersonalAPIKey) error
+}
+
 // SessionStatusEvent represents a proxy-level status change event for any session.
 // It is emitted by KubernetesSessionManager whenever a session's status changes,
 // and is delivered to all active SSE/long-poll subscribers.
@@ -91,6 +98,7 @@ type KubernetesSessionManager struct {
 	settingsRepo          portrepos.SettingsRepository
 	teamConfigRepo        portrepos.TeamConfigRepository
 	personalAPIKeyRepo    portrepos.PersonalAPIKeyRepository
+	personalAPIKeyLoader  PersonalAPIKeyLoader
 	serviceAccountEnsurer ServiceAccountEnsurer
 	// onSessionDeletedHandlers holds callbacks registered via AddSessionDeletedHandler.
 	// Protected by handlersMutex.
@@ -2791,6 +2799,13 @@ func (m *KubernetesSessionManager) SetServiceAccountEnsurer(ensurer ServiceAccou
 	m.serviceAccountEnsurer = ensurer
 }
 
+// SetPersonalAPIKeyLoader wires in the auth-layer loader so that personal API
+// keys created on-the-fly in buildSessionSettings are immediately available for
+// authentication (without requiring a proxy restart to re-run bootstrap).
+func (m *KubernetesSessionManager) SetPersonalAPIKeyLoader(loader PersonalAPIKeyLoader) {
+	m.personalAPIKeyLoader = loader
+}
+
 // AddSessionDeletedHandler registers a handler that is invoked when a session is deleted,
 // before its Kubernetes resources are removed. Multiple handlers can be registered and
 // they are called in registration order.
@@ -3760,6 +3775,15 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				if saveErr := m.personalAPIKeyRepo.Save(ctx, apiKey); saveErr != nil {
 					log.Printf("[K8S_SESSION] Warning: failed to save personal API key for user %s: %v", req.UserID, saveErr)
 					apiKey = nil
+				} else if m.personalAPIKeyLoader != nil {
+					// Register the new key in the auth service immediately so that
+					// it is valid without waiting for a proxy restart + bootstrap.
+					// This is critical for oneshot sessions: the Stop hook calls
+					// delete-session using this key, which would fail with 401 if
+					// the key is only persisted to K8s but not loaded in-memory.
+					if loadErr := m.personalAPIKeyLoader.LoadPersonalAPIKey(ctx, apiKey); loadErr != nil {
+						log.Printf("[K8S_SESSION] Warning: failed to register personal API key for user %s: %v", req.UserID, loadErr)
+					}
 				}
 			}
 		}

--- a/internal/infrastructure/services/kubernetes_session_manager_personal_api_key_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_personal_api_key_test.go
@@ -1,0 +1,171 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+)
+
+// fakePersonalAPIKeyRepo is an in-memory PersonalAPIKeyRepository for tests.
+type fakePersonalAPIKeyRepo struct {
+	keys map[entities.UserID]*entities.PersonalAPIKey
+}
+
+func newFakePersonalAPIKeyRepo() *fakePersonalAPIKeyRepo {
+	return &fakePersonalAPIKeyRepo{keys: make(map[entities.UserID]*entities.PersonalAPIKey)}
+}
+
+func (r *fakePersonalAPIKeyRepo) FindByUserID(_ context.Context, userID entities.UserID) (*entities.PersonalAPIKey, error) {
+	if k, ok := r.keys[userID]; ok {
+		return k, nil
+	}
+	return nil, &notFoundError{}
+}
+
+func (r *fakePersonalAPIKeyRepo) Save(_ context.Context, k *entities.PersonalAPIKey) error {
+	r.keys[k.UserID()] = k
+	return nil
+}
+
+func (r *fakePersonalAPIKeyRepo) Delete(_ context.Context, userID entities.UserID) error {
+	delete(r.keys, userID)
+	return nil
+}
+
+func (r *fakePersonalAPIKeyRepo) List(_ context.Context) ([]*entities.PersonalAPIKey, error) {
+	out := make([]*entities.PersonalAPIKey, 0, len(r.keys))
+	for _, k := range r.keys {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// notFoundError satisfies the error interface and is treated as "not found".
+type notFoundError struct{}
+
+func (e *notFoundError) Error() string { return "not found" }
+
+// fakePersonalAPIKeyLoader records calls to LoadPersonalAPIKey.
+type fakePersonalAPIKeyLoader struct {
+	loaded []*entities.PersonalAPIKey
+}
+
+func (l *fakePersonalAPIKeyLoader) LoadPersonalAPIKey(_ context.Context, k *entities.PersonalAPIKey) error {
+	l.loaded = append(l.loaded, k)
+	return nil
+}
+
+func newTestManagerForPersonalAPIKey(t *testing.T) *KubernetesSessionManager {
+	t.Helper()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}}
+	k8sClient := fake.NewSimpleClientset(ns)
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:     "test-ns",
+			Image:         "test-image:latest",
+			BasePort:      9000,
+			PVCEnabled:    boolPtrForTest(false),
+			CPURequest:    "100m",
+			CPULimit:      "1",
+			MemoryRequest: "128Mi",
+			MemoryLimit:   "512Mi",
+		},
+	}
+	lgr := logger.NewLogger()
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, lgr, k8sClient)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	manager.namespace = "test-ns"
+	return manager
+}
+
+// TestBuildSessionSettings_NewPersonalAPIKeyLoaded verifies that when a new
+// personal API key is created for a user (first session), it is immediately
+// registered via PersonalAPIKeyLoader so that oneshot Stop hooks can
+// authenticate their delete-session calls without a proxy restart.
+func TestBuildSessionSettings_NewPersonalAPIKeyLoaded(t *testing.T) {
+	manager := newTestManagerForPersonalAPIKey(t)
+
+	repo := newFakePersonalAPIKeyRepo()
+	loader := &fakePersonalAPIKeyLoader{}
+
+	manager.SetPersonalAPIKeyRepository(repo)
+	manager.SetPersonalAPIKeyLoader(loader)
+
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "new-user"},
+		"test-deploy",
+		"agentapi-session-test-svc",
+		"test-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+
+	req := &entities.RunServerRequest{
+		UserID: "new-user",
+		Scope:  entities.ScopeUser,
+	}
+
+	manager.buildSessionSettings(context.Background(), session, req, nil)
+
+	if len(loader.loaded) == 0 {
+		t.Fatal("Expected PersonalAPIKeyLoader.LoadPersonalAPIKey to be called for new user, but it was not")
+	}
+	if loader.loaded[0].UserID() != "new-user" {
+		t.Errorf("Expected loaded key user ID %q, got %q", "new-user", loader.loaded[0].UserID())
+	}
+	// Key must also be persisted to the repository
+	if _, err := repo.FindByUserID(context.Background(), "new-user"); err != nil {
+		t.Errorf("Expected personal API key to be saved to repo: %v", err)
+	}
+}
+
+// TestBuildSessionSettings_ExistingPersonalAPIKeyNotReloaded verifies that when a
+// personal API key already exists for a user, the loader is NOT called again
+// (no duplicate registration on every session start).
+func TestBuildSessionSettings_ExistingPersonalAPIKeyNotReloaded(t *testing.T) {
+	manager := newTestManagerForPersonalAPIKey(t)
+
+	repo := newFakePersonalAPIKeyRepo()
+	existing := entities.NewPersonalAPIKey("existing-user", "existing-key-abc")
+	_ = repo.Save(context.Background(), existing)
+
+	loader := &fakePersonalAPIKeyLoader{}
+
+	manager.SetPersonalAPIKeyRepository(repo)
+	manager.SetPersonalAPIKeyLoader(loader)
+
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "existing-user"},
+		"test-deploy",
+		"agentapi-session-test-svc",
+		"test-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+
+	req := &entities.RunServerRequest{
+		UserID: "existing-user",
+		Scope:  entities.ScopeUser,
+	}
+
+	manager.buildSessionSettings(context.Background(), session, req, nil)
+
+	if len(loader.loaded) != 0 {
+		t.Errorf("Expected LoadPersonalAPIKey NOT to be called for existing user, but it was called %d time(s)", len(loader.loaded))
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause**: When a user creates their first session, `buildSessionSettings` generates a new personal API key and saves it to Kubernetes — but never registers it in `SimpleAuthService`'s in-memory map. The bootstrap that loads existing keys only runs at proxy startup.
- **Impact on oneshot sessions**: The oneshot Stop hook runs `agentapi-proxy client delete-session --confirm`, authenticating with `AGENTAPI_KEY` (the personal API key). Since the newly-created key was never loaded into memory, the proxy returns 401 Unauthorized and the session is never deleted.
- **Fix**: Introduces a `PersonalAPIKeyLoader` interface on `KubernetesSessionManager`. When a new key is created, `LoadPersonalAPIKey` is called immediately so the key is valid for authentication right away. The loader is wired to `SimpleAuthService` in `server.go` alongside the existing bootstrap.

## Test plan

- [ ] New test `TestBuildSessionSettings_NewPersonalAPIKeyLoaded` verifies that `LoadPersonalAPIKey` is called when a new key is created for a first-time user
- [ ] New test `TestBuildSessionSettings_ExistingPersonalAPIKeyNotReloaded` verifies that existing users don't trigger redundant reloads
- [ ] All existing tests continue to pass (`go test ./...`)

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)