### PR TITLE
feat(dockerfile): add docker CLI binary to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ COPY --from=agentapi-builder /agentapi /usr/local/bin/agentapi
 # Copy github-mcp-server binary from official image
 COPY --from=ghcr.io/github/github-mcp-server:v0.26.3 /server/github-mcp-server /usr/local/bin/
 
+# Copy docker CLI binary only (no daemon)
+COPY --from=docker:27-cli /usr/local/bin/docker /usr/local/bin/docker
+
 # Download acp-posts binary for Slack integration subprocess
 ARG ACP_POSTS_VERSION=v0.1.0
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,10 @@ COPY --from=agentapi-builder /agentapi /usr/local/bin/agentapi
 # Copy github-mcp-server binary from official image
 COPY --from=ghcr.io/github/github-mcp-server:v0.26.3 /server/github-mcp-server /usr/local/bin/
 
-# Copy docker CLI binary only (no daemon)
+# Copy docker CLI binary and compose plugin (no daemon)
 COPY --from=docker:27-cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker:27-cli /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
+RUN sudo ln -sf /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
 # Download acp-posts binary for Slack integration subprocess
 ARG ACP_POSTS_VERSION=v0.1.0


### PR DESCRIPTION
## Summary

- `docker:27-cli` イメージから `docker` バイナリのみをコピー
- デーモンやその他コンポーネントは含まず、CLI バイナリだけを追加
- DinD サイドカーが有効なセッションで `docker` コマンドが使えるようになる

## Test plan

- [ ] イメージをビルドして `docker version --client` が動作することを確認
- [ ] DinD 有効セッションで `docker ps` 等が疎通することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)