### PR TITLE
fix(team-cache): replace Get+Update with MergePatch to eliminate ConfigMap conflicts

### DIFF
--- a/internal/infrastructure/repositories/kubernetes_user_team_mapping_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_user_team_mapping_repository.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
@@ -84,8 +85,8 @@ func (r *KubernetesUserTeamMappingRepository) Get(ctx context.Context, username 
 }
 
 // Set stores the team memberships for a given username in the ConfigMap.
-// Creates the ConfigMap if it does not exist.
-// Retries up to 3 times on conflict (409) to handle concurrent updates from multiple pods.
+// Uses merge-patch to avoid resourceVersion conflicts under concurrent writes.
+// Falls back to Create when the ConfigMap doesn't yet exist.
 func (r *KubernetesUserTeamMappingRepository) Set(ctx context.Context, username string, teams []auth.GitHubTeamMembership) error {
 	entry := userTeamMappingEntry{
 		Teams:     teams,
@@ -99,9 +100,9 @@ func (r *KubernetesUserTeamMappingRepository) Set(ctx context.Context, username 
 
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		if err := r.upsert(ctx, username, string(rawJSON)); err != nil {
-			if k8serrors.IsConflict(err) && attempt < maxRetries-1 {
-				// Retry on conflict (concurrent update from another pod)
+		if err := r.patchOrCreate(ctx, username, string(rawJSON)); err != nil {
+			// AlreadyExists means two pods raced to create; retry the patch path.
+			if k8serrors.IsAlreadyExists(err) && attempt < maxRetries-1 {
 				continue
 			}
 			return fmt.Errorf("failed to set team mapping for user %s: %w", username, err)
@@ -112,38 +113,37 @@ func (r *KubernetesUserTeamMappingRepository) Set(ctx context.Context, username 
 	return fmt.Errorf("failed to set team mapping for user %s after %d retries", username, maxRetries)
 }
 
-// upsert creates or updates the ConfigMap with the given user entry.
-func (r *KubernetesUserTeamMappingRepository) upsert(ctx context.Context, username, rawJSON string) error {
-	existing, err := r.client.CoreV1().ConfigMaps(r.namespace).Get(ctx, UserTeamMappingConfigMapName, metav1.GetOptions{})
+// patchOrCreate applies the user entry via merge-patch when the ConfigMap exists,
+// or creates the ConfigMap when it does not. Merge-patch does not require
+// resourceVersion, so concurrent writes to different keys never conflict.
+func (r *KubernetesUserTeamMappingRepository) patchOrCreate(ctx context.Context, username, rawJSON string) error {
+	patch := map[string]interface{}{
+		"data": map[string]string{username: rawJSON},
+	}
+	patchBytes, err := json.Marshal(patch)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get ConfigMap: %w", err)
-		}
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
 
-		// ConfigMap does not exist — create it
-		cm := r.buildConfigMap(map[string]string{username: rawJSON})
-		_, err = r.client.CoreV1().ConfigMaps(r.namespace).Create(ctx, cm, metav1.CreateOptions{})
-		if err != nil {
-			// Another pod may have created it concurrently; treat AlreadyExists as conflict
-			if k8serrors.IsAlreadyExists(err) {
-				return &k8serrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonConflict}}
-			}
-			return fmt.Errorf("failed to create ConfigMap: %w", err)
-		}
+	_, err = r.client.CoreV1().ConfigMaps(r.namespace).Patch(
+		ctx,
+		UserTeamMappingConfigMapName,
+		types.MergePatchType,
+		patchBytes,
+		metav1.PatchOptions{},
+	)
+	if err == nil {
 		return nil
 	}
-
-	// ConfigMap exists — update the user's entry
-	if existing.Data == nil {
-		existing.Data = make(map[string]string)
+	if !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to patch ConfigMap: %w", err)
 	}
-	existing.Data[username] = rawJSON
 
-	_, err = r.client.CoreV1().ConfigMaps(r.namespace).Update(ctx, existing, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to update ConfigMap: %w", err)
-	}
-	return nil
+	// ConfigMap does not exist — create it.
+	cm := r.buildConfigMap(map[string]string{username: rawJSON})
+	_, err = r.client.CoreV1().ConfigMaps(r.namespace).Create(ctx, cm, metav1.CreateOptions{})
+	// Propagate AlreadyExists so the caller can retry the patch path.
+	return err
 }
 
 // buildConfigMap constructs the ConfigMap object with the given data.

--- a/internal/infrastructure/repositories/kubernetes_user_team_mapping_repository_test.go
+++ b/internal/infrastructure/repositories/kubernetes_user_team_mapping_repository_test.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -70,5 +71,51 @@ func TestKubernetesUserTeamMappingRepository_Get_NotFound(t *testing.T) {
 	}
 	if found {
 		t.Fatal("expected found=false for nonexistent user")
+	}
+}
+
+func TestKubernetesUserTeamMappingRepository_Set_Concurrent(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	repo := NewKubernetesUserTeamMappingRepository(client, "default")
+	ctx := context.Background()
+
+	const numGoroutines = 10
+	users := make([]string, numGoroutines)
+	for i := range users {
+		users[i] = "user" + string(rune('a'+i))
+	}
+	teams := []auth.GitHubTeamMembership{{Organization: "org", TeamSlug: "team", TeamName: "team", Role: "pull"}}
+
+	var wg sync.WaitGroup
+	errs := make([]error, numGoroutines)
+	for i, u := range users {
+		wg.Add(1)
+		go func(idx int, username string) {
+			defer wg.Done()
+			errs[idx] = repo.Set(ctx, username, teams)
+		}(i, u)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("Set(%s) failed: %v", users[i], err)
+		}
+	}
+
+	// All users should be readable
+	for _, u := range users {
+		got, found, err := repo.Get(ctx, u)
+		if err != nil {
+			t.Errorf("Get(%s) failed: %v", u, err)
+			continue
+		}
+		if !found {
+			t.Errorf("Get(%s): expected found=true", u)
+			continue
+		}
+		if len(got) != 1 {
+			t.Errorf("Get(%s): expected 1 team, got %d", u, len(got))
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `upsert()` used a Get + Update pattern which requires a matching `resourceVersion`. Under concurrent writes from multiple pods, the object is modified between reads and writes, producing repeated 409 "object has been modified" warnings.
- **Fix**: Replace Get + Update with a `MergePatch` (`types.MergePatchType`). Merge-patch does not carry a `resourceVersion`, so concurrent updates to different user keys in the same ConfigMap can no longer conflict. The retry loop is simplified to only handle the narrow `AlreadyExists` race during initial ConfigMap creation.
- **Test**: Added `TestKubernetesUserTeamMappingRepository_Set_Concurrent` — 10 goroutines writing different users simultaneously, verified with the race detector.

## Error being fixed

```
agentapi-proxy [TEAM_CACHE] Warning: failed to write ConfigMap cache for user xxxx: failed to set team mapping for user xxxx: failed to update ConfigMap: Operation cannot be fulfilled on configmaps "agentapi-user-team-mapping": the object has been modified; please apply your changes to the latest version and try again
```

## Test plan

- [x] `go test -race ./internal/infrastructure/repositories/...` passes
- [x] `golangci-lint run` reports 0 issues
- [ ] Deploy to dev and confirm the warning no longer appears

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)