### PR TITLE
feat(dind): add Docker-in-Docker support with opt-in session config

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -591,10 +591,11 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 	}
 
 	// If no ManagerID is specified, check for a default external session manager.
-	// Skip ESM forwarding when sandbox is requested: the remote proxy may not support
-	// sandbox, and sandbox requires local Kubernetes deployment to add init containers.
+	// Skip ESM forwarding when sandbox or DinD is requested: the remote proxy may not support
+	// these features, which require local Kubernetes deployment to add init containers/sidecars.
 	sandboxRequested := startReq.Params != nil && startReq.Params.Sandbox != nil && startReq.Params.Sandbox.Enabled
-	if !sandboxRequested {
+	dindRequested := startReq.Params != nil && startReq.Params.Docker != nil && startReq.Params.Docker.Enabled
+	if !sandboxRequested && !dindRequested {
 		if defaultESM, err := s.findDefaultESM(context.Background(), userID, teams); err == nil && defaultESM != nil {
 			log.Printf("[SESSION] Using default external session manager %s (%s) for session %s", defaultESM.Name, defaultESM.ID, sessionID)
 			if startReq.Params == nil {

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -681,6 +681,12 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		sandbox = startReq.Params.Sandbox
 	}
 
+	// Determine docker params from Params.Docker
+	var docker *entities.DockerParams
+	if startReq.Params != nil && startReq.Params.Docker != nil {
+		docker = startReq.Params.Docker
+	}
+
 	// Build run server request
 	req := &entities.RunServerRequest{
 		UserID:                   userID,
@@ -700,6 +706,7 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		CycleMessage:             cycleMessage,
 		CycleMaxCount:            cycleMaxCount,
 		Sandbox:                  sandbox,
+		Docker:                   docker,
 	}
 
 	// Delegate to session manager

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -49,6 +49,27 @@ type SandboxParams struct {
 	CountMode bool `json:"count_mode,omitempty"`
 }
 
+// DockerParams holds Docker-in-Docker (DinD) configuration for session creation.
+type DockerParams struct {
+	// Enabled activates the DinD sidecar for this session
+	Enabled bool `json:"enabled,omitempty"`
+	// Registries specifies authenticated container registries
+	Registries []DockerRegistry `json:"registries,omitempty"`
+}
+
+// DockerRegistry holds authentication for a container registry.
+type DockerRegistry struct {
+	// Server is the registry server address (e.g., "ghcr.io", "registry.example.com")
+	Server string `json:"server"`
+	// Username is the registry username for inline credentials
+	Username string `json:"username,omitempty"`
+	// Password is the registry password or access token for inline credentials
+	Password string `json:"password,omitempty"`
+	// SecretName is the name of a K8s Secret containing a "config.json" key
+	// with docker config JSON format for registry authentication.
+	SecretName string `json:"secret_name,omitempty"`
+}
+
 // SessionParams represents session parameters for agentapi server
 type SessionParams struct {
 	// Message is the initial message to send to the agent after session starts
@@ -83,6 +104,8 @@ type SessionParams struct {
 	RepoFullName string `json:"repo_full_name,omitempty"`
 	// Sandbox configures network isolation for the session via a sidecar transparent proxy.
 	Sandbox *SandboxParams `json:"sandbox,omitempty"`
+	// Docker configures Docker-in-Docker (DinD) for the session.
+	Docker *DockerParams `json:"docker,omitempty"`
 }
 
 // StartRequest represents the request body for starting a new agentapi server
@@ -130,6 +153,8 @@ type RunServerRequest struct {
 	CycleMaxCount            int               // Maximum number of cycles (0 = unlimited); requires CycleMessage
 	// Sandbox configures network isolation for the session.
 	Sandbox *SandboxParams
+	// Docker configures Docker-in-Docker (DinD) for the session.
+	Docker *DockerParams
 	// ProvisionSettings, when non-nil, is used directly as the provision payload
 	// instead of building it from the other request fields.
 	// Used by the session manager forwarding path (small-cluster mode).

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -320,10 +320,11 @@ func (m *KubernetesSessionManager) StopStatusSubscriber() {
 // If no stock is available, a new session is created from scratch.
 func (m *KubernetesSessionManager) CreateSession(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error) {
 	// Attempt to adopt a stock session before creating a new one.
-	// Skip stock adoption when sandbox is enabled: stock pods lack the init container
-	// and network-filter sidecar, so they cannot enforce network isolation.
+	// Skip stock adoption when sandbox or DinD is enabled: stock pods lack the required
+	// sidecars and would not function correctly for those features.
 	sandboxRequested := req.Sandbox != nil && req.Sandbox.Enabled
-	if !sandboxRequested {
+	dindRequested := req.Docker != nil && req.Docker.Enabled
+	if !sandboxRequested && !dindRequested {
 		if stockSvc, err := m.findStockSession(ctx); err != nil {
 			log.Printf("[K8S_SESSION] Warning: failed to search for stock sessions: %v", err)
 		} else if stockSvc != nil {
@@ -1634,6 +1635,31 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 		initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(effectiveSandbox)
 	}
 
+	// Build DinD sidecar if Docker-in-Docker is enabled.
+	dindEnabled := req.Docker != nil && req.Docker.Enabled
+	var dindSidecar *corev1.Container
+	var dindEnvVars []corev1.EnvVar
+	var dindVolumes []corev1.Volume
+	if dindEnabled {
+		var dockerConfig *sessionsettings.DockerConfig
+		if req.Docker != nil {
+			registries := make([]sessionsettings.RegistryConfig, 0, len(req.Docker.Registries))
+			for _, r := range req.Docker.Registries {
+				registries = append(registries, sessionsettings.RegistryConfig{
+					Server:     r.Server,
+					Username:   r.Username,
+					Password:   r.Password,
+					SecretName: r.SecretName,
+				})
+			}
+			dockerConfig = &sessionsettings.DockerConfig{
+				Enabled:    true,
+				Registries: registries,
+			}
+		}
+		dindSidecar, dindEnvVars, dindVolumes = m.buildDinDContainers(dockerConfig)
+	}
+
 	// Determine working directory
 	// Always use /home/agentapi/workdir as base; clone-repo will create /home/agentapi/workdir/repo
 	// Setting workingDir to repo path would cause Kubernetes to pre-create the dir as root
@@ -1708,7 +1734,7 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env:     append(envVars, sandboxEnvVars...),
+		Env:     append(append(envVars, sandboxEnvVars...), dindEnvVars...),
 		EnvFrom: envFrom,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
@@ -1764,6 +1790,9 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 			},
 		})
 	}
+	if dindEnabled {
+		volumes = append(volumes, dindVolumes...)
+	}
 
 	// Build containers list.
 	// Note: credentials-sync is now handled as a goroutine inside agent-provisioner
@@ -1772,6 +1801,9 @@ func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session
 	containers := []corev1.Container{container}
 	if sandboxSidecar != nil {
 		containers = append(containers, *sandboxSidecar)
+	}
+	if dindSidecar != nil {
+		containers = append(containers, *dindSidecar)
 	}
 
 	// Note: Initial message is now sent by agent-provisioner internally after agentapi
@@ -2126,6 +2158,90 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 	}
 
 	return []corev1.Container{initContainer}, &sidecar, proxyEnvVars
+}
+
+// buildDinDContainers returns the DinD sidecar container, env vars for the main container,
+// and extra volumes needed for Docker-in-Docker support.
+// The DinD daemon listens on TCP port 2375 (no TLS) so no socket volume sharing is needed.
+// The main container gets DOCKER_HOST=tcp://127.0.0.1:2375 to connect to the daemon.
+func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.DockerConfig) (*corev1.Container, []corev1.EnvVar, []corev1.Volume) {
+	dindImage := m.k8sConfig.DinDImage
+	if dindImage == "" {
+		dindImage = "docker:27-dind"
+	}
+
+	trueVal := true
+	falseVal := false
+	rootUID := int64(0)
+
+	sidecar := corev1.Container{
+		Name:            "docker-dind",
+		Image:           dindImage,
+		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
+		Args:            []string{"dockerd", "--host=tcp://0.0.0.0:2375", "--tls=false"},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged:   &trueVal,
+			RunAsUser:    &rootUID,
+			RunAsNonRoot: &falseVal,
+		},
+		Resources: buildResourceRequirements(
+			m.k8sConfig.DinDCPURequest,
+			m.k8sConfig.DinDCPULimit,
+			m.k8sConfig.DinDMemoryRequest,
+			m.k8sConfig.DinDMemoryLimit,
+		),
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "docker-storage",
+				MountPath: "/var/lib/docker",
+			},
+		},
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: "docker-storage",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+
+	// Resolve registry secret: session-level SecretName takes priority over cluster-wide default.
+	registrySecretName := m.k8sConfig.DinDRegistrySecretName
+	if docker != nil {
+		for _, reg := range docker.Registries {
+			if reg.SecretName != "" {
+				registrySecretName = reg.SecretName
+				break
+			}
+		}
+	}
+
+	if registrySecretName != "" {
+		sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
+			Name:      "docker-registry-config",
+			MountPath: "/root/.docker/config.json",
+			SubPath:   "config.json",
+			ReadOnly:  true,
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "docker-registry-config",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: registrySecretName,
+					Optional:   boolPtr(true),
+				},
+			},
+		})
+	}
+
+	// Set DOCKER_HOST in the main container so docker CLI commands connect to the DinD daemon.
+	mainEnvVars := []corev1.EnvVar{
+		{Name: "DOCKER_HOST", Value: "tcp://127.0.0.1:2375"},
+	}
+
+	return &sidecar, mainEnvVars, volumes
 }
 
 // buildResourceRequirements constructs a corev1.ResourceRequirements from string quantities.
@@ -4174,6 +4290,24 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			DeniedDomains:  req.Sandbox.DeniedDomains,
 		}
 		log.Printf("[K8S_SESSION] Network sandbox enabled for session %s (policy: %s, allowed: %v, denied: %v)", session.id, req.Sandbox.PolicyID, req.Sandbox.AllowedDomains, req.Sandbox.DeniedDomains)
+	}
+
+	// Embed Docker-in-Docker configuration when enabled.
+	if req.Docker != nil && req.Docker.Enabled {
+		registries := make([]sessionsettings.RegistryConfig, 0, len(req.Docker.Registries))
+		for _, r := range req.Docker.Registries {
+			registries = append(registries, sessionsettings.RegistryConfig{
+				Server:     r.Server,
+				Username:   r.Username,
+				Password:   r.Password,
+				SecretName: r.SecretName,
+			})
+		}
+		settings.Docker = &sessionsettings.DockerConfig{
+			Enabled:    true,
+			Registries: registries,
+		}
+		log.Printf("[K8S_SESSION] DinD enabled for session %s (registries: %d)", session.id, len(registries))
 	}
 
 	return settings

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -1009,6 +1009,9 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 	if override.Sandbox != nil {
 		merged.Sandbox = override.Sandbox
 	}
+	if override.Docker != nil {
+		merged.Docker = override.Docker
+	}
 	return &merged
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -330,6 +330,25 @@ type KubernetesSessionConfig struct {
 	NetworkFilterInitCPULimit      string `json:"network_filter_init_cpu_limit" mapstructure:"network_filter_init_cpu_limit"`
 	NetworkFilterInitMemoryRequest string `json:"network_filter_init_memory_request" mapstructure:"network_filter_init_memory_request"`
 	NetworkFilterInitMemoryLimit   string `json:"network_filter_init_memory_limit" mapstructure:"network_filter_init_memory_limit"`
+
+	// DinD (Docker in Docker) sidecar configuration.
+	// Sessions with docker.enabled=true in their params get a privileged DinD sidecar
+	// and DOCKER_HOST set so the main container can run docker commands.
+
+	// DinDImage is the container image for the DinD sidecar.
+	// Defaults to "docker:27-dind" if not specified.
+	DinDImage string `json:"dind_image" mapstructure:"dind_image"`
+
+	// DinD sidecar resource configuration
+	DinDCPURequest    string `json:"dind_cpu_request" mapstructure:"dind_cpu_request"`
+	DinDCPULimit      string `json:"dind_cpu_limit" mapstructure:"dind_cpu_limit"`
+	DinDMemoryRequest string `json:"dind_memory_request" mapstructure:"dind_memory_request"`
+	DinDMemoryLimit   string `json:"dind_memory_limit" mapstructure:"dind_memory_limit"`
+
+	// DinDRegistrySecretName is the name of a K8s Secret containing a "config.json" key
+	// with docker config JSON format. When set, this secret is mounted into the DinD
+	// container so the daemon can pull from authenticated registries cluster-wide.
+	DinDRegistrySecretName string `json:"dind_registry_secret_name" mapstructure:"dind_registry_secret_name"`
 }
 
 // MemoryConfig represents memory backend configuration

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -99,6 +99,11 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	}
 	log.Printf("[PROVISIONER] Session setup complete")
 
+	// ── Step 2.3: docker login for DinD registries ───────────────────────────
+	if settings.Docker != nil && settings.Docker.Enabled {
+		go s.runDockerLogins(ctx, settings.Docker)
+	}
+
 	// ── Step 2.5: restore managed files from provision payload ───────────────
 	// Files are embedded in SessionSettings.Files by the proxy at session creation
 	// time (read from agentapi-agent-files-{userID} Secret).
@@ -231,6 +236,66 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 			s.setStatus(StatusError, "agent process exited with code 0")
 		}
 	}()
+}
+
+// runDockerLogins runs in the background after DinD is enabled: waits for the docker daemon
+// to be ready, then runs docker login for each registry with inline credentials.
+// Secret-based registries are already mounted as /root/.docker/config.json in the DinD
+// container, so they need no docker login call here.
+func (s *Server) runDockerLogins(ctx context.Context, docker *sessionsettings.DockerConfig) {
+	if docker == nil || !docker.Enabled {
+		return
+	}
+
+	// Check if there are any inline credentials to log in with.
+	hasInlineCreds := false
+	for _, reg := range docker.Registries {
+		if reg.Username != "" && reg.Password != "" {
+			hasInlineCreds = true
+			break
+		}
+	}
+	if !hasInlineCreds {
+		return
+	}
+
+	// Wait for the DinD daemon to be ready (up to 120 seconds).
+	log.Printf("[PROVISIONER] Waiting for Docker daemon to be ready")
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		cmd := exec.CommandContext(ctx, "docker", "info")
+		if err := cmd.Run(); err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			log.Printf("[PROVISIONER] Context cancelled while waiting for Docker daemon")
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
+	log.Printf("[PROVISIONER] Docker daemon is ready")
+
+	// Run docker login for each registry with inline credentials.
+	for _, reg := range docker.Registries {
+		if reg.Username == "" || reg.Password == "" {
+			continue
+		}
+		log.Printf("[PROVISIONER] Logging into registry %s as %s", reg.Server, reg.Username)
+		args := []string{"login", "-u", reg.Username, "--password-stdin"}
+		if reg.Server != "" {
+			args = append(args, reg.Server)
+		}
+		cmd := exec.CommandContext(ctx, "docker", args...)
+		cmd.Stdin = strings.NewReader(reg.Password)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Printf("[PROVISIONER] Warning: docker login for %s failed: %v", reg.Server, err)
+		} else {
+			log.Printf("[PROVISIONER] Successfully logged into registry %s", reg.Server)
+		}
+	}
 }
 
 // runPreScript executes the pre-script shell snippet before the agent process starts.

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -124,6 +124,28 @@ type SandboxConfig struct {
 	DeniedDomains  []string `yaml:"denied_domains,omitempty"  json:"denied_domains,omitempty"`
 }
 
+// DockerConfig holds Docker-in-Docker (DinD) configuration for a session Pod.
+// When Enabled is true, a DinD sidecar is added to the session Pod and
+// DOCKER_HOST is set so the main container can communicate with the docker daemon.
+type DockerConfig struct {
+	Enabled    bool             `yaml:"enabled"              json:"enabled"`
+	Registries []RegistryConfig `yaml:"registries,omitempty" json:"registries,omitempty"`
+}
+
+// RegistryConfig holds authentication configuration for a container registry.
+type RegistryConfig struct {
+	// Server is the registry server address (e.g., "ghcr.io", "registry.example.com")
+	Server string `yaml:"server"                json:"server"`
+	// Username is the registry username for inline credentials
+	Username string `yaml:"username,omitempty"    json:"username,omitempty"`
+	// Password is the registry password or access token for inline credentials
+	Password string `yaml:"password,omitempty"    json:"password,omitempty"`
+	// SecretName is the name of a K8s Secret containing a "config.json" key
+	// with docker config JSON. When set, Username/Password are ignored for mounting
+	// (inline credentials are still used for docker login by the provisioner).
+	SecretName string `yaml:"secret_name,omitempty" json:"secret_name,omitempty"`
+}
+
 // SessionSettings is the top-level unified settings YAML structure.
 // It consolidates all configuration needed for a session Pod.
 type SessionSettings struct {
@@ -139,6 +161,7 @@ type SessionSettings struct {
 	SlackParams    *SlackParams         `yaml:"slack_params,omitempty"    json:"slack_params,omitempty"`
 	OtelCollector  *OtelCollectorConfig `yaml:"otel_collector,omitempty"  json:"otel_collector,omitempty"`
 	Sandbox        *SandboxConfig       `yaml:"sandbox,omitempty"         json:"sandbox,omitempty"`
+	Docker         *DockerConfig        `yaml:"docker,omitempty"          json:"docker,omitempty"`
 	// Files holds the managed files to be restored at session startup.
 	// They are read from the agentapi-agent-files-{userID} Secret at session creation
 	// time and written to their respective paths by the provisioner.

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5440,6 +5440,51 @@
           },
           "sandbox": {
             "$ref": "#/components/schemas/SandboxParams"
+          },
+          "docker": {
+            "$ref": "#/components/schemas/DockerParams"
+          }
+        }
+      },
+      "DockerParams": {
+        "type": "object",
+        "description": "Docker-in-Docker (DinD) configuration for the session. When enabled, a privileged DinD sidecar is injected into the session Pod and DOCKER_HOST is set so the main container can run docker commands.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "When true, a DinD sidecar (docker:dind) is added to the session Pod and DOCKER_HOST=tcp://127.0.0.1:2375 is set in the main container.",
+            "default": false
+          },
+          "registries": {
+            "type": "array",
+            "description": "Authenticated container registries. Supports inline credentials (username/password) or a reference to a Kubernetes Secret containing docker config JSON.",
+            "items": {
+              "$ref": "#/components/schemas/DockerRegistry"
+            }
+          }
+        }
+      },
+      "DockerRegistry": {
+        "type": "object",
+        "description": "Authentication configuration for a container registry.",
+        "properties": {
+          "server": {
+            "type": "string",
+            "description": "Registry server address (e.g. 'ghcr.io', 'registry.example.com'). Leave empty for Docker Hub.",
+            "example": "ghcr.io"
+          },
+          "username": {
+            "type": "string",
+            "description": "Registry username for inline credentials. Used together with password."
+          },
+          "password": {
+            "type": "string",
+            "description": "Registry password or access token for inline credentials."
+          },
+          "secret_name": {
+            "type": "string",
+            "description": "Name of a Kubernetes Secret containing a 'config.json' key with docker config JSON. When set, this secret is mounted into the DinD container for daemon-level auth. Takes priority over cluster-wide dind_registry_secret_name.",
+            "example": "my-registry-secret"
           }
         }
       },


### PR DESCRIPTION
## Summary

- Add DinD (Docker in Docker) support opt-in per session via `params.docker.enabled=true`
- When enabled, a privileged `docker:dind` sidecar is added to the session Pod and `DOCKER_HOST=tcp://127.0.0.1:2375` is set in the main container
- Support authenticated container registries via inline credentials (provisioner runs `docker login`) or K8s Secret reference (mounted as `/root/.docker/config.json` in DinD)

## Changes

**New session API params:**
```json
{
  "params": {
    "docker": {
      "enabled": true,
      "registries": [
        {
          "server": "ghcr.io",
          "username": "myuser",
          "password": "ghp_xxx"
        },
        {
          "server": "registry.example.com",
          "secret_name": "my-registry-secret"
        }
      ]
    }
  }
}
```

**New Helm/config fields for `KubernetesSessionConfig`:**
- `dind_image` - DinD image (default: `docker:27-dind`)
- `dind_cpu_request/limit`, `dind_memory_request/limit` - resource limits
- `dind_registry_secret_name` - cluster-wide default docker config secret

**Architecture:**
- DinD daemon listens on TCP port 2375 (no TLS) — no socket volume sharing needed
- Main container gets `DOCKER_HOST=tcp://127.0.0.1:2375`
- Registry secret (if any) mounted as `/root/.docker/config.json` in DinD container
- Inline credentials: provisioner waits for DinD readiness, then runs `docker login`
- Stock session adoption skipped when DinD is requested

## Test plan

- [x] `make build` passes
- [x] `make lint` passes (0 issues)
- [x] All tests pass (`go test ./...`)
- [ ] Deploy to dev environment and verify DinD sidecar appears in session Pod
- [ ] Test `docker info` command from within a DinD-enabled session
- [ ] Test docker pull from authenticated registry

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)