### PR TITLE
feat: add project OAuth scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ agentapi-proxy supports flexible authentication mechanisms:
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "read:user read:org"
+        "scope": "read:user read:org project"
       }
     }
   }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,5 +29,5 @@ auth:
     oauth:
       client_id: "${AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID}"
       client_secret: "${AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET}"
-      scope: "read:user read:org"
+      scope: "read:user read:org project"
       base_url: ""  # Defaults to auth.github.base_url

--- a/config.oauth.development.example.json
+++ b/config.oauth.development.example.json
@@ -8,7 +8,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "repo workflow read:org admin:repo_hook notifications user:email",
+        "scope": "repo workflow read:org project admin:repo_hook notifications user:email",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/config.oauth.enterprise.example.json
+++ b/config.oauth.enterprise.example.json
@@ -8,7 +8,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "repo workflow admin:org admin:repo_hook admin:org_hook notifications user:email delete_repo",
+        "scope": "repo workflow project admin:org admin:repo_hook admin:org_hook notifications user:email delete_repo",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/config.oauth.example.json
+++ b/config.oauth.example.json
@@ -8,7 +8,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "repo workflow read:org admin:repo_hook notifications user:email",
+        "scope": "repo workflow read:org project admin:repo_hook notifications user:email",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/config.oauth.public-only.example.json
+++ b/config.oauth.public-only.example.json
@@ -8,7 +8,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "public_repo workflow read:org notifications user:email",
+        "scope": "public_repo workflow read:org project notifications user:email",
         "base_url": "https://github.com",
         "authorize_url": "https://github.com/login/oauth/authorize",
         "token_url": "https://github.com/login/oauth/access_token"

--- a/docs/github-oauth.md
+++ b/docs/github-oauth.md
@@ -54,7 +54,7 @@
       "oauth": {
         "client_id": "${GITHUB_CLIENT_ID}",
         "client_secret": "${GITHUB_CLIENT_SECRET}",
-        "scope": "repo workflow read:org admin:repo_hook notifications user:email",
+        "scope": "repo workflow read:org project admin:repo_hook notifications user:email",
         "base_url": "https://github.com"
       },
       "user_mapping": {
@@ -342,25 +342,26 @@ const sessions = await client.makeAuthenticatedRequest('/search');
 
 #### 1. 基本的な開発（推奨）
 ```json
-"scope": "repo workflow read:org admin:repo_hook notifications user:email"
+"scope": "repo workflow read:org project admin:repo_hook notifications user:email"
 ```
 - **repo**: プライベート・パブリックリポジトリの読み書き、プルリクエスト、イシュー管理
 - **workflow**: GitHub Actionsワークフローファイルの作成・編集
 - **read:org**: Organization メンバーシップの確認
+- **project**: GitHub Projects の読み書き
 - **admin:repo_hook**: リポジトリWebhookの管理
 - **notifications**: 通知の管理
 - **user:email**: ユーザーのメールアドレス取得
 
 #### 2. パブリックリポジトリのみ
 ```json
-"scope": "public_repo workflow read:org notifications user:email"
+"scope": "public_repo workflow read:org project notifications user:email"
 ```
 - **public_repo**: パブリックリポジトリのみの読み書き
 - プライベートリポジトリへのアクセスが不要な場合
 
 #### 3. エンタープライズ環境（フル権限）
 ```json
-"scope": "repo workflow admin:org admin:repo_hook admin:org_hook notifications user:email delete_repo"
+"scope": "repo workflow project admin:org admin:repo_hook admin:org_hook notifications user:email delete_repo"
 ```
 - **admin:org**: Organization設定の完全管理
 - **admin:org_hook**: Organization レベルのWebhook管理
@@ -368,7 +369,7 @@ const sessions = await client.makeAuthenticatedRequest('/search');
 
 #### 4. 読み取り専用（最小権限）
 ```json
-"scope": "read:user read:org"
+"scope": "read:user read:org project"
 ```
 - ユーザー情報とOrganization情報の読み取りのみ
 
@@ -379,6 +380,7 @@ const sessions = await client.makeAuthenticatedRequest('/search');
 | `repo` | プライベート・パブリックリポジトリのフル権限 | 基本的な開発作業 |
 | `public_repo` | パブリックリポジトリのみの読み書き | オープンソース開発 |
 | `workflow` | GitHub Actionsワークフローの管理 | CI/CD設定 |
+| `project` | GitHub Projects の読み書き | プロジェクト管理 |
 | `admin:org` | Organization の完全管理 | 管理者権限 |
 | `admin:repo_hook` | リポジトリWebhookの管理 | 統合・自動化 |
 | `admin:org_hook` | OrganizationWebhookの管理 | エンタープライズ統合 |

--- a/helm/agentapi-proxy/values-auth-example.yaml
+++ b/helm/agentapi-proxy/values-auth-example.yaml
@@ -12,7 +12,7 @@ config:
       oauth:
         clientId: "your-github-client-id"
         clientSecret: "your-github-client-secret"
-        scope: "repo workflow read:org admin:repo_hook notifications user:email"
+        scope: "repo workflow read:org project admin:repo_hook notifications user:email"
 
 # Auth configuration - stored in ConfigMap and mounted to container
 # This allows complex authorization rules that cannot be expressed as environment variables

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -141,7 +141,7 @@ config:
       oauth:
         clientId: ""
         clientSecret: ""
-        scope: "read:user read:org repo workflow"
+        scope: "read:user read:org project repo workflow"
         baseUrl: ""
         # 許可するリダイレクトURI (カンマ区切りで複数指定可能)
         allowedRedirectUris: ""

--- a/internal/app/auth_test.go
+++ b/internal/app/auth_test.go
@@ -31,7 +31,7 @@ func setupTestServerWithOAuth(t *testing.T) (*Server, *httptest.Server) {
 		case "/login/oauth/access_token":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org"}`))
+			_, _ = w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org,project"}`))
 		case "/user":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -58,7 +58,7 @@ func setupTestServerWithOAuth(t *testing.T) (*Server, *httptest.Server) {
 				OAuth: &config.GitHubOAuthConfig{
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
-					Scope:        "read:user read:org",
+					Scope:        "read:user read:org project",
 					BaseURL:      mockServer.URL,
 				},
 			},

--- a/pkg/auth/oauth_integration_test.go
+++ b/pkg/auth/oauth_integration_test.go
@@ -46,7 +46,7 @@ func TestGitHubOAuthIntegration(t *testing.T) {
 				response := map[string]interface{}{
 					"access_token": "gho_integration_test_token",
 					"token_type":   "bearer",
-					"scope":        "read:user,read:org",
+					"scope":        "read:user,read:org,project",
 				}
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(response)
@@ -182,7 +182,7 @@ func TestGitHubOAuthIntegration(t *testing.T) {
 	oauthCfg := &config.GitHubOAuthConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
-		Scope:        "read:user read:org",
+		Scope:        "read:user read:org project",
 		BaseURL:      mockGitHub.URL,
 	}
 

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -16,7 +16,7 @@ func TestGitHubOAuthProvider_GenerateAuthURL(t *testing.T) {
 	cfg := &config.GitHubOAuthConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
-		Scope:        "read:user read:org",
+		Scope:        "read:user read:org project",
 		BaseURL:      "https://github.com",
 	}
 
@@ -37,7 +37,7 @@ func TestGitHubOAuthProvider_GenerateAuthURL(t *testing.T) {
 	assert.Contains(t, authURL, "https://github.com/login/oauth/authorize")
 	assert.Contains(t, authURL, "client_id=test-client-id")
 	assert.Contains(t, authURL, "redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback")
-	assert.Contains(t, authURL, "scope=read%3Auser+read%3Aorg")
+	assert.Contains(t, authURL, "scope=read%3Auser+read%3Aorg+project")
 	assert.Contains(t, authURL, "state=")
 	// State is URL encoded, so we just check that it exists and is not empty
 	stateIndex := strings.Index(authURL, "state=")
@@ -54,7 +54,7 @@ func TestGitHubOAuthProvider_ExchangeCode(t *testing.T) {
 			// Mock token exchange response
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org"}`))
+			_, _ = w.Write([]byte(`{"access_token":"gho_test_token","token_type":"bearer","scope":"read:user,read:org,project"}`))
 		case "/user":
 			// Mock user API response
 			w.Header().Set("Content-Type", "application/json")
@@ -74,7 +74,7 @@ func TestGitHubOAuthProvider_ExchangeCode(t *testing.T) {
 	cfg := &config.GitHubOAuthConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
-		Scope:        "read:user read:org",
+		Scope:        "read:user read:org project",
 		BaseURL:      mockServer.URL,
 	}
 
@@ -113,7 +113,7 @@ func TestGitHubOAuthProvider_ExchangeCode_InvalidState(t *testing.T) {
 	cfg := &config.GitHubOAuthConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
-		Scope:        "read:user read:org",
+		Scope:        "read:user read:org project",
 		BaseURL:      "https://github.com",
 	}
 
@@ -136,7 +136,7 @@ func TestGitHubOAuthProvider_ExchangeCode_ExpiredState(t *testing.T) {
 	cfg := &config.GitHubOAuthConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
-		Scope:        "read:user read:org",
+		Scope:        "read:user read:org project",
 		BaseURL:      "https://github.com",
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@
 //	AGENTAPI_AUTH_GITHUB_TOKEN_HEADER=Authorization
 //	AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_ID=your_client_id
 //	AGENTAPI_AUTH_GITHUB_OAUTH_CLIENT_SECRET=your_client_secret
-//	AGENTAPI_AUTH_GITHUB_OAUTH_SCOPE=read:user read:org
+//	AGENTAPI_AUTH_GITHUB_OAUTH_SCOPE=read:user read:org project
 //	AGENTAPI_AUTH_GITHUB_USER_MAPPING_DEFAULT_ROLE=user
 //	AGENTAPI_ENABLE_MULTIPLE_USERS=true
 //	AGENTAPI_WEBHOOK_BASE_URL=https://example.com
@@ -1048,7 +1048,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("auth.github.token_header", "Authorization")
 	v.SetDefault("auth.github.oauth.client_id", "")
 	v.SetDefault("auth.github.oauth.client_secret", "")
-	v.SetDefault("auth.github.oauth.scope", "read:user read:org")
+	v.SetDefault("auth.github.oauth.scope", "read:user read:org project")
 	v.SetDefault("auth.github.oauth.base_url", "")
 
 	// AWS auth defaults
@@ -1179,7 +1179,7 @@ func applyConfigDefaults(config *Config) {
 			config.Auth.GitHub.TokenHeader = "Authorization"
 		}
 		if config.Auth.GitHub.OAuth != nil && config.Auth.GitHub.OAuth.Scope == "" {
-			config.Auth.GitHub.OAuth.Scope = "read:user read:org"
+			config.Auth.GitHub.OAuth.Scope = "read:user read:org project"
 		}
 	}
 	if config.Auth.AWS != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -109,8 +109,8 @@ func TestLoadConfig(t *testing.T) {
 		}
 		if loadedConfig.Auth.GitHub.OAuth == nil {
 			t.Error("Auth.GitHub.OAuth should not be nil")
-		} else if loadedConfig.Auth.GitHub.OAuth.Scope != "read:user read:org" {
-			t.Errorf("Auth.GitHub.OAuth.Scope should be 'read:user read:org', got '%s'", loadedConfig.Auth.GitHub.OAuth.Scope)
+		} else if loadedConfig.Auth.GitHub.OAuth.Scope != "read:user read:org project" {
+			t.Errorf("Auth.GitHub.OAuth.Scope should be 'read:user read:org project', got '%s'", loadedConfig.Auth.GitHub.OAuth.Scope)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add the GitHub OAuth project scope to default OAuth configuration
- update Helm values, sample configs, and docs to request project access
- update OAuth tests and mocks to include project scope

## Tests
- Not run: go is not installed in this environment