### PR TITLE
fix: include headers in Codex MCP config

### DIFF
--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -450,6 +450,22 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 				fmt.Fprintf(&sb, "env = {%s}\n", strings.Join(envParts, ", "))
 			}
 		}
+		if headers, ok := config["headers"].(map[string]interface{}); ok && len(headers) > 0 && codexMCPServerSupportsHTTPHeaders(serverType) {
+			headerKeys := make([]string, 0, len(headers))
+			for k := range headers {
+				headerKeys = append(headerKeys, k)
+			}
+			sort.Strings(headerKeys)
+			var headerParts []string
+			for _, k := range headerKeys {
+				if v, ok := headers[k].(string); ok {
+					headerParts = append(headerParts, fmt.Sprintf("%q = %q", k, v))
+				}
+			}
+			if len(headerParts) > 0 {
+				fmt.Fprintf(&sb, "http_headers = {%s}\n", strings.Join(headerParts, ", "))
+			}
+		}
 	}
 
 	if err := os.WriteFile(configPath, []byte(sb.String()), 0644); err != nil {
@@ -466,6 +482,15 @@ func codexMCPServerSupportsEnv(serverType string) bool {
 		return false
 	default:
 		return true
+	}
+}
+
+func codexMCPServerSupportsHTTPHeaders(serverType string) bool {
+	switch serverType {
+	case "http", "streamable_http", "sse":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -561,9 +561,10 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 						"env":     map[string]interface{}{"GITHUB_TOKEN": "ghp_xxx"},
 					},
 					"slack": map[string]interface{}{
-						"type": "http",
-						"url":  "https://mcp.example.com/slack",
-						"env":  map[string]interface{}{"SLACK_TOKEN": "xoxb-token"},
+						"type":    "http",
+						"url":     "https://mcp.example.com/slack",
+						"env":     map[string]interface{}{"SLACK_TOKEN": "xoxb-token"},
+						"headers": map[string]interface{}{"Authorization": "Bearer token", "X-Custom": "value"},
 					},
 				},
 			},
@@ -600,6 +601,7 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 		assert.Contains(t, content, "[mcp_servers.slack]")
 		assert.Contains(t, content, `type = "http"`)
 		assert.Contains(t, content, `url = "https://mcp.example.com/slack"`)
+		assert.Contains(t, content, `http_headers = {"Authorization" = "Bearer token", "X-Custom" = "value"}`)
 		assert.Contains(t, content, "GITHUB_TOKEN")
 		assert.NotContains(t, content, "SLACK_TOKEN")
 	})
@@ -622,6 +624,9 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 						"type": "streamable_http",
 						"url":  "https://api.githubcopilot.com/mcp",
 						"env":  map[string]interface{}{"GITHUB_TOKEN": "$GITHUB_TOKEN"},
+						"headers": map[string]interface{}{
+							"Authorization": "Bearer token",
+						},
 					},
 				},
 			},
@@ -652,6 +657,7 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 		assert.Contains(t, content, "[mcp_servers.github]")
 		assert.Contains(t, content, `type = "streamable_http"`)
 		assert.Contains(t, content, `url = "https://api.githubcopilot.com/mcp"`)
+		assert.Contains(t, content, `http_headers = {"Authorization" = "Bearer token"}`)
 		assert.NotContains(t, content, "GITHUB_TOKEN")
 		assert.NotContains(t, content, "env =")
 	})


### PR DESCRIPTION
## Summary
- emit Settings API MCP headers into Codex config.toml as http_headers for HTTP-compatible MCP transports
- keep env omitted for HTTP/streamable_http MCP servers while preserving static headers
- add compile tests covering http and streamable_http headers

## Tests
- mise x -- go test ./pkg/sessionsettings