### PR TITLE
feat: add per-session and per-profile TTL for automatic deletion

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -345,11 +345,21 @@ func startSlackbotCleanupWorker(configData *config.Config, proxyServer *app.Serv
 		sessionTTL = 72 * time.Hour
 	}
 
+	sessionTTLCheckInterval := 1 * time.Minute
+	if configData.SlackbotCleanupWorker.SessionTTLCheckInterval != "" {
+		if d, err := time.ParseDuration(configData.SlackbotCleanupWorker.SessionTTLCheckInterval); err == nil && d > 0 {
+			sessionTTLCheckInterval = d
+		} else {
+			log.Printf("[SLACKBOT_CLEANUP] Invalid session_ttl_check_interval, using default 1m: %v", err)
+		}
+	}
+
 	workerConfig := slackbotcleanup.CleanupWorkerConfig{
-		CheckInterval: checkInterval,
-		SessionTTL:    sessionTTL,
-		Enabled:       true,
-		DryRun:        configData.SlackbotCleanupWorker.DryRun,
+		CheckInterval:           checkInterval,
+		SessionTTLCheckInterval: sessionTTLCheckInterval,
+		SessionTTL:              sessionTTL,
+		Enabled:                 true,
+		DryRun:                  configData.SlackbotCleanupWorker.DryRun,
 	}
 
 	leaseDuration, err := time.ParseDuration(configData.SlackbotCleanupWorker.LeaseDuration)

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -688,6 +688,12 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		docker = startReq.Params.Docker
 	}
 
+	// Determine session TTL from Params.SessionTTL
+	var sessionTTL string
+	if startReq.Params != nil && startReq.Params.SessionTTL != "" {
+		sessionTTL = startReq.Params.SessionTTL
+	}
+
 	// Build run server request
 	req := &entities.RunServerRequest{
 		UserID:                   userID,
@@ -708,6 +714,7 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		CycleMaxCount:            cycleMaxCount,
 		Sandbox:                  sandbox,
 		Docker:                   docker,
+		SessionTTL:               sessionTTL,
 	}
 
 	// Delegate to session manager

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -108,6 +108,11 @@ type SessionParams struct {
 	Sandbox *SandboxParams `json:"sandbox,omitempty"`
 	// Docker configures Docker-in-Docker (DinD) for the session.
 	Docker *DockerParams `json:"docker,omitempty"`
+	// SessionTTL is the duration after the last message before this session is automatically deleted.
+	// Accepted format: Go duration string (e.g. "48h", "7d" where d=24h, "168h").
+	// Empty string means the global cleanup worker TTL is used for Slackbot sessions;
+	// non-Slackbot sessions without this field are not auto-deleted.
+	SessionTTL string `json:"session_ttl,omitempty"`
 }
 
 // StartRequest represents the request body for starting a new agentapi server
@@ -161,6 +166,9 @@ type RunServerRequest struct {
 	// instead of building it from the other request fields.
 	// Used by the session manager forwarding path (small-cluster mode).
 	ProvisionSettings *sessionsettings.SessionSettings
+	// SessionTTL is the duration after the last message before this session is auto-deleted.
+	// Stored as a Go duration string (e.g. "48h"). Empty means use the global cleanup TTL.
+	SessionTTL string
 }
 
 // Session represents a running agentapi session

--- a/internal/domain/entities/session_profile.go
+++ b/internal/domain/entities/session_profile.go
@@ -30,6 +30,10 @@ type SessionProfileConfig struct {
 	// sandboxPolicyID is a reference to a SandboxPolicy resource.
 	// When set, the sandbox sidecar is enabled automatically with this policy applied.
 	sandboxPolicyID string
+	// sessionTTL overrides the global cleanup worker TTL for sessions created with this profile.
+	// Accepted format: Go duration string (e.g. "48h", "168h").
+	// Empty string means the global cleanup worker TTL is used.
+	sessionTTL string
 }
 
 // NewSessionProfile creates a new SessionProfile
@@ -193,6 +197,12 @@ func (c *SessionProfileConfig) SandboxPolicyID() string { return c.sandboxPolicy
 
 // SetSandboxPolicyID sets the sandbox policy ID
 func (c *SessionProfileConfig) SetSandboxPolicyID(id string) { c.sandboxPolicyID = id }
+
+// SessionTTL returns the session TTL override for this profile
+func (c *SessionProfileConfig) SessionTTL() string { return c.sessionTTL }
+
+// SetSessionTTL sets the session TTL override for this profile
+func (c *SessionProfileConfig) SetSessionTTL(ttl string) { c.sessionTTL = ttl }
 
 // --- Error types ---
 

--- a/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
@@ -55,6 +55,7 @@ type sessionProfileConfigJSON struct {
 	ReuseSession           bool                    `json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
 	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
+	SessionTTL             string                  `json:"session_ttl,omitempty"`
 }
 
 // KubernetesSessionProfileRepository implements SessionProfileRepository using Kubernetes Secrets
@@ -317,6 +318,7 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 	cfg.SetReuseSession(pj.Config.ReuseSession)
 	cfg.SetMemoryKey(pj.Config.MemoryKey)
 	cfg.SetSandboxPolicyID(pj.Config.SandboxPolicyID)
+	cfg.SetSessionTTL(pj.Config.SessionTTL)
 	profile.SetConfig(cfg)
 
 	return profile
@@ -341,6 +343,7 @@ func (r *KubernetesSessionProfileRepository) entityToJSON(profile *entities.Sess
 			ReuseSession:           cfg.ReuseSession(),
 			MemoryKey:              cfg.MemoryKey(),
 			SandboxPolicyID:        cfg.SandboxPolicyID(),
+			SessionTTL:             cfg.SessionTTL(),
 		},
 		CreatedAt: profile.CreatedAt(),
 		UpdatedAt: profile.UpdatedAt(),

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -754,6 +754,9 @@ func (m *KubernetesSessionManager) adoptStockSession(
 	if req.InitialMessage != "" {
 		annotations["agentapi.proxy/initial-message"] = req.InitialMessage
 	}
+	if req.SessionTTL != "" {
+		annotations["agentapi.proxy/session-ttl"] = req.SessionTTL
+	}
 
 	currentSvc, err := m.client.CoreV1().Services(m.namespace).Get(ctx, stockSvc.Name, metav1.GetOptions{})
 	if err != nil {
@@ -2418,6 +2421,9 @@ func (m *KubernetesSessionManager) createService(ctx context.Context, session *K
 	// Record the initial message time as the last message time for all sessions.
 	// This annotation is updated by SendMessage when follow-up messages arrive.
 	annotations["agentapi.proxy/last-message-at"] = session.startedAt.UTC().Format(time.RFC3339)
+	if session.Request().SessionTTL != "" {
+		annotations["agentapi.proxy/session-ttl"] = session.Request().SessionTTL
+	}
 
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3420,6 +3426,9 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// Parse session-ttl annotation if present
+	sessionTTL := svc.Annotations["agentapi.proxy/session-ttl"]
+
 	// Create session using constructor
 	session := NewKubernetesSession(
 		sessionID,
@@ -3432,6 +3441,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 			MemoryKey:      memoryKey,
 			Teams:          teams,
 			Oneshot:        oneshot,
+			SessionTTL:     sessionTTL,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,
@@ -3544,6 +3554,9 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// Parse session-ttl annotation if present
+	sessionTTL := svc.Annotations["agentapi.proxy/session-ttl"]
+
 	// Create session using constructor
 	session := NewKubernetesSession(
 		sessionID,
@@ -3556,6 +3569,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 			MemoryKey:      memoryKey,
 			Teams:          teams,
 			Oneshot:        oneshot,
+			SessionTTL:     sessionTTL,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -237,6 +237,16 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 					startReq.Params.Sandbox.PolicyID = cfg.SandboxPolicyID()
 				}
 			}
+
+			// SessionTTL: apply profile's TTL when request does not already specify one.
+			if cfg.SessionTTL() != "" {
+				if startReq.Params == nil {
+					startReq.Params = &entities.SessionParams{}
+				}
+				if startReq.Params.SessionTTL == "" {
+					startReq.Params.SessionTTL = cfg.SessionTTL()
+				}
+			}
 		}
 	}
 
@@ -1011,6 +1021,9 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 	}
 	if override.Docker != nil {
 		merged.Docker = override.Docker
+	}
+	if override.SessionTTL != "" {
+		merged.SessionTTL = override.SessionTTL
 	}
 	return &merged
 }

--- a/internal/interfaces/controllers/session_profile_controller.go
+++ b/internal/interfaces/controllers/session_profile_controller.go
@@ -39,6 +39,7 @@ type SessionProfileConfigRequest struct {
 	ReuseSession           bool                    `json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
 	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
+	SessionTTL             string                  `json:"session_ttl,omitempty"`
 }
 
 // CreateSessionProfileRequest is the request body for creating a session profile
@@ -83,6 +84,7 @@ type SessionProfileConfigResponse struct {
 	ReuseSession           bool                    `json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
 	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
+	SessionTTL             string                  `json:"session_ttl,omitempty"`
 }
 
 // --- Handlers ---
@@ -318,6 +320,7 @@ func (c *SessionProfileController) requestToConfig(req SessionProfileConfigReque
 		cfg.SetParams(req.Params)
 	}
 	cfg.SetSandboxPolicyID(req.SandboxPolicyID)
+	cfg.SetSessionTTL(req.SessionTTL)
 	return cfg
 }
 
@@ -340,6 +343,7 @@ func (c *SessionProfileController) toResponse(p *entities.SessionProfile) Sessio
 			ReuseSession:           cfg.ReuseSession(),
 			MemoryKey:              cfg.MemoryKey(),
 			SandboxPolicyID:        cfg.SandboxPolicyID(),
+			SessionTTL:             cfg.SessionTTL(),
 		},
 		CreatedAt: p.CreatedAt().Format(time.RFC3339),
 		UpdatedAt: p.UpdatedAt().Format(time.RFC3339),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,6 +167,10 @@ type SlackbotCleanupWorkerConfig struct {
 	CheckInterval string `json:"check_interval" mapstructure:"check_interval"`
 	// SessionTTL is the duration after the last message before a session is deleted (e.g., "72h")
 	SessionTTL string `json:"session_ttl" mapstructure:"session_ttl"`
+	// SessionTTLCheckInterval is how often to scan for non-Slackbot sessions that have an
+	// explicit agentapi.proxy/session-ttl annotation. This can be much shorter than
+	// CheckInterval to support short-lived sessions. Default: "1m"
+	SessionTTLCheckInterval string `json:"session_ttl_check_interval" mapstructure:"session_ttl_check_interval"`
 	// DryRun disables actual deletion; stale sessions are only logged.
 	// Useful for verifying TTL settings before enabling real cleanup.
 	DryRun bool `json:"dry_run" mapstructure:"dry_run"`
@@ -797,6 +801,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("slackbot_cleanup_worker.enabled", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_ENABLED")
 	_ = v.BindEnv("slackbot_cleanup_worker.check_interval", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_CHECK_INTERVAL")
 	_ = v.BindEnv("slackbot_cleanup_worker.session_ttl", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_SESSION_TTL")
+	_ = v.BindEnv("slackbot_cleanup_worker.session_ttl_check_interval", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_SESSION_TTL_CHECK_INTERVAL")
 	_ = v.BindEnv("slackbot_cleanup_worker.dry_run", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_DRY_RUN")
 	_ = v.BindEnv("slackbot_cleanup_worker.lease_duration", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_LEASE_DURATION")
 	_ = v.BindEnv("slackbot_cleanup_worker.renew_deadline", "AGENTAPI_SLACKBOT_CLEANUP_WORKER_RENEW_DEADLINE")
@@ -931,6 +936,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("slackbot_cleanup_worker.enabled", false)
 	v.SetDefault("slackbot_cleanup_worker.check_interval", "1h")
 	v.SetDefault("slackbot_cleanup_worker.session_ttl", "72h")
+	v.SetDefault("slackbot_cleanup_worker.session_ttl_check_interval", "1m")
 	v.SetDefault("slackbot_cleanup_worker.namespace", "")
 	v.SetDefault("slackbot_cleanup_worker.lease_duration", "15s")
 	v.SetDefault("slackbot_cleanup_worker.renew_deadline", "10s")

--- a/pkg/slackbot_cleanup/worker.go
+++ b/pkg/slackbot_cleanup/worker.go
@@ -36,9 +36,14 @@ const (
 
 // CleanupWorkerConfig holds configuration for the Slackbot session cleanup worker.
 type CleanupWorkerConfig struct {
-	// CheckInterval is how often the worker scans for stale sessions.
+	// CheckInterval is how often the worker scans for stale Slackbot sessions.
 	// Default: 1h
 	CheckInterval time.Duration
+	// SessionTTLCheckInterval is how often the worker scans for sessions with an explicit
+	// agentapi.proxy/session-ttl annotation. This can be much shorter than CheckInterval
+	// to support short-lived sessions (e.g. 1m TTL).
+	// Default: 1m
+	SessionTTLCheckInterval time.Duration
 	// SessionTTL is the duration after the last message before a session is deleted.
 	// Default: 72h (3 days)
 	SessionTTL time.Duration
@@ -53,10 +58,11 @@ type CleanupWorkerConfig struct {
 // DefaultCleanupWorkerConfig returns the default configuration.
 func DefaultCleanupWorkerConfig() CleanupWorkerConfig {
 	return CleanupWorkerConfig{
-		CheckInterval: 1 * time.Hour,
-		SessionTTL:    72 * time.Hour,
-		Enabled:       true,
-		DryRun:        false,
+		CheckInterval:           1 * time.Hour,
+		SessionTTLCheckInterval: 1 * time.Minute,
+		SessionTTL:              72 * time.Hour,
+		Enabled:                 true,
+		DryRun:                  false,
 	}
 }
 
@@ -110,8 +116,8 @@ func (w *CleanupWorker) Start(ctx context.Context) error {
 	if w.config.DryRun {
 		dryRunNote = " (dry-run mode: no sessions will be deleted)"
 	}
-	log.Printf("[SLACKBOT_CLEANUP] Started with check interval %v, session TTL %v%s",
-		w.config.CheckInterval, w.config.SessionTTL, dryRunNote)
+	log.Printf("[SLACKBOT_CLEANUP] Started with check interval %v, session TTL %v, TTL annotation check interval %v%s",
+		w.config.CheckInterval, w.config.SessionTTL, w.config.SessionTTLCheckInterval, dryRunNote)
 	return nil
 }
 
@@ -134,8 +140,15 @@ func (w *CleanupWorker) Stop() {
 func (w *CleanupWorker) run(ctx context.Context) {
 	defer w.wg.Done()
 
-	ticker := time.NewTicker(w.config.CheckInterval)
-	defer ticker.Stop()
+	slackbotTicker := time.NewTicker(w.config.CheckInterval)
+	defer slackbotTicker.Stop()
+
+	ttlInterval := w.config.SessionTTLCheckInterval
+	if ttlInterval <= 0 {
+		ttlInterval = 1 * time.Minute
+	}
+	ttlTicker := time.NewTicker(ttlInterval)
+	defer ttlTicker.Stop()
 
 	// Run immediately on start
 	w.pruneStaleSlackbotSessions(ctx)
@@ -149,8 +162,9 @@ func (w *CleanupWorker) run(ctx context.Context) {
 		case <-w.stopCh:
 			log.Printf("[SLACKBOT_CLEANUP] Stop signal received")
 			return
-		case <-ticker.C:
+		case <-slackbotTicker.C:
 			w.pruneStaleSlackbotSessions(ctx)
+		case <-ttlTicker.C:
 			w.pruneSessionsWithTTL(ctx)
 		}
 	}

--- a/pkg/slackbot_cleanup/worker.go
+++ b/pkg/slackbot_cleanup/worker.go
@@ -28,6 +28,10 @@ const (
 
 	// sessionIDLabel is the label key holding the session ID on Kubernetes Services.
 	sessionIDLabel = "agentapi.proxy/session-id"
+
+	// sessionTTLAnnotation stores the per-session TTL as a Go duration string (e.g. "48h").
+	// When present, this overrides the global CleanupWorkerConfig.SessionTTL for that session.
+	sessionTTLAnnotation = "agentapi.proxy/session-ttl"
 )
 
 // CleanupWorkerConfig holds configuration for the Slackbot session cleanup worker.
@@ -135,6 +139,7 @@ func (w *CleanupWorker) run(ctx context.Context) {
 
 	// Run immediately on start
 	w.pruneStaleSlackbotSessions(ctx)
+	w.pruneSessionsWithTTL(ctx)
 
 	for {
 		select {
@@ -146,6 +151,7 @@ func (w *CleanupWorker) run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			w.pruneStaleSlackbotSessions(ctx)
+			w.pruneSessionsWithTTL(ctx)
 		}
 	}
 }
@@ -153,9 +159,10 @@ func (w *CleanupWorker) run(ctx context.Context) {
 // pruneStaleSlackbotSessions lists all Slackbot sessions and deletes those whose
 // last message time is older than SessionTTL.  When DryRun is enabled the
 // worker only logs which sessions would be deleted without touching them.
+// If a session has the agentapi.proxy/session-ttl annotation, that value overrides
+// the global SessionTTL for that individual session.
 func (w *CleanupWorker) pruneStaleSlackbotSessions(ctx context.Context) {
 	now := time.Now()
-	threshold := now.Add(-w.config.SessionTTL)
 
 	dryRunPrefix := ""
 	if w.config.DryRun {
@@ -181,14 +188,12 @@ func (w *CleanupWorker) pruneStaleSlackbotSessions(ctx context.Context) {
 		return
 	}
 
-	log.Printf("[SLACKBOT_CLEANUP] %sScanning %d Slackbot session(s) for TTL expiry (threshold: %s)",
-		dryRunPrefix, len(svcList.Items), threshold.Format(time.RFC3339))
+	log.Printf("[SLACKBOT_CLEANUP] %sScanning %d Slackbot session(s) for TTL expiry",
+		dryRunPrefix, len(svcList.Items))
 
 	deleted := 0
 	for _, svc := range svcList.Items {
 		// Defensive check: verify the service actually carries the slackbot label.
-		// The label selector already filters by this key, but we re-check here to
-		// guard against any unexpected label selector behaviour.
 		if svc.Labels[slackbotIDLabelKey] == "" {
 			log.Printf("[SLACKBOT_CLEANUP] %sService %s does not have slackbot label, skipping", dryRunPrefix, svc.Name)
 			continue
@@ -199,6 +204,17 @@ func (w *CleanupWorker) pruneStaleSlackbotSessions(ctx context.Context) {
 			log.Printf("[SLACKBOT_CLEANUP] %sService %s missing session-id label, skipping", dryRunPrefix, svc.Name)
 			continue
 		}
+
+		// Resolve effective TTL: per-session annotation takes priority over global config.
+		effectiveTTL := w.config.SessionTTL
+		if ttlStr, ok := svc.Annotations[sessionTTLAnnotation]; ok && ttlStr != "" {
+			if parsed, err := time.ParseDuration(ttlStr); err == nil {
+				effectiveTTL = parsed
+			} else {
+				log.Printf("[SLACKBOT_CLEANUP] %sSession %s: invalid session-ttl annotation %q, using global TTL", dryRunPrefix, sessionID, ttlStr)
+			}
+		}
+		threshold := now.Add(-effectiveTTL)
 
 		// Determine the reference time for TTL calculation from last-message-at.
 		refTime, err := w.resolveReferenceTime(svc.Annotations)
@@ -213,14 +229,14 @@ func (w *CleanupWorker) pruneStaleSlackbotSessions(ctx context.Context) {
 		}
 
 		if w.config.DryRun {
-			log.Printf("[SLACKBOT_CLEANUP] [DRY-RUN] Would delete session %s (last message at %s, threshold %s)",
-				sessionID, refTime.Format(time.RFC3339), threshold.Format(time.RFC3339))
+			log.Printf("[SLACKBOT_CLEANUP] [DRY-RUN] Would delete session %s (last message at %s, threshold %s, ttl %s)",
+				sessionID, refTime.Format(time.RFC3339), threshold.Format(time.RFC3339), effectiveTTL)
 			deleted++
 			continue
 		}
 
-		log.Printf("[SLACKBOT_CLEANUP] Deleting session %s (last message at %s, threshold %s)",
-			sessionID, refTime.Format(time.RFC3339), threshold.Format(time.RFC3339))
+		log.Printf("[SLACKBOT_CLEANUP] Deleting session %s (last message at %s, threshold %s, ttl %s)",
+			sessionID, refTime.Format(time.RFC3339), threshold.Format(time.RFC3339), effectiveTTL)
 
 		if err := w.sessionManager.DeleteSession(sessionID); err != nil {
 			log.Printf("[SLACKBOT_CLEANUP] Failed to delete session %s: %v", sessionID, err)
@@ -235,6 +251,91 @@ func (w *CleanupWorker) pruneStaleSlackbotSessions(ctx context.Context) {
 			log.Printf("[SLACKBOT_CLEANUP] [DRY-RUN] Would delete %d stale Slackbot session(s)", deleted)
 		} else {
 			log.Printf("[SLACKBOT_CLEANUP] Deleted %d stale Slackbot session(s)", deleted)
+		}
+	}
+}
+
+// pruneSessionsWithTTL scans all agentapi-proxy sessions (regardless of Slackbot label)
+// that have the agentapi.proxy/session-ttl annotation set, and deletes those whose
+// last-message-at is older than the annotation value.  Slackbot sessions are skipped
+// here because they are already handled by pruneStaleSlackbotSessions.
+func (w *CleanupWorker) pruneSessionsWithTTL(ctx context.Context) {
+	now := time.Now()
+
+	dryRunPrefix := ""
+	if w.config.DryRun {
+		dryRunPrefix = "[DRY-RUN] "
+	}
+
+	labelSelector := "app.kubernetes.io/managed-by=agentapi-proxy," +
+		"app.kubernetes.io/name=agentapi-session"
+
+	svcList, err := w.k8sClient.CoreV1().Services(w.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		log.Printf("[SESSION_TTL_CLEANUP] %sFailed to list sessions: %v", dryRunPrefix, err)
+		return
+	}
+
+	deleted := 0
+	for _, svc := range svcList.Items {
+		// Skip Slackbot sessions — they are managed by pruneStaleSlackbotSessions.
+		if svc.Labels[slackbotIDLabelKey] != "" {
+			continue
+		}
+
+		ttlStr, ok := svc.Annotations[sessionTTLAnnotation]
+		if !ok || ttlStr == "" {
+			continue
+		}
+
+		ttl, err := time.ParseDuration(ttlStr)
+		if err != nil {
+			log.Printf("[SESSION_TTL_CLEANUP] %sSession %s: invalid session-ttl %q: %v", dryRunPrefix, svc.Labels[sessionIDLabel], ttlStr, err)
+			continue
+		}
+
+		sessionID := svc.Labels[sessionIDLabel]
+		if sessionID == "" {
+			continue
+		}
+
+		threshold := now.Add(-ttl)
+
+		refTime, err := w.resolveReferenceTime(svc.Annotations)
+		if err != nil {
+			log.Printf("[SESSION_TTL_CLEANUP] %sSession %s: cannot determine reference time (%v), skipping", dryRunPrefix, sessionID, err)
+			continue
+		}
+
+		if refTime.After(threshold) {
+			continue
+		}
+
+		if w.config.DryRun {
+			log.Printf("[SESSION_TTL_CLEANUP] [DRY-RUN] Would delete session %s (last message at %s, threshold %s, ttl %s)",
+				sessionID, refTime.Format(time.RFC3339), threshold.Format(time.RFC3339), ttl)
+			deleted++
+			continue
+		}
+
+		log.Printf("[SESSION_TTL_CLEANUP] Deleting session %s (last message at %s, threshold %s, ttl %s)",
+			sessionID, refTime.Format(time.RFC3339), threshold.Format(time.RFC3339), ttl)
+
+		if err := w.sessionManager.DeleteSession(sessionID); err != nil {
+			log.Printf("[SESSION_TTL_CLEANUP] Failed to delete session %s: %v", sessionID, err)
+		} else {
+			log.Printf("[SESSION_TTL_CLEANUP] Deleted session %s", sessionID)
+			deleted++
+		}
+	}
+
+	if deleted > 0 {
+		if w.config.DryRun {
+			log.Printf("[SESSION_TTL_CLEANUP] [DRY-RUN] Would delete %d session(s) with TTL annotation", deleted)
+		} else {
+			log.Printf("[SESSION_TTL_CLEANUP] Deleted %d session(s) with TTL annotation", deleted)
 		}
 	}
 }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5443,6 +5443,11 @@
           },
           "docker": {
             "$ref": "#/components/schemas/DockerParams"
+          },
+          "session_ttl": {
+            "type": "string",
+            "description": "Duration after the last message before this session is automatically deleted. Accepted format: Go duration string (e.g. '48h', '168h', '7d' is not valid — use hours). Empty string means the global cleanup worker TTL is used for Slackbot sessions; non-Slackbot sessions without this field are not auto-deleted.",
+            "example": "48h"
           }
         }
       },
@@ -7474,6 +7479,15 @@
         },
         "params": {
           "$ref": "#/components/schemas/SessionParams"
+        },
+        "sandbox_policy_id": {
+          "type": "string",
+          "description": "Reference to a SandboxPolicy resource. When set, the sandbox sidecar is enabled automatically with this policy applied."
+        },
+        "session_ttl": {
+          "type": "string",
+          "description": "Default TTL for sessions created with this profile. Overrides the global cleanup worker TTL. Accepted format: Go duration string (e.g. '48h', '168h'). Can be overridden per-session via params.session_ttl.",
+          "example": "72h"
         }
       }
     },


### PR DESCRIPTION
## Summary

- `SessionParams.session_ttl` (Go duration string, e.g. `"48h"`) を追加。セッション作成時に自動削除 TTL を指定できる
- `SessionProfileConfig.session_ttl` を追加。プロファイルにデフォルト TTL を設定でき、そのプロファイルで作成された全セッションに適用される
- TTL は Kubernetes Service の `agentapi.proxy/session-ttl` アノテーションとして保存・復元される
- Slackbot クリーンアップワーカーの変更:
  - Slackbot セッションで `session-ttl` アノテーションがある場合、グローバル TTL より優先する
  - `pruneSessionsWithTTL()` を追加: Slackbot 以外のセッションで `session-ttl` アノテーション付きのものを定期クリーンアップ
- OpenAPI 仕様を更新

## 使い方

**セッション作成時に TTL を指定:**
```json
POST /start
{
  "params": {
    "session_ttl": "48h"
  }
}
```

**プロファイルに TTL を設定 (プロファイルから作成される全セッションに適用):**
```json
POST /session-profiles
{
  "name": "my-profile",
  "config": {
    "session_ttl": "72h"
  }
}
```

TTL は最終メッセージ受信時刻からの経過時間で評価される。

## Test plan

- [ ] ビルド成功確認 (`go build ./...`)
- [ ] テスト通過確認 (`go test ./...`)
- [ ] lint 通過確認 (`golangci-lint run ./...`)
- [ ] セッション作成時に `agentapi.proxy/session-ttl` アノテーションが付与されることを確認
- [ ] プロファイル作成・取得で `session_ttl` が正しく保存・返却されることを確認

🤖🐮 Generated with [Claude Code](https://claude.com/claude-code)