### PR TITLE
fix deleting allocating sessions

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -932,6 +932,15 @@ func (m *KubernetesSessionManager) GetSession(id string) entities.Session {
 		if exists {
 			return session
 		}
+		if errors.IsNotFound(err) {
+			allocation, allocErr := m.getSessionAllocation(context.Background(), id)
+			if allocErr == nil {
+				return sessionFromAllocation(allocation)
+			}
+			if !errors.IsNotFound(allocErr) {
+				log.Printf("[K8S_SESSION] Failed to get session allocation %s: %v", id, allocErr)
+			}
+		}
 		return nil
 	}
 
@@ -1108,19 +1117,10 @@ func (m *KubernetesSessionManager) fetchSessionAllocationsFromK8s(ctx context.Co
 		if allocation.SessionID == "" || allocation.Request == nil {
 			continue
 		}
-		scope := allocation.Request.Scope
-		if scope == "" {
-			scope = entities.ScopeUser
+		session := sessionFromAllocation(&allocation)
+		if session == nil {
+			continue
 		}
-		session := entities.NewProxySessionWithStatus(
-			allocation.SessionID,
-			allocation.Request.UserID,
-			scope,
-			allocation.Request.TeamID,
-			allocation.Request.Tags,
-			allocation.UpdatedAt,
-			allocation.Status,
-		)
 		if len(m.applySessionListFilters([]entities.Session{session}, filter)) == 0 {
 			continue
 		}
@@ -1356,7 +1356,28 @@ func (m *KubernetesSessionManager) DeleteSession(id string) error {
 	}
 
 	if !exists || session == nil {
-		return fmt.Errorf("session not found: %s", id)
+		allocation, allocErr := m.getSessionAllocation(context.Background(), id)
+		if allocErr != nil {
+			if !errors.IsNotFound(allocErr) {
+				log.Printf("[K8S_SESSION] Failed to get session allocation %s during delete: %v", id, allocErr)
+			}
+			return fmt.Errorf("session not found: %s", id)
+		}
+		if sessionFromAllocation(allocation) == nil {
+			return fmt.Errorf("session not found: %s", id)
+		}
+		if err := m.deleteSessionAllocation(context.Background(), id); err != nil {
+			return fmt.Errorf("failed to delete session allocation %s: %w", id, err)
+		}
+		if m.statusEventRepo != nil {
+			delCtx, delCancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer delCancel()
+			if err := m.statusEventRepo.DeleteStatus(delCtx, id); err != nil {
+				log.Printf("[K8S_SESSION] Warning: failed to delete Redis status for allocating session=%s: %v", id, err)
+			}
+		}
+		log.Printf("[K8S_SESSION] Deleted allocating session %s", id)
+		return nil
 	}
 
 	log.Printf("[K8S_SESSION] Deleting session %s", id)

--- a/internal/infrastructure/services/session_allocator.go
+++ b/internal/infrastructure/services/session_allocator.go
@@ -210,6 +210,29 @@ func (m *KubernetesSessionManager) deleteSessionAllocation(ctx context.Context, 
 	return err
 }
 
+func sessionFromAllocation(allocation *SessionAllocationRequest) entities.Session {
+	if allocation == nil || allocation.Request == nil {
+		return nil
+	}
+	scope := allocation.Request.Scope
+	if scope == "" {
+		scope = entities.ScopeUser
+	}
+	status := allocation.Status
+	if status == "" {
+		status = "creating"
+	}
+	return entities.NewProxySessionWithStatus(
+		allocation.SessionID,
+		allocation.Request.UserID,
+		scope,
+		allocation.Request.TeamID,
+		allocation.Request.Tags,
+		allocation.UpdatedAt,
+		status,
+	)
+}
+
 func (m *KubernetesSessionManager) NextSessionAllocation(ctx context.Context, wait time.Duration) (*SessionAllocationRequest, bool, error) {
 	deadline := time.Now().Add(wait)
 	for {

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -245,6 +245,73 @@ func TestListSessionsIncludesAllocatingSessionAllocation(t *testing.T) {
 	}
 }
 
+func TestGetSessionReturnsAllocatingSessionAllocation(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+
+	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+		SessionID: "test-session",
+		Request: &entities.RunServerRequest{
+			UserID: "test-user",
+			Scope:  entities.ScopeUser,
+			Tags:   map[string]string{"purpose": "test"},
+		},
+		Status: "allocating",
+	}); err != nil {
+		t.Fatalf("saveSessionAllocation() error = %v", err)
+	}
+
+	session := manager.GetSession("test-session")
+	if session == nil {
+		t.Fatalf("GetSession() = nil, want allocating session")
+	}
+	if session.ID() != "test-session" {
+		t.Fatalf("session.ID() = %q, want test-session", session.ID())
+	}
+	if session.UserID() != "test-user" {
+		t.Fatalf("session.UserID() = %q, want test-user", session.UserID())
+	}
+	if session.Status() != "allocating" {
+		t.Fatalf("session.Status() = %q, want allocating", session.Status())
+	}
+}
+
+func TestDeleteSessionDeletesAllocatingSessionAllocation(t *testing.T) {
+	t.Setenv("LOG_DIR", t.TempDir())
+
+	cfg := config.DefaultConfig()
+	cfg.KubernetesSession.Namespace = "test-ns"
+
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), fake.NewSimpleClientset())
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+
+	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+		SessionID: "test-session",
+		Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
+		Status:    "allocating",
+	}); err != nil {
+		t.Fatalf("saveSessionAllocation() error = %v", err)
+	}
+
+	if err := manager.DeleteSession("test-session"); err != nil {
+		t.Fatalf("DeleteSession() error = %v", err)
+	}
+
+	_, err = manager.client.CoreV1().Secrets("test-ns").Get(context.Background(), sessionAllocationSecretName("test-session"), metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("allocation Secret should be deleted, got err=%v", err)
+	}
+}
+
 func TestSessionAllocationInvalidatesSessionListCache(t *testing.T) {
 	t.Setenv("LOG_DIR", t.TempDir())
 

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -488,6 +488,17 @@ func (c *SessionController) DeleteSession(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete session")
 	}
 
+	if c.sessionRouteRepo != nil {
+		route, err := c.sessionRouteRepo.Get(ctx.Request().Context(), sessionID)
+		if err != nil {
+			log.Printf("Delete session: failed to look up route for cleanup %s: %v", sessionID, err)
+		} else if route != nil && route.ProxyURL == "" && route.RemoteSessionID == "" {
+			if err := c.sessionRouteRepo.Delete(ctx.Request().Context(), sessionID); err != nil {
+				log.Printf("Delete session: failed to delete pending route for %s: %v", sessionID, err)
+			}
+		}
+	}
+
 	log.Printf("Session %s deletion completed successfully", sessionID)
 
 	return ctx.JSON(http.StatusOK, map[string]interface{}{


### PR DESCRIPTION
## Summary
- return pending/allocating session allocations from GetSession so delete authorization can resolve them
- delete allocation Secrets when DeleteSession is called before a session Service/Deployment exists
- clean up pending external-session routes after deleting an unallocated session
- add regression coverage for GetSession/DeleteSession on allocating allocations

## Tests
- Not run: Go toolchain (go/gofmt) is not installed in this environment
- git diff --check