### PR TITLE
fix(dind): change default DinD image to docker:dind

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -48,21 +48,21 @@ type Server struct {
 	oauthProvider      *auth.GitHubOAuthProvider
 	oauthSessions      sync.Map // sessionID -> OAuthSession
 	notificationSvc    *notification.Service
-	container          *di.Container                      // Internal DI container
-	sessionManager     portrepos.SessionManager           // Session lifecycle manager
-	settingsRepo       portrepos.SettingsRepository       // Settings repository
-	credentialsRepo    portrepos.CredentialsRepository    // Credentials repository
-	shareRepo          portrepos.ShareRepository          // Share repository for session sharing
-	teamConfigRepo     portrepos.TeamConfigRepository     // Team configuration repository
-	memoryRepo         portrepos.MemoryRepository         // Memory repository
-	sandboxPolicyRepo  portrepos.SandboxPolicyRepository                      // Sandbox policy repository
-	sandboxDomainRepo  *repositories.KubernetesSandboxDomainRepository        // Sandbox domain log repository
-	taskRepo           portrepos.TaskRepository           // Task repository
-	taskGroupRepo      portrepos.TaskGroupRepository      // Task group repository
-	sessionRouteRepo   portrepos.SessionRouteRepository   // Session route repository for proxy B routing
-	userFileRepo       portrepos.UserFileRepository       // User-managed files repository
-	sessionProfileRepo portrepos.SessionProfileRepository // Session profile repository
-	router             *Router                            // Router for custom handler registration
+	container          *di.Container                                   // Internal DI container
+	sessionManager     portrepos.SessionManager                        // Session lifecycle manager
+	settingsRepo       portrepos.SettingsRepository                    // Settings repository
+	credentialsRepo    portrepos.CredentialsRepository                 // Credentials repository
+	shareRepo          portrepos.ShareRepository                       // Share repository for session sharing
+	teamConfigRepo     portrepos.TeamConfigRepository                  // Team configuration repository
+	memoryRepo         portrepos.MemoryRepository                      // Memory repository
+	sandboxPolicyRepo  portrepos.SandboxPolicyRepository               // Sandbox policy repository
+	sandboxDomainRepo  *repositories.KubernetesSandboxDomainRepository // Sandbox domain log repository
+	taskRepo           portrepos.TaskRepository                        // Task repository
+	taskGroupRepo      portrepos.TaskGroupRepository                   // Task group repository
+	sessionRouteRepo   portrepos.SessionRouteRepository                // Session route repository for proxy B routing
+	userFileRepo       portrepos.UserFileRepository                    // User-managed files repository
+	sessionProfileRepo portrepos.SessionProfileRepository              // Session profile repository
+	router             *Router                                         // Router for custom handler registration
 }
 
 // NewServer creates a new server instance

--- a/internal/infrastructure/repositories/kubernetes_sandbox_domain_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_sandbox_domain_repository.go
@@ -81,7 +81,7 @@ func (r *KubernetesSandboxDomainRepository) Upsert(ctx context.Context, policyID
 				Name:      name,
 				Namespace: r.namespace,
 				Labels: map[string]string{
-					LabelSandboxDomainType: LabelSandboxDomainTypeValue,
+					LabelSandboxDomainType:     LabelSandboxDomainTypeValue,
 					"agentapi.proxy/policy-id": policyID,
 				},
 			},

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2168,7 +2168,7 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.DockerConfig) (*corev1.Container, []corev1.EnvVar, []corev1.Volume) {
 	dindImage := m.k8sConfig.DinDImage
 	if dindImage == "" {
-		dindImage = "docker:27-dind"
+		dindImage = "docker:dind"
 	}
 
 	trueVal := true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -336,7 +336,7 @@ type KubernetesSessionConfig struct {
 	// and DOCKER_HOST set so the main container can run docker commands.
 
 	// DinDImage is the container image for the DinD sidecar.
-	// Defaults to "docker:27-dind" if not specified.
+	// Defaults to "docker:dind" if not specified.
 	DinDImage string `json:"dind_image" mapstructure:"dind_image"`
 
 	// DinD sidecar resource configuration


### PR DESCRIPTION
## Summary

- DinD サイドカーのデフォルトイメージを `docker:27-dind` から `docker:dind` に変更

## dockerconfigjson について

現在の実装では、`RegistryConfig.SecretName` を指定した場合のみ K8s Secret が DinD サイドカーにマウントされます。**SecretName を使わず `Username`/`Password` のインライン認証を使えば、Secret を pod 内にマウントせずにレジストリ認証が可能です**（プロビジョナーが `docker login` を直接実行）。

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)