### PR TITLE
fix(dind): mount workdir volume into DinD sidecar at /home/agentapi/workdir

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2205,6 +2205,10 @@ func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.D
 				Name:      "docker-storage",
 				MountPath: "/var/lib/docker",
 			},
+			{
+				Name:      "workdir",
+				MountPath: "/home/agentapi/workdir",
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- DinD サイドカーコンテナに `workdir` VolumeMount を追加し、`/home/agentapi/workdir` でマウントするように修正
- メインコンテナと同じ `workdir` ボリュームを同じパスで参照できるようになり、compose のボリュームマウントが正常に動作するようになる
- `buildDinDContainers()` 関数 (`kubernetes_session_manager.go:2203`) の `VolumeMounts` スライスに追加

## Test plan

- [ ] DinD 有効セッションを起動し、メインコンテナの `/home/agentapi/workdir` と DinD サイドカーの `/home/agentapi/workdir` が同一ボリュームであることを確認
- [ ] Docker Compose のボリュームマウントがホストパスを解決できることを確認
- [ ] `make lint` / `make test` が通ることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)