### PR TITLE
Include allocating sessions in search results

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1017,11 +1017,16 @@ func (m *KubernetesSessionManager) ListSessions(filter entities.SessionFilter) [
 
 	// --- cache miss: fetch from Kubernetes ----------------------------------
 	allSessions := m.fetchSessionsFromK8s(ctx, labelSelector, filter)
+	allocationSessions := m.fetchSessionAllocationsFromK8s(ctx, filter)
 
 	// Populate the cache with the full result set (before in-memory filters)
 	// so that different filter combinations that share the same labelSelector
 	// can reuse the same cached K8s data.
-	if m.sessionListCacheRepo != nil {
+	// Do not cache a pre-Service snapshot while allocation requests are still
+	// present. Otherwise /search can serve an empty stale cache after the
+	// allocation Secret is deleted and before the next cache miss observes the
+	// newly-created Service.
+	if m.sessionListCacheRepo != nil && len(allocationSessions) == 0 {
 		cacheKey := m.buildSessionListCacheKey(labelSelector)
 		dtos := sessionsToCacheDTOs(allSessions)
 		if err := m.sessionListCacheRepo.SetSessionListCache(ctx, cacheKey, dtos, redisSessionListCacheTTL); err != nil {
@@ -1029,11 +1034,14 @@ func (m *KubernetesSessionManager) ListSessions(filter entities.SessionFilter) [
 		}
 	}
 
-	return m.withSessionAllocations(ctx, m.applySessionListFilters(allSessions, filter), filter)
+	return mergeSessionAllocations(m.applySessionListFilters(allSessions, filter), allocationSessions)
 }
 
 func (m *KubernetesSessionManager) withSessionAllocations(ctx context.Context, sessions []entities.Session, filter entities.SessionFilter) []entities.Session {
-	allocationSessions := m.fetchSessionAllocationsFromK8s(ctx, filter)
+	return mergeSessionAllocations(sessions, m.fetchSessionAllocationsFromK8s(ctx, filter))
+}
+
+func mergeSessionAllocations(sessions []entities.Session, allocationSessions []entities.Session) []entities.Session {
 	if len(allocationSessions) == 0 {
 		return sessions
 	}
@@ -1048,6 +1056,15 @@ func (m *KubernetesSessionManager) withSessionAllocations(ctx context.Context, s
 		sessions = append(sessions, session)
 	}
 	return sessions
+}
+
+func (m *KubernetesSessionManager) invalidateSessionListCache(reason string) {
+	if m.sessionListCacheRepo == nil {
+		return
+	}
+	if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
+		log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache after %s: %v", reason, err)
+	}
 }
 
 func (m *KubernetesSessionManager) fetchSessionAllocationsFromK8s(ctx context.Context, filter entities.SessionFilter) []entities.Session {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1010,7 +1010,8 @@ func (m *KubernetesSessionManager) ListSessions(filter entities.SessionFilter) [
 	if m.sessionListCacheRepo != nil {
 		cacheKey := m.buildSessionListCacheKey(labelSelector)
 		if cached, err := m.sessionListCacheRepo.GetSessionListCache(ctx, cacheKey); err == nil && cached != nil {
-			return m.filterSessionsFromCache(cached, filter)
+			sessions := m.filterSessionsFromCache(cached, filter)
+			return m.withSessionAllocations(ctx, sessions, filter)
 		}
 	}
 
@@ -1028,7 +1029,73 @@ func (m *KubernetesSessionManager) ListSessions(filter entities.SessionFilter) [
 		}
 	}
 
-	return m.applySessionListFilters(allSessions, filter)
+	return m.withSessionAllocations(ctx, m.applySessionListFilters(allSessions, filter), filter)
+}
+
+func (m *KubernetesSessionManager) withSessionAllocations(ctx context.Context, sessions []entities.Session, filter entities.SessionFilter) []entities.Session {
+	allocationSessions := m.fetchSessionAllocationsFromK8s(ctx, filter)
+	if len(allocationSessions) == 0 {
+		return sessions
+	}
+	seen := make(map[string]struct{}, len(sessions))
+	for _, session := range sessions {
+		seen[session.ID()] = struct{}{}
+	}
+	for _, session := range allocationSessions {
+		if _, ok := seen[session.ID()]; ok {
+			continue
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions
+}
+
+func (m *KubernetesSessionManager) fetchSessionAllocationsFromK8s(ctx context.Context, filter entities.SessionFilter) []entities.Session {
+	secrets, err := m.client.CoreV1().Secrets(m.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "agentapi.proxy/session-allocation=true,agentapi.proxy/session-allocation-status in (pending,allocating)",
+	})
+	if err != nil {
+		log.Printf("[K8S_SESSION] Failed to list session allocations: %v", err)
+		return nil
+	}
+
+	sessions := make([]entities.Session, 0, len(secrets.Items))
+	for i := range secrets.Items {
+		sec := &secrets.Items[i]
+		if sec.DeletionTimestamp != nil {
+			continue
+		}
+		data := sec.Data[sessionAllocationDataKey]
+		if len(data) == 0 {
+			continue
+		}
+		var allocation SessionAllocationRequest
+		if err := json.Unmarshal(data, &allocation); err != nil {
+			log.Printf("[K8S_SESSION] Failed to decode session allocation %s: %v", sec.Name, err)
+			continue
+		}
+		if allocation.SessionID == "" || allocation.Request == nil {
+			continue
+		}
+		scope := allocation.Request.Scope
+		if scope == "" {
+			scope = entities.ScopeUser
+		}
+		session := entities.NewProxySessionWithStatus(
+			allocation.SessionID,
+			allocation.Request.UserID,
+			scope,
+			allocation.Request.TeamID,
+			allocation.Request.Tags,
+			allocation.UpdatedAt,
+			allocation.Status,
+		)
+		if len(m.applySessionListFilters([]entities.Session{session}, filter)) == 0 {
+			continue
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions
 }
 
 // redisSessionListCacheTTL is the TTL passed to the cache repository.

--- a/internal/infrastructure/services/session_allocator.go
+++ b/internal/infrastructure/services/session_allocator.go
@@ -221,6 +221,11 @@ func (m *KubernetesSessionManager) NextSessionAllocation(ctx context.Context, wa
 		if err != nil {
 			return nil, false, err
 		}
+		req, ok, err = m.claimNextSessionAllocation(ctx)
+		if err != nil || ok {
+			cancel()
+			return req, ok, err
+		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			cancel()
@@ -299,6 +304,11 @@ func (m *KubernetesSessionManager) NextExternalSessionAllocation(ctx context.Con
 		updates, cancel, err := m.subscribeSessionAllocation(ctx)
 		if err != nil {
 			return nil, false, err
+		}
+		req, ok, err = m.claimNextExternalSessionAllocation(ctx, managerID)
+		if err != nil || ok {
+			cancel()
+			return req, ok, err
 		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {

--- a/internal/infrastructure/services/session_allocator.go
+++ b/internal/infrastructure/services/session_allocator.go
@@ -179,6 +179,9 @@ func (m *KubernetesSessionManager) saveSessionAllocation(ctx context.Context, re
 			Data: map[string][]byte{sessionAllocationDataKey: data},
 		}
 		_, err = m.client.CoreV1().Secrets(m.namespace).Create(ctx, sec, metav1.CreateOptions{})
+		if err == nil {
+			m.invalidateSessionListCache("session allocation save")
+		}
 		return err
 	}
 	if err != nil {
@@ -190,6 +193,9 @@ func (m *KubernetesSessionManager) saveSessionAllocation(ctx context.Context, re
 	}
 	sec.Data[sessionAllocationDataKey] = data
 	_, err = m.client.CoreV1().Secrets(m.namespace).Update(ctx, sec, metav1.UpdateOptions{})
+	if err == nil {
+		m.invalidateSessionListCache("session allocation save")
+	}
 	return err
 }
 
@@ -197,6 +203,9 @@ func (m *KubernetesSessionManager) deleteSessionAllocation(ctx context.Context, 
 	err := m.client.CoreV1().Secrets(m.namespace).Delete(ctx, sessionAllocationSecretName(sessionID), metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
+	}
+	if err == nil {
+		m.invalidateSessionListCache("session allocation delete")
 	}
 	return err
 }

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -97,6 +97,81 @@ func TestExternalSessionAllocationIsClaimedOnlyByManager(t *testing.T) {
 	}
 }
 
+func TestNextSessionAllocationClaimsRequestCreatedWhileSubscribing(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.SetSessionAllocationNotifier(&subscribeHookNotifier{
+		onSubscribe: func() {
+			if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+				SessionID: "test-session",
+				Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
+				Status:    "pending",
+			}); err != nil {
+				t.Fatalf("saveSessionAllocation() error = %v", err)
+			}
+		},
+	})
+
+	allocation, ok, err := manager.NextSessionAllocation(context.Background(), 30*time.Second)
+	if err != nil {
+		t.Fatalf("NextSessionAllocation() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("NextSessionAllocation() ok=false, want true")
+	}
+	if allocation.SessionID != "test-session" {
+		t.Fatalf("allocation.SessionID = %q, want test-session", allocation.SessionID)
+	}
+	if allocation.Status != "allocating" {
+		t.Fatalf("allocation.Status = %q, want allocating", allocation.Status)
+	}
+}
+
+func TestNextExternalSessionAllocationClaimsRequestCreatedWhileSubscribing(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.SetSessionAllocationNotifier(&subscribeHookNotifier{
+		onSubscribe: func() {
+			if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+				SessionID: "test-session",
+				ManagerID: "manager-a",
+				Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
+				Status:    "pending",
+			}); err != nil {
+				t.Fatalf("saveSessionAllocation() error = %v", err)
+			}
+		},
+	})
+
+	allocation, ok, err := manager.NextExternalSessionAllocation(context.Background(), "manager-a", 30*time.Second)
+	if err != nil {
+		t.Fatalf("NextExternalSessionAllocation() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("NextExternalSessionAllocation() ok=false, want true")
+	}
+	if allocation.SessionID != "test-session" {
+		t.Fatalf("allocation.SessionID = %q, want test-session", allocation.SessionID)
+	}
+	if allocation.Status != "allocating" {
+		t.Fatalf("allocation.Status = %q, want allocating", allocation.Status)
+	}
+}
+
 func TestCompleteSessionAllocationDeletesAllocationSecret(t *testing.T) {
 	t.Setenv("LOG_DIR", t.TempDir())
 
@@ -257,4 +332,21 @@ func (r *recordingSessionListCacheRepo) GetSessionListCache(context.Context, str
 func (r *recordingSessionListCacheRepo) InvalidateSessionListCache(context.Context, string) error {
 	r.invalidations++
 	return nil
+}
+
+type subscribeHookNotifier struct {
+	onSubscribe func()
+}
+
+func (n *subscribeHookNotifier) Notify(context.Context) error {
+	return nil
+}
+
+func (n *subscribeHookNotifier) Subscribe(context.Context) (<-chan struct{}, func(), error) {
+	if n.onSubscribe != nil {
+		n.onSubscribe()
+		n.onSubscribe = nil
+	}
+	ch := make(chan struct{})
+	return ch, func() { close(ch) }, nil
 }

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -127,3 +127,44 @@ func TestCompleteSessionAllocationDeletesAllocationSecret(t *testing.T) {
 		t.Fatalf("allocation Secret should be deleted, got err=%v", err)
 	}
 }
+
+func TestListSessionsIncludesAllocatingSessionAllocation(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+
+	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+		SessionID: "test-session",
+		Request: &entities.RunServerRequest{
+			UserID: "test-user",
+			Scope:  entities.ScopeUser,
+			Tags:   map[string]string{"purpose": "test"},
+		},
+		Status: "allocating",
+	}); err != nil {
+		t.Fatalf("saveSessionAllocation() error = %v", err)
+	}
+
+	sessions := manager.ListSessions(entities.SessionFilter{
+		UserID: "test-user",
+		Status: "allocating",
+		Tags:   map[string]string{"purpose": "test"},
+		Scope:  entities.ScopeUser,
+	})
+
+	if len(sessions) != 1 {
+		t.Fatalf("ListSessions() returned %d sessions, want 1", len(sessions))
+	}
+	if sessions[0].ID() != "test-session" {
+		t.Fatalf("session.ID() = %q, want test-session", sessions[0].ID())
+	}
+	if sessions[0].Status() != "allocating" {
+		t.Fatalf("session.Status() = %q, want allocating", sessions[0].Status())
+	}
+}

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
@@ -167,4 +168,93 @@ func TestListSessionsIncludesAllocatingSessionAllocation(t *testing.T) {
 	if sessions[0].Status() != "allocating" {
 		t.Fatalf("session.Status() = %q, want allocating", sessions[0].Status())
 	}
+}
+
+func TestSessionAllocationInvalidatesSessionListCache(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	cache := &recordingSessionListCacheRepo{}
+	manager.SetSessionListCacheRepository(cache)
+
+	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+		SessionID: "test-session",
+		Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
+		Status:    "pending",
+	}); err != nil {
+		t.Fatalf("saveSessionAllocation() error = %v", err)
+	}
+	if cache.invalidations != 1 {
+		t.Fatalf("invalidations after save = %d, want 1", cache.invalidations)
+	}
+
+	if err := manager.deleteSessionAllocation(context.Background(), "test-session"); err != nil {
+		t.Fatalf("deleteSessionAllocation() error = %v", err)
+	}
+	if cache.invalidations != 2 {
+		t.Fatalf("invalidations after delete = %d, want 2", cache.invalidations)
+	}
+}
+
+func TestListSessionsDoesNotPopulateCacheWhileAllocationExists(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	cache := &recordingSessionListCacheRepo{}
+	manager.SetSessionListCacheRepository(cache)
+
+	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+		SessionID: "test-session",
+		Request: &entities.RunServerRequest{
+			UserID: "test-user",
+			Scope:  entities.ScopeUser,
+			Tags:   map[string]string{"purpose": "test"},
+		},
+		Status: "pending",
+	}); err != nil {
+		t.Fatalf("saveSessionAllocation() error = %v", err)
+	}
+
+	sessions := manager.ListSessions(entities.SessionFilter{
+		UserID: "test-user",
+		Tags:   map[string]string{"purpose": "test"},
+		Scope:  entities.ScopeUser,
+	})
+	if len(sessions) != 1 {
+		t.Fatalf("ListSessions() returned %d sessions, want 1", len(sessions))
+	}
+	if cache.setCalls != 0 {
+		t.Fatalf("SetSessionListCache calls = %d, want 0 while allocation exists", cache.setCalls)
+	}
+}
+
+type recordingSessionListCacheRepo struct {
+	setCalls      int
+	invalidations int
+}
+
+func (r *recordingSessionListCacheRepo) SetSessionListCache(context.Context, string, []portrepos.CachedSessionDTO, time.Duration) error {
+	r.setCalls++
+	return nil
+}
+
+func (r *recordingSessionListCacheRepo) GetSessionListCache(context.Context, string) ([]portrepos.CachedSessionDTO, error) {
+	return nil, nil
+}
+
+func (r *recordingSessionListCacheRepo) InvalidateSessionListCache(context.Context, string) error {
+	r.invalidations++
+	return nil
 }


### PR DESCRIPTION
## Summary
- include pending/allocating session allocation Secrets in ListSessions results
- keep Redis-backed session list cache for concrete sessions while merging live allocation entries
- add a fake Kubernetes client test for allocating allocation visibility

## Verification
- git diff --check
- local gofmt/go test unavailable: no Go toolchain and Docker daemon unavailable in this workspace
