### PR TITLE
feat(sandbox): expose accessed domain list and allowlist addition API

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -242,6 +242,9 @@ func (r *Router) registerCoreRoutes() error {
 	r.echo.GET("/sessions/status/wait", r.handlers.sessionController.WaitSessionsStatus)
 	// Per-session message update long-poll endpoint (must be before /:sessionId/* catch-all)
 	r.echo.GET("/sessions/:sessionId/messages/wait", r.handlers.sessionController.WaitSessionMessages)
+	// Sandbox domain viewer (must be before /:sessionId/* catch-all)
+	r.echo.GET("/sessions/:sessionId/sandbox-domains", r.handlers.sessionController.GetSessionSandboxDomains,
+		auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 	log.Printf("[ROUTES] Session status/message push endpoints registered (SSE + long-poll)")
 
 	// Session sharing routes

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -123,7 +123,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 	// Create sandbox policy controller if sandbox policy repository is available
 	var sandboxPolicyController *controllers.SandboxPolicyController
 	if server.sandboxPolicyRepo != nil {
-		sandboxPolicyController = controllers.NewSandboxPolicyController(server.sandboxPolicyRepo)
+		sandboxPolicyController = controllers.NewSandboxPolicyController(server.sandboxPolicyRepo, server.sandboxDomainRepo)
 		log.Printf("[ROUTER] Sandbox policy controller initialized")
 	}
 
@@ -384,6 +384,7 @@ func (r *Router) registerConditionalRoutes() error {
 		r.echo.POST("/sandbox-policies", r.handlers.sandboxPolicyController.CreateSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		r.echo.GET("/sandbox-policies", r.handlers.sandboxPolicyController.ListSandboxPolicies, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.GET("/sandbox-policies/:id", r.handlers.sandboxPolicyController.GetSandboxPolicy, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.GET("/sandbox-policies/:id/domains", r.handlers.sandboxPolicyController.GetSandboxPolicyDomains, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.PUT("/sandbox-policies/:id", r.handlers.sandboxPolicyController.UpdateSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		r.echo.DELETE("/sandbox-policies/:id", r.handlers.sandboxPolicyController.DeleteSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		log.Printf("[ROUTES] Sandbox policy endpoints registered")

--- a/internal/app/sandbox_domain_collector.go
+++ b/internal/app/sandbox_domain_collector.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/repositories"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+)
+
+// SandboxDomainCollector runs as a background goroutine, periodically querying
+// each sandboxed session's network filter domain log and aggregating the results
+// into per-policy Kubernetes ConfigMaps.
+type SandboxDomainCollector struct {
+	sessionManager *services.KubernetesSessionManager
+	domainRepo     *repositories.KubernetesSandboxDomainRepository
+	httpClient     *http.Client
+	interval       time.Duration
+}
+
+func newSandboxDomainCollector(
+	sessionManager *services.KubernetesSessionManager,
+	domainRepo *repositories.KubernetesSandboxDomainRepository,
+	interval time.Duration,
+) *SandboxDomainCollector {
+	return &SandboxDomainCollector{
+		sessionManager: sessionManager,
+		domainRepo:     domainRepo,
+		httpClient:     &http.Client{Timeout: 5 * time.Second},
+		interval:       interval,
+	}
+}
+
+// start runs the collector loop until ctx is cancelled.
+func (c *SandboxDomainCollector) start(ctx context.Context) {
+	log.Printf("[SANDBOX_DOMAIN_COLLECTOR] Starting (interval: %s)", c.interval)
+	c.collect(ctx)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[SANDBOX_DOMAIN_COLLECTOR] Stopped")
+			return
+		case <-ticker.C:
+			c.collect(ctx)
+		}
+	}
+}
+
+// collect queries all active sandboxed sessions and writes aggregated domain
+// data to the per-policy ConfigMaps.
+func (c *SandboxDomainCollector) collect(ctx context.Context) {
+	allSessions := c.sessionManager.ListSessions(entities.SessionFilter{})
+
+	type domainSets struct {
+		allowed map[string]struct{}
+		denied  map[string]struct{}
+	}
+	policyData := make(map[string]*domainSets)
+
+	for _, session := range allSessions {
+		ks, ok := session.(*services.KubernetesSession)
+		if !ok {
+			continue
+		}
+		req := ks.Request()
+		if req == nil || req.Sandbox == nil || req.Sandbox.PolicyID == "" {
+			continue
+		}
+		policyID := req.Sandbox.PolicyID
+
+		domains, err := c.fetchDomains(ks)
+		if err != nil {
+			log.Printf("[SANDBOX_DOMAIN_COLLECTOR] Failed to fetch domains for session %s: %v", ks.ID(), err)
+			continue
+		}
+
+		if _, ok := policyData[policyID]; !ok {
+			policyData[policyID] = &domainSets{
+				allowed: make(map[string]struct{}),
+				denied:  make(map[string]struct{}),
+			}
+		}
+		for _, d := range domains.Allowed {
+			policyData[policyID].allowed[d] = struct{}{}
+		}
+		for _, d := range domains.Denied {
+			policyData[policyID].denied[d] = struct{}{}
+		}
+	}
+
+	for policyID, sets := range policyData {
+		allowed := make([]string, 0, len(sets.allowed))
+		denied := make([]string, 0, len(sets.denied))
+		for d := range sets.allowed {
+			allowed = append(allowed, d)
+		}
+		for d := range sets.denied {
+			denied = append(denied, d)
+		}
+
+		data := &repositories.SandboxDomainData{
+			Allowed:   allowed,
+			Denied:    denied,
+			UpdatedAt: time.Now(),
+		}
+		if err := c.domainRepo.Upsert(ctx, policyID, data); err != nil {
+			log.Printf("[SANDBOX_DOMAIN_COLLECTOR] Failed to upsert domain data for policy %s: %v", policyID, err)
+		} else {
+			log.Printf("[SANDBOX_DOMAIN_COLLECTOR] Updated policy %s: %d allowed, %d denied domains", policyID, len(allowed), len(denied))
+		}
+	}
+}
+
+type sandboxDomainsResponse struct {
+	Allowed []string `json:"allowed"`
+	Denied  []string `json:"denied"`
+}
+
+func (c *SandboxDomainCollector) fetchDomains(ks *services.KubernetesSession) (*sandboxDomainsResponse, error) {
+	url := fmt.Sprintf("http://%s:%d/sandbox-domains", ks.ServiceDNS(), services.ProvisionerPort)
+	resp, err := c.httpClient.Get(url) //nolint:noctx
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return &sandboxDomainsResponse{}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result sandboxDomainsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -55,7 +55,8 @@ type Server struct {
 	shareRepo          portrepos.ShareRepository          // Share repository for session sharing
 	teamConfigRepo     portrepos.TeamConfigRepository     // Team configuration repository
 	memoryRepo         portrepos.MemoryRepository         // Memory repository
-	sandboxPolicyRepo  portrepos.SandboxPolicyRepository  // Sandbox policy repository
+	sandboxPolicyRepo  portrepos.SandboxPolicyRepository                      // Sandbox policy repository
+	sandboxDomainRepo  *repositories.KubernetesSandboxDomainRepository        // Sandbox domain log repository
 	taskRepo           portrepos.TaskRepository           // Task repository
 	taskGroupRepo      portrepos.TaskGroupRepository      // Task group repository
 	sessionRouteRepo   portrepos.SessionRouteRepository   // Session route repository for proxy B routing
@@ -287,6 +288,13 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 	k8sSessionManager.SetSandboxPolicyRepository(sandboxPolicyRepo)
 	log.Printf("[SERVER] Sandbox policy repository initialized")
 
+	// Initialize sandbox domain repository (Kubernetes ConfigMap-backed)
+	sandboxDomainRepo := repositories.NewKubernetesSandboxDomainRepository(
+		k8sSessionManager.GetClient(),
+		k8sSessionManager.GetNamespace(),
+	)
+	log.Printf("[SERVER] Sandbox domain repository initialized")
+
 	// Initialize task repository (Kubernetes ConfigMap-backed)
 	taskRepo := repositories.NewKubernetesTaskRepository(
 		k8sSessionManager.GetClient(),
@@ -335,6 +343,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 		teamConfigRepo:     teamConfigRepo,
 		memoryRepo:         memoryRepo,
 		sandboxPolicyRepo:  sandboxPolicyRepo,
+		sandboxDomainRepo:  sandboxDomainRepo,
 		taskRepo:           taskRepo,
 		taskGroupRepo:      taskGroupRepo,
 		sessionRouteRepo:   sessionRouteRepo,
@@ -431,6 +440,13 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 
 	// Start cleanup goroutine for defunct processes
 	go s.cleanupDefunctProcesses()
+
+	// Start sandbox domain collector (Kubernetes mode only)
+	if k8sMgr, ok := s.sessionManager.(*services.KubernetesSessionManager); ok && s.sandboxDomainRepo != nil {
+		collector := newSandboxDomainCollector(k8sMgr, s.sandboxDomainRepo, 60*time.Second)
+		go collector.start(context.Background())
+		log.Printf("[SERVER] Sandbox domain collector started (interval: 60s)")
+	}
 
 	// Start cleanup goroutine for expired shares
 	if s.shareRepo != nil {

--- a/internal/infrastructure/repositories/kubernetes_sandbox_domain_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_sandbox_domain_repository.go
@@ -1,0 +1,104 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	LabelSandboxDomainType      = "agentapi.proxy/type"
+	LabelSandboxDomainTypeValue = "sandbox-domains"
+
+	sandboxDomainConfigMapPrefix = "agentapi-sandbox-domains-"
+	sandboxDomainDataKey         = "data.json"
+)
+
+// SandboxDomainData holds the aggregated domain log for a sandbox policy.
+type SandboxDomainData struct {
+	Allowed   []string  `json:"allowed"`
+	Denied    []string  `json:"denied"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// KubernetesSandboxDomainRepository persists sandbox domain logs in Kubernetes ConfigMaps,
+// one ConfigMap per sandbox policy.
+type KubernetesSandboxDomainRepository struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+func NewKubernetesSandboxDomainRepository(client kubernetes.Interface, namespace string) *KubernetesSandboxDomainRepository {
+	return &KubernetesSandboxDomainRepository{client: client, namespace: namespace}
+}
+
+// Get returns the domain data for the given policy ID.
+// Returns nil (no error) when no data has been collected yet.
+func (r *KubernetesSandboxDomainRepository) Get(ctx context.Context, policyID string) (*SandboxDomainData, error) {
+	cm, err := r.client.CoreV1().ConfigMaps(r.namespace).Get(ctx, r.configMapName(policyID), metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get sandbox domain configmap: %w", err)
+	}
+
+	raw, ok := cm.Data[sandboxDomainDataKey]
+	if !ok {
+		return nil, nil
+	}
+
+	var data SandboxDomainData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil, fmt.Errorf("unmarshal sandbox domain data: %w", err)
+	}
+	return &data, nil
+}
+
+// Upsert creates or updates the domain data ConfigMap for the given policy.
+func (r *KubernetesSandboxDomainRepository) Upsert(ctx context.Context, policyID string, data *SandboxDomainData) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal sandbox domain data: %w", err)
+	}
+
+	name := r.configMapName(policyID)
+	existing, err := r.client.CoreV1().ConfigMaps(r.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("get sandbox domain configmap: %w", err)
+		}
+		// Create new ConfigMap
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: r.namespace,
+				Labels: map[string]string{
+					LabelSandboxDomainType: LabelSandboxDomainTypeValue,
+					"agentapi.proxy/policy-id": policyID,
+				},
+			},
+			Data: map[string]string{sandboxDomainDataKey: string(raw)},
+		}
+		_, err = r.client.CoreV1().ConfigMaps(r.namespace).Create(ctx, cm, metav1.CreateOptions{})
+		return err
+	}
+
+	// Update existing ConfigMap
+	if existing.Data == nil {
+		existing.Data = make(map[string]string)
+	}
+	existing.Data[sandboxDomainDataKey] = string(raw)
+	_, err = r.client.CoreV1().ConfigMaps(r.namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+func (r *KubernetesSandboxDomainRepository) configMapName(policyID string) string {
+	return sandboxDomainConfigMapPrefix + policyID
+}

--- a/internal/interfaces/controllers/sandbox_policy_controller.go
+++ b/internal/interfaces/controllers/sandbox_policy_controller.go
@@ -8,17 +8,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/repositories"
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 )
 
 // SandboxPolicyController handles sandbox policy HTTP requests.
 type SandboxPolicyController struct {
-	repo portrepos.SandboxPolicyRepository
+	repo       portrepos.SandboxPolicyRepository
+	domainRepo *repositories.KubernetesSandboxDomainRepository
 }
 
-func NewSandboxPolicyController(repo portrepos.SandboxPolicyRepository) *SandboxPolicyController {
-	return &SandboxPolicyController{repo: repo}
+func NewSandboxPolicyController(repo portrepos.SandboxPolicyRepository, domainRepo *repositories.KubernetesSandboxDomainRepository) *SandboxPolicyController {
+	return &SandboxPolicyController{repo: repo, domainRepo: domainRepo}
 }
 
 func (c *SandboxPolicyController) GetName() string { return "SandboxPolicyController" }
@@ -284,6 +286,63 @@ func (c *SandboxPolicyController) DeleteSandboxPolicy(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]bool{"success": true})
+}
+
+// SandboxPolicyDomainsResponse is the JSON body returned by GET /sandbox-policies/:id/domains.
+type SandboxPolicyDomainsResponse struct {
+	Allowed   []string `json:"allowed"`
+	Denied    []string `json:"denied"`
+	UpdatedAt string   `json:"updated_at,omitempty"`
+}
+
+// GetSandboxPolicyDomains handles GET /sandbox-policies/:id/domains.
+// Returns the aggregated domain log collected by the background worker.
+func (c *SandboxPolicyController) GetSandboxPolicyDomains(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	if c.domainRepo == nil {
+		return echo.NewHTTPError(http.StatusNotImplemented, "Domain collection not available")
+	}
+
+	policy, err := c.repo.GetByID(ctx.Request().Context(), ctx.Param("id"))
+	if err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sandbox policy")
+	}
+	if !c.canAccess(user, policy) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	data, err := c.domainRepo.Get(ctx.Request().Context(), policy.ID())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read domain data")
+	}
+
+	if data == nil {
+		return ctx.JSON(http.StatusOK, SandboxPolicyDomainsResponse{
+			Allowed: []string{},
+			Denied:  []string{},
+		})
+	}
+
+	resp := SandboxPolicyDomainsResponse{
+		Allowed:   data.Allowed,
+		Denied:    data.Denied,
+		UpdatedAt: data.UpdatedAt.Format(time.RFC3339),
+	}
+	if resp.Allowed == nil {
+		resp.Allowed = []string{}
+	}
+	if resp.Denied == nil {
+		resp.Denied = []string{}
+	}
+	return ctx.JSON(http.StatusOK, resp)
 }
 
 // --- Access control ---

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -362,6 +362,11 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 				"description": initialMessage,
 			},
 		}
+		if ks, ok := session.(*services.KubernetesSession); ok {
+			if req := ks.Request(); req != nil && req.Sandbox != nil {
+				sessionData["sandbox_policy_id"] = req.Sandbox.PolicyID
+			}
+		}
 		filteredSessions = append(filteredSessions, sessionData)
 	}
 

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -1007,6 +1007,61 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 	return &merged
 }
 
+// SandboxDomainsResponse is the JSON body returned by GET /sessions/:sessionId/sandbox-domains.
+type SandboxDomainsResponse struct {
+	Allowed []string `json:"allowed"`
+	Denied  []string `json:"denied"`
+}
+
+// GetSessionSandboxDomains handles GET /sessions/:sessionId/sandbox-domains.
+// It forwards the request to the session's agent-provisioner /sandbox-domains endpoint,
+// which in turn queries the network filter control server (127.0.0.1:3129/domains).
+// Returns 404 when the session does not exist, 503 when the network filter is unavailable.
+func (c *SessionController) GetSessionSandboxDomains(ctx echo.Context) error {
+	sessionID := ctx.Param("sessionId")
+
+	session := c.getSessionManager().GetSession(sessionID)
+	if session == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	if !authzCtx.CanAccessResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return echo.NewHTTPError(http.StatusForbidden, "You don't have permission to access this session")
+	}
+
+	ks, ok := session.(*services.KubernetesSession)
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotImplemented, "Sandbox domains not available for this session type")
+	}
+
+	provisionerURL := fmt.Sprintf("http://%s:%d/sandbox-domains", ks.ServiceDNS(), services.ProvisionerPort)
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(provisionerURL)
+	if err != nil {
+		log.Printf("[SESSION] Failed to fetch sandbox domains for %s: %v", sessionID, err)
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Network filter not available")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "Network filter not available for this session")
+	}
+
+	var domainsResp SandboxDomainsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&domainsResp); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to parse domain response")
+	}
+	if domainsResp.Allowed == nil {
+		domainsResp.Allowed = []string{}
+	}
+	if domainsResp.Denied == nil {
+		domainsResp.Denied = []string{}
+	}
+
+	return ctx.JSON(http.StatusOK, domainsResp)
+}
+
 // resolveSessionProfile returns the session profile to apply for a session creation request.
 // If profileID is set, it fetches that profile directly.
 // Otherwise it searches for the default profile scoped to the user or team.

--- a/pkg/networkfilter/control.go
+++ b/pkg/networkfilter/control.go
@@ -1,6 +1,7 @@
 package networkfilter
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -20,6 +21,12 @@ func NewControlServer(proxy *Proxy) *ControlServer {
 	return &ControlServer{proxy: proxy}
 }
 
+// DomainsResponse is the JSON body returned by GET /domains.
+type DomainsResponse struct {
+	Allowed []string `json:"allowed"`
+	Denied  []string `json:"denied"`
+}
+
 // Run starts the HTTP control server on lis and blocks until lis is closed.
 func (c *ControlServer) Run(lis net.Listener) error {
 	mux := http.NewServeMux()
@@ -27,6 +34,19 @@ func (c *ControlServer) Run(lis net.Listener) error {
 		c.proxy.EnablePolicy()
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprintln(w, "policy enabled")
+	})
+	mux.HandleFunc("GET /domains", func(w http.ResponseWriter, _ *http.Request) {
+		allowed, denied := c.proxy.Domains()
+		if allowed == nil {
+			allowed = []string{}
+		}
+		if denied == nil {
+			denied = []string{}
+		}
+		resp := DomainsResponse{Allowed: allowed, Denied: denied}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	srv := &http.Server{Handler: mux}
 	log.Printf("[network-filter] control server listening on %s", lis.Addr())

--- a/pkg/networkfilter/proxy.go
+++ b/pkg/networkfilter/proxy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -28,6 +29,45 @@ const (
 // passthroughFilter allows all traffic (empty denylist, no allowlist).
 var passthroughFilter = &Filter{}
 
+// DomainLog tracks which domains were accessed (allowed) or rejected (denied) by the proxy.
+type DomainLog struct {
+	mu      sync.RWMutex
+	allowed map[string]struct{}
+	denied  map[string]struct{}
+}
+
+func newDomainLog() *DomainLog {
+	return &DomainLog{
+		allowed: make(map[string]struct{}),
+		denied:  make(map[string]struct{}),
+	}
+}
+
+func (d *DomainLog) recordAllowed(domain string) {
+	d.mu.Lock()
+	d.allowed[domain] = struct{}{}
+	d.mu.Unlock()
+}
+
+func (d *DomainLog) recordDenied(domain string) {
+	d.mu.Lock()
+	d.denied[domain] = struct{}{}
+	d.mu.Unlock()
+}
+
+// Snapshot returns a copy of the current allowed and denied domain sets.
+func (d *DomainLog) Snapshot() (allowed, denied []string) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	for k := range d.allowed {
+		allowed = append(allowed, k)
+	}
+	for k := range d.denied {
+		denied = append(denied, k)
+	}
+	return
+}
+
 // Proxy is a forward proxy that enforces a domain deny-list.
 // It handles three types of incoming connections on a single port:
 //
@@ -42,17 +82,26 @@ var passthroughFilter = &Filter{}
 type Proxy struct {
 	configuredFilter *Filter
 	activeFilter     atomic.Pointer[Filter]
+	domainLog        *DomainLog
 }
 
 // NewProxy creates a Proxy with the given filter.
 // When active is true, the policy is enforced immediately.
 // When active is false, all traffic is allowed until EnablePolicy is called.
 func NewProxy(filter *Filter, active bool) *Proxy {
-	p := &Proxy{configuredFilter: filter}
+	p := &Proxy{
+		configuredFilter: filter,
+		domainLog:        newDomainLog(),
+	}
 	if active {
 		p.activeFilter.Store(filter)
 	}
 	return p
+}
+
+// Domains returns the current snapshot of accessed (allowed) and rejected (denied) domains.
+func (p *Proxy) Domains() (allowed, denied []string) {
+	return p.domainLog.Snapshot()
 }
 
 // EnablePolicy activates the configured filter. After this call, all connections
@@ -130,9 +179,11 @@ func (p *Proxy) handleCONNECT(conn net.Conn, req *http.Request) {
 	log.Printf("[network-filter] CONNECT %s: %s", result, req.Host)
 
 	if result == FilterResultBlocked {
+		p.domainLog.recordDenied(host)
 		_, _ = fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\nblocked by network filter\n")
 		return
 	}
+	p.domainLog.recordAllowed(host)
 
 	upConn, err := net.DialTimeout("tcp", req.Host, dialTimeout)
 	if err != nil {
@@ -158,6 +209,7 @@ func (p *Proxy) handleHTTP(conn net.Conn, br *bufio.Reader, req *http.Request) {
 	log.Printf("[network-filter] HTTP %s: %s", result, host)
 
 	if result == FilterResultBlocked {
+		p.domainLog.recordDenied(host)
 		resp := &http.Response{
 			Status:     "403 Forbidden",
 			StatusCode: http.StatusForbidden,
@@ -170,6 +222,7 @@ func (p *Proxy) handleHTTP(conn net.Conn, br *bufio.Reader, req *http.Request) {
 		_ = resp.Write(conn)
 		return
 	}
+	p.domainLog.recordAllowed(host)
 
 	upstream := req.Host
 	if upstream == "" {
@@ -220,8 +273,10 @@ func (p *Proxy) handleTransparentTLS(conn net.Conn, br *bufio.Reader) {
 	log.Printf("[network-filter] TLS %s: %s", result, sni)
 
 	if result == FilterResultBlocked {
+		p.domainLog.recordDenied(sni)
 		return
 	}
+	p.domainLog.recordAllowed(sni)
 
 	upstream := net.JoinHostPort(sni, "443")
 	upConn, err := net.DialTimeout("tcp", upstream, dialTimeout)

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -103,6 +104,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/status", s.handleStatus)
 	mux.HandleFunc("/provision", s.handleProvision)
+	mux.HandleFunc("/sandbox-domains", s.handleSandboxDomains)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", s.port),
@@ -215,6 +217,27 @@ func (s *Server) GetStatus() Status {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.status
+}
+
+// handleSandboxDomains proxies GET /sandbox-domains to the network filter control
+// server (127.0.0.1:3129/domains) and returns the accessed domain list.
+// Returns 503 when the network filter is not running (no sandbox sidecar).
+func (s *Server) handleSandboxDomains(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	resp, err := http.Get("http://127.0.0.1:3129/domains") //nolint:noctx
+	if err != nil {
+		http.Error(w, "network filter not available", http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
 }
 
 // runStartupScript executes the common startup pre-script as soon as the Pod

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -458,6 +458,80 @@
         ]
       }
     },
+    "/sessions/{sessionId}/sandbox-domains": {
+      "get": {
+        "summary": "Get domains accessed by a sandboxed session",
+        "description": "Returns the list of domains that the session's network filter proxy has seen, split into allowed (accessed) and denied (blocked) sets. Only available for Kubernetes sessions with a sandbox sidecar. Returns 503 when the network filter is not running.",
+        "operationId": "getSessionSandboxDomains",
+        "tags": [
+          "Sessions",
+          "Sandbox"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "description": "Session ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domain lists from the network filter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "allowed": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Domains that were allowed through the filter"
+                    },
+                    "denied": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Domains that were blocked by the filter"
+                    }
+                  },
+                  "required": ["allowed", "denied"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "501": {
+            "description": "Not implemented for this session type"
+          },
+          "503": {
+            "description": "Network filter not available for this session"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
     "/sessions/{sessionId}/share": {
       "post": {
         "summary": "Create a share URL",

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5510,6 +5510,10 @@
               }
             },
             "description": "Session metadata"
+          },
+          "sandbox_policy_id": {
+            "type": "string",
+            "description": "ID of the sandbox policy applied to this session (Kubernetes sessions only)"
           }
         }
       },

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -458,6 +458,65 @@
         ]
       }
     },
+    "/sandbox-policies/{id}/domains": {
+      "get": {
+        "summary": "Get aggregated domains for a sandbox policy",
+        "description": "Returns the allowed/denied domain lists collected by the background domain collector from all sessions using this policy. Data is refreshed every 60 seconds. Returns empty lists when no data has been collected yet.",
+        "operationId": "getSandboxPolicyDomains",
+        "tags": [
+          "Sandbox"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Sandbox policy ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregated domain lists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "allowed": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "description": "Domains allowed through the filter"
+                    },
+                    "denied": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "description": "Domains blocked by the filter"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the data was last collected"
+                    }
+                  },
+                  "required": ["allowed", "denied"]
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Sandbox policy not found" },
+          "501": { "description": "Domain collection not available" }
+        },
+        "security": [
+          { "ApiKeyAuth": [] },
+          { "BearerAuth": [] }
+        ]
+      }
+    },
     "/sessions/{sessionId}/sandbox-domains": {
       "get": {
         "summary": "Get domains accessed by a sandboxed session",


### PR DESCRIPTION
## Summary

- Adds `GET /sessions/:sessionId/sandbox-domains` endpoint to agentapi-proxy that returns the domains accessed (allowed) and blocked (denied) by the session's network filter sidecar
- Adds `GET /domains` endpoint to the local network filter control server (`pkg/networkfilter/control.go`) with thread-safe domain tracking in the `Proxy` struct
- Adds `GET /sandbox-domains` to the agent-provisioner server, which proxies `http://127.0.0.1:3129/domains` — the network filter control API accessible inside the pod
- Updates `spec/openapi.json` with the new endpoint schema

## How it works

1. The NFA sidecar (`ghcr.io/takutakahashi/nfa`) runs inside the session pod and tracks all domains it has allowed or blocked on its control server at `127.0.0.1:3129/domains`
2. The agent-provisioner (port 9001) adds a `/sandbox-domains` handler that calls this local endpoint
3. agentapi-proxy's new `GET /sessions/:sessionId/sandbox-domains` calls the session's provisioner and returns the result

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Confirm `GET /sessions/:sessionId/sandbox-domains` returns 503 for non-sandbox sessions
- [ ] Confirm `GET /sessions/:sessionId/sandbox-domains` returns 501 for non-Kubernetes sessions
- [ ] Review OpenAPI spec update

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)