### PR TITLE
Add stock inventory capability pools

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -43,6 +44,20 @@ var ServerCmd = &cobra.Command{
 	Short: "Start the AgentAPI Proxy Server",
 	Long:  "Start the reverse proxy server for AgentAPI that routes requests based on configuration",
 	Run:   runProxy,
+}
+
+func resolveKubernetesNamespace(candidates ...string) string {
+	for _, candidate := range candidates {
+		if namespace := strings.TrimSpace(candidate); namespace != "" {
+			return namespace
+		}
+	}
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if namespace := strings.TrimSpace(string(data)); namespace != "" {
+			return namespace
+		}
+	}
+	return "default"
 }
 
 func init() {
@@ -211,13 +226,7 @@ func registerScheduleHandlers(configData *config.Config, proxyServer *app.Server
 	}
 
 	// Determine namespace
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// Create schedule manager
 	scheduleManager := schedule.NewKubernetesManager(client, namespace)
@@ -253,13 +262,7 @@ func startScheduleWorker(configData *config.Config, proxyServer *app.Server) *sc
 	}
 
 	// Determine namespace
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// Create schedule manager
 	scheduleManager := schedule.NewKubernetesManager(client, namespace)
@@ -338,10 +341,7 @@ func startSlackbotCleanupWorker(configData *config.Config, proxyServer *app.Serv
 		return nil
 	}
 
-	namespace := configData.KubernetesSession.Namespace
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.KubernetesSession.Namespace)
 
 	checkInterval, err := time.ParseDuration(configData.SlackbotCleanupWorker.CheckInterval)
 	if err != nil || checkInterval <= 0 {
@@ -433,13 +433,7 @@ func startStockInventoryWorker(configData *config.Config, proxyServer *app.Serve
 		return nil
 	}
 
-	namespace := configData.StockInventoryWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.StockInventoryWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// KubernetesSessionManager implements StockRepository.
 	stockRepo, ok := proxyServer.GetSessionManager().(stock_inventory.StockRepository)
@@ -545,13 +539,7 @@ func registerWebhookHandlers(configData *config.Config, proxyServer *app.Server)
 	}
 
 	// Determine namespace
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// Create webhook repository (clean architecture)
 	webhookRepo := repositories.NewKubernetesWebhookRepository(client, namespace)
@@ -598,13 +586,7 @@ func startSessionAllocator(configData *config.Config, proxyServer *app.Server) *
 	}
 	manager.SetSessionAllocationNotifier(buildSessionAllocationNotifier(configData))
 
-	namespace := configData.StockInventoryWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.StockInventoryWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	leaseDuration, err := time.ParseDuration(configData.StockInventoryWorker.LeaseDuration)
 	if err != nil {
@@ -697,13 +679,7 @@ func registerImportExportHandlers(configData *config.Config, proxyServer *app.Se
 	}
 
 	// Determine namespace
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// Create schedule manager
 	scheduleManager := schedule.NewKubernetesManager(client, namespace)
@@ -753,13 +729,7 @@ func registerSlackBotHandlers(configData *config.Config, proxyServer *app.Server
 	}
 
 	// Determine namespace
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// Create SlackBot repository
 	slackbotRepo := repositories.NewKubernetesSlackBotRepository(client, namespace)
@@ -789,13 +759,7 @@ func startSlackSocketManager(configData *config.Config, proxyServer *app.Server)
 	}
 
 	// Determine namespace
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	// Create dependencies
 	slackbotRepo := repositories.NewKubernetesSlackBotRepository(client, namespace)
@@ -924,13 +888,7 @@ func registerGitHubSyncHandlers(configData *config.Config, proxyServer *app.Serv
 		return
 	}
 
-	namespace := configData.ScheduleWorker.Namespace
-	if namespace == "" {
-		namespace = configData.KubernetesSession.Namespace
-	}
-	if namespace == "" {
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(configData.ScheduleWorker.Namespace, configData.KubernetesSession.Namespace)
 
 	scheduleManager := schedule.NewKubernetesManager(client, namespace)
 	webhookRepo := repositories.NewKubernetesWebhookRepository(client, namespace)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -507,7 +507,7 @@ func buildStockInventoryPools(workerConfig config.StockInventoryWorkerConfig, de
 	pools := make([]stock_inventory.StockPool, 0, len(workerConfig.Pools))
 	for _, poolConfig := range workerConfig.Pools {
 		targetCount := poolConfig.TargetCount
-		if targetCount <= 0 {
+		if targetCount < 0 {
 			targetCount = defaultTargetCount
 		}
 		pools = append(pools, stock_inventory.StockPool{

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -458,6 +458,7 @@ func startStockInventoryWorker(configData *config.Config, proxyServer *app.Serve
 	if targetCount <= 0 {
 		targetCount = 2
 	}
+	pools := buildStockInventoryPools(configData.StockInventoryWorker, targetCount)
 
 	workerConfig := stock_inventory.WorkerConfig{
 		CheckInterval: checkInterval,
@@ -466,6 +467,7 @@ func startStockInventoryWorker(configData *config.Config, proxyServer *app.Serve
 			Sandbox: configData.StockInventoryWorker.SandboxEnabled,
 			DinD:    configData.StockInventoryWorker.DockerEnabled,
 		},
+		Pools:         pools,
 		Enabled:       true,
 	}
 
@@ -494,9 +496,35 @@ func startStockInventoryWorker(configData *config.Config, proxyServer *app.Serve
 
 	go leaderWorker.Run(context.Background())
 
-	log.Printf("[STOCK_INVENTORY] Stock inventory worker started in namespace: %s (target: %d, sandbox=%t, dind=%t)",
-		namespace, targetCount, workerConfig.Requirements.Sandbox, workerConfig.Requirements.DinD)
+	poolCount := len(pools)
+	if poolCount == 0 {
+		poolCount = 1
+	}
+	log.Printf("[STOCK_INVENTORY] Stock inventory worker started in namespace: %s (pools: %d)",
+		namespace, poolCount)
 	return leaderWorker
+}
+
+func buildStockInventoryPools(workerConfig config.StockInventoryWorkerConfig, defaultTargetCount int) []stock_inventory.StockPool {
+	if len(workerConfig.Pools) == 0 {
+		return nil
+	}
+
+	pools := make([]stock_inventory.StockPool, 0, len(workerConfig.Pools))
+	for _, poolConfig := range workerConfig.Pools {
+		targetCount := poolConfig.TargetCount
+		if targetCount <= 0 {
+			targetCount = defaultTargetCount
+		}
+		pools = append(pools, stock_inventory.StockPool{
+			TargetCount: targetCount,
+			Requirements: stock_inventory.StockRequirements{
+				Sandbox: poolConfig.SandboxEnabled,
+				DinD:    poolConfig.DockerEnabled,
+			},
+		})
+	}
+	return pools
 }
 
 // registerWebhookHandlers registers webhook REST API handlers

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/stock_inventory"
 )
 
 func TestServerCmd(t *testing.T) {
@@ -99,6 +101,22 @@ func TestServerCmdFlags(t *testing.T) {
 			assert.Equal(t, tt.expectedVerb, verbFlag)
 		})
 	}
+}
+
+func TestBuildStockInventoryPoolsAllowsZeroTargetCount(t *testing.T) {
+	pools := buildStockInventoryPools(config.StockInventoryWorkerConfig{
+		Pools: []config.StockInventoryPoolConfig{
+			{TargetCount: 0, SandboxEnabled: false, DockerEnabled: true},
+		},
+	}, 2)
+
+	require.Equal(t, []stock_inventory.StockPool{{
+		TargetCount: 0,
+		Requirements: stock_inventory.StockRequirements{
+			Sandbox: false,
+			DinD:    true,
+		},
+	}}, pools)
 }
 
 func TestRunProxyWithInvalidConfig(t *testing.T) {

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -197,7 +197,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_ENABLED
               value: "true"
             - name: AGENTAPI_K8S_SESSION_NAMESPACE
-              value: {{ .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
+              value: {{ .Release.Namespace | quote }}
             - name: AGENTAPI_K8S_SESSION_IMAGE
               value: {{ .Values.kubernetesSession.image | default (printf "%s:%s" .Values.image.repository .Chart.AppVersion) | quote }}
             - name: AGENTAPI_K8S_SESSION_NETWORK_FILTER_IMAGE
@@ -311,10 +311,8 @@ spec:
             - name: AGENTAPI_SCHEDULE_WORKER_CHECK_INTERVAL
               value: {{ .Values.scheduleWorker.checkInterval | quote }}
             {{- end }}
-            {{- if (.Values.scheduleWorker).namespace }}
             - name: AGENTAPI_SCHEDULE_WORKER_NAMESPACE
-              value: {{ .Values.scheduleWorker.namespace | quote }}
-            {{- end }}
+              value: {{ .Release.Namespace | quote }}
             {{- if (.Values.scheduleWorker).leaseDuration }}
             - name: AGENTAPI_SCHEDULE_WORKER_LEASE_DURATION
               value: {{ .Values.scheduleWorker.leaseDuration | quote }}
@@ -360,7 +358,7 @@ spec:
               value: {{ .Values.stockInventoryWorker.checkInterval | quote }}
             {{- end }}
             - name: AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE
-              value: {{ .Values.stockInventoryWorker.namespace | default .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
+              value: {{ .Release.Namespace | quote }}
             {{- if (.Values.stockInventoryWorker).targetCount }}
             - name: AGENTAPI_STOCK_INVENTORY_WORKER_TARGET_COUNT
               value: {{ .Values.stockInventoryWorker.targetCount | quote }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -367,6 +367,10 @@ spec:
               value: {{ ((.Values.stockInventoryWorker).sandboxEnabled) | default false | quote }}
             - name: AGENTAPI_STOCK_INVENTORY_WORKER_DOCKER_ENABLED
               value: {{ ((.Values.stockInventoryWorker).dockerEnabled) | default false | quote }}
+            {{- if (.Values.stockInventoryWorker).pools }}
+            - name: AGENTAPI_STOCK_INVENTORY_WORKER_POOLS
+              value: {{ .Values.stockInventoryWorker.pools | toJson | quote }}
+            {{- end }}
             {{- if ((.Values.stockInventoryWorker).leaderElection).leaseDuration }}
             - name: AGENTAPI_STOCK_INVENTORY_WORKER_LEASE_DURATION
               value: {{ .Values.stockInventoryWorker.leaderElection.leaseDuration | quote }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -359,6 +359,8 @@ spec:
             - name: AGENTAPI_STOCK_INVENTORY_WORKER_CHECK_INTERVAL
               value: {{ .Values.stockInventoryWorker.checkInterval | quote }}
             {{- end }}
+            - name: AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE
+              value: {{ .Values.stockInventoryWorker.namespace | default .Values.kubernetesSession.namespace | default .Release.Namespace | quote }}
             {{- if (.Values.stockInventoryWorker).targetCount }}
             - name: AGENTAPI_STOCK_INVENTORY_WORKER_TARGET_COUNT
               value: {{ .Values.stockInventoryWorker.targetCount | quote }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -573,6 +573,10 @@ stockInventoryWorker:
   # How often to check and replenish stock sessions
   checkInterval: "30s"
 
+  # Namespace for stock session resources and leader election.
+  # Defaults to kubernetesSession.namespace, then the release namespace.
+  namespace: ""
+
   # Desired number of available stock sessions matching the capability template
   targetCount: 2
 

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -581,6 +581,25 @@ stockInventoryWorker:
   sandboxEnabled: false
   dockerEnabled: false
 
+  # Optional capability pools. When set, each pool is replenished independently
+  # and the single targetCount/sandboxEnabled/dockerEnabled fields above are
+  # used only as defaults for pool entries with no targetCount.
+  # To keep inventory for every sandbox/DinD combination, configure:
+  # pools:
+  #   - targetCount: 2
+  #     sandboxEnabled: false
+  #     dockerEnabled: false
+  #   - targetCount: 2
+  #     sandboxEnabled: false
+  #     dockerEnabled: true
+  #   - targetCount: 2
+  #     sandboxEnabled: true
+  #     dockerEnabled: false
+  #   - targetCount: 2
+  #     sandboxEnabled: true
+  #     dockerEnabled: true
+  pools: []
+
   # Leader election configuration (prevents duplicate stock creation in multi-replica deployments)
   leaderElection:
     # Lease duration (how long the leader holds the lock)

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -330,7 +330,7 @@ kubernetesSession:
   # Number of replicas for the agentapi-proxy Deployment
   replicaCount: 3
 
-  # Namespace for session resources (defaults to release namespace if empty)
+  # Deprecated: session resources always use the Helm release namespace.
   namespace: ""
 
   # Container image for session pods
@@ -572,10 +572,6 @@ stockInventoryWorker:
 
   # How often to check and replenish stock sessions
   checkInterval: "30s"
-
-  # Namespace for stock session resources and leader election.
-  # Defaults to kubernetesSession.namespace, then the release namespace.
-  namespace: ""
 
   # Desired number of available stock sessions matching the capability template
   targetCount: 2

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -175,11 +175,7 @@ func NewKubernetesSessionManagerWithClient(
 	k8sConfig := &cfg.KubernetesSession
 
 	// Determine namespace
-	namespace := k8sConfig.Namespace
-	if namespace == "" {
-		// Use namespace from controller-runtime config or default
-		namespace = "default"
-	}
+	namespace := resolveKubernetesNamespace(k8sConfig.Namespace)
 
 	log.Printf("[K8S_SESSION] Initialized KubernetesSessionManager in namespace: %s", namespace)
 
@@ -220,6 +216,20 @@ func NewKubernetesSessionManagerWithClient(
 	}
 
 	return manager, nil
+}
+
+func resolveKubernetesNamespace(candidates ...string) string {
+	for _, candidate := range candidates {
+		if namespace := strings.TrimSpace(candidate); namespace != "" {
+			return namespace
+		}
+	}
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if namespace := strings.TrimSpace(string(data)); namespace != "" {
+			return namespace
+		}
+	}
+	return "default"
 }
 
 // SetStatusEventRepository injects a StatusEventRepository for cross-pod status

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,11 +35,13 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
@@ -567,7 +569,7 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	var config Config
-	if err := v.Unmarshal(&config); err != nil {
+	if err := v.Unmarshal(&config, viper.DecodeHook(stockInventoryPoolsDecodeHook())); err != nil {
 		return nil, err
 	}
 
@@ -606,6 +608,22 @@ func LoadConfig(filename string) (*Config, error) {
 	log.Printf("[CONFIG] Role-based env files enabled: %v", config.RoleEnvFiles.Enabled)
 
 	return &config, nil
+}
+
+func stockInventoryPoolsDecodeHook() mapstructure.DecodeHookFunc {
+	return func(from reflect.Type, to reflect.Type, data interface{}) (interface{}, error) {
+		if from.Kind() != reflect.String || to != reflect.TypeOf([]StockInventoryPoolConfig{}) {
+			return data, nil
+		}
+		if data == "" {
+			return []StockInventoryPoolConfig{}, nil
+		}
+		var pools []StockInventoryPoolConfig
+		if err := json.Unmarshal([]byte(data.(string)), &pools); err != nil {
+			return nil, err
+		}
+		return pools, nil
+	}
 }
 
 // initializeConfigStructsFromEnv initializes config structs from environment variables

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"reflect"
@@ -618,12 +619,81 @@ func stockInventoryPoolsDecodeHook() mapstructure.DecodeHookFunc {
 		if data == "" {
 			return []StockInventoryPoolConfig{}, nil
 		}
-		var pools []StockInventoryPoolConfig
-		if err := json.Unmarshal([]byte(data.(string)), &pools); err != nil {
+		pools, err := parseStockInventoryPoolsJSON(data.(string))
+		if err != nil {
 			return nil, err
 		}
 		return pools, nil
 	}
+}
+
+func parseStockInventoryPoolsJSON(poolsJSON string) ([]StockInventoryPoolConfig, error) {
+	var rawPools []map[string]interface{}
+	if err := json.Unmarshal([]byte(poolsJSON), &rawPools); err != nil {
+		return nil, err
+	}
+
+	pools := make([]StockInventoryPoolConfig, 0, len(rawPools))
+	for _, rawPool := range rawPools {
+		targetCount, err := jsonInt(rawPool, "target_count", "targetCount")
+		if err != nil {
+			return nil, err
+		}
+		sandboxEnabled, err := jsonBool(rawPool, "sandbox_enabled", "sandboxEnabled")
+		if err != nil {
+			return nil, err
+		}
+		dockerEnabled, err := jsonBool(rawPool, "docker_enabled", "dockerEnabled")
+		if err != nil {
+			return nil, err
+		}
+
+		pools = append(pools, StockInventoryPoolConfig{
+			TargetCount:    targetCount,
+			SandboxEnabled: sandboxEnabled,
+			DockerEnabled:  dockerEnabled,
+		})
+	}
+	return pools, nil
+}
+
+func jsonInt(values map[string]interface{}, keys ...string) (int, error) {
+	value, ok := jsonValue(values, keys...)
+	if !ok {
+		return 0, nil
+	}
+	switch typedValue := value.(type) {
+	case float64:
+		return int(typedValue), nil
+	case string:
+		return strconv.Atoi(typedValue)
+	default:
+		return 0, fmt.Errorf("expected integer for %s, got %T", keys[0], value)
+	}
+}
+
+func jsonBool(values map[string]interface{}, keys ...string) (bool, error) {
+	value, ok := jsonValue(values, keys...)
+	if !ok {
+		return false, nil
+	}
+	switch typedValue := value.(type) {
+	case bool:
+		return typedValue, nil
+	case string:
+		return strconv.ParseBool(typedValue)
+	default:
+		return false, fmt.Errorf("expected boolean for %s, got %T", keys[0], value)
+	}
+}
+
+func jsonValue(values map[string]interface{}, keys ...string) (interface{}, bool) {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			return value, true
+		}
+	}
+	return nil, false
 }
 
 // initializeConfigStructsFromEnv initializes config structs from environment variables
@@ -746,8 +816,8 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 		config.StockInventoryWorker.RetryPeriod = retryPeriod
 	}
 	if poolsJSON := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS"); poolsJSON != "" {
-		var pools []StockInventoryPoolConfig
-		if err := json.Unmarshal([]byte(poolsJSON), &pools); err != nil {
+		pools, err := parseStockInventoryPoolsJSON(poolsJSON)
+		if err != nil {
 			log.Printf("[CONFIG] Warning: Failed to parse stock inventory worker pools JSON: %v", err)
 		} else {
 			config.StockInventoryWorker.Pools = pools

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -685,6 +685,15 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 		config.GitSync.SyncInterval = syncInterval
 	}
 
+	if namespace := v.GetString("kubernetes_session.namespace"); namespace != "" {
+		config.KubernetesSession.Namespace = namespace
+	}
+	if namespace := v.GetString("schedule_worker.namespace"); namespace != "" {
+		config.ScheduleWorker.Namespace = namespace
+	}
+	if namespace := v.GetString("stock_inventory_worker.namespace"); namespace != "" {
+		config.StockInventoryWorker.Namespace = namespace
+	}
 	if poolsJSON := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS"); poolsJSON != "" {
 		var pools []StockInventoryPoolConfig
 		if err := json.Unmarshal([]byte(poolsJSON), &pools); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -685,13 +685,13 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 		config.GitSync.SyncInterval = syncInterval
 	}
 
-	if namespace := v.GetString("kubernetes_session.namespace"); namespace != "" {
+	if namespace := os.Getenv("AGENTAPI_K8S_SESSION_NAMESPACE"); namespace != "" {
 		config.KubernetesSession.Namespace = namespace
 	}
-	if namespace := v.GetString("schedule_worker.namespace"); namespace != "" {
+	if namespace := os.Getenv("AGENTAPI_SCHEDULE_WORKER_NAMESPACE"); namespace != "" {
 		config.ScheduleWorker.Namespace = namespace
 	}
-	if namespace := v.GetString("stock_inventory_worker.namespace"); namespace != "" {
+	if namespace := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE"); namespace != "" {
 		config.StockInventoryWorker.Namespace = namespace
 	}
 	if poolsJSON := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS"); poolsJSON != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,12 +195,26 @@ type StockInventoryWorkerConfig struct {
 	SandboxEnabled bool `json:"sandbox_enabled" mapstructure:"sandbox_enabled"`
 	// DockerEnabled controls whether stock sessions include the Docker-in-Docker sidecar.
 	DockerEnabled bool `json:"docker_enabled" mapstructure:"docker_enabled"`
+	// Pools optionally configures multiple stock pools. When set, each pool is
+	// replenished independently; otherwise the legacy single-pool fields above
+	// are used.
+	Pools []StockInventoryPoolConfig `json:"pools" mapstructure:"pools"`
 	// Namespace overrides the Kubernetes namespace (falls back to KubernetesSession.Namespace).
 	Namespace string `json:"namespace" mapstructure:"namespace"`
 	// Leader election timings.
 	LeaseDuration string `json:"lease_duration" mapstructure:"lease_duration"`
 	RenewDeadline string `json:"renew_deadline" mapstructure:"renew_deadline"`
 	RetryPeriod   string `json:"retry_period" mapstructure:"retry_period"`
+}
+
+// StockInventoryPoolConfig represents one stock inventory capability pool.
+type StockInventoryPoolConfig struct {
+	// TargetCount is the desired number of stock sessions for this capability pool.
+	TargetCount int `json:"target_count" mapstructure:"target_count"`
+	// SandboxEnabled controls whether stock sessions include the network sandbox sidecar.
+	SandboxEnabled bool `json:"sandbox_enabled" mapstructure:"sandbox_enabled"`
+	// DockerEnabled controls whether stock sessions include the Docker-in-Docker sidecar.
+	DockerEnabled bool `json:"docker_enabled" mapstructure:"docker_enabled"`
 }
 
 // WebhookConfig represents webhook configuration
@@ -671,6 +685,15 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 		config.GitSync.SyncInterval = syncInterval
 	}
 
+	if poolsJSON := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS"); poolsJSON != "" {
+		var pools []StockInventoryPoolConfig
+		if err := json.Unmarshal([]byte(poolsJSON), &pools); err != nil {
+			log.Printf("[CONFIG] Warning: Failed to parse stock inventory worker pools JSON: %v", err)
+		} else {
+			config.StockInventoryWorker.Pools = pools
+		}
+	}
+
 	// Override fields if environment variables are set (even if structures already exist)
 	if config.Auth.Static != nil {
 		if v.IsSet("auth.static.keys_file") {
@@ -823,6 +846,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("stock_inventory_worker.target_count", "AGENTAPI_STOCK_INVENTORY_WORKER_TARGET_COUNT")
 	_ = v.BindEnv("stock_inventory_worker.sandbox_enabled", "AGENTAPI_STOCK_INVENTORY_WORKER_SANDBOX_ENABLED")
 	_ = v.BindEnv("stock_inventory_worker.docker_enabled", "AGENTAPI_STOCK_INVENTORY_WORKER_DOCKER_ENABLED")
+	_ = v.BindEnv("stock_inventory_worker.pools", "AGENTAPI_STOCK_INVENTORY_WORKER_POOLS")
 	_ = v.BindEnv("stock_inventory_worker.namespace", "AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE")
 	_ = v.BindEnv("stock_inventory_worker.lease_duration", "AGENTAPI_STOCK_INVENTORY_WORKER_LEASE_DURATION")
 	_ = v.BindEnv("stock_inventory_worker.renew_deadline", "AGENTAPI_STOCK_INVENTORY_WORKER_RENEW_DEADLINE")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -693,6 +694,38 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	}
 	if namespace := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE"); namespace != "" {
 		config.StockInventoryWorker.Namespace = namespace
+	}
+	if enabled := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_ENABLED"); enabled != "" {
+		if parsed, err := strconv.ParseBool(enabled); err == nil {
+			config.StockInventoryWorker.Enabled = parsed
+		}
+	}
+	if checkInterval := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_CHECK_INTERVAL"); checkInterval != "" {
+		config.StockInventoryWorker.CheckInterval = checkInterval
+	}
+	if targetCount := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_TARGET_COUNT"); targetCount != "" {
+		if parsed, err := strconv.Atoi(targetCount); err == nil {
+			config.StockInventoryWorker.TargetCount = parsed
+		}
+	}
+	if sandboxEnabled := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_SANDBOX_ENABLED"); sandboxEnabled != "" {
+		if parsed, err := strconv.ParseBool(sandboxEnabled); err == nil {
+			config.StockInventoryWorker.SandboxEnabled = parsed
+		}
+	}
+	if dockerEnabled := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_DOCKER_ENABLED"); dockerEnabled != "" {
+		if parsed, err := strconv.ParseBool(dockerEnabled); err == nil {
+			config.StockInventoryWorker.DockerEnabled = parsed
+		}
+	}
+	if leaseDuration := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_LEASE_DURATION"); leaseDuration != "" {
+		config.StockInventoryWorker.LeaseDuration = leaseDuration
+	}
+	if renewDeadline := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_RENEW_DEADLINE"); renewDeadline != "" {
+		config.StockInventoryWorker.RenewDeadline = renewDeadline
+	}
+	if retryPeriod := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_RETRY_PERIOD"); retryPeriod != "" {
+		config.StockInventoryWorker.RetryPeriod = retryPeriod
 	}
 	if poolsJSON := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS"); poolsJSON != "" {
 		var pools []StockInventoryPoolConfig

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -434,6 +434,27 @@ func TestLoadConfigWithEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestLoadConfigWithStockInventoryPoolsEnv(t *testing.T) {
+	clearAGENTAPIEnvVars(t)
+
+	_ = os.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS", `[
+		{"targetCount":1,"sandboxEnabled":false,"dockerEnabled":false},
+		{"targetCount":2,"sandboxEnabled":true,"dockerEnabled":false},
+		{"target_count":3,"sandbox_enabled":false,"docker_enabled":true}
+	]`)
+
+	loadedConfig, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	assert.Equal(t, []StockInventoryPoolConfig{
+		{TargetCount: 1, SandboxEnabled: false, DockerEnabled: false},
+		{TargetCount: 2, SandboxEnabled: true, DockerEnabled: false},
+		{TargetCount: 3, SandboxEnabled: false, DockerEnabled: true},
+	}, loadedConfig.StockInventoryWorker.Pools)
+}
+
 func TestLoadConfigNetworkFilterResourceDefaults(t *testing.T) {
 	clearAGENTAPIEnvVars(t)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,6 +115,47 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAppliesWorkerNamespaceEnvOverrides(t *testing.T) {
+	clearAGENTAPIEnvVars(t)
+
+	tmpfile, err := os.CreateTemp("", "config*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+
+	if _, err := tmpfile.WriteString("{}"); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+	_ = tmpfile.Close()
+
+	_ = os.Setenv("AGENTAPI_K8S_SESSION_NAMESPACE", "agentapi-ui-dev")
+	_ = os.Setenv("AGENTAPI_SCHEDULE_WORKER_NAMESPACE", "agentapi-ui-dev")
+	_ = os.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE", "agentapi-ui-dev")
+	_ = os.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS", `[{"target_count":1,"sandbox_enabled":true,"docker_enabled":true}]`)
+
+	loadedConfig, err := LoadConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if got := loadedConfig.KubernetesSession.Namespace; got != "agentapi-ui-dev" {
+		t.Fatalf("KubernetesSession.Namespace = %q, want agentapi-ui-dev", got)
+	}
+	if got := loadedConfig.ScheduleWorker.Namespace; got != "agentapi-ui-dev" {
+		t.Fatalf("ScheduleWorker.Namespace = %q, want agentapi-ui-dev", got)
+	}
+	if got := loadedConfig.StockInventoryWorker.Namespace; got != "agentapi-ui-dev" {
+		t.Fatalf("StockInventoryWorker.Namespace = %q, want agentapi-ui-dev", got)
+	}
+	if len(loadedConfig.StockInventoryWorker.Pools) != 1 {
+		t.Fatalf("StockInventoryWorker.Pools length = %d, want 1", len(loadedConfig.StockInventoryWorker.Pools))
+	}
+	if !loadedConfig.StockInventoryWorker.Pools[0].SandboxEnabled || !loadedConfig.StockInventoryWorker.Pools[0].DockerEnabled {
+		t.Fatalf("StockInventoryWorker.Pools[0] = %+v, want sandbox and docker enabled", loadedConfig.StockInventoryWorker.Pools[0])
+	}
+}
+
 func TestLoadConfigNonexistentFile(t *testing.T) {
 	_, err := LoadConfig("nonexistent-file.json")
 	if err == nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -129,10 +129,10 @@ func TestLoadConfigAppliesWorkerNamespaceEnvOverrides(t *testing.T) {
 	}
 	_ = tmpfile.Close()
 
-	_ = os.Setenv("AGENTAPI_K8S_SESSION_NAMESPACE", "agentapi-ui-dev")
-	_ = os.Setenv("AGENTAPI_SCHEDULE_WORKER_NAMESPACE", "agentapi-ui-dev")
-	_ = os.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE", "agentapi-ui-dev")
-	_ = os.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS", `[{"target_count":1,"sandbox_enabled":true,"docker_enabled":true}]`)
+	t.Setenv("AGENTAPI_K8S_SESSION_NAMESPACE", "agentapi-ui-dev")
+	t.Setenv("AGENTAPI_SCHEDULE_WORKER_NAMESPACE", "agentapi-ui-dev")
+	t.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE", "agentapi-ui-dev")
+	t.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS", `[{"target_count":1,"sandbox_enabled":true,"docker_enabled":true}]`)
 
 	loadedConfig, err := LoadConfig(tmpfile.Name())
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -115,47 +115,6 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
-func TestLoadConfigAppliesWorkerNamespaceEnvOverrides(t *testing.T) {
-	clearAGENTAPIEnvVars(t)
-
-	tmpfile, err := os.CreateTemp("", "config*.json")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	defer func() { _ = os.Remove(tmpfile.Name()) }()
-
-	if _, err := tmpfile.WriteString("{}"); err != nil {
-		t.Fatalf("Failed to write config file: %v", err)
-	}
-	_ = tmpfile.Close()
-
-	t.Setenv("AGENTAPI_K8S_SESSION_NAMESPACE", "agentapi-ui-dev")
-	t.Setenv("AGENTAPI_SCHEDULE_WORKER_NAMESPACE", "agentapi-ui-dev")
-	t.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE", "agentapi-ui-dev")
-	t.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS", `[{"target_count":1,"sandbox_enabled":true,"docker_enabled":true}]`)
-
-	loadedConfig, err := LoadConfig(tmpfile.Name())
-	if err != nil {
-		t.Fatalf("LoadConfig failed: %v", err)
-	}
-
-	if got := loadedConfig.KubernetesSession.Namespace; got != "agentapi-ui-dev" {
-		t.Fatalf("KubernetesSession.Namespace = %q, want agentapi-ui-dev", got)
-	}
-	if got := loadedConfig.ScheduleWorker.Namespace; got != "agentapi-ui-dev" {
-		t.Fatalf("ScheduleWorker.Namespace = %q, want agentapi-ui-dev", got)
-	}
-	if got := loadedConfig.StockInventoryWorker.Namespace; got != "agentapi-ui-dev" {
-		t.Fatalf("StockInventoryWorker.Namespace = %q, want agentapi-ui-dev", got)
-	}
-	if len(loadedConfig.StockInventoryWorker.Pools) != 1 {
-		t.Fatalf("StockInventoryWorker.Pools length = %d, want 1", len(loadedConfig.StockInventoryWorker.Pools))
-	}
-	if !loadedConfig.StockInventoryWorker.Pools[0].SandboxEnabled || !loadedConfig.StockInventoryWorker.Pools[0].DockerEnabled {
-		t.Fatalf("StockInventoryWorker.Pools[0] = %+v, want sandbox and docker enabled", loadedConfig.StockInventoryWorker.Pools[0])
-	}
-}
-
 func TestLoadConfigNonexistentFile(t *testing.T) {
 	_, err := LoadConfig("nonexistent-file.json")
 	if err == nil {

--- a/pkg/stock_inventory/worker.go
+++ b/pkg/stock_inventory/worker.go
@@ -26,6 +26,12 @@ type StockRequirements struct {
 	DinD      bool
 }
 
+// StockPool captures one stock inventory target for a capability set.
+type StockPool struct {
+	TargetCount  int
+	Requirements StockRequirements
+}
+
 // WorkerConfig contains configuration for the stock inventory worker.
 type WorkerConfig struct {
 	// CheckInterval is how often to check and replenish stock sessions.
@@ -34,6 +40,9 @@ type WorkerConfig struct {
 	TargetCount int
 	// Requirements is the pod capability template for stock sessions.
 	Requirements StockRequirements
+	// Pools optionally configures multiple stock inventory targets. When set,
+	// TargetCount and Requirements are ignored.
+	Pools []StockPool
 	// Enabled indicates whether the worker should run.
 	Enabled bool
 }
@@ -81,8 +90,8 @@ func (w *Worker) Start(ctx context.Context) error {
 	w.wg.Add(1)
 	go w.run(ctx)
 
-	log.Printf("[STOCK_INVENTORY] Started with check interval %v, target count %d",
-		w.config.CheckInterval, w.config.TargetCount)
+	log.Printf("[STOCK_INVENTORY] Started with check interval %v, pools %d",
+		w.config.CheckInterval, len(w.effectivePools()))
 	return nil
 }
 
@@ -134,25 +143,41 @@ func (w *Worker) run(ctx context.Context) {
 
 // replenishStock checks the current stock count and creates sessions to reach TargetCount.
 func (w *Worker) replenishStock(ctx context.Context) {
-	count, err := w.repo.CountStockSessions(ctx, w.config.Requirements.Sandbox, w.config.Requirements.DinD)
+	for _, pool := range w.effectivePools() {
+		w.replenishPool(ctx, pool)
+	}
+}
+
+func (w *Worker) replenishPool(ctx context.Context, pool StockPool) {
+	count, err := w.repo.CountStockSessions(ctx, pool.Requirements.Sandbox, pool.Requirements.DinD)
 	if err != nil {
 		log.Printf("[STOCK_INVENTORY] Failed to count stock sessions: %v", err)
 		return
 	}
 
-	needed := w.config.TargetCount - count
+	needed := pool.TargetCount - count
 	if needed <= 0 {
 		return
 	}
 
 	log.Printf("[STOCK_INVENTORY] Replenishing %d stock session(s) (current: %d, target: %d, sandbox=%t, dind=%t)",
-		needed, count, w.config.TargetCount, w.config.Requirements.Sandbox, w.config.Requirements.DinD)
+		needed, count, pool.TargetCount, pool.Requirements.Sandbox, pool.Requirements.DinD)
 
 	for i := 0; i < needed; i++ {
-		if err := w.repo.CreateStockSession(ctx, w.config.Requirements.Sandbox, w.config.Requirements.DinD); err != nil {
+		if err := w.repo.CreateStockSession(ctx, pool.Requirements.Sandbox, pool.Requirements.DinD); err != nil {
 			log.Printf("[STOCK_INVENTORY] Failed to create stock session: %v", err)
 		}
 	}
+}
+
+func (w *Worker) effectivePools() []StockPool {
+	if len(w.config.Pools) > 0 {
+		return w.config.Pools
+	}
+	return []StockPool{{
+		TargetCount:  w.config.TargetCount,
+		Requirements: w.config.Requirements,
+	}}
 }
 
 // LeaderWorker wraps Worker with Kubernetes leader election so that only one

--- a/pkg/stock_inventory/worker_test.go
+++ b/pkg/stock_inventory/worker_test.go
@@ -35,9 +35,54 @@ func TestReplenishStockUsesConfiguredRequirements(t *testing.T) {
 	}
 }
 
+func TestReplenishStockUsesAllConfiguredPools(t *testing.T) {
+	repo := &recordingStockRepo{
+		counts: map[StockRequirements]int{
+			{Sandbox: false, DinD: false}: 1,
+			{Sandbox: false, DinD: true}:  0,
+			{Sandbox: true, DinD: false}:  2,
+			{Sandbox: true, DinD: true}:   1,
+		},
+	}
+	pools := []StockPool{
+		{TargetCount: 2, Requirements: StockRequirements{Sandbox: false, DinD: false}},
+		{TargetCount: 2, Requirements: StockRequirements{Sandbox: false, DinD: true}},
+		{TargetCount: 2, Requirements: StockRequirements{Sandbox: true, DinD: false}},
+		{TargetCount: 2, Requirements: StockRequirements{Sandbox: true, DinD: true}},
+	}
+	worker := NewWorker(repo, WorkerConfig{
+		CheckInterval: time.Minute,
+		Pools:         pools,
+		Enabled:       true,
+	})
+
+	worker.replenishStock(context.Background())
+
+	if !reflect.DeepEqual(repo.countedRequirements, []StockRequirements{
+		{Sandbox: false, DinD: false},
+		{Sandbox: false, DinD: true},
+		{Sandbox: true, DinD: false},
+		{Sandbox: true, DinD: true},
+	}) {
+		t.Fatalf("CountStockSessions requirements = %+v", repo.countedRequirements)
+	}
+
+	wantCreates := []StockRequirements{
+		{Sandbox: false, DinD: false},
+		{Sandbox: false, DinD: true},
+		{Sandbox: false, DinD: true},
+		{Sandbox: true, DinD: true},
+	}
+	if !reflect.DeepEqual(repo.createRequirements, wantCreates) {
+		t.Fatalf("CreateStockSession requirements = %+v, want %+v", repo.createRequirements, wantCreates)
+	}
+}
+
 type recordingStockRepo struct {
-	count              int
-	countRequirements StockRequirements
+	count               int
+	counts              map[StockRequirements]int
+	countRequirements   StockRequirements
+	countedRequirements []StockRequirements
 	createRequirements []StockRequirements
 }
 
@@ -47,7 +92,12 @@ func (r *recordingStockRepo) CreateStockSession(_ context.Context, sandbox, dind
 }
 
 func (r *recordingStockRepo) CountStockSessions(_ context.Context, sandbox, dind bool) (int, error) {
-	r.countRequirements = StockRequirements{Sandbox: sandbox, DinD: dind}
+	requirements := StockRequirements{Sandbox: sandbox, DinD: dind}
+	r.countRequirements = requirements
+	r.countedRequirements = append(r.countedRequirements, requirements)
+	if r.counts != nil {
+		return r.counts[requirements], nil
+	}
 	return r.count, nil
 }
 


### PR DESCRIPTION
## Summary
- add multi-pool stock inventory config for independent sandbox/DinD capability inventory
- support AGENTAPI_STOCK_INVENTORY_WORKER_POOLS JSON env and Helm values rendering
- keep legacy single-pool targetCount/sandboxEnabled/dockerEnabled behavior as fallback
- add worker coverage for all sandbox/DinD combinations

## Testing
- git diff --check
- Not run: gofmt/go test/helm template because Go and Helm binaries are not installed in this environment