### PR TITLE
fix: omit env for Codex HTTP MCP servers

### DIFF
--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -414,7 +414,9 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 		// The Codex CLI expects mcp_servers to be a map keyed by server name.
 		fmt.Fprintf(&sb, "[mcp_servers.%s]\n", name)
 
+		serverType := ""
 		if v, ok := config["type"].(string); ok {
+			serverType = v
 			fmt.Fprintf(&sb, "type = %q\n", v)
 		}
 		if v, ok := config["url"].(string); ok {
@@ -432,7 +434,7 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 			}
 			fmt.Fprintf(&sb, "args = [%s]\n", strings.Join(parts, ", "))
 		}
-		if env, ok := config["env"].(map[string]interface{}); ok && len(env) > 0 {
+		if env, ok := config["env"].(map[string]interface{}); ok && len(env) > 0 && codexMCPServerSupportsEnv(serverType) {
 			envKeys := make([]string, 0, len(env))
 			for k := range env {
 				envKeys = append(envKeys, k)
@@ -456,6 +458,15 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 
 	log.Printf("[COMPILE-SETTINGS] Appended %d MCP server(s) to %s", len(mcpServers), configPath)
 	return nil
+}
+
+func codexMCPServerSupportsEnv(serverType string) bool {
+	switch serverType {
+	case "http", "streamable_http":
+		return false
+	default:
+		return true
+	}
 }
 
 // generateStartupScript creates executable shell script with the startup command.

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -563,6 +563,7 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 					"slack": map[string]interface{}{
 						"type": "http",
 						"url":  "https://mcp.example.com/slack",
+						"env":  map[string]interface{}{"SLACK_TOKEN": "xoxb-token"},
 					},
 				},
 			},
@@ -600,6 +601,59 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 		assert.Contains(t, content, `type = "http"`)
 		assert.Contains(t, content, `url = "https://mcp.example.com/slack"`)
 		assert.Contains(t, content, "GITHUB_TOKEN")
+		assert.NotContains(t, content, "SLACK_TOKEN")
+	})
+
+	t.Run("omits env for streamable_http mcp_servers", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-codex-mcp-streamable-http-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-codex-mcp-streamable-http",
+				UserID:    "user-codex-mcp-streamable-http",
+				Scope:     "user",
+				AgentType: "codex-acp",
+			},
+			Codex: CodexConfig{
+				MCPServers: map[string]interface{}{
+					"github": map[string]interface{}{
+						"type": "streamable_http",
+						"url":  "https://api.githubcopilot.com/mcp",
+						"env":  map[string]interface{}{"GITHUB_TOKEN": "$GITHUB_TOKEN"},
+					},
+				},
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".codex/config.toml")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		content := string(data)
+
+		assert.Contains(t, content, "[mcp_servers.github]")
+		assert.Contains(t, content, `type = "streamable_http"`)
+		assert.Contains(t, content, `url = "https://api.githubcopilot.com/mcp"`)
+		assert.NotContains(t, content, "GITHUB_TOKEN")
+		assert.NotContains(t, content, "env =")
 	})
 
 	t.Run("appends mcp_servers after existing ConfigTOML", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- omit `env = {...}` when generating Codex MCP config for `type = "http"` and `type = "streamable_http"`
- keep env generation for stdio MCP servers
- add regression coverage for both HTTP and streamable HTTP cases

## Context
Production session `716e9dcb-46f9-4763-b25c-ef6933eaed73` failed because Codex rejected this config:

```toml
[mcp_servers.github]
type = "http"
url = "https://api.githubcopilot.com/mcp"
env = {GITHUB_TOKEN = "$GITHUB_TOKEN"}
```

Codex reports: `env is not supported for streamable_http`.

## Verification
- `go test ./pkg/sessionsettings`