### PR TITLE
Configure Redis subchart as Deployment

### DIFF
--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -603,10 +603,14 @@ redis:
   # Bitnami Redis サブチャートの設定
   # https://github.com/bitnami/charts/tree/main/bitnami/redis
   architecture: standalone
+  image:
+    tag: latest
+    pullPolicy: Always
   auth:
     enabled: false
     password: ""
   master:
+    kind: Deployment
     persistence:
       enabled: false
       size: 1Gi


### PR DESCRIPTION
## Summary
- Configure the Redis subchart master workload as a Deployment
- Set the Redis image tag to latest and pullPolicy to Always

## Verification
- Not run: helm CLI is not installed in this environment