### PR TITLE
Stop webhook reuse targets before sending

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1473,11 +1473,9 @@ func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, m
 		}
 	}
 
-	isACP := agentType == "claude-acp" || agentType == "codex-acp"
-
 	var jsonData []byte
 	var postURL string
-	if isACP {
+	if isACPAgentType(agentType) {
 		// Fetch the ACP session ID from GET /session.
 		acpSessionID, err := m.getACPSessionIDFromPod(ctx, baseURL)
 		if err != nil {
@@ -1584,9 +1582,9 @@ func (m *KubernetesSessionManager) getACPSessionIDFromPod(ctx context.Context, b
 	return body.SessionId, nil
 }
 
-// StopAgent sends a stop_agent action to the running agent in the session via the
-// claude-agentapi POST /action endpoint. This terminates the running agent task
-// without deleting the session.
+// StopAgent sends a stop/cancel signal to the running agent without deleting the session.
+// ACP-backed sessions use JSON-RPC session/cancel; agentapi-compatible sessions use
+// the POST /action stop_agent endpoint.
 func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) error {
 	// Get session
 	session := m.GetSession(id)
@@ -1608,12 +1606,33 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 		m.k8sConfig.BasePort,
 	)
 
-	// Send stop_agent action as defined in the claude-agentapi OpenAPI spec
-	payload := map[string]interface{}{
-		"type": "stop_agent",
+	agentType := ""
+	if ks, ok := session.(*KubernetesSession); ok {
+		if req := ks.Request(); req != nil {
+			agentType = req.AgentType
+		}
 	}
 
-	// Marshal JSON
+	var payload interface{}
+	if isACPAgentType(agentType) {
+		url = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/rpc",
+			serviceName,
+			m.namespace,
+			m.k8sConfig.BasePort,
+		)
+		payload = map[string]interface{}{
+			"jsonrpc": "2.0",
+			"method":  "session/cancel",
+			"params": map[string]string{
+				"sessionId": id,
+			},
+		}
+	} else {
+		payload = map[string]interface{}{
+			"type": "stop_agent",
+		}
+	}
+
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("failed to marshal stop_agent payload: %w", err)
@@ -1639,8 +1658,12 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 		return fmt.Errorf("unexpected status code from stop_agent signal: %d", resp.StatusCode)
 	}
 
-	log.Printf("[K8S_SESSION] Successfully sent stop_agent signal to session %s", id)
+	log.Printf("[K8S_SESSION] Successfully sent stop_agent signal to session %s (agentType=%q)", id, agentType)
 	return nil
+}
+
+func isACPAgentType(agentType string) bool {
+	return agentType == "claude-acp" || agentType == "codex-acp"
 }
 
 // GetMessages retrieves conversation history from a session

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -1,6 +1,12 @@
 package services
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,5 +70,106 @@ func TestSubscribeMessageEvents_ReceivesBroadcast(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for message event")
+	}
+}
+
+func TestStopAgentUsesACPCancelForACPSessions(t *testing.T) {
+	m := newTestManagerForCycle(t)
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "user1", AgentType: "codex-acp"},
+		"test-deploy", "test-svc", "test-pvc", "test-ns",
+		9000, nil, nil,
+	)
+	session.SetStatusSilent("active")
+	m.mutex.Lock()
+	m.sessions["test-session"] = session
+	m.mutex.Unlock()
+
+	var requestPath string
+	var payload map[string]interface{}
+	withRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+		requestPath = req.URL.Path
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+		return jsonResponse(http.StatusOK), nil
+	})
+
+	if err := m.StopAgent(context.Background(), "test-session"); err != nil {
+		t.Fatalf("StopAgent() error = %v", err)
+	}
+	if requestPath != "/rpc" {
+		t.Fatalf("expected /rpc, got %q", requestPath)
+	}
+	if payload["jsonrpc"] != "2.0" || payload["method"] != "session/cancel" {
+		t.Fatalf("unexpected ACP cancel payload: %#v", payload)
+	}
+	params, ok := payload["params"].(map[string]interface{})
+	if !ok || params["sessionId"] != "test-session" {
+		t.Fatalf("unexpected params: %#v", payload["params"])
+	}
+}
+
+func TestStopAgentUsesActionForAgentAPISessions(t *testing.T) {
+	m := newTestManagerForCycle(t)
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "user1", AgentType: "claude-agentapi"},
+		"test-deploy", "test-svc", "test-pvc", "test-ns",
+		9000, nil, nil,
+	)
+	session.SetStatusSilent("active")
+	m.mutex.Lock()
+	m.sessions["test-session"] = session
+	m.mutex.Unlock()
+
+	var requestPath string
+	var body string
+	withRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+		requestPath = req.URL.Path
+		data, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		body = string(data)
+		return jsonResponse(http.StatusOK), nil
+	})
+
+	if err := m.StopAgent(context.Background(), "test-session"); err != nil {
+		t.Fatalf("StopAgent() error = %v", err)
+	}
+	if requestPath != "/action" {
+		t.Fatalf("expected /action, got %q", requestPath)
+	}
+	if !strings.Contains(body, `"type":"stop_agent"`) {
+		t.Fatalf("unexpected action payload: %s", body)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func withRoundTripper(t *testing.T, f roundTripFunc) {
+	t.Helper()
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: f}
+	t.Cleanup(func() {
+		http.DefaultClient = originalClient
+	})
+}
+
+func jsonResponse(statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(bytes.NewBufferString(`{"ok":true}`)),
+		Header:     make(http.Header),
 	}
 }

--- a/internal/interfaces/controllers/webhook_session_service.go
+++ b/internal/interfaces/controllers/webhook_session_service.go
@@ -167,6 +167,7 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 		ReuseSession:             sessionConfig != nil && sessionConfig.ReuseSession(),
 		ReuseMatchTags:           tags,
 		ReuseMessage:             reuseMessage,
+		StopBeforeReuse:          true,
 		MaxSessions:              webhook.MaxSessions(),
 		LimitMatchTags:           map[string]string{"webhook_id": webhook.ID()},
 	})

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -55,6 +55,9 @@ type LaunchRequest struct {
 	ReuseMatchTags map[string]string
 	// ReuseMessage is sent to the reused session. Falls back to InitialMessage when empty.
 	ReuseMessage string
+	// StopBeforeReuse stops the running agent before sending ReuseMessage.
+	// This keeps the session resources in place while making a busy agent receive follow-up input.
+	StopBeforeReuse bool
 
 	// Session limit: when MaxSessions > 0, launch fails if the number of sessions
 	// matching LimitMatchTags already equals or exceeds MaxSessions.
@@ -149,6 +152,11 @@ func (uc *LaunchUseCase) Launch(ctx context.Context, sessionID string, req Launc
 			reuseMessage := req.ReuseMessage
 			if reuseMessage == "" {
 				reuseMessage = req.InitialMessage
+			}
+			if req.StopBeforeReuse {
+				if err := uc.sessionManager.StopAgent(ctx, existing[0].ID()); err != nil {
+					return LaunchResult{}, fmt.Errorf("failed to stop existing session before reuse: %w", err)
+				}
 			}
 			if err := uc.sessionManager.SendMessage(ctx, existing[0].ID(), reuseMessage); err != nil {
 				return LaunchResult{}, fmt.Errorf("failed to route message to existing session: %w", err)

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -10,23 +12,39 @@ import (
 )
 
 type recordingSessionManager struct {
-	req *entities.RunServerRequest
+	req             *entities.RunServerRequest
+	existing        []entities.Session
+	sendMessageErr  error
+	stopAgentErr    error
+	sendMessageID   string
+	sendMessageBody string
+	stopAgentID     string
+	calls           []string
+	createdID       string
 }
 
 func (m *recordingSessionManager) CreateSession(_ context.Context, id string, req *entities.RunServerRequest, _ []byte) (entities.Session, error) {
 	m.req = req
+	m.createdID = id
 	return &launchTestSession{id: id, userID: req.UserID, status: "active"}, nil
 }
 
 func (m *recordingSessionManager) GetSession(string) entities.Session { return nil }
 func (m *recordingSessionManager) ListSessions(entities.SessionFilter) []entities.Session {
-	return nil
+	return m.existing
 }
 func (m *recordingSessionManager) DeleteSession(string) error { return nil }
-func (m *recordingSessionManager) SendMessage(context.Context, string, string) error {
-	return nil
+func (m *recordingSessionManager) SendMessage(_ context.Context, id string, message string) error {
+	m.calls = append(m.calls, "send")
+	m.sendMessageID = id
+	m.sendMessageBody = message
+	return m.sendMessageErr
 }
-func (m *recordingSessionManager) StopAgent(context.Context, string) error { return nil }
+func (m *recordingSessionManager) StopAgent(_ context.Context, id string) error {
+	m.calls = append(m.calls, "stop")
+	m.stopAgentID = id
+	return m.stopAgentErr
+}
 func (m *recordingSessionManager) GetMessages(context.Context, string) ([]repositories.Message, error) {
 	return nil, nil
 }
@@ -142,5 +160,116 @@ func TestLaunchExplicitDockerOverridesProfileDocker(t *testing.T) {
 	}
 	if sessionManager.req.Docker.Enabled {
 		t.Fatalf("expected explicit Docker.Enabled=false to override profile, got %#v", sessionManager.req.Docker)
+	}
+}
+
+func TestLaunchReuseRoutesMessageToExistingSession(t *testing.T) {
+	sessionManager := &recordingSessionManager{
+		existing: []entities.Session{&launchTestSession{id: "existing-1", userID: "user-1", status: "active"}},
+	}
+	launcher := NewLaunchUseCase(sessionManager)
+
+	result, err := launcher.Launch(context.Background(), "new-1", LaunchRequest{
+		UserID:         "user-1",
+		Scope:          entities.ScopeUser,
+		InitialMessage: "initial",
+		ReuseSession:   true,
+		ReuseMatchTags: map[string]string{"webhook_id": "webhook-1"},
+		ReuseMessage:   "reuse",
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if !result.SessionReused || result.SessionID != "existing-1" {
+		t.Fatalf("expected reused existing session, got %#v", result)
+	}
+	if sessionManager.req != nil {
+		t.Fatal("CreateSession should not be called when reuse succeeds")
+	}
+	if sessionManager.sendMessageID != "existing-1" || sessionManager.sendMessageBody != "reuse" {
+		t.Fatalf("unexpected SendMessage call: id=%q body=%q", sessionManager.sendMessageID, sessionManager.sendMessageBody)
+	}
+}
+
+func TestLaunchReuseStopsExistingSessionBeforeSendingWhenRequested(t *testing.T) {
+	sessionManager := &recordingSessionManager{
+		existing: []entities.Session{&launchTestSession{id: "existing-1", userID: "user-1", status: "active"}},
+	}
+	launcher := NewLaunchUseCase(sessionManager)
+
+	result, err := launcher.Launch(context.Background(), "new-1", LaunchRequest{
+		UserID:          "user-1",
+		Scope:           entities.ScopeUser,
+		InitialMessage:  "initial",
+		ReuseSession:    true,
+		ReuseMatchTags:  map[string]string{"webhook_id": "webhook-1"},
+		ReuseMessage:    "reuse",
+		StopBeforeReuse: true,
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if !result.SessionReused || result.SessionID != "existing-1" {
+		t.Fatalf("expected reused existing session, got %#v", result)
+	}
+	if sessionManager.req != nil {
+		t.Fatal("CreateSession should not be called when reuse succeeds")
+	}
+	if sessionManager.stopAgentID != "existing-1" {
+		t.Fatalf("unexpected StopAgent id: %q", sessionManager.stopAgentID)
+	}
+	if sessionManager.sendMessageID != "existing-1" || sessionManager.sendMessageBody != "reuse" {
+		t.Fatalf("unexpected SendMessage call: id=%q body=%q", sessionManager.sendMessageID, sessionManager.sendMessageBody)
+	}
+	if !reflect.DeepEqual(sessionManager.calls, []string{"stop", "send"}) {
+		t.Fatalf("unexpected call order: %#v", sessionManager.calls)
+	}
+}
+
+func TestLaunchReuseReturnsErrorWhenStopBeforeReuseFails(t *testing.T) {
+	sessionManager := &recordingSessionManager{
+		existing:     []entities.Session{&launchTestSession{id: "existing-1", userID: "user-1", status: "active"}},
+		stopAgentErr: errors.New("stop failed"),
+	}
+	launcher := NewLaunchUseCase(sessionManager)
+
+	_, err := launcher.Launch(context.Background(), "new-1", LaunchRequest{
+		UserID:          "user-1",
+		Scope:           entities.ScopeUser,
+		InitialMessage:  "initial",
+		ReuseSession:    true,
+		ReuseMatchTags:  map[string]string{"webhook_id": "webhook-1"},
+		StopBeforeReuse: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if sessionManager.sendMessageID != "" {
+		t.Fatal("SendMessage should not be called when StopAgent fails")
+	}
+	if sessionManager.req != nil {
+		t.Fatal("CreateSession should not be called when StopAgent fails")
+	}
+}
+
+func TestLaunchReuseReturnsErrorForNonStaleSendFailure(t *testing.T) {
+	sessionManager := &recordingSessionManager{
+		existing:       []entities.Session{&launchTestSession{id: "existing-1", userID: "user-1", status: "active"}},
+		sendMessageErr: errors.New("connection refused"),
+	}
+	launcher := NewLaunchUseCase(sessionManager)
+
+	_, err := launcher.Launch(context.Background(), "new-1", LaunchRequest{
+		UserID:         "user-1",
+		Scope:          entities.ScopeUser,
+		InitialMessage: "initial",
+		ReuseSession:   true,
+		ReuseMatchTags: map[string]string{"webhook_id": "webhook-1"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if sessionManager.req != nil {
+		t.Fatal("CreateSession should not be called for non-stale reuse errors")
 	}
 }


### PR DESCRIPTION
## Summary
- Adjust webhook session reuse so follow-up webhook deliveries stop the existing target agent before sending the reuse message.
- Keep the session resources in place and reuse the same session instead of falling back to a fresh session on send failures.
- Scope the stop-before-reuse behavior to webhook-triggered launches; schedule/slackbot reuse behavior is unchanged.
- Make StopAgent agent-type aware: claude-acp/codex-acp use JSON-RPC session/cancel, while agentapi-compatible sessions keep using POST /action stop_agent.

## Verification
- mise exec -- go test ./internal/usecases/session ./internal/infrastructure/services
- mise exec -- go test ./internal/interfaces/controllers -run "Webhook|Launch|Session"

## Production observation
- Production agentapi-proxy v1.463.0 logs showed aido webhook reuse attempts failing when routing a follow-up message to an existing session.
- The requested behavior is to stop the reuse target first so it can receive the follow-up message.