### PR TITLE
chore: update agentapi and Claude Code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   GO_VERSION: "1.25"
+  AGENTAPI_VERSION: "v0.12.2"
+  CLAUDE_CODE_VERSION: "2.1.170"
 
 jobs:
   ci:
@@ -38,16 +40,14 @@ jobs:
       with:
         path: |
           ~/.cache/agentapi
-        key: ${{ runner.os }}-agentapi-${{ hashFiles('**/go.mod') }}-v2
-        restore-keys: |
-          ${{ runner.os }}-agentapi-
+        key: ${{ runner.os }}-agentapi-${{ env.AGENTAPI_VERSION }}-${{ hashFiles('**/go.mod') }}
 
     - name: Download agentapi binary
       run: |
         mkdir -p ~/.cache/agentapi
         if [ ! -f ~/.cache/agentapi/agentapi ]; then
           echo "Downloading agentapi binary..."
-          curl -L -o ~/.cache/agentapi/agentapi https://github.com/coder/agentapi/releases/latest/download/agentapi-linux-amd64
+          curl -L -o ~/.cache/agentapi/agentapi https://github.com/coder/agentapi/releases/download/${{ env.AGENTAPI_VERSION }}/agentapi-linux-amd64
           chmod +x ~/.cache/agentapi/agentapi
         else
           echo "Using cached agentapi binary"
@@ -64,16 +64,14 @@ jobs:
       with:
         path: |
           ~/.cache/claude-code
-        key: ${{ runner.os }}-claude-code-${{ hashFiles('**/go.mod') }}-v2
-        restore-keys: |
-          ${{ runner.os }}-claude-code-
+        key: ${{ runner.os }}-claude-code-${{ env.CLAUDE_CODE_VERSION }}-${{ hashFiles('**/go.mod') }}
 
     - name: Install Claude Code
       run: |
         mkdir -p ~/.cache/claude-code
         if [ ! -f ~/.cache/claude-code/claude ]; then
           echo "Installing Claude Code..."
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@${{ env.CLAUDE_CODE_VERSION }}
           cp $(which claude) ~/.cache/claude-code/claude
         else
           echo "Using cached Claude Code"

--- a/.github/workflows/dev-image-build.yml
+++ b/.github/workflows/dev-image-build.yml
@@ -130,7 +130,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=min
           build-args: |
-            AGENTAPI_VERSION=v0.6.0
+            AGENTAPI_VERSION=v0.12.2
       
       - name: Print image information
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,4 +60,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            AGENTAPI_VERSION=v0.6.0
+            AGENTAPI_VERSION=v0.12.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM alpine:3.22 AS agentapi-downloader
 
 ARG TARGETOS=linux
 ARG TARGETARCH
-ARG AGENTAPI_VERSION=v0.6.0
+ARG AGENTAPI_VERSION=v0.12.2
 
 RUN apk add --no-cache ca-certificates curl && \
     set -ex && \
@@ -147,7 +147,7 @@ RUN curl https://mise.run | sh && \
 # The installer creates a symlink at ~/.local/bin/claude -> ~/.local/share/claude/versions/X.X.X
 # We copy with -L to follow the symlink and get the actual binary, then clean up
 # Then create a symlink at ~/.local/bin/claude -> /opt/claude/bin/claude for volume mount compatibility
-RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.12 && \
+RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.170 && \
     sudo mkdir -p /opt/claude/bin && \
     sudo cp -L /home/agentapi/.local/bin/claude /opt/claude/bin/claude && \
     sudo chown agentapi:agentapi /opt/claude/bin/claude && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ FROM ubuntu:24.04
 # Install essential packages: ca-certificates, curl, bash, git, make, sudo, jq, procps, and GitHub CLI
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables unzip && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,9 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     echo 'export PATH="/home/agentapi/.cargo/bin:$PATH"' >> /home/agentapi/.bashrc && \
     rm -rf /home/agentapi/.cache/uv 2>/dev/null || true
 
+# Install Bun for build-time global package installation.
+RUN curl -fsSL https://bun.sh/install | bash
+
 # Create npm, npx, bun, bunx, and node wrapper scripts that use claude x with BUN_BE_BUN=1
 RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x npm "$@"\n' | sudo tee /usr/local/bin/npm > /dev/null && \
     sudo chmod +x /usr/local/bin/npm && \
@@ -177,19 +180,19 @@ RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x npm "$@"
 ENV PATH="/opt/claude/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:/home/agentapi/.bun/bin:/home/agentapi/.bun/bin:$PATH"
 
 # install claude-agentapi
-RUN bun add -g @takutakahashi/claude-agentapi
+RUN /home/agentapi/.bun/bin/bun add -g @takutakahashi/claude-agentapi
 
 # Install codex CLI and place a wrapper in /opt/claude/bin (first in PATH).
 # The bun-installed codex script uses "#!/usr/bin/env node", but /usr/local/bin/node is a
 # claude wrapper. The wrapper here explicitly invokes bun so codex works reliably in the proxy.
 # Uses the absolute path to the codex script so it works even when HOME is overridden.
-RUN bun add -g @openai/codex && \
+RUN /home/agentapi/.bun/bin/bun add -g @openai/codex && \
     printf '#!/bin/bash\nexec bun /home/agentapi/.bun/bin/codex "$@"\n' | \
     sudo tee /opt/claude/bin/codex > /dev/null && \
     sudo chmod +x /opt/claude/bin/codex
 
 # Install claude-agent-sdk CLI and create arch-agnostic symlink
-RUN bun add -g @anthropic-ai/claude-agent-sdk && \
+RUN /home/agentapi/.bun/bin/bun add -g @anthropic-ai/claude-agent-sdk && \
     ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) SDK_ARCH="linux-x64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,11 +166,11 @@ RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | 
     sudo chmod +x /usr/local/bin/npm && \
     printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/npx > /dev/null && \
     sudo chmod +x /usr/local/bin/npx && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/bun > /dev/null && \
+    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/bun > /dev/null && \
     sudo chmod +x /usr/local/bin/bun && \
     printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/bunx > /dev/null && \
     sudo chmod +x /usr/local/bin/bunx && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/node > /dev/null && \
+    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/node > /dev/null && \
     sudo chmod +x /usr/local/bin/node
 
 # Set combined PATH environment variable (including /opt/claude/bin for claude CLI)

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,19 +177,19 @@ RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x npm "$@"
 ENV PATH="/opt/claude/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:/home/agentapi/.bun/bin:/home/agentapi/.bun/bin:$PATH"
 
 # install claude-agentapi
-RUN bun install -g @takutakahashi/claude-agentapi
+RUN bun add -g @takutakahashi/claude-agentapi
 
 # Install codex CLI and place a wrapper in /opt/claude/bin (first in PATH).
 # The bun-installed codex script uses "#!/usr/bin/env node", but /usr/local/bin/node is a
 # claude wrapper. The wrapper here explicitly invokes bun so codex works reliably in the proxy.
 # Uses the absolute path to the codex script so it works even when HOME is overridden.
-RUN bun install -g @openai/codex && \
+RUN bun add -g @openai/codex && \
     printf '#!/bin/bash\nexec bun /home/agentapi/.bun/bin/codex "$@"\n' | \
     sudo tee /opt/claude/bin/codex > /dev/null && \
     sudo chmod +x /opt/claude/bin/codex
 
 # Install claude-agent-sdk CLI and create arch-agnostic symlink
-RUN bun install -g @anthropic-ai/claude-agent-sdk && \
+RUN bun add -g @anthropic-ai/claude-agent-sdk && \
     ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
       amd64) SDK_ARCH="linux-x64" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,15 +162,15 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     rm -rf /home/agentapi/.cache/uv 2>/dev/null || true
 
 # Create npm, npx, bun, bunx, and node wrapper scripts that use claude x with BUN_BE_BUN=1
-RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/npm > /dev/null && \
+RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x npm "$@"\n' | sudo tee /usr/local/bin/npm > /dev/null && \
     sudo chmod +x /usr/local/bin/npm && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/npx > /dev/null && \
+    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x npx "$@"\n' | sudo tee /usr/local/bin/npx > /dev/null && \
     sudo chmod +x /usr/local/bin/npx && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/bun > /dev/null && \
+    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x bun "$@"\n' | sudo tee /usr/local/bin/bun > /dev/null && \
     sudo chmod +x /usr/local/bin/bun && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/bunx > /dev/null && \
+    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x bunx "$@"\n' | sudo tee /usr/local/bin/bunx > /dev/null && \
     sudo chmod +x /usr/local/bin/bunx && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/node > /dev/null && \
+    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x node "$@"\n' | sudo tee /usr/local/bin/node > /dev/null && \
     sudo chmod +x /usr/local/bin/node
 
 # Set combined PATH environment variable (including /opt/claude/bin for claude CLI)

--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,8 @@ COPY --from=builder /app/bin/agentapi-proxy /usr/local/bin/
 COPY config/CLAUDE.md /tmp/config/CLAUDE.md
 COPY config/CLAUDE.md /etc/claude-code/CLAUDE.md
 COPY config/managed-settings.json /etc/claude-code/managed-settings.json
+COPY config/claude.json /tmp/config/claude.json
+COPY config/claude-settings.json /tmp/config/claude-settings.json
 
 # Copy Codex configuration files for entrypoint script
 # AGENTS.md is the Codex equivalent of CLAUDE.md (user-level instructions → ~/.codex/instructions.md)

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -332,6 +332,9 @@ func runGenerateSettingSchedule() error {
 			ClaudeJSON: map[string]interface{}{
 				"hasCompletedOnboarding":        true,
 				"bypassPermissionsModeAccepted": true,
+				"hasTrustDialogAccepted":        true,
+				"hasCompletedProjectOnboarding": true,
+				"dontCrawlDirectory":            true,
 			},
 		},
 	}
@@ -430,6 +433,9 @@ func runGenerateSettingSlackBot(cmd *cobra.Command) error {
 			ClaudeJSON: map[string]interface{}{
 				"hasCompletedOnboarding":        true,
 				"bypassPermissionsModeAccepted": true,
+				"hasTrustDialogAccepted":        true,
+				"hasCompletedProjectOnboarding": true,
+				"dontCrawlDirectory":            true,
 			},
 		},
 	}

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/takutakahashi/agentapi-proxy/pkg/claudeconfig"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 	"gopkg.in/yaml.v3"
 )
@@ -329,13 +330,8 @@ func runGenerateSettingSchedule() error {
 		Env:            env,
 		InitialMessage: initialMessage,
 		Claude: sessionsettings.ClaudeConfig{
-			ClaudeJSON: map[string]interface{}{
-				"hasCompletedOnboarding":        true,
-				"bypassPermissionsModeAccepted": true,
-				"hasTrustDialogAccepted":        true,
-				"hasCompletedProjectOnboarding": true,
-				"dontCrawlDirectory":            true,
-			},
+			ClaudeJSON:   claudeconfig.EnsureClaudeJSONDefaults(nil),
+			SettingsJSON: claudeconfig.EnsureSettingsJSONDefaults(nil),
 		},
 	}
 	result.Startup = buildStartupConfig(agentType)
@@ -430,13 +426,8 @@ func runGenerateSettingSlackBot(cmd *cobra.Command) error {
 		Env:            env,
 		InitialMessage: initialMessage,
 		Claude: sessionsettings.ClaudeConfig{
-			ClaudeJSON: map[string]interface{}{
-				"hasCompletedOnboarding":        true,
-				"bypassPermissionsModeAccepted": true,
-				"hasTrustDialogAccepted":        true,
-				"hasCompletedProjectOnboarding": true,
-				"dontCrawlDirectory":            true,
-			},
+			ClaudeJSON:   claudeconfig.EnsureClaudeJSONDefaults(nil),
+			SettingsJSON: claudeconfig.EnsureSettingsJSONDefaults(nil),
 		},
 	}
 	result.Startup = buildStartupConfig(agentType)

--- a/config/claude-settings.json
+++ b/config/claude-settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "skipDangerousModePermissionPrompt": true
+  },
+  "skipDangerousModePermissionPrompt": true
+}

--- a/config/claude.json
+++ b/config/claude.json
@@ -1,4 +1,7 @@
 {
   "hasCompletedOnboarding": true,
-  "bypassPermissionsModeAccepted": true
+  "bypassPermissionsModeAccepted": true,
+  "hasTrustDialogAccepted": true,
+  "hasCompletedProjectOnboarding": true,
+  "dontCrawlDirectory": true
 }

--- a/config/claude.json
+++ b/config/claude.json
@@ -3,5 +3,31 @@
   "bypassPermissionsModeAccepted": true,
   "hasTrustDialogAccepted": true,
   "hasCompletedProjectOnboarding": true,
-  "dontCrawlDirectory": true
+  "dontCrawlDirectory": true,
+  "projects": {
+    "/home/agentapi/workdir": {
+      "allowedTools": [],
+      "mcpContextUris": [],
+      "mcpServers": {},
+      "enabledMcpjsonServers": [],
+      "disabledMcpjsonServers": [],
+      "hasTrustDialogAccepted": true,
+      "hasCompletedProjectOnboarding": true,
+      "projectOnboardingSeenCount": 4,
+      "hasClaudeMdExternalIncludesApproved": true,
+      "hasClaudeMdExternalIncludesWarningShown": true
+    },
+    "/home/agentapi/workdir/repo": {
+      "allowedTools": [],
+      "mcpContextUris": [],
+      "mcpServers": {},
+      "enabledMcpjsonServers": [],
+      "disabledMcpjsonServers": [],
+      "hasTrustDialogAccepted": true,
+      "hasCompletedProjectOnboarding": true,
+      "projectOnboardingSeenCount": 4,
+      "hasClaudeMdExternalIncludesApproved": true,
+      "hasClaudeMdExternalIncludesWarningShown": true
+    }
+  }
 }

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/claudeconfig"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
@@ -4114,11 +4115,8 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	}
 
 	settings.Claude = sessionsettings.ClaudeConfig{
-		ClaudeJSON: map[string]interface{}{
-			"hasCompletedOnboarding":        true,
-			"bypassPermissionsModeAccepted": true,
-		},
-		SettingsJSON: settingsJSON,
+		ClaudeJSON:   claudeconfig.EnsureClaudeJSONDefaults(nil),
+		SettingsJSON: claudeconfig.EnsureSettingsJSONDefaults(settingsJSON),
 		MCPServers:   materialized.MCPServers,
 	}
 

--- a/pkg/claudeconfig/defaults.go
+++ b/pkg/claudeconfig/defaults.go
@@ -80,6 +80,7 @@ func EnsureSettingsJSONDefaults(settings map[string]interface{}) map[string]inte
 
 	permissions["defaultMode"] = "bypassPermissions"
 	permissions["skipDangerousModePermissionPrompt"] = true
+	settings["skipDangerousModePermissionPrompt"] = true
 
 	return settings
 }

--- a/pkg/claudeconfig/defaults.go
+++ b/pkg/claudeconfig/defaults.go
@@ -1,0 +1,85 @@
+package claudeconfig
+
+// TrustedProjectDirs are the directories Claude Code can use as working
+// directories in agentapi session containers.
+var TrustedProjectDirs = []string{
+	"/home/agentapi/workdir",
+	"/home/agentapi/workdir/repo",
+}
+
+// EnsureClaudeJSONDefaults mutates config so Claude Code first-run, bypass
+// permission, and workspace trust prompts are pre-accepted for session pods.
+func EnsureClaudeJSONDefaults(config map[string]interface{}) map[string]interface{} {
+	if config == nil {
+		config = make(map[string]interface{})
+	}
+
+	config["hasCompletedOnboarding"] = true
+	config["bypassPermissionsModeAccepted"] = true
+
+	// Keep legacy/top-level keys for older Claude Code versions. Current
+	// Claude Code stores trust state per project under ~/.claude.json.projects.
+	config["hasTrustDialogAccepted"] = true
+	config["hasCompletedProjectOnboarding"] = true
+	config["dontCrawlDirectory"] = true
+
+	projects, ok := config["projects"].(map[string]interface{})
+	if !ok {
+		projects = make(map[string]interface{})
+		config["projects"] = projects
+	}
+
+	for _, dir := range TrustedProjectDirs {
+		project, ok := projects[dir].(map[string]interface{})
+		if !ok {
+			project = make(map[string]interface{})
+			projects[dir] = project
+		}
+		ensureProjectDefaults(project)
+	}
+
+	return config
+}
+
+func ensureProjectDefaults(project map[string]interface{}) {
+	if _, ok := project["allowedTools"]; !ok {
+		project["allowedTools"] = []interface{}{}
+	}
+	if _, ok := project["mcpContextUris"]; !ok {
+		project["mcpContextUris"] = []interface{}{}
+	}
+	if _, ok := project["mcpServers"]; !ok {
+		project["mcpServers"] = map[string]interface{}{}
+	}
+	if _, ok := project["enabledMcpjsonServers"]; !ok {
+		project["enabledMcpjsonServers"] = []interface{}{}
+	}
+	if _, ok := project["disabledMcpjsonServers"]; !ok {
+		project["disabledMcpjsonServers"] = []interface{}{}
+	}
+
+	project["hasTrustDialogAccepted"] = true
+	project["hasCompletedProjectOnboarding"] = true
+	project["projectOnboardingSeenCount"] = 4
+	project["hasClaudeMdExternalIncludesApproved"] = true
+	project["hasClaudeMdExternalIncludesWarningShown"] = true
+}
+
+// EnsureSettingsJSONDefaults mutates settings so Claude Code uses the official
+// permissions settings for non-interactive agent containers.
+func EnsureSettingsJSONDefaults(settings map[string]interface{}) map[string]interface{} {
+	if settings == nil {
+		settings = make(map[string]interface{})
+	}
+
+	permissions, ok := settings["permissions"].(map[string]interface{})
+	if !ok {
+		permissions = make(map[string]interface{})
+		settings["permissions"] = permissions
+	}
+
+	permissions["defaultMode"] = "bypassPermissions"
+	permissions["skipDangerousModePermissionPrompt"] = true
+
+	return settings
+}

--- a/pkg/claudeconfig/defaults_test.go
+++ b/pkg/claudeconfig/defaults_test.go
@@ -53,4 +53,7 @@ func TestEnsureSettingsJSONDefaults(t *testing.T) {
 	if permissions["skipDangerousModePermissionPrompt"] != true {
 		t.Fatalf("expected skipDangerousModePermissionPrompt")
 	}
+	if settings["skipDangerousModePermissionPrompt"] != true {
+		t.Fatalf("expected top-level skipDangerousModePermissionPrompt")
+	}
 }

--- a/pkg/claudeconfig/defaults_test.go
+++ b/pkg/claudeconfig/defaults_test.go
@@ -1,0 +1,56 @@
+package claudeconfig
+
+import "testing"
+
+func TestEnsureClaudeJSONDefaults(t *testing.T) {
+	config := EnsureClaudeJSONDefaults(map[string]interface{}{
+		"custom": "value",
+		"projects": map[string]interface{}{
+			"/home/agentapi/workdir": map[string]interface{}{
+				"allowedTools": []interface{}{"Bash(git *)"},
+			},
+		},
+	})
+
+	if config["custom"] != "value" {
+		t.Fatalf("expected custom key to be preserved")
+	}
+	if config["hasCompletedOnboarding"] != true {
+		t.Fatalf("expected hasCompletedOnboarding")
+	}
+	if config["bypassPermissionsModeAccepted"] != true {
+		t.Fatalf("expected bypassPermissionsModeAccepted")
+	}
+
+	projects := config["projects"].(map[string]interface{})
+	for _, dir := range TrustedProjectDirs {
+		project, ok := projects[dir].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected project defaults for %s", dir)
+		}
+		if project["hasTrustDialogAccepted"] != true {
+			t.Fatalf("expected %s to be trusted", dir)
+		}
+		if project["hasCompletedProjectOnboarding"] != true {
+			t.Fatalf("expected %s project onboarding complete", dir)
+		}
+	}
+}
+
+func TestEnsureSettingsJSONDefaults(t *testing.T) {
+	settings := EnsureSettingsJSONDefaults(map[string]interface{}{
+		"custom": "value",
+	})
+
+	if settings["custom"] != "value" {
+		t.Fatalf("expected custom key to be preserved")
+	}
+
+	permissions := settings["permissions"].(map[string]interface{})
+	if permissions["defaultMode"] != "bypassPermissions" {
+		t.Fatalf("expected defaultMode bypassPermissions")
+	}
+	if permissions["skipDangerousModePermissionPrompt"] != true {
+		t.Fatalf("expected skipDangerousModePermissionPrompt")
+	}
+}

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -8,6 +8,44 @@ import (
 	"testing"
 )
 
+func TestEnsureClaudeStartupDefaults(t *testing.T) {
+	homeDir := t.TempDir()
+
+	if err := ensureClaudeStartupDefaults(homeDir); err != nil {
+		t.Fatalf("ensureClaudeStartupDefaults failed: %v", err)
+	}
+
+	settingsData, err := os.ReadFile(filepath.Join(homeDir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(settingsData, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+	permissions := settings["permissions"].(map[string]interface{})
+	if permissions["defaultMode"] != "bypassPermissions" {
+		t.Fatalf("expected defaultMode bypassPermissions")
+	}
+	if settings["skipDangerousModePermissionPrompt"] != true {
+		t.Fatalf("expected top-level skipDangerousModePermissionPrompt")
+	}
+
+	claudeData, err := os.ReadFile(filepath.Join(homeDir, ".claude.json"))
+	if err != nil {
+		t.Fatalf("failed to read .claude.json: %v", err)
+	}
+	var claudeJSON map[string]interface{}
+	if err := json.Unmarshal(claudeData, &claudeJSON); err != nil {
+		t.Fatalf("failed to parse .claude.json: %v", err)
+	}
+	projects := claudeJSON["projects"].(map[string]interface{})
+	workdir := projects["/home/agentapi/workdir"].(map[string]interface{})
+	if workdir["hasTrustDialogAccepted"] != true {
+		t.Fatalf("expected workdir trust accepted")
+	}
+}
+
 // TestWriteWebhookPayloadFile_WritesWhenAbsent verifies that
 // writeWebhookPayloadFile creates the file with the given payload when
 // webhookPayloadPath does not exist (stock-session case).

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -12,8 +12,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 
+	"github.com/takutakahashi/agentapi-proxy/pkg/claudeconfig"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
@@ -81,6 +83,13 @@ func (s *Server) Start(ctx context.Context) error {
 	// beyond the HTTP request that triggered them.
 	s.serverCtx = ctx
 
+	// Seed Claude Code settings before the startup pre-script runs. Stock pods
+	// execute bun/npm wrappers via `claude x` before session provisioning, so
+	// compile-time settings are not available yet.
+	if err := ensureClaudeStartupDefaults("/home/agentapi"); err != nil {
+		log.Printf("[PROVISIONER] Warning: failed to seed Claude startup settings: %v", err)
+	}
+
 	// Run the common startup pre-script immediately in the background.
 	// This pre-fetches ACP packages while the Pod is idle (stock inventory or
 	// Pod restart), so provisioning does not have to wait for network downloads.
@@ -146,6 +155,62 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		log.Printf("[PROVISIONER] Failed to encode status response: %v", err)
 	}
+}
+
+func ensureClaudeStartupDefaults(homeDir string) error {
+	claudeDir := filepath.Join(homeDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create .claude directory: %w", err)
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	settingsJSON, err := readJSONMap(settingsPath)
+	if err != nil {
+		return fmt.Errorf("failed to read Claude settings: %w", err)
+	}
+	claudeconfig.EnsureSettingsJSONDefaults(settingsJSON)
+	if err := writeJSONMap(settingsPath, settingsJSON); err != nil {
+		return fmt.Errorf("failed to write Claude settings: %w", err)
+	}
+
+	claudeJSONPath := filepath.Join(homeDir, ".claude.json")
+	claudeJSON, err := readJSONMap(claudeJSONPath)
+	if err != nil {
+		return fmt.Errorf("failed to read Claude config: %w", err)
+	}
+	claudeconfig.EnsureClaudeJSONDefaults(claudeJSON)
+	if err := writeJSONMap(claudeJSONPath, claudeJSON); err != nil {
+		return fmt.Errorf("failed to write Claude config: %w", err)
+	}
+
+	return nil
+}
+
+func readJSONMap(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]interface{}), nil
+		}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return make(map[string]interface{}), nil
+	}
+
+	result := make(map[string]interface{})
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func writeJSONMap(path string, data map[string]interface{}) error {
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o644)
 }
 
 // setStatus updates the provisioning state thread-safely.

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -23,8 +23,8 @@ import (
 // It pre-fetches the latest ACP package binaries so that agent startup does
 // not incur a network download when a provision request arrives.
 // Override with the PROVISIONER_PRE_SCRIPT environment variable.
-const defaultStartupScript = `bun install --global @agentclientprotocol/claude-agent-acp@latest
-npm install --global @zed-industries/codex-acp@latest
+const defaultStartupScript = `bun add -g @agentclientprotocol/claude-agent-acp@latest
+bun add -g @zed-industries/codex-acp@latest
 `
 
 // Status represents the provisioning lifecycle state.

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -121,6 +121,9 @@ func generateClaudeJSON(outputDir string, claudeJSON map[string]interface{}, mcp
 	// Always set required onboarding fields
 	existing["hasCompletedOnboarding"] = true
 	existing["bypassPermissionsModeAccepted"] = true
+	existing["hasTrustDialogAccepted"] = true
+	existing["hasCompletedProjectOnboarding"] = true
+	existing["dontCrawlDirectory"] = true
 
 	// Write MCP servers directly into claude.json so Claude Code reads them natively
 	if len(mcpServers) > 0 {

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/takutakahashi/agentapi-proxy/pkg/claudeconfig"
 	"gopkg.in/yaml.v3"
 )
 
@@ -118,12 +119,8 @@ func generateClaudeJSON(outputDir string, claudeJSON map[string]interface{}, mcp
 		existing[k] = v
 	}
 
-	// Always set required onboarding fields
-	existing["hasCompletedOnboarding"] = true
-	existing["bypassPermissionsModeAccepted"] = true
-	existing["hasTrustDialogAccepted"] = true
-	existing["hasCompletedProjectOnboarding"] = true
-	existing["dontCrawlDirectory"] = true
+	// Always set required onboarding, bypass, and workspace trust fields.
+	claudeconfig.EnsureClaudeJSONDefaults(existing)
 
 	// Write MCP servers directly into claude.json so Claude Code reads them natively
 	if len(mcpServers) > 0 {
@@ -174,6 +171,7 @@ func generateSettingsJSON(outputDir string, settingsJSON map[string]interface{})
 	// Always set autoUpdatesChannel to "stable" to prevent automatic updates
 	// to non-stable channels in session containers.
 	settingsJSON["autoUpdatesChannel"] = "stable"
+	claudeconfig.EnsureSettingsJSONDefaults(settingsJSON)
 
 	data, err := json.MarshalIndent(settingsJSON, "", "  ")
 	if err != nil {

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -486,6 +486,7 @@ func assertClaudePermissionsBypass(t *testing.T, settingsJSON map[string]interfa
 	require.True(t, ok, "permissions should exist")
 	assert.Equal(t, "bypassPermissions", permissions["defaultMode"])
 	assert.Equal(t, true, permissions["skipDangerousModePermissionPrompt"])
+	assert.Equal(t, true, settingsJSON["skipDangerousModePermissionPrompt"])
 }
 
 func TestCompile_CodexConfigTOML(t *testing.T) {

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -189,6 +189,8 @@ func TestCompile_ClaudeJSON(t *testing.T) {
 	assert.Equal(t, true, claudeJSON["hasTrustDialogAccepted"])
 	assert.Equal(t, true, claudeJSON["hasCompletedProjectOnboarding"])
 	assert.Equal(t, true, claudeJSON["dontCrawlDirectory"])
+	assertClaudeProjectTrusted(t, claudeJSON, "/home/agentapi/workdir")
+	assertClaudeProjectTrusted(t, claudeJSON, "/home/agentapi/workdir/repo")
 
 	// Verify custom key is preserved
 	assert.Equal(t, "customValue", claudeJSON["customKey"])
@@ -364,6 +366,7 @@ func TestCompile_MCPServersInClaudeJSON(t *testing.T) {
 	// Verify onboarding flags are still present
 	assert.Equal(t, true, claudeJSON["hasCompletedOnboarding"])
 	assert.Equal(t, true, claudeJSON["bypassPermissionsModeAccepted"])
+	assertClaudeProjectTrusted(t, claudeJSON, "/home/agentapi/workdir")
 }
 
 func TestCompile_AutoUpdatesChannelStable(t *testing.T) {
@@ -408,6 +411,7 @@ func TestCompile_AutoUpdatesChannelStable(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "stable", settingsJSON["autoUpdatesChannel"])
+		assertClaudePermissionsBypass(t, settingsJSON)
 	})
 
 	t.Run("custom settingsJSON also has autoUpdatesChannel stable", func(t *testing.T) {
@@ -460,9 +464,28 @@ func TestCompile_AutoUpdatesChannelStable(t *testing.T) {
 
 		// autoUpdatesChannel should always be "stable"
 		assert.Equal(t, "stable", settingsJSON["autoUpdatesChannel"])
+		assertClaudePermissionsBypass(t, settingsJSON)
 		// Custom key should be preserved
 		assert.Equal(t, "customValue", settingsJSON["customKey"])
 	})
+}
+
+func assertClaudeProjectTrusted(t *testing.T, claudeJSON map[string]interface{}, dir string) {
+	t.Helper()
+	projects, ok := claudeJSON["projects"].(map[string]interface{})
+	require.True(t, ok, "projects should exist")
+	project, ok := projects[dir].(map[string]interface{})
+	require.True(t, ok, "project %s should exist", dir)
+	assert.Equal(t, true, project["hasTrustDialogAccepted"])
+	assert.Equal(t, true, project["hasCompletedProjectOnboarding"])
+}
+
+func assertClaudePermissionsBypass(t *testing.T, settingsJSON map[string]interface{}) {
+	t.Helper()
+	permissions, ok := settingsJSON["permissions"].(map[string]interface{})
+	require.True(t, ok, "permissions should exist")
+	assert.Equal(t, "bypassPermissions", permissions["defaultMode"])
+	assert.Equal(t, true, permissions["skipDangerousModePermissionPrompt"])
 }
 
 func TestCompile_CodexConfigTOML(t *testing.T) {

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -186,6 +186,9 @@ func TestCompile_ClaudeJSON(t *testing.T) {
 	// Verify onboarding flags are always present
 	assert.Equal(t, true, claudeJSON["hasCompletedOnboarding"])
 	assert.Equal(t, true, claudeJSON["bypassPermissionsModeAccepted"])
+	assert.Equal(t, true, claudeJSON["hasTrustDialogAccepted"])
+	assert.Equal(t, true, claudeJSON["hasCompletedProjectOnboarding"])
+	assert.Equal(t, true, claudeJSON["dontCrawlDirectory"])
 
 	// Verify custom key is preserved
 	assert.Equal(t, "customValue", claudeJSON["customKey"])

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -106,6 +106,9 @@ func mergeClaudeConfig(homeDir string) error {
 	configToMerge := map[string]interface{}{
 		"hasCompletedOnboarding":        true,
 		"bypassPermissionsModeAccepted": true,
+		"hasTrustDialogAccepted":        true,
+		"hasCompletedProjectOnboarding": true,
+		"dontCrawlDirectory":            true,
 	}
 
 	// Read existing ~/.claude.json if it exists

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v57/github"
+	"github.com/takutakahashi/agentapi-proxy/pkg/claudeconfig"
 	github_pkg "github.com/takutakahashi/agentapi-proxy/pkg/github"
 )
 
@@ -102,15 +103,6 @@ func mergeClaudeConfig(homeDir string) error {
 
 	targetPath := filepath.Join(homeDir, ".claude.json")
 
-	// Define the configuration to merge as a map
-	configToMerge := map[string]interface{}{
-		"hasCompletedOnboarding":        true,
-		"bypassPermissionsModeAccepted": true,
-		"hasTrustDialogAccepted":        true,
-		"hasCompletedProjectOnboarding": true,
-		"dontCrawlDirectory":            true,
-	}
-
 	// Read existing ~/.claude.json if it exists
 	var targetJSON map[string]interface{}
 	targetData, err := os.ReadFile(targetPath)
@@ -127,10 +119,7 @@ func mergeClaudeConfig(homeDir string) error {
 		}
 	}
 
-	// Merge configuration map into target
-	for key, value := range configToMerge {
-		targetJSON[key] = value
-	}
+	claudeconfig.EnsureClaudeJSONDefaults(targetJSON)
 
 	// Write merged JSON back
 	mergedData, err := json.MarshalIndent(targetJSON, "", "  ")

--- a/pkg/startup/sync.go
+++ b/pkg/startup/sync.go
@@ -131,6 +131,9 @@ func generateClaudeJSON(outputDir string) error {
 
 	existing["hasCompletedOnboarding"] = true
 	existing["bypassPermissionsModeAccepted"] = true
+	existing["hasTrustDialogAccepted"] = true
+	existing["hasCompletedProjectOnboarding"] = true
+	existing["dontCrawlDirectory"] = true
 
 	data, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {

--- a/pkg/startup/sync.go
+++ b/pkg/startup/sync.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/takutakahashi/agentapi-proxy/pkg/claudeconfig"
 	github_pkg "github.com/takutakahashi/agentapi-proxy/pkg/github"
 )
 
@@ -129,11 +130,7 @@ func generateClaudeJSON(outputDir string) error {
 		}
 	}
 
-	existing["hasCompletedOnboarding"] = true
-	existing["bypassPermissionsModeAccepted"] = true
-	existing["hasTrustDialogAccepted"] = true
-	existing["hasCompletedProjectOnboarding"] = true
-	existing["dontCrawlDirectory"] = true
+	claudeconfig.EnsureClaudeJSONDefaults(existing)
 
 	data, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {

--- a/pkg/startup/sync_test.go
+++ b/pkg/startup/sync_test.go
@@ -421,6 +421,15 @@ func TestGenerateClaudeJSON(t *testing.T) {
 		if result["bypassPermissionsModeAccepted"] != true {
 			t.Error("Expected bypassPermissionsModeAccepted to be true")
 		}
+		if result["hasTrustDialogAccepted"] != true {
+			t.Error("Expected hasTrustDialogAccepted to be true")
+		}
+		if result["hasCompletedProjectOnboarding"] != true {
+			t.Error("Expected hasCompletedProjectOnboarding to be true")
+		}
+		if result["dontCrawlDirectory"] != true {
+			t.Error("Expected dontCrawlDirectory to be true")
+		}
 	})
 
 	t.Run("preserves existing fields", func(t *testing.T) {

--- a/pkg/startup/sync_test.go
+++ b/pkg/startup/sync_test.go
@@ -430,6 +430,8 @@ func TestGenerateClaudeJSON(t *testing.T) {
 		if result["dontCrawlDirectory"] != true {
 			t.Error("Expected dontCrawlDirectory to be true")
 		}
+		assertSyncProjectTrusted(t, result, "/home/agentapi/workdir")
+		assertSyncProjectTrusted(t, result, "/home/agentapi/workdir/repo")
 	})
 
 	t.Run("preserves existing fields", func(t *testing.T) {
@@ -1791,4 +1793,22 @@ func TestCloneMarketplace_GHESWithLocalURL(t *testing.T) {
 			t.Error("expected .git to exist after clone")
 		}
 	})
+}
+
+func assertSyncProjectTrusted(t *testing.T, claudeJSON map[string]interface{}, dir string) {
+	t.Helper()
+	projects, ok := claudeJSON["projects"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected projects to exist")
+	}
+	project, ok := projects[dir].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected project %s to exist", dir)
+	}
+	if project["hasTrustDialogAccepted"] != true {
+		t.Fatalf("expected project %s to be trusted", dir)
+	}
+	if project["hasCompletedProjectOnboarding"] != true {
+		t.Fatalf("expected project %s onboarding to be complete", dir)
+	}
 }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -7,6 +7,28 @@ export CLAUDE_MD_PATH="${CLAUDE_MD_PATH:-/tmp/config/CLAUDE.md}"
 # Create .claude directory if it doesn't exist
 mkdir -p /home/agentapi/.claude
 
+# Ensure Claude Code can run during stock-pod startup before per-session
+# provisioning writes ~/.claude/settings.json. In particular, the provisioner
+# startup pre-script uses bun/npm wrappers implemented via `claude x`, which
+# otherwise shows the bypass-permissions warning before setup has run.
+if [ -f /tmp/config/claude-settings.json ]; then
+    if [ -f /home/agentapi/.claude/settings.json ]; then
+        tmp_settings="$(mktemp)"
+        jq -s '.[0] * .[1]' /home/agentapi/.claude/settings.json /tmp/config/claude-settings.json > "$tmp_settings" && mv "$tmp_settings" /home/agentapi/.claude/settings.json
+    else
+        cp /tmp/config/claude-settings.json /home/agentapi/.claude/settings.json
+    fi
+fi
+
+if [ -f /tmp/config/claude.json ]; then
+    if [ -f /home/agentapi/.claude.json ]; then
+        tmp_claude_json="$(mktemp)"
+        jq -s '.[0] * .[1]' /home/agentapi/.claude.json /tmp/config/claude.json > "$tmp_claude_json" && mv "$tmp_claude_json" /home/agentapi/.claude.json
+    else
+        cp /tmp/config/claude.json /home/agentapi/.claude.json
+    fi
+fi
+
 # Copy CLAUDE.md if it doesn't exist or if it's older than the source
 if [ ! -f /home/agentapi/.claude/CLAUDE.md ] || [ /tmp/config/CLAUDE.md -nt /home/agentapi/.claude/CLAUDE.md ]; then
     echo "Copying CLAUDE.md to .claude directory..."


### PR DESCRIPTION
## Summary
- Update Docker image agentapi binary from v0.6.0 to v0.12.2
- Update Docker image Claude Code installer target from 2.1.12 to 2.1.170
- Pin CI agentapi and Claude Code versions in cache keys so old cached binaries are not restored

## Verification
- Verified agentapi v0.12.2 linux-amd64 release asset responds from GitHub
- Verified Claude Code 2.1.170 manifest is available from downloads.claude.ai
- git diff --check passed
- mise exec -- make lint passed
- mise exec -- make test failed in cmd: TestRunProxyWithInvalidConfig starts Kubernetes-backed server initialization in this session environment, restores live sessions, then exits with signal: interrupt. Earlier run also required installing build-essential for go test -race.
- Docker build was not run because the Docker daemon is unavailable in this environment: Cannot connect to the Docker daemon at unix:///var/run/docker.sock.