### PR TITLE
feat(sandbox): add SandboxPolicy resource for reusable network filter rules

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -34,6 +34,7 @@ type HandlerRegistry struct {
 	shareController           *controllers.ShareController
 	personalAPIKeyController  *controllers.PersonalAPIKeyController
 	memoryController          *controllers.MemoryController
+	sandboxPolicyController   *controllers.SandboxPolicyController
 	taskController            *controllers.TaskController
 	taskGroupController       *controllers.TaskGroupController
 	fileController            *controllers.FileController
@@ -119,6 +120,13 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] Memory controller initialized")
 	}
 
+	// Create sandbox policy controller if sandbox policy repository is available
+	var sandboxPolicyController *controllers.SandboxPolicyController
+	if server.sandboxPolicyRepo != nil {
+		sandboxPolicyController = controllers.NewSandboxPolicyController(server.sandboxPolicyRepo)
+		log.Printf("[ROUTER] Sandbox policy controller initialized")
+	}
+
 	// Create task controller if task repository is available
 	var taskController *controllers.TaskController
 	if server.taskRepo != nil {
@@ -164,6 +172,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 			shareController:           shareController,
 			personalAPIKeyController:  personalAPIKeyController,
 			memoryController:          memoryController,
+			sandboxPolicyController:   sandboxPolicyController,
 			taskController:            taskController,
 			taskGroupController:       taskGroupController,
 			fileController:            fileController,
@@ -364,6 +373,19 @@ func (r *Router) registerConditionalRoutes() error {
 		log.Printf("[ROUTES] Memory endpoints registered")
 	} else {
 		log.Printf("[ROUTES] Memory repository not available, skipping memory routes")
+	}
+
+	// Add sandbox policy routes if sandbox policy repository is available (Kubernetes mode only)
+	if r.server.sandboxPolicyRepo != nil && r.handlers.sandboxPolicyController != nil {
+		log.Printf("[ROUTES] Registering sandbox policy endpoints...")
+		r.echo.POST("/sandbox-policies", r.handlers.sandboxPolicyController.CreateSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.GET("/sandbox-policies", r.handlers.sandboxPolicyController.ListSandboxPolicies, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.GET("/sandbox-policies/:id", r.handlers.sandboxPolicyController.GetSandboxPolicy, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.PUT("/sandbox-policies/:id", r.handlers.sandboxPolicyController.UpdateSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.DELETE("/sandbox-policies/:id", r.handlers.sandboxPolicyController.DeleteSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		log.Printf("[ROUTES] Sandbox policy endpoints registered")
+	} else {
+		log.Printf("[ROUTES] Sandbox policy repository not available, skipping sandbox policy routes")
 	}
 
 	// Add task routes if task repository is available (Kubernetes mode only)

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -55,6 +55,7 @@ type Server struct {
 	shareRepo          portrepos.ShareRepository          // Share repository for session sharing
 	teamConfigRepo     portrepos.TeamConfigRepository     // Team configuration repository
 	memoryRepo         portrepos.MemoryRepository         // Memory repository
+	sandboxPolicyRepo  portrepos.SandboxPolicyRepository  // Sandbox policy repository
 	taskRepo           portrepos.TaskRepository           // Task repository
 	taskGroupRepo      portrepos.TaskGroupRepository      // Task group repository
 	sessionRouteRepo   portrepos.SessionRouteRepository   // Session route repository for proxy B routing
@@ -114,7 +115,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 			// (at least 3 parts, not starting with "start", "search", "sessions", "oauth", "auth", "notification", or "notifications")
 			if len(pathParts) >= 3 && pathParts[1] != "" {
 				firstSegment := pathParts[1]
-				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files" && firstSegment != "session-profiles"
+				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files" && firstSegment != "session-profiles" && firstSegment != "sandbox-policies"
 			}
 			return false
 		},
@@ -278,6 +279,14 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 		log.Printf("[SERVER] Memory repository initialized (backend: kubernetes)")
 	}
 
+	// Initialize sandbox policy repository (Kubernetes ConfigMap-backed)
+	sandboxPolicyRepo := portrepos.SandboxPolicyRepository(repositories.NewKubernetesSandboxPolicyRepository(
+		k8sSessionManager.GetClient(),
+		k8sSessionManager.GetNamespace(),
+	))
+	k8sSessionManager.SetSandboxPolicyRepository(sandboxPolicyRepo)
+	log.Printf("[SERVER] Sandbox policy repository initialized")
+
 	// Initialize task repository (Kubernetes ConfigMap-backed)
 	taskRepo := repositories.NewKubernetesTaskRepository(
 		k8sSessionManager.GetClient(),
@@ -325,6 +334,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 		shareRepo:          shareRepo,
 		teamConfigRepo:     teamConfigRepo,
 		memoryRepo:         memoryRepo,
+		sandboxPolicyRepo:  sandboxPolicyRepo,
 		taskRepo:           taskRepo,
 		taskGroupRepo:      taskGroupRepo,
 		sessionRouteRepo:   sessionRouteRepo,

--- a/internal/domain/entities/sandbox_policy.go
+++ b/internal/domain/entities/sandbox_policy.go
@@ -1,0 +1,110 @@
+package entities
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrSandboxPolicyNotFound is returned when a sandbox policy is not found.
+type ErrSandboxPolicyNotFound struct {
+	ID string
+}
+
+func (e ErrSandboxPolicyNotFound) Error() string {
+	return "sandbox policy not found: " + e.ID
+}
+
+// SandboxPolicy is a named, reusable set of network filter rules.
+// Sessions reference a policy by ID; the policy's domain lists are merged
+// with any session-level overrides at creation time.
+type SandboxPolicy struct {
+	id             string
+	name           string
+	description    string
+	allowedDomains []string
+	deniedDomains  []string
+	scope          ResourceScope
+	ownerID        string
+	teamID         string
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
+// NewSandboxPolicy creates a new SandboxPolicy.
+func NewSandboxPolicy(id, name, description string, allowedDomains, deniedDomains []string, scope ResourceScope, ownerID, teamID string) *SandboxPolicy {
+	now := time.Now()
+	return &SandboxPolicy{
+		id:             id,
+		name:           name,
+		description:    description,
+		allowedDomains: copyStringSlice(allowedDomains),
+		deniedDomains:  copyStringSlice(deniedDomains),
+		scope:          scope,
+		ownerID:        ownerID,
+		teamID:         teamID,
+		createdAt:      now,
+		updatedAt:      now,
+	}
+}
+
+func (p *SandboxPolicy) ID() string             { return p.id }
+func (p *SandboxPolicy) Name() string           { return p.name }
+func (p *SandboxPolicy) Description() string    { return p.description }
+func (p *SandboxPolicy) AllowedDomains() []string { return copyStringSlice(p.allowedDomains) }
+func (p *SandboxPolicy) DeniedDomains() []string  { return copyStringSlice(p.deniedDomains) }
+func (p *SandboxPolicy) Scope() ResourceScope    { return p.scope }
+func (p *SandboxPolicy) OwnerID() string         { return p.ownerID }
+func (p *SandboxPolicy) TeamID() string          { return p.teamID }
+func (p *SandboxPolicy) CreatedAt() time.Time    { return p.createdAt }
+func (p *SandboxPolicy) UpdatedAt() time.Time    { return p.updatedAt }
+
+func (p *SandboxPolicy) SetName(name string) {
+	p.name = name
+	p.updatedAt = time.Now()
+}
+
+func (p *SandboxPolicy) SetDescription(description string) {
+	p.description = description
+	p.updatedAt = time.Now()
+}
+
+func (p *SandboxPolicy) SetAllowedDomains(domains []string) {
+	p.allowedDomains = copyStringSlice(domains)
+	p.updatedAt = time.Now()
+}
+
+func (p *SandboxPolicy) SetDeniedDomains(domains []string) {
+	p.deniedDomains = copyStringSlice(domains)
+	p.updatedAt = time.Now()
+}
+
+func (p *SandboxPolicy) SetCreatedAt(t time.Time) { p.createdAt = t }
+func (p *SandboxPolicy) SetUpdatedAt(t time.Time) { p.updatedAt = t }
+
+func (p *SandboxPolicy) Validate() error {
+	if p.id == "" {
+		return errors.New("sandbox policy id is required")
+	}
+	if p.name == "" {
+		return errors.New("sandbox policy name is required")
+	}
+	if p.ownerID == "" {
+		return errors.New("sandbox policy owner_id is required")
+	}
+	if p.scope != ScopeUser && p.scope != ScopeTeam {
+		return errors.New("sandbox policy scope must be 'user' or 'team'")
+	}
+	if p.scope == ScopeTeam && p.teamID == "" {
+		return errors.New("sandbox policy team_id is required when scope is 'team'")
+	}
+	return nil
+}
+
+func copyStringSlice(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -34,6 +34,9 @@ type SlackParams struct {
 type SandboxParams struct {
 	// Enabled activates the network filter sidecar (iptables redirect + transparent proxy).
 	Enabled bool `json:"enabled,omitempty"`
+	// PolicyID references a SandboxPolicy resource whose domain lists are merged into the session.
+	// Session-level AllowedDomains and DeniedDomains are appended on top of the policy.
+	PolicyID string `json:"policy_id,omitempty"`
 	// AllowedDomains is the list of hostnames whose traffic is permitted (allowlist mode).
 	// When non-empty, all other domains are blocked. Takes precedence over DeniedDomains.
 	AllowedDomains []string `json:"allowed_domains,omitempty"`

--- a/internal/domain/entities/session_profile.go
+++ b/internal/domain/entities/session_profile.go
@@ -27,6 +27,9 @@ type SessionProfileConfig struct {
 	params                 *SessionParams
 	reuseSession           bool
 	memoryKey              map[string]string
+	// sandboxPolicyID is a reference to a SandboxPolicy resource.
+	// When set, the sandbox sidecar is enabled automatically with this policy applied.
+	sandboxPolicyID string
 }
 
 // NewSessionProfile creates a new SessionProfile
@@ -184,6 +187,12 @@ func (c *SessionProfileConfig) MemoryKey() map[string]string { return c.memoryKe
 
 // SetMemoryKey sets the memory key map
 func (c *SessionProfileConfig) SetMemoryKey(key map[string]string) { c.memoryKey = key }
+
+// SandboxPolicyID returns the sandbox policy ID
+func (c *SessionProfileConfig) SandboxPolicyID() string { return c.sandboxPolicyID }
+
+// SetSandboxPolicyID sets the sandbox policy ID
+func (c *SessionProfileConfig) SetSandboxPolicyID(id string) { c.sandboxPolicyID = id }
 
 // --- Error types ---
 

--- a/internal/infrastructure/repositories/kubernetes_sandbox_policy_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_sandbox_policy_repository.go
@@ -1,0 +1,272 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+const (
+	LabelSandboxPolicyType      = "agentapi.proxy/type"
+	LabelSandboxPolicyTypeValue = "sandbox-policy"
+	LabelSandboxPolicyScope     = "agentapi.proxy/scope"
+	LabelSandboxPolicyOwnerHash = "agentapi.proxy/owner-hash"
+	LabelSandboxPolicyTeamHash  = "agentapi.proxy/team-hash"
+
+	AnnotationSandboxPolicyOwnerID = "agentapi.proxy/owner-id"
+	AnnotationSandboxPolicyTeamID  = "agentapi.proxy/team-id"
+
+	ConfigMapKeySandboxPolicy  = "sandbox-policy.json"
+	SandboxPolicyConfigMapPrefix = "agentapi-sandbox-policy-"
+)
+
+type sandboxPolicyJSON struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Description    string    `json:"description,omitempty"`
+	AllowedDomains []string  `json:"allowed_domains,omitempty"`
+	DeniedDomains  []string  `json:"denied_domains,omitempty"`
+	Scope          string    `json:"scope"`
+	OwnerID        string    `json:"owner_id"`
+	TeamID         string    `json:"team_id,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// KubernetesSandboxPolicyRepository implements SandboxPolicyRepository using Kubernetes ConfigMaps.
+type KubernetesSandboxPolicyRepository struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+func NewKubernetesSandboxPolicyRepository(client kubernetes.Interface, namespace string) *KubernetesSandboxPolicyRepository {
+	return &KubernetesSandboxPolicyRepository{client: client, namespace: namespace}
+}
+
+func (r *KubernetesSandboxPolicyRepository) Create(ctx context.Context, policy *entities.SandboxPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return fmt.Errorf("invalid sandbox policy: %w", err)
+	}
+
+	data, err := r.toJSONBytes(policy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sandbox policy: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        r.configMapName(policy.ID()),
+			Namespace:   r.namespace,
+			Labels:      r.buildLabels(policy),
+			Annotations: r.buildAnnotations(policy),
+		},
+		Data: map[string]string{ConfigMapKeySandboxPolicy: string(data)},
+	}
+
+	_, err = r.client.CoreV1().ConfigMaps(r.namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			return fmt.Errorf("sandbox policy already exists: %s", policy.ID())
+		}
+		return fmt.Errorf("failed to create sandbox policy ConfigMap: %w", err)
+	}
+	return nil
+}
+
+func (r *KubernetesSandboxPolicyRepository) GetByID(ctx context.Context, id string) (*entities.SandboxPolicy, error) {
+	cm, err := r.client.CoreV1().ConfigMaps(r.namespace).Get(ctx, r.configMapName(id), metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, entities.ErrSandboxPolicyNotFound{ID: id}
+		}
+		return nil, fmt.Errorf("failed to get sandbox policy ConfigMap: %w", err)
+	}
+	return r.loadFromConfigMap(cm)
+}
+
+func (r *KubernetesSandboxPolicyRepository) List(ctx context.Context, filter repositories.SandboxPolicyFilter) ([]*entities.SandboxPolicy, error) {
+	labelSelector := r.buildLabelSelector(filter)
+
+	cmList, err := r.client.CoreV1().ConfigMaps(r.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sandbox policy ConfigMaps: %w", err)
+	}
+
+	teamIDSet := make(map[string]struct{})
+	for _, tid := range filter.TeamIDs {
+		teamIDSet[tid] = struct{}{}
+	}
+
+	var result []*entities.SandboxPolicy
+	for i := range cmList.Items {
+		policy, err := r.loadFromConfigMap(&cmList.Items[i])
+		if err != nil {
+			continue
+		}
+		if len(filter.TeamIDs) > 0 {
+			if _, ok := teamIDSet[policy.TeamID()]; !ok {
+				continue
+			}
+		}
+		if filter.Name != "" && policy.Name() != filter.Name {
+			continue
+		}
+		result = append(result, policy)
+	}
+
+	if result == nil {
+		result = []*entities.SandboxPolicy{}
+	}
+	return result, nil
+}
+
+func (r *KubernetesSandboxPolicyRepository) Update(ctx context.Context, policy *entities.SandboxPolicy) error {
+	if err := policy.Validate(); err != nil {
+		return fmt.Errorf("invalid sandbox policy: %w", err)
+	}
+
+	existing, err := r.client.CoreV1().ConfigMaps(r.namespace).Get(ctx, r.configMapName(policy.ID()), metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return entities.ErrSandboxPolicyNotFound{ID: policy.ID()}
+		}
+		return fmt.Errorf("failed to get sandbox policy ConfigMap for update: %w", err)
+	}
+
+	data, err := r.toJSONBytes(policy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sandbox policy: %w", err)
+	}
+
+	existing.Labels = r.buildLabels(policy)
+	existing.Annotations = r.buildAnnotations(policy)
+	if existing.Data == nil {
+		existing.Data = make(map[string]string)
+	}
+	existing.Data[ConfigMapKeySandboxPolicy] = string(data)
+
+	_, err = r.client.CoreV1().ConfigMaps(r.namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update sandbox policy ConfigMap: %w", err)
+	}
+	return nil
+}
+
+func (r *KubernetesSandboxPolicyRepository) Delete(ctx context.Context, id string) error {
+	err := r.client.CoreV1().ConfigMaps(r.namespace).Delete(ctx, r.configMapName(id), metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return entities.ErrSandboxPolicyNotFound{ID: id}
+		}
+		return fmt.Errorf("failed to delete sandbox policy ConfigMap: %w", err)
+	}
+	return nil
+}
+
+func (r *KubernetesSandboxPolicyRepository) configMapName(id string) string {
+	return SandboxPolicyConfigMapPrefix + id
+}
+
+func (r *KubernetesSandboxPolicyRepository) buildLabelSelector(filter repositories.SandboxPolicyFilter) string {
+	parts := []string{fmt.Sprintf("%s=%s", LabelSandboxPolicyType, LabelSandboxPolicyTypeValue)}
+
+	if len(filter.TeamIDs) == 0 {
+		if filter.Scope != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", LabelSandboxPolicyScope, string(filter.Scope)))
+		}
+		if filter.OwnerID != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", LabelSandboxPolicyOwnerHash, hashID(filter.OwnerID)))
+		}
+		if filter.TeamID != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", LabelSandboxPolicyTeamHash, hashID(filter.TeamID)))
+		}
+	} else if filter.Scope != "" {
+		parts = append(parts, fmt.Sprintf("%s=%s", LabelSandboxPolicyScope, string(filter.Scope)))
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func (r *KubernetesSandboxPolicyRepository) buildLabels(p *entities.SandboxPolicy) map[string]string {
+	labels := map[string]string{
+		LabelSandboxPolicyType:      LabelSandboxPolicyTypeValue,
+		LabelSandboxPolicyScope:     string(p.Scope()),
+		LabelSandboxPolicyOwnerHash: hashID(p.OwnerID()),
+	}
+	if p.Scope() == entities.ScopeTeam && p.TeamID() != "" {
+		labels[LabelSandboxPolicyTeamHash] = hashID(p.TeamID())
+	}
+	return labels
+}
+
+func (r *KubernetesSandboxPolicyRepository) buildAnnotations(p *entities.SandboxPolicy) map[string]string {
+	annotations := map[string]string{
+		AnnotationSandboxPolicyOwnerID: p.OwnerID(),
+	}
+	if p.TeamID() != "" {
+		annotations[AnnotationSandboxPolicyTeamID] = p.TeamID()
+	}
+	return annotations
+}
+
+func (r *KubernetesSandboxPolicyRepository) toJSONBytes(p *entities.SandboxPolicy) ([]byte, error) {
+	pj := &sandboxPolicyJSON{
+		ID:             p.ID(),
+		Name:           p.Name(),
+		Description:    p.Description(),
+		AllowedDomains: p.AllowedDomains(),
+		DeniedDomains:  p.DeniedDomains(),
+		Scope:          string(p.Scope()),
+		OwnerID:        p.OwnerID(),
+		TeamID:         p.TeamID(),
+		CreatedAt:      p.CreatedAt(),
+		UpdatedAt:      p.UpdatedAt(),
+	}
+	return json.Marshal(pj)
+}
+
+func (r *KubernetesSandboxPolicyRepository) loadFromConfigMap(cm *corev1.ConfigMap) (*entities.SandboxPolicy, error) {
+	rawJSON, ok := cm.Data[ConfigMapKeySandboxPolicy]
+	if !ok {
+		return nil, fmt.Errorf("ConfigMap %s is missing sandbox-policy.json data", cm.Name)
+	}
+
+	var pj sandboxPolicyJSON
+	if err := json.Unmarshal([]byte(rawJSON), &pj); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal sandbox policy JSON from ConfigMap %s: %w", cm.Name, err)
+	}
+
+	if ownerID, ok := cm.Annotations[AnnotationSandboxPolicyOwnerID]; ok && ownerID != "" {
+		pj.OwnerID = ownerID
+	}
+	if teamID, ok := cm.Annotations[AnnotationSandboxPolicyTeamID]; ok && teamID != "" {
+		pj.TeamID = teamID
+	}
+
+	p := entities.NewSandboxPolicy(
+		pj.ID,
+		pj.Name,
+		pj.Description,
+		pj.AllowedDomains,
+		pj.DeniedDomains,
+		entities.ResourceScope(pj.Scope),
+		pj.OwnerID,
+		pj.TeamID,
+	)
+	p.SetCreatedAt(pj.CreatedAt)
+	p.SetUpdatedAt(pj.UpdatedAt)
+
+	return p, nil
+}

--- a/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
@@ -54,6 +54,7 @@ type sessionProfileConfigJSON struct {
 	Params                 *entities.SessionParams `json:"params,omitempty"`
 	ReuseSession           bool                    `json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
+	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
 }
 
 // KubernetesSessionProfileRepository implements SessionProfileRepository using Kubernetes Secrets
@@ -315,6 +316,7 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 	cfg.SetParams(pj.Config.Params)
 	cfg.SetReuseSession(pj.Config.ReuseSession)
 	cfg.SetMemoryKey(pj.Config.MemoryKey)
+	cfg.SetSandboxPolicyID(pj.Config.SandboxPolicyID)
 	profile.SetConfig(cfg)
 
 	return profile
@@ -338,6 +340,7 @@ func (r *KubernetesSessionProfileRepository) entityToJSON(profile *entities.Sess
 			Params:                 cfg.Params(),
 			ReuseSession:           cfg.ReuseSession(),
 			MemoryKey:              cfg.MemoryKey(),
+			SandboxPolicyID:        cfg.SandboxPolicyID(),
 		},
 		CreatedAt: profile.CreatedAt(),
 		UpdatedAt: profile.UpdatedAt(),

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -98,6 +98,7 @@ type KubernetesSessionManager struct {
 	settingsRepo          portrepos.SettingsRepository
 	teamConfigRepo        portrepos.TeamConfigRepository
 	personalAPIKeyRepo    portrepos.PersonalAPIKeyRepository
+	sandboxPolicyRepo     portrepos.SandboxPolicyRepository
 	personalAPIKeyLoader  PersonalAPIKeyLoader
 	serviceAccountEnsurer ServiceAccountEnsurer
 	// onSessionDeletedHandlers holds callbacks registered via AddSessionDeletedHandler.
@@ -1629,7 +1630,8 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 	var sandboxSidecar *corev1.Container
 	var sandboxEnvVars []corev1.EnvVar
 	if sandboxEnabled {
-		initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(req)
+		effectiveSandbox := m.resolveSandboxParams(ctx, req)
+		initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(effectiveSandbox)
 	}
 
 	// Determine working directory
@@ -2021,19 +2023,44 @@ func (m *KubernetesSessionManager) createOneshotSettingsSecret(
 	return nil
 }
 
+// resolveSandboxParams returns effective SandboxParams by merging a referenced SandboxPolicy
+// (if PolicyID is set) with the session-level overrides in req.Sandbox.
+// Policy domains are prepended; session-level domains are appended on top.
+func (m *KubernetesSessionManager) resolveSandboxParams(ctx context.Context, req *entities.RunServerRequest) *entities.SandboxParams {
+	if req.Sandbox == nil {
+		return nil
+	}
+	effective := &entities.SandboxParams{
+		Enabled:        req.Sandbox.Enabled,
+		AllowedDomains: req.Sandbox.AllowedDomains,
+		DeniedDomains:  req.Sandbox.DeniedDomains,
+	}
+	if req.Sandbox.PolicyID == "" || m.sandboxPolicyRepo == nil {
+		return effective
+	}
+	policy, err := m.sandboxPolicyRepo.GetByID(ctx, req.Sandbox.PolicyID)
+	if err != nil {
+		log.Printf("[K8S_SESSION] sandbox policy %s not found, ignoring: %v", req.Sandbox.PolicyID, err)
+		return effective
+	}
+	effective.AllowedDomains = append(policy.AllowedDomains(), effective.AllowedDomains...)
+	effective.DeniedDomains = append(policy.DeniedDomains(), effective.DeniedDomains...)
+	return effective
+}
+
 // buildSandboxContainers returns the init container (iptables setup) and sidecar
 // (network-filter proxy) needed for session network sandboxing.
 // The sidecar runs as UID 0 (root) so that iptables rules can skip its traffic
 // via the "--uid-owner 0" match, preventing redirect loops.
-func (m *KubernetesSessionManager) buildSandboxContainers(req *entities.RunServerRequest) ([]corev1.Container, *corev1.Container, []corev1.EnvVar) {
+func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.SandboxParams) ([]corev1.Container, *corev1.Container, []corev1.EnvVar) {
 	var filterEnvVars []corev1.EnvVar
-	if req.Sandbox != nil && len(req.Sandbox.AllowedDomains) > 0 {
+	if sandbox != nil && len(sandbox.AllowedDomains) > 0 {
 		filterEnvVars = []corev1.EnvVar{
-			{Name: "NETWORK_FILTER_ALLOWED_DOMAINS", Value: strings.Join(req.Sandbox.AllowedDomains, ",")},
+			{Name: "NETWORK_FILTER_ALLOWED_DOMAINS", Value: strings.Join(sandbox.AllowedDomains, ",")},
 		}
-	} else if req.Sandbox != nil && len(req.Sandbox.DeniedDomains) > 0 {
+	} else if sandbox != nil && len(sandbox.DeniedDomains) > 0 {
 		filterEnvVars = []corev1.EnvVar{
-			{Name: "NETWORK_FILTER_DENIED_DOMAINS", Value: strings.Join(req.Sandbox.DeniedDomains, ",")},
+			{Name: "NETWORK_FILTER_DENIED_DOMAINS", Value: strings.Join(sandbox.DeniedDomains, ",")},
 		}
 	}
 
@@ -2792,6 +2819,11 @@ func (m *KubernetesSessionManager) SetSettingsRepository(repo portrepos.Settings
 // SetTeamConfigRepository sets the team config repository for service account configuration
 func (m *KubernetesSessionManager) SetTeamConfigRepository(repo portrepos.TeamConfigRepository) {
 	m.teamConfigRepo = repo
+}
+
+// SetSandboxPolicyRepository sets the sandbox policy repository for policy resolution at session creation.
+func (m *KubernetesSessionManager) SetSandboxPolicyRepository(repo portrepos.SandboxPolicyRepository) {
+	m.sandboxPolicyRepo = repo
 }
 
 // SetServiceAccountEnsurer sets the service account ensurer for team-scoped session creation
@@ -4142,10 +4174,11 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	if req.Sandbox != nil && req.Sandbox.Enabled {
 		settings.Sandbox = &sessionsettings.SandboxConfig{
 			Enabled:        true,
+			PolicyID:       req.Sandbox.PolicyID,
 			AllowedDomains: req.Sandbox.AllowedDomains,
 			DeniedDomains:  req.Sandbox.DeniedDomains,
 		}
-		log.Printf("[K8S_SESSION] Network sandbox enabled for session %s (allowed: %v, denied: %v)", session.id, req.Sandbox.AllowedDomains, req.Sandbox.DeniedDomains)
+		log.Printf("[K8S_SESSION] Network sandbox enabled for session %s (policy: %s, allowed: %v, denied: %v)", session.id, req.Sandbox.PolicyID, req.Sandbox.AllowedDomains, req.Sandbox.DeniedDomains)
 	}
 
 	return settings

--- a/internal/interfaces/controllers/sandbox_policy_controller.go
+++ b/internal/interfaces/controllers/sandbox_policy_controller.go
@@ -1,0 +1,355 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// SandboxPolicyController handles sandbox policy HTTP requests.
+type SandboxPolicyController struct {
+	repo portrepos.SandboxPolicyRepository
+}
+
+func NewSandboxPolicyController(repo portrepos.SandboxPolicyRepository) *SandboxPolicyController {
+	return &SandboxPolicyController{repo: repo}
+}
+
+func (c *SandboxPolicyController) GetName() string { return "SandboxPolicyController" }
+
+// --- DTOs ---
+
+type CreateSandboxPolicyRequest struct {
+	Name           string   `json:"name"`
+	Description    string   `json:"description,omitempty"`
+	AllowedDomains []string `json:"allowed_domains,omitempty"`
+	DeniedDomains  []string `json:"denied_domains,omitempty"`
+	Scope          string   `json:"scope"`
+	TeamID         string   `json:"team_id,omitempty"`
+}
+
+type UpdateSandboxPolicyRequest struct {
+	Name           *string   `json:"name,omitempty"`
+	Description    *string   `json:"description,omitempty"`
+	AllowedDomains *[]string `json:"allowed_domains,omitempty"`
+	DeniedDomains  *[]string `json:"denied_domains,omitempty"`
+}
+
+type SandboxPolicyResponse struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Description    string   `json:"description,omitempty"`
+	AllowedDomains []string `json:"allowed_domains,omitempty"`
+	DeniedDomains  []string `json:"denied_domains,omitempty"`
+	Scope          string   `json:"scope"`
+	OwnerID        string   `json:"owner_id"`
+	TeamID         string   `json:"team_id,omitempty"`
+	CreatedAt      string   `json:"created_at"`
+	UpdatedAt      string   `json:"updated_at"`
+}
+
+type SandboxPolicyListResponse struct {
+	SandboxPolicies []*SandboxPolicyResponse `json:"sandbox_policies"`
+	Total           int                      `json:"total"`
+}
+
+// --- Handlers ---
+
+// CreateSandboxPolicy handles POST /sandbox-policies
+func (c *SandboxPolicyController) CreateSandboxPolicy(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var req CreateSandboxPolicyRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	req.Scope, req.TeamID = auth.ResolveUserScope(user, req.Scope, req.TeamID)
+
+	if req.Name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+	}
+	if req.Scope != string(entities.ScopeUser) && req.Scope != string(entities.ScopeTeam) {
+		return echo.NewHTTPError(http.StatusBadRequest, "scope must be 'user' or 'team'")
+	}
+	if req.Scope == string(entities.ScopeTeam) && req.TeamID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "team_id is required when scope is 'team'")
+	}
+	if !c.canCreate(user, req.Scope, req.TeamID) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	policy := entities.NewSandboxPolicy(
+		uuid.New().String(),
+		req.Name,
+		req.Description,
+		req.AllowedDomains,
+		req.DeniedDomains,
+		entities.ResourceScope(req.Scope),
+		string(user.ID()),
+		req.TeamID,
+	)
+
+	if err := c.repo.Create(ctx.Request().Context(), policy); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create sandbox policy")
+	}
+
+	return ctx.JSON(http.StatusCreated, c.toResponse(policy))
+}
+
+// GetSandboxPolicy handles GET /sandbox-policies/:id
+func (c *SandboxPolicyController) GetSandboxPolicy(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	policy, err := c.repo.GetByID(ctx.Request().Context(), ctx.Param("id"))
+	if err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sandbox policy")
+	}
+
+	if !c.canAccess(user, policy) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	return ctx.JSON(http.StatusOK, c.toResponse(policy))
+}
+
+// ListSandboxPolicies handles GET /sandbox-policies
+func (c *SandboxPolicyController) ListSandboxPolicies(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	scopeParam := ctx.QueryParam("scope")
+	teamIDParam := ctx.QueryParam("team_id")
+	scopeParam, teamIDParam = auth.ResolveUserScope(user, scopeParam, teamIDParam)
+
+	var policies []*entities.SandboxPolicy
+
+	switch scopeParam {
+	case string(entities.ScopeUser):
+		result, err := c.repo.List(ctx.Request().Context(), portrepos.SandboxPolicyFilter{
+			Scope:   entities.ScopeUser,
+			OwnerID: string(user.ID()),
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list sandbox policies")
+		}
+		policies = result
+
+	case string(entities.ScopeTeam):
+		if teamIDParam == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "team_id is required when scope is 'team'")
+		}
+		if !c.isMemberOfTeam(user, teamIDParam) {
+			return echo.NewHTTPError(http.StatusForbidden, "Access denied: not a member of the specified team")
+		}
+		result, err := c.repo.List(ctx.Request().Context(), portrepos.SandboxPolicyFilter{
+			Scope:  entities.ScopeTeam,
+			TeamID: teamIDParam,
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list sandbox policies")
+		}
+		policies = result
+
+	default:
+		userResult, err := c.repo.List(ctx.Request().Context(), portrepos.SandboxPolicyFilter{
+			Scope:   entities.ScopeUser,
+			OwnerID: string(user.ID()),
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list sandbox policies")
+		}
+		teamIDs := c.userTeamIDs(user)
+		var teamResult []*entities.SandboxPolicy
+		if len(teamIDs) > 0 {
+			teamResult, err = c.repo.List(ctx.Request().Context(), portrepos.SandboxPolicyFilter{
+				Scope:   entities.ScopeTeam,
+				TeamIDs: teamIDs,
+			})
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to list sandbox policies")
+			}
+		}
+		policies = append(userResult, teamResult...)
+	}
+
+	if policies == nil {
+		policies = []*entities.SandboxPolicy{}
+	}
+
+	resp := &SandboxPolicyListResponse{Total: len(policies)}
+	for _, p := range policies {
+		resp.SandboxPolicies = append(resp.SandboxPolicies, c.toResponse(p))
+	}
+	if resp.SandboxPolicies == nil {
+		resp.SandboxPolicies = []*SandboxPolicyResponse{}
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// UpdateSandboxPolicy handles PUT /sandbox-policies/:id
+func (c *SandboxPolicyController) UpdateSandboxPolicy(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	policy, err := c.repo.GetByID(ctx.Request().Context(), ctx.Param("id"))
+	if err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sandbox policy")
+	}
+
+	if !c.canModify(user, policy) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	var req UpdateSandboxPolicyRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	if req.Name != nil {
+		policy.SetName(*req.Name)
+	}
+	if req.Description != nil {
+		policy.SetDescription(*req.Description)
+	}
+	if req.AllowedDomains != nil {
+		policy.SetAllowedDomains(*req.AllowedDomains)
+	}
+	if req.DeniedDomains != nil {
+		policy.SetDeniedDomains(*req.DeniedDomains)
+	}
+
+	if err := c.repo.Update(ctx.Request().Context(), policy); err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update sandbox policy")
+	}
+
+	return ctx.JSON(http.StatusOK, c.toResponse(policy))
+}
+
+// DeleteSandboxPolicy handles DELETE /sandbox-policies/:id
+func (c *SandboxPolicyController) DeleteSandboxPolicy(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	policy, err := c.repo.GetByID(ctx.Request().Context(), ctx.Param("id"))
+	if err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sandbox policy")
+	}
+
+	if !c.canModify(user, policy) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	if err := c.repo.Delete(ctx.Request().Context(), policy.ID()); err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete sandbox policy")
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]bool{"success": true})
+}
+
+// --- Access control ---
+
+func (c *SandboxPolicyController) canCreate(user *entities.User, scope, teamID string) bool {
+	if scope == string(entities.ScopeUser) {
+		return true
+	}
+	return c.isMemberOfTeam(user, teamID)
+}
+
+func (c *SandboxPolicyController) canAccess(user *entities.User, policy *entities.SandboxPolicy) bool {
+	switch policy.Scope() {
+	case entities.ScopeUser:
+		return string(user.ID()) == policy.OwnerID()
+	case entities.ScopeTeam:
+		return c.isMemberOfTeam(user, policy.TeamID())
+	default:
+		return false
+	}
+}
+
+func (c *SandboxPolicyController) canModify(user *entities.User, policy *entities.SandboxPolicy) bool {
+	return c.canAccess(user, policy)
+}
+
+func (c *SandboxPolicyController) isMemberOfTeam(user *entities.User, teamID string) bool {
+	if teamID == "" {
+		return false
+	}
+	if user.UserType() == entities.UserTypeServiceAccount {
+		return user.TeamID() == teamID
+	}
+	return user.IsMemberOfTeam(teamID)
+}
+
+func (c *SandboxPolicyController) userTeamIDs(user *entities.User) []string {
+	if user.UserType() == entities.UserTypeServiceAccount {
+		if user.TeamID() != "" {
+			return []string{user.TeamID()}
+		}
+		return nil
+	}
+	githubInfo := user.GitHubInfo()
+	if githubInfo == nil {
+		return nil
+	}
+	teams := githubInfo.Teams()
+	teamIDs := make([]string, 0, len(teams))
+	for _, team := range teams {
+		teamIDs = append(teamIDs, team.Organization+"/"+team.TeamSlug)
+	}
+	return teamIDs
+}
+
+func (c *SandboxPolicyController) toResponse(p *entities.SandboxPolicy) *SandboxPolicyResponse {
+	return &SandboxPolicyResponse{
+		ID:             p.ID(),
+		Name:           p.Name(),
+		Description:    p.Description(),
+		AllowedDomains: p.AllowedDomains(),
+		DeniedDomains:  p.DeniedDomains(),
+		Scope:          string(p.Scope()),
+		OwnerID:        p.OwnerID(),
+		TeamID:         p.TeamID(),
+		CreatedAt:      p.CreatedAt().Format(time.RFC3339),
+		UpdatedAt:      p.UpdatedAt().Format(time.RFC3339),
+	}
+}

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -224,6 +224,19 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 				}
 				startReq.MemoryKey = merged
 			}
+
+			// SandboxPolicyID: apply profile's policy when request does not already specify one.
+			if cfg.SandboxPolicyID() != "" {
+				if startReq.Params == nil {
+					startReq.Params = &entities.SessionParams{}
+				}
+				if startReq.Params.Sandbox == nil {
+					startReq.Params.Sandbox = &entities.SandboxParams{Enabled: true, PolicyID: cfg.SandboxPolicyID()}
+				} else if startReq.Params.Sandbox.PolicyID == "" {
+					startReq.Params.Sandbox.Enabled = true
+					startReq.Params.Sandbox.PolicyID = cfg.SandboxPolicyID()
+				}
+			}
 		}
 	}
 

--- a/internal/interfaces/controllers/session_profile_controller.go
+++ b/internal/interfaces/controllers/session_profile_controller.go
@@ -38,6 +38,7 @@ type SessionProfileConfigRequest struct {
 	Params                 *entities.SessionParams `json:"params,omitempty"`
 	ReuseSession           bool                    `json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
+	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
 }
 
 // CreateSessionProfileRequest is the request body for creating a session profile
@@ -81,6 +82,7 @@ type SessionProfileConfigResponse struct {
 	Params                 *entities.SessionParams `json:"params,omitempty"`
 	ReuseSession           bool                    `json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
+	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
 }
 
 // --- Handlers ---
@@ -315,6 +317,7 @@ func (c *SessionProfileController) requestToConfig(req SessionProfileConfigReque
 	if req.Params != nil {
 		cfg.SetParams(req.Params)
 	}
+	cfg.SetSandboxPolicyID(req.SandboxPolicyID)
 	return cfg
 }
 
@@ -336,6 +339,7 @@ func (c *SessionProfileController) toResponse(p *entities.SessionProfile) Sessio
 			Params:                 cfg.Params(),
 			ReuseSession:           cfg.ReuseSession(),
 			MemoryKey:              cfg.MemoryKey(),
+			SandboxPolicyID:        cfg.SandboxPolicyID(),
 		},
 		CreatedAt: p.CreatedAt().Format(time.RFC3339),
 		UpdatedAt: p.UpdatedAt().Format(time.RFC3339),

--- a/internal/usecases/ports/repositories/sandbox_policy_repository.go
+++ b/internal/usecases/ports/repositories/sandbox_policy_repository.go
@@ -1,0 +1,25 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+// SandboxPolicyFilter defines filter criteria for listing sandbox policies.
+type SandboxPolicyFilter struct {
+	Scope   entities.ResourceScope
+	OwnerID string
+	TeamID  string
+	TeamIDs []string
+	Name    string
+}
+
+// SandboxPolicyRepository defines the interface for sandbox policy persistence.
+type SandboxPolicyRepository interface {
+	Create(ctx context.Context, policy *entities.SandboxPolicy) error
+	GetByID(ctx context.Context, id string) (*entities.SandboxPolicy, error)
+	List(ctx context.Context, filter SandboxPolicyFilter) ([]*entities.SandboxPolicy, error)
+	Update(ctx context.Context, policy *entities.SandboxPolicy) error
+	Delete(ctx context.Context, id string) error
+}

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -119,6 +119,7 @@ func parseFileSecretKey(k string) (int, bool) {
 // AllowedDomains (allowlist) takes precedence over DeniedDomains (denylist).
 type SandboxConfig struct {
 	Enabled        bool     `yaml:"enabled"                   json:"enabled"`
+	PolicyID       string   `yaml:"policy_id,omitempty"       json:"policy_id,omitempty"`
 	AllowedDomains []string `yaml:"allowed_domains,omitempty" json:"allowed_domains,omitempty"`
 	DeniedDomains  []string `yaml:"denied_domains,omitempty"  json:"denied_domains,omitempty"`
 }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -2136,6 +2136,122 @@
         }
       }
     },
+    "/sandbox-policies": {
+      "post": {
+        "summary": "Create a sandbox policy",
+        "description": "Creates a named, reusable set of network filter rules. Sessions can reference this policy by ID at creation time.",
+        "operationId": "createSandboxPolicy",
+        "tags": ["SandboxPolicy"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {"$ref": "#/components/schemas/CreateSandboxPolicyRequest"}
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Sandbox policy created",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/SandboxPolicy"}
+              }
+            }
+          },
+          "400": {"description": "Bad request"},
+          "401": {"description": "Unauthorized"},
+          "403": {"description": "Forbidden"}
+        }
+      },
+      "get": {
+        "summary": "List sandbox policies",
+        "description": "Returns sandbox policies visible to the authenticated user.",
+        "operationId": "listSandboxPolicies",
+        "tags": ["SandboxPolicy"],
+        "parameters": [
+          {"name": "scope", "in": "query", "schema": {"type": "string", "enum": ["user", "team"]}},
+          {"name": "team_id", "in": "query", "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "List of sandbox policies",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/SandboxPolicyListResponse"}
+              }
+            }
+          },
+          "401": {"description": "Unauthorized"}
+        }
+      }
+    },
+    "/sandbox-policies/{id}": {
+      "get": {
+        "summary": "Get a sandbox policy",
+        "operationId": "getSandboxPolicy",
+        "tags": ["SandboxPolicy"],
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Sandbox policy",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/SandboxPolicy"}
+              }
+            }
+          },
+          "401": {"description": "Unauthorized"},
+          "403": {"description": "Forbidden"},
+          "404": {"description": "Sandbox policy not found"}
+        }
+      },
+      "put": {
+        "summary": "Update a sandbox policy",
+        "operationId": "updateSandboxPolicy",
+        "tags": ["SandboxPolicy"],
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {"$ref": "#/components/schemas/UpdateSandboxPolicyRequest"}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated sandbox policy",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/SandboxPolicy"}
+              }
+            }
+          },
+          "401": {"description": "Unauthorized"},
+          "403": {"description": "Forbidden"},
+          "404": {"description": "Sandbox policy not found"}
+        }
+      },
+      "delete": {
+        "summary": "Delete a sandbox policy",
+        "operationId": "deleteSandboxPolicy",
+        "tags": ["SandboxPolicy"],
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {"description": "Deleted successfully"},
+          "401": {"description": "Unauthorized"},
+          "403": {"description": "Forbidden"},
+          "404": {"description": "Sandbox policy not found"}
+        }
+      }
+    },
     "/hooks/slack/{id}": {
       "post": {
         "summary": "Receive Slack event",
@@ -5112,12 +5228,17 @@
       },
       "SandboxParams": {
         "type": "object",
-        "description": "Network sandbox configuration for the session. When enabled, outbound HTTP/HTTPS traffic is routed through a transparent proxy sidecar. allowed_domains (allowlist) takes precedence over denied_domains (denylist).",
+        "description": "Network sandbox configuration for the session. When enabled, outbound HTTP/HTTPS traffic is routed through a transparent proxy sidecar. allowed_domains (allowlist) takes precedence over denied_domains (denylist). A policy_id may reference a SandboxPolicy resource whose domain lists are merged before session-level overrides.",
         "properties": {
           "enabled": {
             "type": "boolean",
             "description": "When true, the network-filter init container and sidecar are injected into the session Pod. The init container configures iptables to redirect HTTP/HTTPS traffic through the sidecar.",
             "default": false
+          },
+          "policy_id": {
+            "type": "string",
+            "description": "ID of a SandboxPolicy resource to use as the base rule set. The policy's allowed_domains and denied_domains are merged with session-level overrides. Session-level domains take precedence.",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
           },
           "allowed_domains": {
             "type": "array",
@@ -5141,6 +5262,105 @@
               "*.evil.com"
             ]
           }
+        }
+      },
+      "SandboxPolicy": {
+        "type": "object",
+        "description": "A named, reusable set of network filter rules. Sessions reference a policy by ID; the policy's domain lists are merged with session-level overrides at creation time.",
+        "required": ["id", "name", "scope", "owner_id", "created_at", "updated_at"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier (UUID)",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name for the policy",
+            "example": "github-access"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description",
+            "example": "Allows access to GitHub and npm registry"
+          },
+          "allowed_domains": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Allowlist: only these domains are permitted. Supports wildcard prefixes.",
+            "example": ["github.com", "*.github.com", "registry.npmjs.org"]
+          },
+          "denied_domains": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Denylist: these domains are blocked. Used only when allowed_domains is empty.",
+            "example": ["raw.githubusercontent.com"]
+          },
+          "scope": {
+            "type": "string",
+            "enum": ["user", "team"],
+            "description": "Resource scope"
+          },
+          "owner_id": {
+            "type": "string",
+            "description": "User ID of the creator"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "Team identifier (required when scope is 'team')"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateSandboxPolicyRequest": {
+        "type": "object",
+        "required": ["name", "scope"],
+        "properties": {
+          "name": {"type": "string", "example": "github-access"},
+          "description": {"type": "string"},
+          "allowed_domains": {
+            "type": "array",
+            "items": {"type": "string"},
+            "example": ["github.com", "*.github.com"]
+          },
+          "denied_domains": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "scope": {"type": "string", "enum": ["user", "team"]},
+          "team_id": {"type": "string"}
+        }
+      },
+      "UpdateSandboxPolicyRequest": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "description": {"type": "string"},
+          "allowed_domains": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "denied_domains": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        }
+      },
+      "SandboxPolicyListResponse": {
+        "type": "object",
+        "properties": {
+          "sandbox_policies": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/SandboxPolicy"}
+          },
+          "total": {"type": "integer"}
         }
       },
       "SlackParams": {


### PR DESCRIPTION
## Summary

- `SandboxPolicy` を独立したリソースとして追加。ユーザーが名前付きのネットワークフィルタールールセットを CRUD API で定義できるようになった
- セッション作成時に `policy_id` でポリシーを参照すると、ポリシーのドメインリストがセッションレベルの設定にマージされる
- セッションレベルの `denied_domains` でポリシー内のドメインを除外することも可能

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `internal/domain/entities/sandbox_policy.go` | `SandboxPolicy` エンティティ（新規） |
| `internal/usecases/ports/repositories/sandbox_policy_repository.go` | リポジトリインターフェース（新規） |
| `internal/infrastructure/repositories/kubernetes_sandbox_policy_repository.go` | ConfigMap バックエンド実装（新規） |
| `internal/interfaces/controllers/sandbox_policy_controller.go` | CRUD HTTP ハンドラ（新規） |
| `internal/domain/entities/session.go` | `SandboxParams.PolicyID` フィールド追加 |
| `pkg/sessionsettings/types.go` | `SandboxConfig.PolicyID` フィールド追加 |
| `internal/infrastructure/services/kubernetes_session_manager.go` | `resolveSandboxParams()` でポリシー解決、`buildSandboxContainers` のシグネチャ変更 |
| `internal/app/server.go` | `sandboxPolicyRepo` の初期化・注入 |
| `internal/app/router.go` | `/sandbox-policies` エンドポイント登録 |
| `spec/openapi.json` | スキーマとパス追加 |

## 使い方

\`\`\`bash
# ポリシー作成
curl -X POST /sandbox-policies \
  -d '{"name":"github-access","scope":"user","allowed_domains":["github.com","*.github.com","registry.npmjs.org"]}'

# セッション作成時にポリシーを参照（+ raw.githubusercontent.com だけ除外）
curl -X POST /start \
  -d '{"params":{"sandbox":{"enabled":true,"policy_id":"<id>","denied_domains":["raw.githubusercontent.com"]}}}'
\`\`\`

## Test plan

- [x] \`make build\` 通過
- [x] \`go test ./...\` 全テスト通過
- [x] \`golangci-lint run\` 0 issues

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)