### PR TITLE
Fix decrypted env vars in session settings

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4476,6 +4476,87 @@ func (m *KubernetesSessionManager) readSettingsPatch(ctx context.Context, secret
 	return &patch
 }
 
+// readSettingsPatchByName reads an agentapi settings entry through SettingsRepository.
+// The repository is responsible for storage details such as encrypted_env_vars, so
+// session startup receives plaintext values before merge/materialize.
+func (m *KubernetesSessionManager) readSettingsPatchByName(ctx context.Context, settingsName string) *settingspatch.SettingsPatch {
+	if settingsName == "" {
+		return nil
+	}
+	secretName := fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(settingsName))
+	rawPatch := m.readSettingsPatch(ctx, secretName)
+	if m.settingsRepo == nil {
+		return rawPatch
+	}
+	settings, err := m.settingsRepo.FindByName(ctx, settingsName)
+	if err != nil {
+		return rawPatch
+	}
+	if rawPatch != nil {
+		patch := *rawPatch
+		if envVars := settings.EnvVars(); len(envVars) > 0 {
+			patch.EnvVars = cloneStringMap(envVars)
+		}
+		return &patch
+	}
+	patch := settingsToPatch(settings)
+	return &patch
+}
+
+func settingsToPatch(settings *entities.Settings) settingspatch.SettingsPatch {
+	patch := settingspatch.SettingsPatch{
+		AuthMode:        string(settings.AuthMode()),
+		OAuthToken:      settings.ClaudeCodeOAuthToken(),
+		EnvVars:         cloneStringMap(settings.EnvVars()),
+		EnabledPlugins:  append([]string(nil), settings.EnabledPlugins()...),
+		PreferredTeamID: settings.PreferredTeamID(),
+	}
+
+	if bedrock := settings.Bedrock(); bedrock != nil {
+		patch.Bedrock = &settingspatch.BedrockPatch{
+			Model:           bedrock.Model(),
+			AccessKeyID:     bedrock.AccessKeyID(),
+			SecretAccessKey: bedrock.SecretAccessKey(),
+			RoleARN:         bedrock.RoleARN(),
+			Profile:         bedrock.Profile(),
+		}
+	}
+
+	if mcpServers := settings.MCPServers(); mcpServers != nil && !mcpServers.IsEmpty() {
+		patch.MCPServers = make(map[string]*settingspatch.MCPServerPatch, len(mcpServers.Servers()))
+		for name, server := range mcpServers.Servers() {
+			patch.MCPServers[name] = &settingspatch.MCPServerPatch{
+				Type:    server.Type(),
+				URL:     server.URL(),
+				Command: server.Command(),
+				Args:    append([]string(nil), server.Args()...),
+				Env:     cloneStringMap(server.Env()),
+				Headers: cloneStringMap(server.Headers()),
+			}
+		}
+	}
+
+	if marketplaces := settings.Marketplaces(); marketplaces != nil && !marketplaces.IsEmpty() {
+		patch.Marketplaces = make(map[string]*settingspatch.MarketplacePatch, len(marketplaces.Marketplaces()))
+		for name, marketplace := range marketplaces.Marketplaces() {
+			patch.Marketplaces[name] = &settingspatch.MarketplacePatch{URL: marketplace.URL()}
+		}
+	}
+
+	return patch
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
 // resolveSettings reads settings patches from the relevant Kubernetes Secrets
 // (base → team[] → user → oneshot) and returns materialized session configuration.
 //
@@ -4498,6 +4579,11 @@ func (m *KubernetesSessionManager) resolveSettings(
 			layers = append(layers, *p)
 		}
 	}
+	appendSettingsIfExists := func(settingsName string) {
+		if p := m.readSettingsPatchByName(ctx, settingsName); p != nil {
+			layers = append(layers, *p)
+		}
+	}
 
 	// 1. base (lowest priority)
 	if m.k8sConfig.SettingsBaseSecret != "" {
@@ -4507,23 +4593,23 @@ func (m *KubernetesSessionManager) resolveSettings(
 	// 2. teams (in order)
 	if req.Scope == entities.ScopeTeam && req.TeamID != "" {
 		// Team-scoped session: always use the specified team only (preferred_team_id is ignored)
-		appendIfExists(fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(req.TeamID)))
+		appendSettingsIfExists(req.TeamID)
 	} else {
 		// User-scoped session: check if the user has a preferred team set
 		preferredTeamID := m.resolvePreferredTeamID(ctx, req)
 		if preferredTeamID != "" {
 			// Use only the preferred team's settings
 			log.Printf("[K8S_SESSION] Using preferred team settings: %s", preferredTeamID)
-			appendIfExists(fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(preferredTeamID)))
+			appendSettingsIfExists(preferredTeamID)
 		} else {
 			// Default: apply all teams in order
 			for _, team := range req.Teams {
-				appendIfExists(fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(team)))
+				appendSettingsIfExists(team)
 			}
 		}
 		// 3. user
 		if req.UserID != "" {
-			appendIfExists(fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(req.UserID)))
+			appendSettingsIfExists(req.UserID)
 		}
 	}
 
@@ -4547,8 +4633,11 @@ func (m *KubernetesSessionManager) resolvePreferredTeamID(ctx context.Context, r
 	if req.UserID == "" {
 		return ""
 	}
-	userSecretName := fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(req.UserID))
-	userPatch := m.readSettingsPatch(ctx, userSecretName)
+	userPatch := m.readSettingsPatchByName(ctx, req.UserID)
+	if userPatch == nil {
+		userSecretName := fmt.Sprintf("agentapi-settings-%s", sanitizeSecretName(req.UserID))
+		userPatch = m.readSettingsPatch(ctx, userSecretName)
+	}
 	if userPatch == nil || userPatch.PreferredTeamID == "" {
 		return ""
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -1,0 +1,127 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+)
+
+type fakeSettingsRepository struct {
+	settings map[string]*entities.Settings
+}
+
+func (r *fakeSettingsRepository) Save(ctx context.Context, settings *entities.Settings) error {
+	r.settings[settings.Name()] = settings
+	return nil
+}
+
+func (r *fakeSettingsRepository) FindByName(ctx context.Context, name string) (*entities.Settings, error) {
+	settings, ok := r.settings[name]
+	if !ok {
+		return nil, fmt.Errorf("settings not found: %s", name)
+	}
+	return settings, nil
+}
+
+func (r *fakeSettingsRepository) Delete(ctx context.Context, name string) error {
+	delete(r.settings, name)
+	return nil
+}
+
+func (r *fakeSettingsRepository) Exists(ctx context.Context, name string) (bool, error) {
+	_, ok := r.settings[name]
+	return ok, nil
+}
+
+func (r *fakeSettingsRepository) List(ctx context.Context) ([]*entities.Settings, error) {
+	result := make([]*entities.Settings, 0, len(r.settings))
+	for _, settings := range r.settings {
+		result = append(result, settings)
+	}
+	return result, nil
+}
+
+func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:     "test-ns",
+			Image:         "test-image:latest",
+			BasePort:      9000,
+			PVCEnabled:    boolPtrForTest(false),
+			CPURequest:    "100m",
+			CPULimit:      "1",
+			MemoryRequest: "128Mi",
+			MemoryLimit:   "512Mi",
+		},
+	}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.namespace = "test-ns"
+
+	teamSettings := entities.NewSettings("org/team-a")
+	teamSettings.SetEnvVars(map[string]string{"SECRET_TOKEN": "decrypted-secret"})
+	manager.SetSettingsRepository(&fakeSettingsRepository{
+		settings: map[string]*entities.Settings{
+			"org/team-a": teamSettings,
+		},
+	})
+
+	// This is the shape written by KubernetesSettingsRepository when env vars are
+	// encrypted. The session manager must not rely on this raw JSON for team/user
+	// settings because SettingsPatch intentionally has no decryptor.
+	_, err = k8sClient.CoreV1().Secrets("test-ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "agentapi-settings-org-team-a", Namespace: "test-ns"},
+		Data: map[string][]byte{
+			"settings.json": []byte(`{
+				"name": "org/team-a",
+				"encrypted_env_vars": {
+					"SECRET_TOKEN": {
+						"v": "ciphertext",
+						"alg": "aes-256-gcm",
+						"kid": "sha256:test",
+						"at": "2026-06-10T00:00:00Z",
+						"ver": "v1"
+					}
+				}
+			}`),
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create settings secret: %v", err)
+	}
+
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "test-user"},
+		"test-deploy",
+		"agentapi-session-test-svc",
+		"test-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+	req := &entities.RunServerRequest{
+		UserID: "test-user",
+		Scope:  entities.ScopeTeam,
+		TeamID: "org/team-a",
+	}
+
+	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	if got := settings.Env["SECRET_TOKEN"]; got != "decrypted-secret" {
+		t.Fatalf("SECRET_TOKEN = %q, want decrypted-secret", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve team/user settings through SettingsRepository during session startup so encrypted_env_vars are decrypted before materialization
- Preserve raw settings patch data such as hooks while replacing env_vars with repository-decrypted values
- Add a session manager regression test for team settings that only contain encrypted_env_vars in the raw Secret

## Tests
- mise exec -- go test ./pkg/settingspatch ./internal/infrastructure/repositories ./internal/infrastructure/services