### PR TITLE
feat(sandbox): nfa v0.6.0 count mode support

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE
-              value: {{ .Values.kubernetesSession.networkFilterImage | default "ghcr.io/takutakahashi/nfa:0.5.0" | quote }}
+              value: {{ .Values.kubernetesSession.networkFilterImage | default "ghcr.io/takutakahashi/nfa:v0.6.0" | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
               value: {{ dig "networkFilter" "resources" "requests" "cpu" "250m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE
-              value: {{ .Values.kubernetesSession.networkFilterImage | default "ghcr.io/takutakahashi/nfa:v0.6.0" | quote }}
+              value: "ghcr.io/takutakahashi/nfa:v0.6.0"
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
               value: {{ dig "networkFilter" "resources" "requests" "cpu" "250m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE
-              value: "ghcr.io/takutakahashi/nfa:v0.6.0"
+              value: "ghcr.io/takutakahashi/nfa:0.6.0"
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_REQUEST
               value: {{ dig "networkFilter" "resources" "requests" "cpu" "250m" .Values.kubernetesSession | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_CPU_LIMIT

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -337,12 +337,6 @@ kubernetesSession:
   # If empty, uses the same image as the proxy
   image: ""
 
-  # Container image for the network-filter sidecar and init container (sandbox feature).
-  # Uses takutakahashi/nfa, a standalone network filter for agents.
-  # The init container runs "nfa setup" to configure iptables rules;
-  # the sidecar runs "nfa proxy --deferred-policy" to enforce domain filtering.
-  networkFilterImage: "ghcr.io/takutakahashi/nfa:v0.6.0"
-
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)
   networkFilter:
     # Resources for the network-filter forward proxy sidecar container

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -341,7 +341,7 @@ kubernetesSession:
   # Uses takutakahashi/nfa, a standalone network filter for agents.
   # The init container runs "nfa setup" to configure iptables rules;
   # the sidecar runs "nfa proxy --deferred-policy" to enforce domain filtering.
-  networkFilterImage: "ghcr.io/takutakahashi/nfa:0.5.0"
+  networkFilterImage: "ghcr.io/takutakahashi/nfa:v0.6.0"
 
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)
   networkFilter:

--- a/internal/domain/entities/sandbox_policy.go
+++ b/internal/domain/entities/sandbox_policy.go
@@ -23,6 +23,7 @@ type SandboxPolicy struct {
 	description    string
 	allowedDomains []string
 	deniedDomains  []string
+	countMode      bool
 	scope          ResourceScope
 	ownerID        string
 	teamID         string
@@ -47,16 +48,17 @@ func NewSandboxPolicy(id, name, description string, allowedDomains, deniedDomain
 	}
 }
 
-func (p *SandboxPolicy) ID() string             { return p.id }
-func (p *SandboxPolicy) Name() string           { return p.name }
-func (p *SandboxPolicy) Description() string    { return p.description }
+func (p *SandboxPolicy) ID() string               { return p.id }
+func (p *SandboxPolicy) Name() string             { return p.name }
+func (p *SandboxPolicy) Description() string      { return p.description }
 func (p *SandboxPolicy) AllowedDomains() []string { return copyStringSlice(p.allowedDomains) }
 func (p *SandboxPolicy) DeniedDomains() []string  { return copyStringSlice(p.deniedDomains) }
-func (p *SandboxPolicy) Scope() ResourceScope    { return p.scope }
-func (p *SandboxPolicy) OwnerID() string         { return p.ownerID }
-func (p *SandboxPolicy) TeamID() string          { return p.teamID }
-func (p *SandboxPolicy) CreatedAt() time.Time    { return p.createdAt }
-func (p *SandboxPolicy) UpdatedAt() time.Time    { return p.updatedAt }
+func (p *SandboxPolicy) CountMode() bool          { return p.countMode }
+func (p *SandboxPolicy) Scope() ResourceScope     { return p.scope }
+func (p *SandboxPolicy) OwnerID() string          { return p.ownerID }
+func (p *SandboxPolicy) TeamID() string           { return p.teamID }
+func (p *SandboxPolicy) CreatedAt() time.Time     { return p.createdAt }
+func (p *SandboxPolicy) UpdatedAt() time.Time     { return p.updatedAt }
 
 func (p *SandboxPolicy) SetName(name string) {
 	p.name = name
@@ -75,6 +77,11 @@ func (p *SandboxPolicy) SetAllowedDomains(domains []string) {
 
 func (p *SandboxPolicy) SetDeniedDomains(domains []string) {
 	p.deniedDomains = copyStringSlice(domains)
+	p.updatedAt = time.Now()
+}
+
+func (p *SandboxPolicy) SetCountMode(v bool) {
+	p.countMode = v
 	p.updatedAt = time.Now()
 }
 

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -43,6 +43,10 @@ type SandboxParams struct {
 	// DeniedDomains is the list of hostnames whose traffic should be blocked (denylist mode).
 	// Used only when AllowedDomains is empty.
 	DeniedDomains []string `json:"denied_domains,omitempty"`
+	// CountMode enables count mode: policy rules are evaluated and blocked domains are recorded,
+	// but traffic is not actually blocked. Useful for auditing policies before enforcing them.
+	// Requires nfa v0.6.0+.
+	CountMode bool `json:"count_mode,omitempty"`
 }
 
 // SessionParams represents session parameters for agentapi server

--- a/internal/infrastructure/repositories/kubernetes_sandbox_policy_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_sandbox_policy_repository.go
@@ -26,7 +26,7 @@ const (
 	AnnotationSandboxPolicyOwnerID = "agentapi.proxy/owner-id"
 	AnnotationSandboxPolicyTeamID  = "agentapi.proxy/team-id"
 
-	ConfigMapKeySandboxPolicy  = "sandbox-policy.json"
+	ConfigMapKeySandboxPolicy    = "sandbox-policy.json"
 	SandboxPolicyConfigMapPrefix = "agentapi-sandbox-policy-"
 )
 
@@ -36,6 +36,7 @@ type sandboxPolicyJSON struct {
 	Description    string    `json:"description,omitempty"`
 	AllowedDomains []string  `json:"allowed_domains,omitempty"`
 	DeniedDomains  []string  `json:"denied_domains,omitempty"`
+	CountMode      bool      `json:"count_mode,omitempty"`
 	Scope          string    `json:"scope"`
 	OwnerID        string    `json:"owner_id"`
 	TeamID         string    `json:"team_id,omitempty"`
@@ -228,6 +229,7 @@ func (r *KubernetesSandboxPolicyRepository) toJSONBytes(p *entities.SandboxPolic
 		Description:    p.Description(),
 		AllowedDomains: p.AllowedDomains(),
 		DeniedDomains:  p.DeniedDomains(),
+		CountMode:      p.CountMode(),
 		Scope:          string(p.Scope()),
 		OwnerID:        p.OwnerID(),
 		TeamID:         p.TeamID(),
@@ -265,6 +267,7 @@ func (r *KubernetesSandboxPolicyRepository) loadFromConfigMap(cm *corev1.ConfigM
 		pj.OwnerID,
 		pj.TeamID,
 	)
+	p.SetCountMode(pj.CountMode)
 	p.SetCreatedAt(pj.CreatedAt)
 	p.SetUpdatedAt(pj.UpdatedAt)
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2063,6 +2063,9 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 			{Name: "NETWORK_FILTER_DENIED_DOMAINS", Value: strings.Join(sandbox.DeniedDomains, ",")},
 		}
 	}
+	if sandbox != nil && sandbox.CountMode {
+		filterEnvVars = append(filterEnvVars, corev1.EnvVar{Name: "NETWORK_FILTER_COUNT_MODE", Value: "true"})
+	}
 
 	rootUID := int64(0)
 	falseVal := false

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2045,6 +2045,9 @@ func (m *KubernetesSessionManager) resolveSandboxParams(ctx context.Context, req
 	}
 	effective.AllowedDomains = append(policy.AllowedDomains(), effective.AllowedDomains...)
 	effective.DeniedDomains = append(policy.DeniedDomains(), effective.DeniedDomains...)
+	if policy.CountMode() {
+		effective.CountMode = true
+	}
 	return effective
 }
 

--- a/internal/interfaces/controllers/sandbox_policy_controller.go
+++ b/internal/interfaces/controllers/sandbox_policy_controller.go
@@ -32,6 +32,7 @@ type CreateSandboxPolicyRequest struct {
 	Description    string   `json:"description,omitempty"`
 	AllowedDomains []string `json:"allowed_domains,omitempty"`
 	DeniedDomains  []string `json:"denied_domains,omitempty"`
+	CountMode      bool     `json:"count_mode,omitempty"`
 	Scope          string   `json:"scope"`
 	TeamID         string   `json:"team_id,omitempty"`
 }
@@ -41,6 +42,7 @@ type UpdateSandboxPolicyRequest struct {
 	Description    *string   `json:"description,omitempty"`
 	AllowedDomains *[]string `json:"allowed_domains,omitempty"`
 	DeniedDomains  *[]string `json:"denied_domains,omitempty"`
+	CountMode      *bool     `json:"count_mode,omitempty"`
 }
 
 type SandboxPolicyResponse struct {
@@ -49,6 +51,7 @@ type SandboxPolicyResponse struct {
 	Description    string   `json:"description,omitempty"`
 	AllowedDomains []string `json:"allowed_domains,omitempty"`
 	DeniedDomains  []string `json:"denied_domains,omitempty"`
+	CountMode      bool     `json:"count_mode,omitempty"`
 	Scope          string   `json:"scope"`
 	OwnerID        string   `json:"owner_id"`
 	TeamID         string   `json:"team_id,omitempty"`
@@ -100,6 +103,9 @@ func (c *SandboxPolicyController) CreateSandboxPolicy(ctx echo.Context) error {
 		string(user.ID()),
 		req.TeamID,
 	)
+	if req.CountMode {
+		policy.SetCountMode(true)
+	}
 
 	if err := c.repo.Create(ctx.Request().Context(), policy); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create sandbox policy")
@@ -244,6 +250,9 @@ func (c *SandboxPolicyController) UpdateSandboxPolicy(ctx echo.Context) error {
 	}
 	if req.DeniedDomains != nil {
 		policy.SetDeniedDomains(*req.DeniedDomains)
+	}
+	if req.CountMode != nil {
+		policy.SetCountMode(*req.CountMode)
 	}
 
 	if err := c.repo.Update(ctx.Request().Context(), policy); err != nil {
@@ -405,6 +414,7 @@ func (c *SandboxPolicyController) toResponse(p *entities.SandboxPolicy) *Sandbox
 		Description:    p.Description(),
 		AllowedDomains: p.AllowedDomains(),
 		DeniedDomains:  p.DeniedDomains(),
+		CountMode:      p.CountMode(),
 		Scope:          string(p.Scope()),
 		OwnerID:        p.OwnerID(),
 		TeamID:         p.TeamID(),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -894,7 +894,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
-	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.5.0")
+	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:v0.6.0")
 	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
 	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
 	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -894,7 +894,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
-	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:v0.6.0")
+	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.6.0")
 	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
 	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
 	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5434,6 +5434,11 @@
             "description": "Denylist: these domains are blocked. Used only when allowed_domains is empty.",
             "example": ["raw.githubusercontent.com"]
           },
+          "count_mode": {
+            "type": "boolean",
+            "description": "When true, policy rules are evaluated and blocked domains are recorded, but traffic is not actually blocked. Useful for auditing policies before enforcing them in production. Requires nfa v0.6.0+.",
+            "default": false
+          },
           "scope": {
             "type": "string",
             "enum": ["user", "team"],
@@ -5472,6 +5477,11 @@
             "type": "array",
             "items": {"type": "string"}
           },
+          "count_mode": {
+            "type": "boolean",
+            "description": "When true, enables count mode: policy rules are evaluated and blocked domains are recorded, but traffic is not actually blocked.",
+            "default": false
+          },
           "scope": {"type": "string", "enum": ["user", "team"]},
           "team_id": {"type": "string"}
         }
@@ -5488,6 +5498,11 @@
           "denied_domains": {
             "type": "array",
             "items": {"type": "string"}
+          },
+          "count_mode": {
+            "type": "boolean",
+            "description": "When true, enables count mode: policy rules are evaluated and blocked domains are recorded, but traffic is not actually blocked.",
+            "default": false
           }
         }
       },

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5394,6 +5394,11 @@
               "example.com",
               "*.evil.com"
             ]
+          },
+          "count_mode": {
+            "type": "boolean",
+            "description": "When true, enables count mode: policy rules are evaluated and blocked domains are recorded, but traffic is not actually blocked. Useful for auditing policies before enforcing them in production. Requires nfa v0.6.0+.",
+            "default": false
           }
         }
       },


### PR DESCRIPTION
## Summary

- `SandboxParams` に `count_mode` フィールドを追加（nfa v0.6.0 の COUNT モードに対応）
- `NETWORK_FILTER_COUNT_MODE=true` 環境変数を nfa サイドカーに渡すよう `buildSandboxContainers` を更新
- デフォルトの nfa イメージを `0.5.0` → `v0.6.0` にバンプ（`pkg/config/config.go` と Helm values）
- `spec/openapi.json` の `SandboxParams` に `count_mode` フィールドを追加

## count mode とは

nfa v0.6.0 で追加された機能。ポリシールールを評価してブロック対象ドメインを記録するが、トラフィックは実際にはブロックしない。本番適用前のポリシー監査に利用できる。

- `NETWORK_FILTER_COUNT_MODE=true` 環境変数で有効化
- API: `sandbox.count_mode: true`

## Test plan

- [ ] `SandboxParams.CountMode = true` のセッション作成時に `NETWORK_FILTER_COUNT_MODE=true` が nfa サイドカーに渡されることを確認
- [ ] count mode 有効時にトラフィックがブロックされないことを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)