### PR TITLE
Fix profile Docker params for scheduled sessions

### DIFF
--- a/internal/interfaces/controllers/slackbot_event_handler.go
+++ b/internal/interfaces/controllers/slackbot_event_handler.go
@@ -419,23 +419,38 @@ func (h *SlackBotEventHandler) ProcessEvent(ctx context.Context, botID string, p
 		}
 
 		var slackSandbox *entities.SandboxParams
+		var slackDocker *entities.DockerParams
+		var slackInitialMessageWaitSecond *int
+		var slackCycleMessage, slackSessionTTL string
+		var slackCycleMaxCount int
 		if bot != nil && bot.SessionConfig() != nil && bot.SessionConfig().Params() != nil {
-			slackSandbox = bot.SessionConfig().Params().Sandbox
+			params := bot.SessionConfig().Params()
+			slackSandbox = params.Sandbox
+			slackDocker = params.Docker
+			slackInitialMessageWaitSecond = params.InitialMessageWaitSecond
+			slackCycleMessage = params.CycleMessage
+			slackCycleMaxCount = params.CycleMaxCount
+			slackSessionTTL = params.SessionTTL
 		}
 
 		result, err := h.launcher.Launch(bgCtx, sessionID, sessionuc.LaunchRequest{
-			UserID:           userID,
-			Scope:            scope,
-			TeamID:           teamID,
-			Teams:            teams,
-			Environment:      env,
-			Tags:             tags,
-			InitialMessage:   initialMessage,
-			AgentType:        agentType,
-			MemoryKey:        memoryKey,
-			RepoInfo:         repoInfo,
-			Sandbox:          slackSandbox,
-			SessionProfileID: slackSessionProfileID,
+			UserID:                   userID,
+			Scope:                    scope,
+			TeamID:                   teamID,
+			Teams:                    teams,
+			Environment:              env,
+			Tags:                     tags,
+			InitialMessage:           initialMessage,
+			AgentType:                agentType,
+			MemoryKey:                memoryKey,
+			RepoInfo:                 repoInfo,
+			Sandbox:                  slackSandbox,
+			Docker:                   slackDocker,
+			InitialMessageWaitSecond: slackInitialMessageWaitSecond,
+			CycleMessage:             slackCycleMessage,
+			CycleMaxCount:            slackCycleMaxCount,
+			SessionTTL:               slackSessionTTL,
+			SessionProfileID:         slackSessionProfileID,
 			SlackParams: func() *entities.SlackParams {
 				sp := &entities.SlackParams{
 					Channel:  channel,

--- a/internal/interfaces/controllers/webhook_custom_controller.go
+++ b/internal/interfaces/controllers/webhook_custom_controller.go
@@ -275,27 +275,47 @@ Please ensure the webhook payload is valid JSON.
 `, wh.Name(), parseErr.Error(), truncateString(string(rawBody), 500))
 
 	var githubToken, agentType string
+	var slackParams *entities.SlackParams
+	var sandbox *entities.SandboxParams
+	var docker *entities.DockerParams
+	var initialMessageWaitSecond *int
+	var cycleMessage, sessionTTL string
+	var cycleMaxCount int
 	var oneshot bool
 	if sessionConfig != nil && sessionConfig.Params() != nil {
 		params := sessionConfig.Params()
 		githubToken = params.GithubToken
 		agentType = params.AgentType
+		slackParams = params.Slack
+		sandbox = params.Sandbox
+		docker = params.Docker
+		initialMessageWaitSecond = params.InitialMessageWaitSecond
+		cycleMessage = params.CycleMessage
+		cycleMaxCount = params.CycleMaxCount
+		sessionTTL = params.SessionTTL
 		oneshot = params.Oneshot
 	}
 
 	result, err := c.launcher.Launch(ctx.Request().Context(), sessionID, sessionuc.LaunchRequest{
-		UserID:         wh.UserID(),
-		Scope:          wh.Scope(),
-		TeamID:         wh.TeamID(),
-		Teams:          sessionuc.ResolveTeams(wh.Scope(), wh.TeamID(), wh.UserTeams()),
-		Environment:    env,
-		Tags:           tags,
-		InitialMessage: initialMessage,
-		GithubToken:    githubToken,
-		AgentType:      agentType,
-		Oneshot:        oneshot,
-		MaxSessions:    wh.MaxSessions(),
-		LimitMatchTags: map[string]string{"webhook_id": wh.ID()},
+		UserID:                   wh.UserID(),
+		Scope:                    wh.Scope(),
+		TeamID:                   wh.TeamID(),
+		Teams:                    sessionuc.ResolveTeams(wh.Scope(), wh.TeamID(), wh.UserTeams()),
+		Environment:              env,
+		Tags:                     tags,
+		InitialMessage:           initialMessage,
+		GithubToken:              githubToken,
+		AgentType:                agentType,
+		SlackParams:              slackParams,
+		Sandbox:                  sandbox,
+		Docker:                   docker,
+		Oneshot:                  oneshot,
+		InitialMessageWaitSecond: initialMessageWaitSecond,
+		CycleMessage:             cycleMessage,
+		CycleMaxCount:            cycleMaxCount,
+		SessionTTL:               sessionTTL,
+		MaxSessions:              wh.MaxSessions(),
+		LimitMatchTags:           map[string]string{"webhook_id": wh.ID()},
 	})
 	if err != nil {
 		log.Printf("[WEBHOOK_CUSTOM] Failed to create error session: %v", err)

--- a/internal/interfaces/controllers/webhook_session_service.go
+++ b/internal/interfaces/controllers/webhook_session_service.go
@@ -90,16 +90,25 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 	// Determine session params fields from rendered params
 	var githubToken, agentType string
 	var oneshot bool
+	var initialMessageWaitSecond *int
+	var cycleMessage, sessionTTL string
+	var cycleMaxCount int
 	if renderedParams != nil {
 		githubToken = renderedParams.GithubToken
 		agentType = renderedParams.AgentType
 		oneshot = renderedParams.Oneshot
+		initialMessageWaitSecond = renderedParams.InitialMessageWaitSecond
+		cycleMessage = renderedParams.CycleMessage
+		cycleMaxCount = renderedParams.CycleMaxCount
+		sessionTTL = renderedParams.SessionTTL
 	}
 
 	// Sandbox is not a template field — read directly from the merged session config params.
 	var sandbox *entities.SandboxParams
+	var docker *entities.DockerParams
 	if sessionConfig != nil && sessionConfig.Params() != nil {
 		sandbox = sessionConfig.Params().Sandbox
+		docker = sessionConfig.Params().Docker
 	}
 
 	// Build repository info from tags
@@ -136,25 +145,30 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 		sessionProfileID = sessionConfig.SessionProfileID()
 	}
 	result, err := s.launcher.Launch(ctx, sessionID, sessionuc.LaunchRequest{
-		UserID:           webhook.UserID(),
-		Scope:            webhook.Scope(),
-		TeamID:           webhook.TeamID(),
-		Teams:            sessionuc.ResolveTeams(webhook.Scope(), webhook.TeamID(), webhook.UserTeams()),
-		Environment:      env,
-		Tags:             tags,
-		InitialMessage:   initialMessage,
-		GithubToken:      githubToken,
-		AgentType:        agentType,
-		Oneshot:          oneshot,
-		Sandbox:          sandbox,
-		RepoInfo:         repoInfo,
-		WebhookPayload:   webhookPayload,
-		SessionProfileID: sessionProfileID,
-		ReuseSession:     sessionConfig != nil && sessionConfig.ReuseSession(),
-		ReuseMatchTags:   tags,
-		ReuseMessage:     reuseMessage,
-		MaxSessions:      webhook.MaxSessions(),
-		LimitMatchTags:   map[string]string{"webhook_id": webhook.ID()},
+		UserID:                   webhook.UserID(),
+		Scope:                    webhook.Scope(),
+		TeamID:                   webhook.TeamID(),
+		Teams:                    sessionuc.ResolveTeams(webhook.Scope(), webhook.TeamID(), webhook.UserTeams()),
+		Environment:              env,
+		Tags:                     tags,
+		InitialMessage:           initialMessage,
+		GithubToken:              githubToken,
+		AgentType:                agentType,
+		Oneshot:                  oneshot,
+		InitialMessageWaitSecond: initialMessageWaitSecond,
+		CycleMessage:             cycleMessage,
+		CycleMaxCount:            cycleMaxCount,
+		Sandbox:                  sandbox,
+		Docker:                   docker,
+		SessionTTL:               sessionTTL,
+		RepoInfo:                 repoInfo,
+		WebhookPayload:           webhookPayload,
+		SessionProfileID:         sessionProfileID,
+		ReuseSession:             sessionConfig != nil && sessionConfig.ReuseSession(),
+		ReuseMatchTags:           tags,
+		ReuseMessage:             reuseMessage,
+		MaxSessions:              webhook.MaxSessions(),
+		LimitMatchTags:           map[string]string{"webhook_id": webhook.ID()},
 	})
 	if err != nil {
 		return "", false, fmt.Errorf("failed to create session: %w", err)

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -35,6 +35,10 @@ type LaunchRequest struct {
 	RepoInfo                 *entities.RepositoryInfo
 	InitialMessageWaitSecond *int
 	Sandbox                  *entities.SandboxParams
+	Docker                   *entities.DockerParams
+	CycleMessage             string
+	CycleMaxCount            int
+	SessionTTL               string
 
 	// Webhook payload to mount in the session filesystem (optional)
 	WebhookPayload []byte
@@ -186,7 +190,11 @@ func (uc *LaunchUseCase) Launch(ctx context.Context, sessionID string, req Launc
 		RepoInfo:                 req.RepoInfo,
 		InitialMessageWaitSecond: req.InitialMessageWaitSecond,
 		MemoryKey:                req.MemoryKey,
+		CycleMessage:             req.CycleMessage,
+		CycleMaxCount:            req.CycleMaxCount,
 		Sandbox:                  req.Sandbox,
+		Docker:                   req.Docker,
+		SessionTTL:               req.SessionTTL,
 	}
 
 	session, err := uc.sessionManager.CreateSession(ctx, sessionID, runReq, req.WebhookPayload)
@@ -333,5 +341,23 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 		if req.Sandbox == nil && cfg.Params().Sandbox != nil {
 			req.Sandbox = cfg.Params().Sandbox
 		}
+		if req.Docker == nil && cfg.Params().Docker != nil {
+			req.Docker = cfg.Params().Docker
+		}
+		if req.InitialMessageWaitSecond == nil && cfg.Params().InitialMessageWaitSecond != nil {
+			req.InitialMessageWaitSecond = cfg.Params().InitialMessageWaitSecond
+		}
+		if req.CycleMessage == "" {
+			req.CycleMessage = cfg.Params().CycleMessage
+		}
+		if req.CycleMaxCount == 0 {
+			req.CycleMaxCount = cfg.Params().CycleMaxCount
+		}
+		if req.SessionTTL == "" {
+			req.SessionTTL = cfg.Params().SessionTTL
+		}
+	}
+	if cfg.SessionTTL() != "" && req.SessionTTL == "" {
+		req.SessionTTL = cfg.SessionTTL()
 	}
 }

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+type recordingSessionManager struct {
+	req *entities.RunServerRequest
+}
+
+func (m *recordingSessionManager) CreateSession(_ context.Context, id string, req *entities.RunServerRequest, _ []byte) (entities.Session, error) {
+	m.req = req
+	return &launchTestSession{id: id, userID: req.UserID, status: "active"}, nil
+}
+
+func (m *recordingSessionManager) GetSession(string) entities.Session { return nil }
+func (m *recordingSessionManager) ListSessions(entities.SessionFilter) []entities.Session {
+	return nil
+}
+func (m *recordingSessionManager) DeleteSession(string) error { return nil }
+func (m *recordingSessionManager) SendMessage(context.Context, string, string) error {
+	return nil
+}
+func (m *recordingSessionManager) StopAgent(context.Context, string) error { return nil }
+func (m *recordingSessionManager) GetMessages(context.Context, string) ([]repositories.Message, error) {
+	return nil, nil
+}
+func (m *recordingSessionManager) Shutdown(time.Duration) error { return nil }
+
+type launchTestSession struct {
+	id     string
+	userID string
+	status string
+}
+
+func (s *launchTestSession) ID() string                    { return s.id }
+func (s *launchTestSession) Addr() string                  { return "" }
+func (s *launchTestSession) UserID() string                { return s.userID }
+func (s *launchTestSession) Scope() entities.ResourceScope { return entities.ScopeUser }
+func (s *launchTestSession) TeamID() string                { return "" }
+func (s *launchTestSession) Tags() map[string]string       { return nil }
+func (s *launchTestSession) Status() string                { return s.status }
+func (s *launchTestSession) StartedAt() time.Time          { return time.Time{} }
+func (s *launchTestSession) UpdatedAt() time.Time          { return time.Time{} }
+func (s *launchTestSession) LastMessageAt() time.Time      { return time.Time{} }
+func (s *launchTestSession) Description() string           { return "" }
+func (s *launchTestSession) Cancel()                       {}
+
+type fakeSessionProfileRepo struct {
+	profiles []*entities.SessionProfile
+}
+
+func (r *fakeSessionProfileRepo) Create(context.Context, *entities.SessionProfile) error {
+	return nil
+}
+func (r *fakeSessionProfileRepo) Get(_ context.Context, id string) (*entities.SessionProfile, error) {
+	for _, p := range r.profiles {
+		if p.ID() == id {
+			return p, nil
+		}
+	}
+	return nil, entities.ErrSessionProfileNotFound{ID: id}
+}
+func (r *fakeSessionProfileRepo) List(_ context.Context, filter repositories.SessionProfileFilter) ([]*entities.SessionProfile, error) {
+	var result []*entities.SessionProfile
+	for _, p := range r.profiles {
+		if p.UserID() != filter.UserID || p.Scope() != filter.Scope {
+			continue
+		}
+		if filter.Scope == entities.ScopeTeam && p.TeamID() != filter.TeamID {
+			continue
+		}
+		result = append(result, p)
+	}
+	return result, nil
+}
+func (r *fakeSessionProfileRepo) Update(context.Context, *entities.SessionProfile) error {
+	return nil
+}
+func (r *fakeSessionProfileRepo) Delete(context.Context, string) error { return nil }
+
+func TestLaunchAppliesDefaultProfileDocker(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetParams(&entities.SessionParams{
+		Docker:     &entities.DockerParams{Enabled: true},
+		SessionTTL: "48h",
+	})
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req == nil {
+		t.Fatal("CreateSession was not called")
+	}
+	if sessionManager.req.Docker == nil || !sessionManager.req.Docker.Enabled {
+		t.Fatalf("expected profile Docker.Enabled to be applied, got %#v", sessionManager.req.Docker)
+	}
+	if sessionManager.req.SessionTTL != "48h" {
+		t.Fatalf("expected profile SessionTTL to be applied, got %q", sessionManager.req.SessionTTL)
+	}
+}
+
+func TestLaunchExplicitDockerOverridesProfileDocker(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetParams(&entities.SessionParams{
+		Docker: &entities.DockerParams{Enabled: true},
+	})
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+		Docker: &entities.DockerParams{Enabled: false},
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req == nil || sessionManager.req.Docker == nil {
+		t.Fatalf("expected explicit Docker params, got %#v", sessionManager.req)
+	}
+	if sessionManager.req.Docker.Enabled {
+		t.Fatalf("expected explicit Docker.Enabled=false to override profile, got %#v", sessionManager.req.Docker)
+	}
+}

--- a/pkg/schedule/handlers.go
+++ b/pkg/schedule/handlers.go
@@ -520,6 +520,10 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 	var initialMessage, githubToken, agentType string
 	var slackParams *entities.SlackParams
 	var sandbox *entities.SandboxParams
+	var docker *entities.DockerParams
+	var initialMessageWaitSecond *int
+	var cycleMessage, sessionTTL string
+	var cycleMaxCount int
 	var oneshot bool
 	if schedule.SessionConfig.Params != nil {
 		initialMessage = schedule.SessionConfig.Params.Message
@@ -530,25 +534,35 @@ func (h *Handlers) TriggerSchedule(c echo.Context) error {
 		agentType = schedule.SessionConfig.Params.AgentType
 		slackParams = schedule.SessionConfig.Params.Slack
 		sandbox = schedule.SessionConfig.Params.Sandbox
+		docker = schedule.SessionConfig.Params.Docker
+		initialMessageWaitSecond = schedule.SessionConfig.Params.InitialMessageWaitSecond
+		cycleMessage = schedule.SessionConfig.Params.CycleMessage
+		cycleMaxCount = schedule.SessionConfig.Params.CycleMaxCount
+		sessionTTL = schedule.SessionConfig.Params.SessionTTL
 		oneshot = schedule.SessionConfig.Params.Oneshot
 	}
 
 	result, err := h.launcher.Launch(c.Request().Context(), sessionID, sessionuc.LaunchRequest{
-		UserID:           schedule.UserID,
-		Scope:            scheduleScope,
-		TeamID:           schedule.TeamID,
-		Teams:            teams,
-		Environment:      schedule.SessionConfig.Environment,
-		Tags:             tags,
-		InitialMessage:   initialMessage,
-		GithubToken:      githubToken,
-		AgentType:        agentType,
-		SlackParams:      slackParams,
-		Sandbox:          sandbox,
-		Oneshot:          oneshot,
-		MemoryKey:        schedule.SessionConfig.MemoryKey,
-		RepoInfo:         app.ExtractRepositoryInfo(tags, sessionID),
-		SessionProfileID: schedule.SessionConfig.SessionProfileID,
+		UserID:                   schedule.UserID,
+		Scope:                    scheduleScope,
+		TeamID:                   schedule.TeamID,
+		Teams:                    teams,
+		Environment:              schedule.SessionConfig.Environment,
+		Tags:                     tags,
+		InitialMessage:           initialMessage,
+		GithubToken:              githubToken,
+		AgentType:                agentType,
+		SlackParams:              slackParams,
+		Sandbox:                  sandbox,
+		Docker:                   docker,
+		Oneshot:                  oneshot,
+		InitialMessageWaitSecond: initialMessageWaitSecond,
+		CycleMessage:             cycleMessage,
+		CycleMaxCount:            cycleMaxCount,
+		SessionTTL:               sessionTTL,
+		MemoryKey:                schedule.SessionConfig.MemoryKey,
+		RepoInfo:                 app.ExtractRepositoryInfo(tags, sessionID),
+		SessionProfileID:         schedule.SessionConfig.SessionProfileID,
 		// Session reuse: when enabled, an existing active session matching schedule_id
 		// tag receives the message instead of a new session being created.
 		ReuseSession:   schedule.SessionConfig.ReuseSession,

--- a/pkg/schedule/worker.go
+++ b/pkg/schedule/worker.go
@@ -248,6 +248,10 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 	var initialMessage, githubToken, agentType string
 	var slackParams *entities.SlackParams
 	var sandbox *entities.SandboxParams
+	var docker *entities.DockerParams
+	var initialMessageWaitSecond *int
+	var cycleMessage, sessionTTL string
+	var cycleMaxCount int
 	var oneshot bool
 	if schedule.SessionConfig.Params != nil {
 		initialMessage = schedule.SessionConfig.Params.Message
@@ -258,6 +262,11 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 		agentType = schedule.SessionConfig.Params.AgentType
 		slackParams = schedule.SessionConfig.Params.Slack
 		sandbox = schedule.SessionConfig.Params.Sandbox
+		docker = schedule.SessionConfig.Params.Docker
+		initialMessageWaitSecond = schedule.SessionConfig.Params.InitialMessageWaitSecond
+		cycleMessage = schedule.SessionConfig.Params.CycleMessage
+		cycleMaxCount = schedule.SessionConfig.Params.CycleMaxCount
+		sessionTTL = schedule.SessionConfig.Params.SessionTTL
 		oneshot = schedule.SessionConfig.Params.Oneshot
 	}
 
@@ -284,18 +293,23 @@ func (w *Worker) buildLaunchRequest(schedule *Schedule, sessionID string) sessio
 		TeamID: schedule.TeamID,
 		// ResolveTeams centralises the scope-based teams logic so that it cannot
 		// accidentally diverge between the worker and the manual-trigger handler.
-		Teams:            sessionuc.ResolveTeams(scheduleScope, schedule.TeamID, schedule.UserTeams),
-		Environment:      schedule.SessionConfig.Environment,
-		Tags:             tags,
-		InitialMessage:   initialMessage,
-		GithubToken:      githubToken,
-		AgentType:        agentType,
-		SlackParams:      slackParams,
-		Sandbox:          sandbox,
-		Oneshot:          oneshot,
-		MemoryKey:        memoryKey,
-		RepoInfo:         app.ExtractRepositoryInfo(tags, sessionID),
-		SessionProfileID: schedule.SessionConfig.SessionProfileID,
+		Teams:                    sessionuc.ResolveTeams(scheduleScope, schedule.TeamID, schedule.UserTeams),
+		Environment:              schedule.SessionConfig.Environment,
+		Tags:                     tags,
+		InitialMessage:           initialMessage,
+		GithubToken:              githubToken,
+		AgentType:                agentType,
+		SlackParams:              slackParams,
+		Sandbox:                  sandbox,
+		Docker:                   docker,
+		Oneshot:                  oneshot,
+		InitialMessageWaitSecond: initialMessageWaitSecond,
+		CycleMessage:             cycleMessage,
+		CycleMaxCount:            cycleMaxCount,
+		SessionTTL:               sessionTTL,
+		MemoryKey:                memoryKey,
+		RepoInfo:                 app.ExtractRepositoryInfo(tags, sessionID),
+		SessionProfileID:         schedule.SessionConfig.SessionProfileID,
 		// Session reuse: when enabled, an existing active session matching schedule_id
 		// tag receives the message instead of a new session being created.
 		ReuseSession:   schedule.SessionConfig.ReuseSession,


### PR DESCRIPTION
## Summary
- pass Docker-in-Docker and related session params through LaunchUseCase into RunServerRequest
- include schedule worker/manual trigger params so scheduled sessions preserve explicit Docker config
- apply profile Docker params for LaunchUseCase-created sessions and add regression tests

## Notes
- This fixes scheduled sessions not receiving DinD when the default or explicit session profile enables params.docker.
- Also keeps webhook/slackbot LaunchRequest callers aligned with the expanded params surface.

## Verification
- git diff --check
- Not run: gofmt/go test (Go toolchain is not installed in this environment)