### PR TITLE
Fix session allocation response latency

### DIFF
--- a/internal/domain/entities/proxy_session.go
+++ b/internal/domain/entities/proxy_session.go
@@ -16,8 +16,16 @@ type ProxySession struct {
 
 // NewProxySession creates a new ProxySession
 func NewProxySession(id, userID string, scope ResourceScope, teamID string, tags map[string]string, startedAt time.Time) *ProxySession {
+	return NewProxySessionWithStatus(id, userID, scope, teamID, tags, startedAt, "running")
+}
+
+// NewProxySessionWithStatus creates a new ProxySession with an explicit status.
+func NewProxySessionWithStatus(id, userID string, scope ResourceScope, teamID string, tags map[string]string, startedAt time.Time, status string) *ProxySession {
 	if tags == nil {
 		tags = make(map[string]string)
+	}
+	if status == "" {
+		status = "running"
 	}
 	return &ProxySession{
 		id:        id,
@@ -25,7 +33,7 @@ func NewProxySession(id, userID string, scope ResourceScope, teamID string, tags
 		scope:     scope,
 		teamID:    teamID,
 		tags:      tags,
-		status:    "running",
+		status:    status,
 		startedAt: startedAt,
 	}
 }

--- a/internal/infrastructure/services/session_allocator.go
+++ b/internal/infrastructure/services/session_allocator.go
@@ -78,52 +78,7 @@ func (m *KubernetesSessionManager) submitSessionAllocation(ctx context.Context, 
 		log.Printf("[SESSION_ALLOCATOR] Warning: failed to notify allocation request %s: %v", id, err)
 	}
 
-	timeout := time.Duration(m.k8sConfig.PodStartTimeout) * time.Second
-	if timeout <= 0 {
-		timeout = 120 * time.Second
-	}
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-
-	updates, cancel, err := m.subscribeSessionAllocation(ctx)
-	if err != nil {
-		_ = m.deleteSessionAllocation(context.Background(), id)
-		return nil, fmt.Errorf("failed to subscribe session allocation updates: %w", err)
-	}
-	defer cancel()
-	for {
-		current, err := m.getSessionAllocation(ctx, id)
-		if err != nil {
-			_ = m.deleteSessionAllocation(context.Background(), id)
-			return nil, fmt.Errorf("failed to read session allocation: %w", err)
-		}
-		switch current.Status {
-		case "assigned":
-			allocatedID := current.AllocatedSessionID
-			if allocatedID == "" {
-				allocatedID = id
-			}
-			if sess := m.GetSession(allocatedID); sess != nil {
-				_ = m.deleteSessionAllocation(context.Background(), id)
-				return sess, nil
-			}
-		case "error":
-			_ = m.deleteSessionAllocation(context.Background(), id)
-			return nil, fmt.Errorf("session allocation failed: %s", current.Message)
-		default:
-			log.Printf("[SESSION_ALLOCATOR] Waiting for allocation request %s status=%s", id, current.Status)
-		}
-
-		select {
-		case <-ctx.Done():
-			_ = m.deleteSessionAllocation(context.Background(), id)
-			return nil, ctx.Err()
-		case <-deadline.C:
-			_ = m.deleteSessionAllocation(context.Background(), id)
-			return nil, fmt.Errorf("session allocation timed out for %s", id)
-		case <-updates:
-		}
-	}
+	return entities.NewProxySessionWithStatus(id, req.UserID, req.Scope, req.TeamID, req.Tags, allocation.UpdatedAt, "creating"), nil
 }
 
 func (m *KubernetesSessionManager) isSessionAllocatorEnabled() bool {
@@ -303,7 +258,13 @@ func (m *KubernetesSessionManager) CompleteSessionAllocation(ctx context.Context
 	if err := m.saveSessionAllocation(ctx, req); err != nil {
 		return err
 	}
-	return m.notifySessionAllocation(ctx)
+	if err := m.notifySessionAllocation(ctx); err != nil {
+		return err
+	}
+	if err := m.deleteSessionAllocation(context.Background(), sessionID); err != nil {
+		log.Printf("[SESSION_ALLOCATOR] Warning: failed to delete completed allocation %s: %v", sessionID, err)
+	}
+	return nil
 }
 
 func (m *KubernetesSessionManager) notifySessionAllocation(ctx context.Context) error {

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateSessionWithAllocatorReturnsAfterSubmittingAllocation(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+	cfg.KubernetesSession.PodStartTimeout = 30
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.SetSessionAllocatorEnabled(true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	session, err := manager.CreateSession(ctx, "test-session", &entities.RunServerRequest{
+		UserID: "test-user",
+		Scope:  entities.ScopeUser,
+		Tags:   map[string]string{"purpose": "test"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	if session.ID() != "test-session" {
+		t.Fatalf("session.ID() = %q, want test-session", session.ID())
+	}
+	if session.Status() != "creating" {
+		t.Fatalf("session.Status() = %q, want creating", session.Status())
+	}
+
+	sec, err := manager.client.CoreV1().Secrets("test-ns").Get(context.Background(), sessionAllocationSecretName("test-session"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected allocation Secret to be created: %v", err)
+	}
+	if got := sec.Labels["agentapi.proxy/session-allocation-status"]; got != "pending" {
+		t.Fatalf("allocation status label = %q, want pending", got)
+	}
+}
+
+func TestCompleteSessionAllocationDeletesAllocationSecret(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+
+	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+		SessionID: "test-session",
+		Request:   &entities.RunServerRequest{UserID: "test-user"},
+		Status:    "allocating",
+	}); err != nil {
+		t.Fatalf("saveSessionAllocation() error = %v", err)
+	}
+
+	if err := manager.CompleteSessionAllocation(context.Background(), "test-session", SessionAllocationResult{
+		Status:             "assigned",
+		AllocatedSessionID: "test-session",
+	}); err != nil {
+		t.Fatalf("CompleteSessionAllocation() error = %v", err)
+	}
+
+	_, err = manager.client.CoreV1().Secrets("test-ns").Get(context.Background(), sessionAllocationSecretName("test-session"), metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("allocation Secret should be deleted, got err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Return from allocator-backed session creation immediately after submitting the allocation request
- Reuse ProxySession with an explicit creating status for accepted-but-not-yet-materialized sessions
- Move allocation Secret cleanup to allocation completion and cover both behaviors with tests

## Verification
- Not run: go/gofmt are not installed in this workspace
- Live kubectl logs not checked: kubectl is not installed in this workspace
- Helm release checked: agentapi-proxy is deployed in agentapi-ui-dev at revision 931