### PR TITLE
Default provisioner proxy URL to Helm service

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -245,7 +245,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_POD_STOP_TIMEOUT
               value: {{ .Values.kubernetesSession.podStopTimeout | quote }}
             - name: AGENTAPI_K8S_SESSION_PROVISIONER_PROXY_URL
-              value: {{ dig "provisioner" "proxyUrl" "" .Values.kubernetesSession | quote }}
+              value: {{ (dig "provisioner" "proxyUrl" "" .Values.kubernetesSession | default (printf "http://%s.%s.svc.cluster.local:%v" (include "agentapi-proxy.fullname" .) .Release.Namespace .Values.service.port)) | quote }}
             {{- if or .Values.github.token (and .Values.github.app.id .Values.github.app.privateKey.secretName) }}
             - name: AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME
               value: {{ printf "%s-github-session" (include "agentapi-proxy.fullname" .) | quote }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -398,6 +398,8 @@ kubernetesSession:
   podStopTimeout: 30
 
   # Session Pods poll the proxy internal API for provisioning jobs.
+  # Empty defaults to this chart's Service DNS:
+  # http://<release-fullname>.<release-namespace>.svc.cluster.local:<service.port>
   provisioner:
     proxyUrl: ""
 


### PR DESCRIPTION
## Summary
- default AGENTAPI_K8S_SESSION_PROVISIONER_PROXY_URL to this chart's Service DNS
- document the default for kubernetesSession.provisioner.proxyUrl

## Testing
- git diff --check
- Not run: helm template (helm is not installed in this environment)
- Not run: go test ./pkg/config ./internal/infrastructure/services (go is not installed in this environment)