### PR TITLE
Expand env placeholders for Codex MCP config

### DIFF
--- a/pkg/mcp/merge.go
+++ b/pkg/mcp/merge.go
@@ -124,8 +124,14 @@ func mergeFile(result *MCPConfig, filePath string, opts MergeOptions, log func(s
 // envVarPattern matches ${VAR} and ${VAR:-default} patterns
 var envVarPattern = regexp.MustCompile(`\$\{([^}:]+)(:-([^}]*))?\}`)
 
-// ExpandEnvVars expands ${VAR} and ${VAR:-default} patterns in a string
+// ExpandEnvVars expands ${VAR} and ${VAR:-default} patterns in a string.
 func ExpandEnvVars(s string) string {
+	return ExpandEnvVarsWithMap(s, nil)
+}
+
+// ExpandEnvVarsWithMap expands ${VAR} and ${VAR:-default} patterns in a string.
+// Values in env take precedence over process environment variables.
+func ExpandEnvVarsWithMap(s string, env map[string]string) string {
 	return envVarPattern.ReplaceAllStringFunc(s, func(match string) string {
 		submatch := envVarPattern.FindStringSubmatch(match)
 		if len(submatch) < 2 {
@@ -139,6 +145,11 @@ func ExpandEnvVars(s string) string {
 			defaultVal = submatch[3]
 		}
 
+		if env != nil {
+			if val, ok := env[varName]; ok && val != "" {
+				return val
+			}
+		}
 		if val := os.Getenv(varName); val != "" {
 			return val
 		}

--- a/pkg/mcp/merge_test.go
+++ b/pkg/mcp/merge_test.go
@@ -307,6 +307,20 @@ func TestExpandEnvVars(t *testing.T) {
 	}
 }
 
+func TestExpandEnvVarsWithMap(t *testing.T) {
+	t.Setenv("TEST_VAR", "process-value")
+
+	env := map[string]string{
+		"TEST_VAR": "map-value",
+		"EMPTY":    "",
+	}
+
+	assert.Equal(t, "Bearer map-value", ExpandEnvVarsWithMap("Bearer ${TEST_VAR}", env))
+	assert.Equal(t, "process-value", ExpandEnvVarsWithMap("${TEST_VAR}", nil))
+	assert.Equal(t, "fallback", ExpandEnvVarsWithMap("${EMPTY:-fallback}", env))
+	assert.Equal(t, "${MISSING}", ExpandEnvVarsWithMap("${MISSING}", env))
+}
+
 func TestWriteConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "output", "merged.json")

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	mcputil "github.com/takutakahashi/agentapi-proxy/pkg/mcp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -409,6 +410,7 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 			log.Printf("[COMPILE-SETTINGS] Warning: skipping MCP server %q: value is not a map", name)
 			continue
 		}
+		envValues := codexMCPEnvValues(config)
 
 		// Use [mcp_servers.<name>] nested-table format (not [[mcp_servers]] array-of-tables).
 		// The Codex CLI expects mcp_servers to be a map keyed by server name.
@@ -420,16 +422,16 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 			fmt.Fprintf(&sb, "type = %q\n", v)
 		}
 		if v, ok := config["url"].(string); ok {
-			fmt.Fprintf(&sb, "url = %q\n", v)
+			fmt.Fprintf(&sb, "url = %q\n", mcputil.ExpandEnvVarsWithMap(v, envValues))
 		}
 		if v, ok := config["command"].(string); ok {
-			fmt.Fprintf(&sb, "command = %q\n", v)
+			fmt.Fprintf(&sb, "command = %q\n", mcputil.ExpandEnvVarsWithMap(v, envValues))
 		}
 		if args, ok := config["args"].([]interface{}); ok && len(args) > 0 {
 			parts := make([]string, 0, len(args))
 			for _, a := range args {
 				if s, ok := a.(string); ok {
-					parts = append(parts, fmt.Sprintf("%q", s))
+					parts = append(parts, fmt.Sprintf("%q", mcputil.ExpandEnvVarsWithMap(s, envValues)))
 				}
 			}
 			fmt.Fprintf(&sb, "args = [%s]\n", strings.Join(parts, ", "))
@@ -443,7 +445,7 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 			var envParts []string
 			for _, k := range envKeys {
 				if v, ok := env[k].(string); ok {
-					envParts = append(envParts, fmt.Sprintf("%s = %q", k, v))
+					envParts = append(envParts, fmt.Sprintf("%s = %q", k, mcputil.ExpandEnvVarsWithMap(v, envValues)))
 				}
 			}
 			if len(envParts) > 0 {
@@ -459,7 +461,7 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 			var headerParts []string
 			for _, k := range headerKeys {
 				if v, ok := headers[k].(string); ok {
-					headerParts = append(headerParts, fmt.Sprintf("%q = %q", k, v))
+					headerParts = append(headerParts, fmt.Sprintf("%q = %q", k, mcputil.ExpandEnvVarsWithMap(v, envValues)))
 				}
 			}
 			if len(headerParts) > 0 {
@@ -474,6 +476,21 @@ func generateCodexMCPServers(outputDir string, mcpServers map[string]interface{}
 
 	log.Printf("[COMPILE-SETTINGS] Appended %d MCP server(s) to %s", len(mcpServers), configPath)
 	return nil
+}
+
+func codexMCPEnvValues(config map[string]interface{}) map[string]string {
+	env, ok := config["env"].(map[string]interface{})
+	if !ok || len(env) == 0 {
+		return nil
+	}
+
+	values := make(map[string]string, len(env))
+	for k, v := range env {
+		if s, ok := v.(string); ok {
+			values[k] = s
+		}
+	}
+	return values
 }
 
 func codexMCPServerSupportsEnv(serverType string) bool {

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -662,6 +662,65 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 		assert.NotContains(t, content, "env =")
 	})
 
+	t.Run("expands env placeholders for http mcp_servers without emitting env", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-codex-mcp-http-env-placeholders-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-codex-mcp-http-env-placeholders",
+				UserID:    "user-codex-mcp-http-env-placeholders",
+				Scope:     "user",
+				AgentType: "codex-acp",
+			},
+			Codex: CodexConfig{
+				MCPServers: map[string]interface{}{
+					"github": map[string]interface{}{
+						"type": "http",
+						"url":  "https://api.example.com/${MCP_TENANT:-default}/mcp",
+						"env": map[string]interface{}{
+							"GITHUB_TOKEN": "ghp_secret",
+							"MCP_TENANT":   "acme",
+						},
+						"headers": map[string]interface{}{
+							"Authorization": "Bearer ${GITHUB_TOKEN}",
+							"X-Tenant":      "${MCP_TENANT}",
+						},
+					},
+				},
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".codex/config.toml")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		content := string(data)
+
+		assert.Contains(t, content, `url = "https://api.example.com/acme/mcp"`)
+		assert.Contains(t, content, `http_headers = {"Authorization" = "Bearer ghp_secret", "X-Tenant" = "acme"}`)
+		assert.NotContains(t, content, "env =")
+		assert.NotContains(t, content, "${GITHUB_TOKEN}")
+		assert.NotContains(t, content, "${MCP_TENANT}")
+	})
+
 	t.Run("appends mcp_servers after existing ConfigTOML", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "compile-codex-mcp-append-*")
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary
- expand MCP \ placeholders using each server's env map before writing Codex config.toml
- keep omitting env for HTTP/streamable_http servers while allowing headers and URLs to receive resolved values
- add coverage for map-backed env expansion and Codex HTTP MCP output

## Tests
- mise exec -- go test ./pkg/mcp ./pkg/sessionsettings