### PR TITLE
feat(sandbox): switch network filter to takutakahashi/nfa

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE
-              value: {{ .Values.kubernetesSession.networkFilterImage | default "ghcr.io/takutakahashi/nfa:v0.5.0" | quote }}
+              value: {{ .Values.kubernetesSession.networkFilterImage | default "ghcr.io/takutakahashi/nfa:0.5.0" | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
               value: {{ dig "networkFilter" "resources" "requests" "cpu" "250m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -200,12 +200,8 @@ spec:
               value: {{ .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
-            {{- if .Values.kubernetesSession.sandboxInitImage }}
-            - name: AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE
-              value: {{ .Values.kubernetesSession.sandboxInitImage | quote }}
-            {{- end }}
-            - name: AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME
-              value: {{ printf "%s-sandbox-iptables" (include "agentapi-proxy.fullname" .) | quote }}
+            - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE
+              value: {{ .Values.kubernetesSession.networkFilterImage | default "ghcr.io/takutakahashi/nfa:v0.5.0" | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
               value: {{ dig "networkFilter" "resources" "requests" "cpu" "250m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -337,11 +337,11 @@ kubernetesSession:
   # If empty, uses the same image as the proxy
   image: ""
 
-  # Container image for the network-filter-setup init container (sandbox feature).
-  # This init container only needs sh and iptables, so a small image can be used
-  # instead of the full session image — useful in environments with image allowlists.
-  # If empty, falls back to the session image (image field above, or proxy image).
-  sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"
+  # Container image for the network-filter sidecar and init container (sandbox feature).
+  # Uses takutakahashi/nfa, a standalone network filter for agents.
+  # The init container runs "nfa setup" to configure iptables rules;
+  # the sidecar runs "nfa proxy --deferred-policy" to enforce domain filtering.
+  networkFilterImage: "ghcr.io/takutakahashi/nfa:v0.5.0"
 
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)
   networkFilter:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -341,7 +341,7 @@ kubernetesSession:
   # Uses takutakahashi/nfa, a standalone network filter for agents.
   # The init container runs "nfa setup" to configure iptables rules;
   # the sidecar runs "nfa proxy --deferred-policy" to enforce domain filtering.
-  networkFilterImage: "ghcr.io/takutakahashi/nfa:v0.5.0"
+  networkFilterImage: "ghcr.io/takutakahashi/nfa:0.5.0"
 
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)
   networkFilter:

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2067,17 +2067,13 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 	rootUID := int64(0)
 	falseVal := false
 
-	sandboxInitImage := m.k8sConfig.SandboxInitImage
-	if sandboxInitImage == "" {
-		sandboxInitImage = m.k8sConfig.Image
-	}
+	nfaImage := m.k8sConfig.NetworkFilterImage
 
 	initContainer := corev1.Container{
 		Name:            "network-filter-setup",
-		Image:           sandboxInitImage,
+		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"iptables-restore"},
-		Args:            []string{"/etc/iptables/rules.v4"},
+		Command:         []string{"nfa", "setup"},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    &rootUID,
 			RunAsNonRoot: &falseVal,
@@ -2086,22 +2082,15 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 			},
 		},
 		Resources: buildResourceRequirements(m.k8sConfig.NetworkFilterInitCPURequest, m.k8sConfig.NetworkFilterInitCPULimit, m.k8sConfig.NetworkFilterInitMemoryRequest, m.k8sConfig.NetworkFilterInitMemoryLimit),
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "sandbox-iptables",
-				MountPath: "/etc/iptables",
-				ReadOnly:  true,
-			},
-		},
 	}
 
 	proxyAddr := fmt.Sprintf("http://127.0.0.1:%d", networkfilter.ProxyPort)
 
 	sidecar := corev1.Container{
 		Name:            "network-filter",
-		Image:           m.k8sConfig.Image,
+		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"agentapi-proxy", "network-filter", "proxy", "--deferred-policy"},
+		Command:         []string{"nfa", "proxy", "--deferred-policy"},
 		Env:             filterEnvVars,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &rootUID,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -314,7 +314,7 @@ type KubernetesSessionConfig struct {
 	SandboxIptablesConfigMapName string `json:"sandbox_iptables_configmap_name" mapstructure:"sandbox_iptables_configmap_name"`
 
 	// NetworkFilterImage is the container image for both the network-filter-setup init
-	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:v0.5.0.
+	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:0.5.0.
 	// The init container runs "nfa setup" to configure iptables rules; the sidecar runs
 	// "nfa proxy --deferred-policy" to enforce domain filtering.
 	NetworkFilterImage string `json:"network_filter_image" mapstructure:"network_filter_image"`
@@ -894,7 +894,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
-	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:v0.5.0")
+	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.5.0")
 	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
 	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
 	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -313,6 +313,12 @@ type KubernetesSessionConfig struct {
 	// Defaults to "{release-name}-sandbox-iptables" (created by the Helm chart).
 	SandboxIptablesConfigMapName string `json:"sandbox_iptables_configmap_name" mapstructure:"sandbox_iptables_configmap_name"`
 
+	// NetworkFilterImage is the container image for both the network-filter-setup init
+	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:v0.5.0.
+	// The init container runs "nfa setup" to configure iptables rules; the sidecar runs
+	// "nfa proxy --deferred-policy" to enforce domain filtering.
+	NetworkFilterImage string `json:"network_filter_image" mapstructure:"network_filter_image"`
+
 	// Network filter sidecar resource configuration
 	NetworkFilterCPURequest    string `json:"network_filter_cpu_request" mapstructure:"network_filter_cpu_request"`
 	NetworkFilterCPULimit      string `json:"network_filter_cpu_limit" mapstructure:"network_filter_cpu_limit"`
@@ -730,6 +736,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.init_container_image", "AGENTAPI_K8S_SESSION_INIT_CONTAINER_IMAGE")
 	_ = v.BindEnv("kubernetes_session.sandbox_init_image", "AGENTAPI_K8S_SESSION_SANDBOX_INIT_IMAGE")
 	_ = v.BindEnv("kubernetes_session.sandbox_iptables_configmap_name", "AGENTAPI_K8S_SESSION_SANDBOX_IPTABLES_CONFIGMAP_NAME")
+	_ = v.BindEnv("kubernetes_session.network_filter_image", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE")
 	_ = v.BindEnv("kubernetes_session.network_filter_cpu_request", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST")
 	_ = v.BindEnv("kubernetes_session.network_filter_cpu_limit", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT")
 	_ = v.BindEnv("kubernetes_session.network_filter_memory_request", "AGENTAPI_K8S_SESSION_NETWORK_FILTER_MEMORY_REQUEST")
@@ -887,6 +894,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
+	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:v0.5.0")
 	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
 	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
 	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")


### PR DESCRIPTION
## Summary

- Replaces the self-hosted network filter sidecar with the standalone [`takutakahashi/nfa`](https://github.com/takutakahashi/nfa) image (`ghcr.io/takutakahashi/nfa:v0.5.0`)
- Init container now runs `nfa setup` (direct iptables programmatic setup) instead of `iptables-restore /etc/iptables/rules.v4`, removing the dependency on the sandbox-iptables ConfigMap volume mount
- Sidecar now runs `nfa proxy --deferred-policy` instead of `agentapi-proxy network-filter proxy --deferred-policy`
- Both containers use the new `NetworkFilterImage` config field (env: `AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE`, default: `ghcr.io/takutakahashi/nfa:v0.5.0`)
- Helm chart: replaces `sandboxInitImage` with `networkFilterImage`; passes `AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE` instead of the old iptables configmap name env var

The filter rules and bypass domains in nfa are identical to the previous implementation.

## Test plan

- [ ] CI passes
- [ ] Deploy to dev environment via `make devbuild` and verify sandbox sessions start and network filtering works
- [ ] Confirm that a sandboxed session can reach `*.anthropic.com` (bypassed) but cannot reach arbitrary domains

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)