### PR TITLE
Render session profile initial message templates

### DIFF
--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -212,7 +212,6 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 					startReq.Params = mergeSessionParams(cfg.Params(), startReq.Params)
 				}
 			}
-
 			// MemoryKey: profile is base, request keys override
 			if len(cfg.MemoryKey()) > 0 {
 				merged := make(map[string]string, len(cfg.MemoryKey()))
@@ -223,6 +222,17 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 					merged[k] = v
 				}
 				startReq.MemoryKey = merged
+			}
+			if cfg.InitialMessageTemplate() != "" && (startReq.Params == nil || startReq.Params.Message == "") {
+				rendered, err := RenderTemplate(cfg.InitialMessageTemplate(), sessionProfileTemplatePayload(userID, startReq))
+				if err != nil {
+					log.Printf("[SESSION] Warning: failed to render profile initial_message_template: %v", err)
+				} else {
+					if startReq.Params == nil {
+						startReq.Params = &entities.SessionParams{}
+					}
+					startReq.Params.Message = rendered
+				}
 			}
 		}
 	}
@@ -992,6 +1002,32 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 		merged.Sandbox = override.Sandbox
 	}
 	return &merged
+}
+
+func sessionProfileTemplatePayload(userID string, req entities.StartRequest) map[string]interface{} {
+	var params map[string]interface{}
+	if req.Params != nil {
+		params = map[string]interface{}{
+			"message":                     req.Params.Message,
+			"github_token":                req.Params.GithubToken,
+			"agent_type":                  req.Params.AgentType,
+			"oneshot":                     req.Params.Oneshot,
+			"initial_message_wait_second": req.Params.InitialMessageWaitSecond,
+			"manager_id":                  req.Params.ManagerID,
+			"cycle_message":               req.Params.CycleMessage,
+			"cycle_max_count":             req.Params.CycleMaxCount,
+			"repo_full_name":              req.Params.RepoFullName,
+		}
+	}
+	return map[string]interface{}{
+		"user_id":     userID,
+		"scope":       string(req.Scope),
+		"team_id":     req.TeamID,
+		"environment": req.Environment,
+		"tags":        req.Tags,
+		"memory_key":  req.MemoryKey,
+		"params":      params,
+	}
 }
 
 // resolveSessionProfile returns the session profile to apply for a session creation request.

--- a/internal/interfaces/controllers/webhook_session_service.go
+++ b/internal/interfaces/controllers/webhook_session_service.go
@@ -21,6 +21,7 @@ import (
 type WebhookSessionService struct {
 	repo           repositories.WebhookRepository
 	sessionManager repositories.SessionManager
+	profileRepo    repositories.SessionProfileRepository
 	launcher       *sessionuc.LaunchUseCase
 }
 
@@ -29,6 +30,7 @@ func NewWebhookSessionService(repo repositories.WebhookRepository, sessionManage
 	return &WebhookSessionService{
 		repo:           repo,
 		sessionManager: sessionManager,
+		profileRepo:    sessionProfileRepo,
 		launcher: sessionuc.NewLaunchUseCase(sessionManager).
 			WithMemoryRepository(memoryRepo).
 			WithSessionProfileRepository(sessionProfileRepo),
@@ -56,6 +58,7 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 	trigger := params.Trigger
 
 	sessionConfig := MergeSessionConfigs(webhook.SessionConfig(), trigger.SessionConfig())
+	sessionConfig, profileAlreadyApplied := s.applySessionProfileConfig(ctx, webhook, sessionConfig)
 
 	env, err := s.renderConfigMap(sessionConfig, params.Payload, func(sc *entities.WebhookSessionConfig) map[string]string {
 		return sc.Environment()
@@ -69,6 +72,13 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("failed to render tags: %w", err)
+	}
+
+	memoryKey, err := s.renderConfigMap(sessionConfig, params.Payload, func(sc *entities.WebhookSessionConfig) map[string]string {
+		return sc.MemoryKey()
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("failed to render memory key: %w", err)
 	}
 
 	// Merge caller-provided tags (webhook-type-specific metadata)
@@ -132,29 +142,32 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 	// Teams is resolved here so it is never accidentally omitted (fixes the bug where
 	// webhook-triggered sessions were created without team-level settings injection).
 	var sessionProfileID string
-	if sessionConfig != nil {
+	if sessionConfig != nil && !profileAlreadyApplied {
 		sessionProfileID = sessionConfig.SessionProfileID()
 	}
 	result, err := s.launcher.Launch(ctx, sessionID, sessionuc.LaunchRequest{
-		UserID:           webhook.UserID(),
-		Scope:            webhook.Scope(),
-		TeamID:           webhook.TeamID(),
-		Teams:            sessionuc.ResolveTeams(webhook.Scope(), webhook.TeamID(), webhook.UserTeams()),
-		Environment:      env,
-		Tags:             tags,
-		InitialMessage:   initialMessage,
-		GithubToken:      githubToken,
-		AgentType:        agentType,
-		Oneshot:          oneshot,
-		Sandbox:          sandbox,
-		RepoInfo:         repoInfo,
-		WebhookPayload:   webhookPayload,
-		SessionProfileID: sessionProfileID,
-		ReuseSession:     sessionConfig != nil && sessionConfig.ReuseSession(),
-		ReuseMatchTags:   tags,
-		ReuseMessage:     reuseMessage,
-		MaxSessions:      webhook.MaxSessions(),
-		LimitMatchTags:   map[string]string{"webhook_id": webhook.ID()},
+		UserID:                       webhook.UserID(),
+		Scope:                        webhook.Scope(),
+		TeamID:                       webhook.TeamID(),
+		Teams:                        sessionuc.ResolveTeams(webhook.Scope(), webhook.TeamID(), webhook.UserTeams()),
+		Environment:                  env,
+		Tags:                         tags,
+		InitialMessage:               initialMessage,
+		GithubToken:                  githubToken,
+		AgentType:                    agentType,
+		Oneshot:                      oneshot,
+		Sandbox:                      sandbox,
+		MemoryKey:                    memoryKey,
+		RepoInfo:                     repoInfo,
+		WebhookPayload:               webhookPayload,
+		TemplatePayload:              params.Payload,
+		SessionProfileID:             sessionProfileID,
+		SkipSessionProfileResolution: profileAlreadyApplied,
+		ReuseSession:                 sessionConfig != nil && sessionConfig.ReuseSession(),
+		ReuseMatchTags:               tags,
+		ReuseMessage:                 reuseMessage,
+		MaxSessions:                  webhook.MaxSessions(),
+		LimitMatchTags:               map[string]string{"webhook_id": webhook.ID()},
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("failed to create session: %w", err)
@@ -208,6 +221,7 @@ func MergeSessionConfigs(base, override *entities.WebhookSessionConfig) *entitie
 	// Merge maps (override wins on key conflicts)
 	result.SetEnvironment(mergeMaps(base.Environment(), override.Environment()))
 	result.SetTags(mergeMaps(base.Tags(), override.Tags()))
+	result.SetMemoryKey(mergeMaps(base.MemoryKey(), override.MemoryKey()))
 
 	// Override scalar fields
 	result.SetInitialMessageTemplate(firstNonEmpty(override.InitialMessageTemplate(), base.InitialMessageTemplate()))
@@ -223,6 +237,71 @@ func MergeSessionConfigs(base, override *entities.WebhookSessionConfig) *entitie
 	result.SetReuseSession(base.ReuseSession() || override.ReuseSession())
 	result.SetMountPayload(base.MountPayload() || override.MountPayload())
 
+	return result
+}
+
+func (s *WebhookSessionService) applySessionProfileConfig(ctx context.Context, webhook *entities.Webhook, sessionConfig *entities.WebhookSessionConfig) (*entities.WebhookSessionConfig, bool) {
+	if s.profileRepo == nil {
+		return sessionConfig, false
+	}
+
+	profileID := ""
+	if sessionConfig != nil {
+		profileID = sessionConfig.SessionProfileID()
+	}
+
+	var profile *entities.SessionProfile
+	var err error
+	if profileID != "" {
+		profile, err = s.profileRepo.Get(ctx, profileID)
+		if err != nil {
+			log.Printf("[WEBHOOK] Warning: could not resolve session_profile_id %q: %v", profileID, err)
+			return sessionConfig, false
+		}
+	} else {
+		profile = s.resolveDefaultSessionProfile(ctx, webhook)
+		if profile == nil {
+			return sessionConfig, false
+		}
+	}
+
+	profileConfig := sessionProfileConfigToWebhookConfig(profile.Config())
+	merged := MergeSessionConfigs(profileConfig, sessionConfig)
+	return merged, true
+}
+
+func (s *WebhookSessionService) resolveDefaultSessionProfile(ctx context.Context, webhook *entities.Webhook) *entities.SessionProfile {
+	filter := repositories.SessionProfileFilter{
+		UserID: webhook.UserID(),
+		Scope:  webhook.Scope(),
+	}
+	if webhook.Scope() == entities.ScopeTeam {
+		filter.TeamID = webhook.TeamID()
+	}
+
+	profiles, err := s.profileRepo.List(ctx, filter)
+	if err != nil {
+		log.Printf("[WEBHOOK] Warning: could not list session profiles for default lookup: %v", err)
+		return nil
+	}
+	for _, profile := range profiles {
+		if profile.IsDefault() {
+			log.Printf("[WEBHOOK] Applying default session profile %q (%s) for webhook %s", profile.ID(), profile.Name(), webhook.ID())
+			return profile
+		}
+	}
+	return nil
+}
+
+func sessionProfileConfigToWebhookConfig(cfg entities.SessionProfileConfig) *entities.WebhookSessionConfig {
+	result := entities.NewWebhookSessionConfig()
+	result.SetEnvironment(cfg.Environment())
+	result.SetTags(cfg.Tags())
+	result.SetInitialMessageTemplate(cfg.InitialMessageTemplate())
+	result.SetReuseMessageTemplate(cfg.ReuseMessageTemplate())
+	result.SetParams(cfg.Params())
+	result.SetReuseSession(cfg.ReuseSession())
+	result.SetMemoryKey(cfg.MemoryKey())
 	return result
 }
 

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -1,11 +1,13 @@
 package session
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/google/uuid"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
@@ -39,6 +41,9 @@ type LaunchRequest struct {
 	// Webhook payload to mount in the session filesystem (optional)
 	WebhookPayload []byte
 
+	// TemplatePayload is optional data used to render profile message templates.
+	TemplatePayload map[string]interface{}
+
 	// MemoryKey is an optional tag map used to identify memories for this session.
 	// When non-empty, memories matching these tags are injected into CLAUDE.md at startup.
 	// When empty, memory integration is disabled.
@@ -60,6 +65,9 @@ type LaunchRequest struct {
 	// SessionProfileID is an optional reference to a SessionProfile.
 	// When set, the profile's config is merged as a base; explicit request fields override it.
 	SessionProfileID string
+	// SkipSessionProfileResolution prevents Launch from resolving a profile again when
+	// the caller has already applied it before rendering trigger-specific templates.
+	SkipSessionProfileResolution bool
 }
 
 // LaunchResult is returned by LaunchUseCase.Launch.
@@ -128,7 +136,7 @@ func (uc *LaunchUseCase) WithSessionProfileRepository(repo repositories.SessionP
 func (uc *LaunchUseCase) Launch(ctx context.Context, sessionID string, req LaunchRequest) (LaunchResult, error) {
 	// 0. Resolve session profile: merge profile config as base; explicit request fields override.
 	// When SessionProfileID is empty, fall back to the default profile for the user/team.
-	if uc.sessionProfileRepo != nil {
+	if uc.sessionProfileRepo != nil && !req.SkipSessionProfileResolution {
 		profile := uc.resolveSessionProfile(ctx, req)
 		if profile != nil {
 			applyProfileToLaunchRequest(profile.Config(), &req)
@@ -334,4 +342,55 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 			req.Sandbox = cfg.Params().Sandbox
 		}
 	}
+	if req.InitialMessage == "" && cfg.InitialMessageTemplate() != "" {
+		rendered, err := renderLaunchTemplate(cfg.InitialMessageTemplate(), launchTemplatePayload(req))
+		if err != nil {
+			log.Printf("[LAUNCH] Warning: failed to render profile initial_message_template: %v", err)
+			return
+		}
+		req.InitialMessage = rendered
+	}
+	if req.ReuseMessage == "" && cfg.ReuseMessageTemplate() != "" {
+		rendered, err := renderLaunchTemplate(cfg.ReuseMessageTemplate(), launchTemplatePayload(req))
+		if err != nil {
+			log.Printf("[LAUNCH] Warning: failed to render profile reuse_message_template: %v", err)
+			return
+		}
+		req.ReuseMessage = rendered
+	}
+	if cfg.ReuseSession() {
+		req.ReuseSession = true
+	}
+}
+
+func launchTemplatePayload(req *LaunchRequest) map[string]interface{} {
+	if req.TemplatePayload != nil {
+		return req.TemplatePayload
+	}
+	return map[string]interface{}{
+		"user_id":                     req.UserID,
+		"scope":                       string(req.Scope),
+		"team_id":                     req.TeamID,
+		"teams":                       req.Teams,
+		"environment":                 req.Environment,
+		"tags":                        req.Tags,
+		"memory_key":                  req.MemoryKey,
+		"initial_message":             req.InitialMessage,
+		"github_token":                req.GithubToken,
+		"agent_type":                  req.AgentType,
+		"oneshot":                     req.Oneshot,
+		"initial_message_wait_second": req.InitialMessageWaitSecond,
+	}
+}
+
+func renderLaunchTemplate(tmplStr string, payload map[string]interface{}) (string, error) {
+	tmpl, err := template.New("session_profile").Parse(tmplStr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, payload); err != nil {
+		return "", fmt.Errorf("failed to execute template: %w", err)
+	}
+	return buf.String(), nil
 }

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+type fakeLaunchSession struct {
+	id string
+}
+
+func (s fakeLaunchSession) ID() string                    { return s.id }
+func (s fakeLaunchSession) Addr() string                  { return "" }
+func (s fakeLaunchSession) UserID() string                { return "" }
+func (s fakeLaunchSession) Scope() entities.ResourceScope { return entities.ScopeUser }
+func (s fakeLaunchSession) TeamID() string                { return "" }
+func (s fakeLaunchSession) Tags() map[string]string       { return nil }
+func (s fakeLaunchSession) Status() string                { return "active" }
+func (s fakeLaunchSession) StartedAt() time.Time          { return time.Time{} }
+func (s fakeLaunchSession) UpdatedAt() time.Time          { return time.Time{} }
+func (s fakeLaunchSession) LastMessageAt() time.Time      { return time.Time{} }
+func (s fakeLaunchSession) Description() string           { return "" }
+func (s fakeLaunchSession) Cancel()                       {}
+
+type fakeLaunchSessionManager struct {
+	createReq *entities.RunServerRequest
+}
+
+func (m *fakeLaunchSessionManager) CreateSession(_ context.Context, id string, req *entities.RunServerRequest, _ []byte) (entities.Session, error) {
+	m.createReq = req
+	return fakeLaunchSession{id: id}, nil
+}
+
+func (m *fakeLaunchSessionManager) GetSession(id string) entities.Session { return nil }
+func (m *fakeLaunchSessionManager) ListSessions(filter entities.SessionFilter) []entities.Session {
+	return nil
+}
+func (m *fakeLaunchSessionManager) DeleteSession(id string) error { return nil }
+func (m *fakeLaunchSessionManager) SendMessage(_ context.Context, id string, message string) error {
+	return nil
+}
+func (m *fakeLaunchSessionManager) StopAgent(_ context.Context, id string) error { return nil }
+func (m *fakeLaunchSessionManager) GetMessages(_ context.Context, id string) ([]repositories.Message, error) {
+	return nil, nil
+}
+func (m *fakeLaunchSessionManager) Shutdown(timeout time.Duration) error { return nil }
+
+type fakeLaunchProfileRepo struct {
+	profile *entities.SessionProfile
+}
+
+func (r *fakeLaunchProfileRepo) Create(ctx context.Context, profile *entities.SessionProfile) error {
+	return nil
+}
+func (r *fakeLaunchProfileRepo) Get(ctx context.Context, id string) (*entities.SessionProfile, error) {
+	return r.profile, nil
+}
+func (r *fakeLaunchProfileRepo) List(ctx context.Context, filter repositories.SessionProfileFilter) ([]*entities.SessionProfile, error) {
+	return []*entities.SessionProfile{r.profile}, nil
+}
+func (r *fakeLaunchProfileRepo) Update(ctx context.Context, profile *entities.SessionProfile) error {
+	return nil
+}
+func (r *fakeLaunchProfileRepo) Delete(ctx context.Context, id string) error { return nil }
+
+func TestLaunchAppliesProfileInitialMessageTemplate(t *testing.T) {
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetInitialMessageTemplate("Review {{ .repository_full_name }}")
+	profile.SetConfig(cfg)
+
+	manager := &fakeLaunchSessionManager{}
+	uc := NewLaunchUseCase(manager).WithSessionProfileRepository(&fakeLaunchProfileRepo{profile: profile})
+
+	_, err := uc.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID:           "user-1",
+		Scope:            entities.ScopeUser,
+		SessionProfileID: "profile-1",
+		TemplatePayload: map[string]interface{}{
+			"repository_full_name": "org/repo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+	if manager.createReq == nil {
+		t.Fatal("CreateSession was not called")
+	}
+	if got, want := manager.createReq.InitialMessage, "Review org/repo"; got != want {
+		t.Fatalf("InitialMessage = %q, want %q", got, want)
+	}
+}
+
+func TestLaunchExplicitInitialMessageOverridesProfileTemplate(t *testing.T) {
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetInitialMessageTemplate("from profile")
+	profile.SetConfig(cfg)
+
+	manager := &fakeLaunchSessionManager{}
+	uc := NewLaunchUseCase(manager).WithSessionProfileRepository(&fakeLaunchProfileRepo{profile: profile})
+
+	_, err := uc.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID:           "user-1",
+		Scope:            entities.ScopeUser,
+		SessionProfileID: "profile-1",
+		InitialMessage:   "from request",
+	})
+	if err != nil {
+		t.Fatalf("Launch returned error: %v", err)
+	}
+	if got, want := manager.createReq.InitialMessage, "from request"; got != want {
+		t.Fatalf("InitialMessage = %q, want %q", got, want)
+	}
+}

--- a/pkg/schedule/handlers.go
+++ b/pkg/schedule/handlers.go
@@ -516,6 +516,7 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 	}
 	tags["schedule_id"] = schedule.ID
 	tags["schedule_name"] = schedule.Name
+	schedulePayload := scheduleTemplatePayload(schedule, tags, schedule.SessionConfig.MemoryKey)
 
 	var initialMessage, githubToken, agentType string
 	var slackParams *entities.SlackParams
@@ -548,6 +549,7 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 		Oneshot:          oneshot,
 		MemoryKey:        schedule.SessionConfig.MemoryKey,
 		RepoInfo:         app.ExtractRepositoryInfo(tags, sessionID),
+		TemplatePayload:  schedulePayload,
 		SessionProfileID: schedule.SessionConfig.SessionProfileID,
 		// Session reuse: when enabled, an existing active session matching schedule_id
 		// tag receives the message instead of a new session being created.

--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -264,17 +264,14 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 	// Render memory_key values as Go templates with schedule context.
 	// This allows values like {{ .schedule_id }} to be resolved at runtime.
 	memoryKey := schedule.SessionConfig.MemoryKey
+	schedulePayload := scheduleTemplatePayload(schedule, tags, memoryKey)
 	if len(memoryKey) > 0 {
-		schedulePayload := map[string]interface{}{
-			"schedule_id":   schedule.ID,
-			"schedule_name": schedule.Name,
-			"timezone":      schedule.Timezone,
-		}
 		rendered, err := renderScheduleTemplateMap(memoryKey, schedulePayload)
 		if err != nil {
 			log.Printf("[SCHEDULE_WORKER] Failed to render memory_key templates for schedule %s: %v", schedule.ID, err)
 		} else {
 			memoryKey = rendered
+			schedulePayload = scheduleTemplatePayload(schedule, tags, memoryKey)
 		}
 	}
 
@@ -295,6 +292,7 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 		Oneshot:          oneshot,
 		MemoryKey:        memoryKey,
 		RepoInfo:         app.ExtractRepositoryInfo(tags, sessionID),
+		TemplatePayload:  schedulePayload,
 		SessionProfileID: schedule.SessionConfig.SessionProfileID,
 		// Session reuse: when enabled, an existing active session matching schedule_id
 		// tag receives the message instead of a new session being created.
@@ -360,6 +358,39 @@ func (w *Worker) updateNextExecution(ctx context.Context, schedule *Schedule) {
 				schedule.ID, nextAt)
 		}
 	}
+}
+
+func scheduleTemplatePayload(schedule *Schedule, tags map[string]string, memoryKey map[string]string) map[string]interface{} {
+	payload := map[string]interface{}{
+		"schedule_id":     schedule.ID,
+		"schedule_name":   schedule.Name,
+		"user_id":         schedule.UserID,
+		"scope":           string(schedule.GetScope()),
+		"team_id":         schedule.TeamID,
+		"user_teams":      schedule.UserTeams,
+		"timezone":        schedule.Timezone,
+		"cron_expr":       schedule.CronExpr,
+		"execution_count": schedule.ExecutionCount,
+		"tags":            tags,
+		"environment":     schedule.SessionConfig.Environment,
+		"memory_key":      memoryKey,
+	}
+	if schedule.ScheduledAt != nil {
+		payload["scheduled_at"] = schedule.ScheduledAt.Format(time.RFC3339)
+	}
+	if schedule.NextExecutionAt != nil {
+		payload["next_execution_at"] = schedule.NextExecutionAt.Format(time.RFC3339)
+	}
+	if schedule.LastExecution != nil {
+		payload["last_execution"] = map[string]interface{}{
+			"executed_at":    schedule.LastExecution.ExecutedAt.Format(time.RFC3339),
+			"session_id":     schedule.LastExecution.SessionID,
+			"status":         schedule.LastExecution.Status,
+			"error":          schedule.LastExecution.Error,
+			"session_reused": schedule.LastExecution.SessionReused,
+		}
+	}
+	return payload
 }
 
 // renderScheduleTemplateMap renders all template values in a map using schedule context data.


### PR DESCRIPTION
## Summary
- render session profile initial_message_template into startup messages when params.message is not provided
- pass template variables for direct sessions, webhooks, and schedules
- merge profile config before webhook template rendering and add launch use case coverage

## Tests
- mise exec -- go test ./internal/usecases/session ./internal/interfaces/controllers ./pkg/schedule