### PR TITLE
feat(dind): set default resource requests/limits for DinD sidecar

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2195,10 +2195,10 @@ func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.D
 			RunAsNonRoot: &falseVal,
 		},
 		Resources: buildResourceRequirements(
-			m.k8sConfig.DinDCPURequest,
-			m.k8sConfig.DinDCPULimit,
-			m.k8sConfig.DinDMemoryRequest,
-			m.k8sConfig.DinDMemoryLimit,
+			defaultIfEmpty(m.k8sConfig.DinDCPURequest, "2"),
+			defaultIfEmpty(m.k8sConfig.DinDCPULimit, "2"),
+			defaultIfEmpty(m.k8sConfig.DinDMemoryRequest, "2Gi"),
+			defaultIfEmpty(m.k8sConfig.DinDMemoryLimit, "2Gi"),
 		),
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -2252,6 +2252,13 @@ func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.D
 	}
 
 	return &sidecar, mainEnvVars, volumes
+}
+
+func defaultIfEmpty(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
 }
 
 // buildResourceRequirements constructs a corev1.ResourceRequirements from string quantities.


### PR DESCRIPTION
## Summary

- DinD サイドカーコンテナに resources が設定されていない問題を修正
- 設定値が空の場合のデフォルト値を追加: CPU=2、Memory=2Gi（requests/limits 共通）
- `config.yaml` で `dind_cpu_request` などを明示的に設定すれば上書き可能

## Test plan

- [ ] ビルド確認: `go build ./...` 通過済み
- [ ] テスト確認: `go test ./...` 全パス済み
- [ ] lint 確認: `golangci-lint run` 0 issues 済み

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)