### PR TITLE
fix(config): wire dind_registry_secret_name env var binding and Helm value

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -254,6 +254,10 @@ spec:
             - name: AGENTAPI_K8S_SESSION_CONFIG_FILE
               value: "/etc/k8s-session-config/k8s-session-config.yaml"
             {{- end }}
+            {{- if (.Values.kubernetesSession).dindRegistrySecretName }}
+            - name: AGENTAPI_K8S_SESSION_DIND_REGISTRY_SECRET_NAME
+              value: {{ .Values.kubernetesSession.dindRegistrySecretName | quote }}
+            {{- end }}
             # Slack Integration configuration
             # claude-posts runs as a subprocess inside the agentapi container (not as a sidecar)
             {{- $slackIntegration := (.Values.kubernetesSession).slackIntegration }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -410,6 +410,19 @@ kubernetesSession:
   #     effect: "PreferNoSchedule"
   tolerations: []
 
+  # Docker private registry authentication for DinD (Docker-in-Docker) sessions.
+  # Name of a Kubernetes Secret containing a "config.json" key with Docker config JSON.
+  # When set, the secret is mounted into the DinD sidecar container so the daemon can
+  # pull from authenticated registries for all sessions in the cluster.
+  # Create it with:
+  #   kubectl create secret generic docker-registry-config \
+  #     --from-file=config.json=/path/to/.docker/config.json
+  # or:
+  #   kubectl create secret docker-registry docker-registry-config \
+  #     --docker-server=<registry> --docker-username=<user> --docker-password=<pass>
+  #   (then rename the .dockerconfigjson key to config.json)
+  dindRegistrySecretName: ""
+
   # GitHub authentication for repository cloning in session pods
   # A Secret is automatically created when github.app.id and github.app.privateKey.secretName are set
   # The Secret will be used by the clone-repo init container

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -768,6 +768,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")
 	_ = v.BindEnv("kubernetes_session.codex_requirements_configmap_name", "AGENTAPI_K8S_SESSION_CODEX_REQUIREMENTS_CONFIGMAP_NAME")
+	_ = v.BindEnv("kubernetes_session.dind_registry_secret_name", "AGENTAPI_K8S_SESSION_DIND_REGISTRY_SECRET_NAME")
 
 	// MCP servers configuration
 


### PR DESCRIPTION
## Summary

- `DinDRegistrySecretName` が `KubernetesSessionConfig` に存在していたが `BindEnv` 呼び出しがなく、環境変数 `AGENTAPI_K8S_SESSION_DIND_REGISTRY_SECRET_NAME` が無視されていたバグを修正
- Helm chart にも対応する value (`kubernetesSession.dindRegistrySecretName`) と env var テンプレートが存在しなかった問題を修正

## 変更内容

- `pkg/config/config.go`: `kubernetes_session.dind_registry_secret_name` ↔ `AGENTAPI_K8S_SESSION_DIND_REGISTRY_SECRET_NAME` の `BindEnv` 追加
- `helm/agentapi-proxy/values.yaml`: `kubernetesSession.dindRegistrySecretName` フィールドを追加（使用方法コメント付き）
- `helm/agentapi-proxy/templates/deployment.yaml`: `dindRegistrySecretName` が設定されている場合に `AGENTAPI_K8S_SESSION_DIND_REGISTRY_SECRET_NAME` env var を注入するテンプレートを追加

## 開発環境への適用手順

1. Docker config JSON を含む Secret を作成:
   ```bash
   kubectl create secret generic docker-registry-config \
     --from-file=config.json=/path/to/.docker/config.json \
     -n agentapi-ui-dev
   ```
2. Helm values に追加:
   ```yaml
   kubernetesSession:
     dindRegistrySecretName: "docker-registry-config"
   ```
3. `make devbuild` 後に Helm upgrade

## Test plan

- [ ] lint: `0 issues` 確認済み
- [ ] ビルド: `go build ./...` 成功確認済み
- [ ] 開発環境に適用してセッション起動時に private registry へのログインを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)