### PR TITLE
feat(sandbox): add ignored domain list to sandbox policy domains

### DIFF
--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -385,6 +385,7 @@ func (r *Router) registerConditionalRoutes() error {
 		r.echo.GET("/sandbox-policies", r.handlers.sandboxPolicyController.ListSandboxPolicies, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.GET("/sandbox-policies/:id", r.handlers.sandboxPolicyController.GetSandboxPolicy, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.GET("/sandbox-policies/:id/domains", r.handlers.sandboxPolicyController.GetSandboxPolicyDomains, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.PUT("/sandbox-policies/:id/domains/ignored", r.handlers.sandboxPolicyController.UpdateIgnoredDomains, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		r.echo.PUT("/sandbox-policies/:id", r.handlers.sandboxPolicyController.UpdateSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		r.echo.DELETE("/sandbox-policies/:id", r.handlers.sandboxPolicyController.DeleteSandboxPolicy, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		log.Printf("[ROUTES] Sandbox policy endpoints registered")

--- a/internal/app/sandbox_domain_collector.go
+++ b/internal/app/sandbox_domain_collector.go
@@ -107,9 +107,16 @@ func (c *SandboxDomainCollector) collect(ctx context.Context) {
 			denied = append(denied, d)
 		}
 
+		// Preserve the existing ignored list so user dismissals survive re-collection.
+		var ignored []string
+		if existing, err := c.domainRepo.Get(ctx, policyID); err == nil && existing != nil {
+			ignored = existing.Ignored
+		}
+
 		data := &repositories.SandboxDomainData{
 			Allowed:   allowed,
 			Denied:    denied,
+			Ignored:   ignored,
 			UpdatedAt: time.Now(),
 		}
 		if err := c.domainRepo.Upsert(ctx, policyID, data); err != nil {

--- a/internal/infrastructure/repositories/kubernetes_sandbox_domain_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_sandbox_domain_repository.go
@@ -24,6 +24,7 @@ const (
 type SandboxDomainData struct {
 	Allowed   []string  `json:"allowed"`
 	Denied    []string  `json:"denied"`
+	Ignored   []string  `json:"ignored,omitempty"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 

--- a/internal/interfaces/controllers/sandbox_policy_controller.go
+++ b/internal/interfaces/controllers/sandbox_policy_controller.go
@@ -297,11 +297,77 @@ func (c *SandboxPolicyController) DeleteSandboxPolicy(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, map[string]bool{"success": true})
 }
 
+// UpdateIgnoredDomains handles PUT /sandbox-policies/:id/domains/ignored.
+// Replaces the ignored domain list for the given policy's collected domain data.
+func (c *SandboxPolicyController) UpdateIgnoredDomains(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	if c.domainRepo == nil {
+		return echo.NewHTTPError(http.StatusNotImplemented, "Domain collection not available")
+	}
+
+	policy, err := c.repo.GetByID(ctx.Request().Context(), ctx.Param("id"))
+	if err != nil {
+		var notFound entities.ErrSandboxPolicyNotFound
+		if errors.As(err, &notFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "Sandbox policy not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get sandbox policy")
+	}
+	if !c.canModify(user, policy) {
+		return echo.NewHTTPError(http.StatusForbidden, "Access denied")
+	}
+
+	var req UpdateIgnoredDomainsRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	data, err := c.domainRepo.Get(ctx.Request().Context(), policy.ID())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read domain data")
+	}
+	if data == nil {
+		data = &repositories.SandboxDomainData{}
+	}
+	data.Ignored = req.Ignored
+
+	if err := c.domainRepo.Upsert(ctx.Request().Context(), policy.ID(), data); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update ignored domains")
+	}
+
+	resp := SandboxPolicyDomainsResponse{
+		Allowed:   data.Allowed,
+		Denied:    data.Denied,
+		Ignored:   data.Ignored,
+		UpdatedAt: data.UpdatedAt.Format(time.RFC3339),
+	}
+	if resp.Allowed == nil {
+		resp.Allowed = []string{}
+	}
+	if resp.Denied == nil {
+		resp.Denied = []string{}
+	}
+	if resp.Ignored == nil {
+		resp.Ignored = []string{}
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
 // SandboxPolicyDomainsResponse is the JSON body returned by GET /sandbox-policies/:id/domains.
 type SandboxPolicyDomainsResponse struct {
 	Allowed   []string `json:"allowed"`
 	Denied    []string `json:"denied"`
+	Ignored   []string `json:"ignored"`
 	UpdatedAt string   `json:"updated_at,omitempty"`
+}
+
+// UpdateIgnoredDomainsRequest is the JSON body for PUT /sandbox-policies/:id/domains/ignored.
+type UpdateIgnoredDomainsRequest struct {
+	Ignored []string `json:"ignored"`
 }
 
 // GetSandboxPolicyDomains handles GET /sandbox-policies/:id/domains.
@@ -337,12 +403,14 @@ func (c *SandboxPolicyController) GetSandboxPolicyDomains(ctx echo.Context) erro
 		return ctx.JSON(http.StatusOK, SandboxPolicyDomainsResponse{
 			Allowed: []string{},
 			Denied:  []string{},
+			Ignored: []string{},
 		})
 	}
 
 	resp := SandboxPolicyDomainsResponse{
 		Allowed:   data.Allowed,
 		Denied:    data.Denied,
+		Ignored:   data.Ignored,
 		UpdatedAt: data.UpdatedAt.Format(time.RFC3339),
 	}
 	if resp.Allowed == nil {
@@ -350,6 +418,9 @@ func (c *SandboxPolicyController) GetSandboxPolicyDomains(ctx echo.Context) erro
 	}
 	if resp.Denied == nil {
 		resp.Denied = []string{}
+	}
+	if resp.Ignored == nil {
+		resp.Ignored = []string{}
 	}
 	return ctx.JSON(http.StatusOK, resp)
 }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -461,7 +461,7 @@
     "/sandbox-policies/{id}/domains": {
       "get": {
         "summary": "Get aggregated domains for a sandbox policy",
-        "description": "Returns the allowed/denied domain lists collected by the background domain collector from all sessions using this policy. Data is refreshed every 60 seconds. Returns empty lists when no data has been collected yet.",
+        "description": "Returns the allowed/denied/ignored domain lists collected by the background domain collector from all sessions using this policy. Data is refreshed every 60 seconds. Returns empty lists when no data has been collected yet.",
         "operationId": "getSandboxPolicyDomains",
         "tags": [
           "Sandbox"
@@ -495,17 +495,101 @@
                       "items": { "type": "string" },
                       "description": "Domains blocked by the filter"
                     },
+                    "ignored": {
+                      "type": "array",
+                      "items": { "type": "string" },
+                      "description": "Domains the user has chosen to ignore (not shown as suggestions)"
+                    },
                     "updated_at": {
                       "type": "string",
                       "format": "date-time",
                       "description": "When the data was last collected"
                     }
                   },
-                  "required": ["allowed", "denied"]
+                  "required": ["allowed", "denied", "ignored"]
                 }
               }
             }
           },
+          "401": { "description": "Unauthorized" },
+          "403": { "description": "Forbidden" },
+          "404": { "description": "Sandbox policy not found" },
+          "501": { "description": "Domain collection not available" }
+        },
+        "security": [
+          { "ApiKeyAuth": [] },
+          { "BearerAuth": [] }
+        ]
+      }
+    },
+    "/sandbox-policies/{id}/domains/ignored": {
+      "put": {
+        "summary": "Update the ignored domain list for a sandbox policy",
+        "description": "Replaces the ignored domain list stored in the collected domain data for the given policy. Ignored domains are suppressed from the import suggestion UI so users are not repeatedly prompted to act on them.",
+        "operationId": "updateSandboxPolicyIgnoredDomains",
+        "tags": [
+          "Sandbox"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Sandbox policy ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ignored": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Full list of domains to ignore"
+                  }
+                },
+                "required": ["ignored"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated domain lists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "allowed": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "denied": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "ignored": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": ["allowed", "denied", "ignored"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid request body" },
           "401": { "description": "Unauthorized" },
           "403": { "description": "Forbidden" },
           "404": { "description": "Sandbox policy not found" },


### PR DESCRIPTION
## Summary

- `SandboxDomainData` に `ignored` フィールドを追加し、ユーザーが「無視」したドメインを永続化
- バックグラウンドコレクターが更新時に ignored リストを保持するよう修正
- `GET /sandbox-policies/:id/domains` レスポンスに `ignored` フィールドを追加
- 新エンドポイント `PUT /sandbox-policies/:id/domains/ignored` を追加（ignored リストをまとめて更新）
- OpenAPI spec を更新

## Test plan

- [ ] `GET /sandbox-policies/:id/domains` のレスポンスに `ignored: []` が含まれることを確認
- [ ] `PUT /sandbox-policies/:id/domains/ignored` で ignored リストを更新できることを確認
- [ ] バックグラウンドコレクター実行後も ignored リストが保持されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)