### PR TITLE
Fix restored ACP session routing

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1472,6 +1472,9 @@ func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, m
 			agentType = req.AgentType
 		}
 	}
+	if agentType == "" {
+		agentType = m.getSessionAgentTypeFromService(ctx, serviceName)
+	}
 
 	var jsonData []byte
 	var postURL string
@@ -1612,6 +1615,9 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 			agentType = req.AgentType
 		}
 	}
+	if agentType == "" {
+		agentType = m.getSessionAgentTypeFromService(ctx, serviceName)
+	}
 
 	var payload interface{}
 	if isACPAgentType(agentType) {
@@ -1664,6 +1670,27 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 
 func isACPAgentType(agentType string) bool {
 	return agentType == "claude-acp" || agentType == "codex-acp"
+}
+
+func restoreAgentTypeFromService(svc *corev1.Service) string {
+	if svc == nil {
+		return ""
+	}
+	if agentType := svc.Annotations["agentapi.proxy/agent-type"]; agentType != "" {
+		return agentType
+	}
+	return svc.Labels["agentapi.proxy/agent-type"]
+}
+
+func (m *KubernetesSessionManager) getSessionAgentTypeFromService(ctx context.Context, serviceName string) string {
+	svc, err := m.client.CoreV1().Services(m.namespace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Printf("[K8S_SESSION] Failed to get service %s for agent type fallback: %v", serviceName, err)
+		}
+		return ""
+	}
+	return restoreAgentTypeFromService(svc)
 }
 
 // GetMessages retrieves conversation history from a session
@@ -3486,6 +3513,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 
 	// Parse session-ttl annotation if present
 	sessionTTL := svc.Annotations["agentapi.proxy/session-ttl"]
+	agentType := restoreAgentTypeFromService(svc)
 
 	// Create session using constructor
 	session := NewKubernetesSession(
@@ -3500,6 +3528,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 			Teams:          teams,
 			Oneshot:        oneshot,
 			SessionTTL:     sessionTTL,
+			AgentType:      agentType,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,
@@ -3614,6 +3643,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 
 	// Parse session-ttl annotation if present
 	sessionTTL := svc.Annotations["agentapi.proxy/session-ttl"]
+	agentType := restoreAgentTypeFromService(svc)
 
 	// Create session using constructor
 	session := NewKubernetesSession(
@@ -3628,6 +3658,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithDeployment(svc *
 			Teams:          teams,
 			Oneshot:        oneshot,
 			SessionTTL:     sessionTTL,
+			AgentType:      agentType,
 		},
 		fmt.Sprintf("agentapi-session-%s", sessionID),
 		svc.Name,

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestBroadcastMessageUpdate_UpdatesLastMessageAt verifies that broadcastMessageUpdate
@@ -112,6 +114,74 @@ func TestStopAgentUsesACPCancelForACPSessions(t *testing.T) {
 	params, ok := payload["params"].(map[string]interface{})
 	if !ok || params["sessionId"] != "test-session" {
 		t.Fatalf("unexpected params: %#v", payload["params"])
+	}
+}
+
+func TestStopAgentUsesServiceAgentTypeFallbackForRestoredACPSession(t *testing.T) {
+	m := newTestManagerForCycle(t)
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "user1"},
+		"test-deploy", "agentapi-session-test-session-svc", "test-pvc", "test-ns",
+		9000, nil, nil,
+	)
+	session.SetStatusSilent("active")
+	m.mutex.Lock()
+	m.sessions["test-session"] = session
+	m.mutex.Unlock()
+
+	_, err := m.client.CoreV1().Services("test-ns").Create(context.Background(), &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agentapi-session-test-session-svc",
+			Annotations: map[string]string{
+				"agentapi.proxy/agent-type": "codex-acp",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create service error = %v", err)
+	}
+
+	var requestPath string
+	withRoundTripper(t, func(req *http.Request) (*http.Response, error) {
+		requestPath = req.URL.Path
+		return jsonResponse(http.StatusOK), nil
+	})
+
+	if err := m.StopAgent(context.Background(), "test-session"); err != nil {
+		t.Fatalf("StopAgent() error = %v", err)
+	}
+	if requestPath != "/rpc" {
+		t.Fatalf("expected /rpc from Service agent-type fallback, got %q", requestPath)
+	}
+}
+
+func TestRestoreSessionFromServiceRestoresAgentType(t *testing.T) {
+	m := newTestManagerForCycle(t)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agentapi-session-test-session-svc",
+			Labels: map[string]string{
+				"agentapi.proxy/session-id": "test-session",
+				"agentapi.proxy/user-id":    "user1",
+				"agentapi.proxy/scope":      "user",
+				"agentapi.proxy/agent-type": "codex-acp",
+			},
+			Annotations: map[string]string{
+				"agentapi.proxy/agent-type": "codex-acp",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 9000}},
+		},
+	}
+
+	session := m.restoreSessionFromService(svc)
+	if session == nil || session.Request() == nil {
+		t.Fatalf("expected restored session, got %#v", session)
+	}
+	if session.Request().AgentType != "codex-acp" {
+		t.Fatalf("expected AgentType codex-acp, got %q", session.Request().AgentType)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Restore agentapi.proxy/agent-type from Kubernetes Service metadata when rebuilding sessions after proxy restart.
- Fall back to Service metadata in SendMessage and StopAgent when an in-memory restored session has an empty RunServerRequest.AgentType.
- Add regression coverage for restored codex-acp sessions using /rpc instead of /action.

## Production symptom
A custom webhook with reuse_session=true matched an existing restored ACP session, then failed with:

failed to stop existing session before reuse: unexpected status code from stop_agent signal: 404

The Service had agentapi.proxy/agent-type=codex-acp, but restored sessions did not put that value back into RunServerRequest.AgentType, so StopAgent routed to /action instead of ACP /rpc.

## Test
- mise exec -- go test ./internal/infrastructure/services