### PR TITLE
Add HTML asset upload support

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -52,6 +52,13 @@ var (
 	memoryUnion       bool
 )
 
+// asset subcommand flags
+var (
+	assetHTML     string
+	assetHTMLFile string
+	assetFormat   string
+)
+
 // memory save-session subcommand flags
 var (
 	memorySaveSessionScope  string
@@ -226,6 +233,19 @@ var memoryCmd = &cobra.Command{
 	Use:   "memory",
 	Short: "Manage memory entries",
 	Long:  "Create, list, get, update, delete, and upsert memory entries",
+}
+
+var assetCmd = &cobra.Command{
+	Use:   "asset",
+	Short: "Manage static HTML assets",
+	Long:  "Upload HTML and receive an externally reachable asset URL",
+}
+
+var assetCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Upload an HTML asset",
+	Long:  "Upload HTML from --html, --html-file, or stdin and receive an externally reachable asset URL.",
+	Run:   runAssetCreate,
 }
 
 var memoryListCmd = &cobra.Command{
@@ -535,6 +555,13 @@ func init() {
 	memoryCmd.AddCommand(memoryUpsertCmd)
 	memoryCmd.AddCommand(memorySaveSessionCmd)
 
+	// asset create flags
+	assetCreateCmd.Flags().StringVar(&assetHTML, "html", "", "HTML content to upload")
+	assetCreateCmd.Flags().StringVar(&assetHTMLFile, "html-file", "", "Path to file containing HTML content; use - for stdin")
+	assetCreateCmd.Flags().StringVar(&assetFormat, "format", "url", `Output format: "url" or "json"`)
+
+	assetCmd.AddCommand(assetCreateCmd)
+
 	// summarize-drafts flags
 	summarizeDraftsCmd.Flags().StringVar(&summarizeDraftsSourceSessionID, "source-session-id", "", "Session ID whose draft memories should be summarized (required)")
 	summarizeDraftsCmd.Flags().StringVar(&summarizeDraftsScope, "scope", "user", `Memory scope: "user" or "team"`)
@@ -560,6 +587,7 @@ func init() {
 	ClientCmd.AddCommand(sendNotificationClientCmd)
 	ClientCmd.AddCommand(taskCmd)
 	ClientCmd.AddCommand(memoryCmd)
+	ClientCmd.AddCommand(assetCmd)
 }
 
 const (
@@ -1046,6 +1074,13 @@ func resolveBaseClient() (*client.Client, error) {
 // readContentFlag reads the memory content from --content or --content-file flags.
 func readContentFlag(content, contentFile string) (string, error) {
 	if contentFile != "" {
+		if contentFile == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return "", fmt.Errorf("failed to read stdin: %w", err)
+			}
+			return string(data), nil
+		}
 		data, err := os.ReadFile(contentFile)
 		if err != nil {
 			return "", fmt.Errorf("failed to read content file %q: %w", contentFile, err)
@@ -1053,6 +1088,45 @@ func readContentFlag(content, contentFile string) (string, error) {
 		return string(data), nil
 	}
 	return content, nil
+}
+
+func runAssetCreate(cmd *cobra.Command, args []string) {
+	html, err := readContentFlag(assetHTML, assetHTMLFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if html == "" {
+		fmt.Fprintf(os.Stderr, "Error: provide --html, --html-file, or --html-file -\n")
+		os.Exit(1)
+	}
+
+	c, err := resolveMemoryClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	asset, err := c.CreateAsset(context.Background(), &client.CreateAssetRequest{HTML: html})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating asset: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch assetFormat {
+	case "json":
+		out, err := json.MarshalIndent(asset, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting response: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(out))
+	case "url", "":
+		fmt.Println(asset.URL)
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unsupported --format %q\n", assetFormat)
+		os.Exit(1)
+	}
 }
 
 // formatMemoriesMarkdown formats memory entries as Markdown suitable for CLAUDE.md injection.

--- a/helm/agentapi-proxy/templates/asset-nginx.yaml
+++ b/helm/agentapi-proxy/templates/asset-nginx.yaml
@@ -1,0 +1,99 @@
+{{- $asset := .Values.asset | default dict -}}
+{{- $assetBackend := $asset.backend | default "nginx" -}}
+{{- $assetEnabled := $asset.enabled | default true -}}
+{{- $assetPersistence := $asset.persistence | default dict -}}
+{{- $assetNginx := $asset.nginx | default dict -}}
+{{- $assetNginxImage := $assetNginx.image | default dict -}}
+{{- $assetNginxService := $assetNginx.service | default dict -}}
+{{- $assetNginxResources := $assetNginx.resources | default (dict "requests" (dict "memory" "64Mi" "cpu" "50m") "limits" (dict "memory" "128Mi" "cpu" "250m")) -}}
+{{- if and $assetEnabled (eq $assetBackend "nginx") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-asset-nginx
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+      listen 80;
+      server_name _;
+      root /usr/share/nginx/html;
+
+      location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-asset-nginx
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: assets
+spec:
+  replicas: {{ $assetNginx.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agentapi-proxy.name" . }}-assets
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "agentapi-proxy.name" . }}-assets
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: assets
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: nginx
+          image: "{{ $assetNginxImage.repository | default "nginx" }}:{{ $assetNginxImage.tag | default "1.27-alpine" }}"
+          imagePullPolicy: {{ $assetNginxImage.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - name: asset-storage
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+          resources:
+            {{- toYaml $assetNginxResources | nindent 12 }}
+      volumes:
+        - name: asset-storage
+          {{ if $assetPersistence.enabled | default true }}
+          persistentVolumeClaim:
+            claimName: {{ include "agentapi-proxy.fullname" . }}-assets
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "agentapi-proxy.fullname" . }}-asset-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-assets
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: assets
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $assetNginxService.port | default 80 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "agentapi-proxy.name" . }}-assets
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: assets
+{{- end }}

--- a/helm/agentapi-proxy/templates/asset-pvc.yaml
+++ b/helm/agentapi-proxy/templates/asset-pvc.yaml
@@ -1,0 +1,21 @@
+{{- $asset := .Values.asset | default dict -}}
+{{- $assetBackend := $asset.backend | default "nginx" -}}
+{{- $assetEnabled := $asset.enabled | default true -}}
+{{- $assetPersistence := $asset.persistence | default dict -}}
+{{- if and $assetEnabled (eq $assetBackend "nginx") ($assetPersistence.enabled | default true) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agentapi-proxy.fullname" . }}-assets
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml ($assetPersistence.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ $assetPersistence.size | default "1Gi" | quote }}
+  {{- if $assetPersistence.storageClass }}
+  storageClassName: {{ $assetPersistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -1,3 +1,10 @@
+{{- $asset := .Values.asset | default dict }}
+{{- $assetBackend := $asset.backend | default "nginx" }}
+{{- $assetEnabled := $asset.enabled | default true }}
+{{- $assetStoragePath := $asset.storagePath | default "/var/lib/agentapi-assets" }}
+{{- $assetPersistence := $asset.persistence | default dict }}
+{{- $assetPersistenceEnabled := $assetPersistence.enabled | default true }}
+{{- $assetS3 := $asset.s3 | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -185,6 +192,40 @@ spec:
             {{- else if $hostname }}
             - name: AGENTAPI_WEBHOOK_BASE_URL
               value: {{ printf "https://%s" $hostname | quote }}
+            {{- end }}
+            # Static asset upload configuration
+            - name: AGENTAPI_ASSET_BACKEND
+              value: {{ $assetBackend | quote }}
+            {{ $assetPublicBaseURL := $asset.publicBaseUrl | default "" }}
+            {{ $assetHost := .Values.config.hostname | default "" }}
+            {{ if .Values.global }}
+              {{ $assetHost = .Values.global.apiHostname | default $assetHost }}
+            {{ end }}
+            {{ if and (eq $assetHost "") .Values.ingress.hosts }}
+              {{ $assetHost = (index .Values.ingress.hosts 0).host }}
+            {{ end }}
+            {{ if and (eq $assetPublicBaseURL "") $assetHost }}
+              {{ $assetPublicBaseURL = printf "https://%s" $assetHost }}
+            {{ end }}
+            - name: AGENTAPI_ASSET_PUBLIC_BASE_URL
+              value: {{ $assetPublicBaseURL | quote }}
+            - name: AGENTAPI_ASSET_STORAGE_PATH
+              value: {{ $assetStoragePath | quote }}
+            {{- if $assetS3.bucket }}
+            - name: AGENTAPI_ASSET_S3_BUCKET
+              value: {{ $assetS3.bucket | quote }}
+            {{- end }}
+            {{- if $assetS3.region }}
+            - name: AGENTAPI_ASSET_S3_REGION
+              value: {{ $assetS3.region | quote }}
+            {{- end }}
+            {{- if $assetS3.prefix }}
+            - name: AGENTAPI_ASSET_S3_PREFIX
+              value: {{ $assetS3.prefix | quote }}
+            {{- end }}
+            {{- if $assetS3.endpoint }}
+            - name: AGENTAPI_ASSET_S3_ENDPOINT
+              value: {{ $assetS3.endpoint | quote }}
             {{- end }}
             {{- if .Values.config.webhook.githubEnterpriseHost }}
             - name: AGENTAPI_WEBHOOK_GITHUB_ENTERPRISE_HOST
@@ -483,6 +524,10 @@ spec:
               mountPath: /etc/k8s-session-config
               readOnly: true
             {{- end }}
+            {{- if and $assetEnabled (eq $assetBackend "nginx") }}
+            - name: asset-storage
+              mountPath: {{ $assetStoragePath | quote }}
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -526,6 +571,15 @@ spec:
         - name: k8s-session-config
           configMap:
             name: {{ include "agentapi-proxy.fullname" . }}-k8s-session-config
+        {{- end }}
+        {{- if and $assetEnabled (eq $assetBackend "nginx") }}
+        - name: asset-storage
+          {{ if $assetPersistenceEnabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "agentapi-proxy.fullname" . }}-assets
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
         {{- end }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/helm/agentapi-proxy/templates/ingress.yaml
+++ b/helm/agentapi-proxy/templates/ingress.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.ingress.enabled -}}
+{{- $asset := .Values.asset | default dict }}
+{{- $assetBackend := $asset.backend | default "nginx" }}
+{{- $assetEnabled := $asset.enabled | default true }}
+{{- $assetNginx := $asset.nginx | default dict }}
+{{- $assetNginxService := $assetNginx.service | default dict }}
+{{- $assetNginxServicePort := $assetNginxService.port | default 80 }}
 {{- $ingressClassName := .Values.ingress.className }}
 {{- if .Values.global }}
   {{- if .Values.global.ingress }}
@@ -56,6 +62,22 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+          {{- if and $assetEnabled (eq $assetBackend "nginx") }}
+          - path: /assets
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.fullname" $ }}-assets
+                port:
+                  number: {{ $assetNginxServicePort }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.fullname" $ }}-assets
+              servicePort: {{ $assetNginxServicePort }}
+              {{- end }}
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
@@ -77,6 +99,22 @@ spec:
     - host: {{ $apiHostname | quote }}
       http:
         paths:
+          {{- if and $assetEnabled (eq $assetBackend "nginx") }}
+          - path: /assets
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.fullname" . }}-assets
+                port:
+                  number: {{ $assetNginxServicePort }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.fullname" . }}-assets
+              servicePort: {{ $assetNginxServicePort }}
+              {{- end }}
+          {{- end }}
           - path: /
             {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -67,6 +67,38 @@ service:
   port: 8080
   agentapiPort: 9000
 
+asset:
+  enabled: true
+  backend: nginx
+  publicBaseUrl: ""
+  storagePath: /var/lib/agentapi-assets
+  nginx:
+    image:
+      repository: nginx
+      tag: "1.27-alpine"
+      pullPolicy: IfNotPresent
+    replicaCount: 1
+    service:
+      port: 80
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "250m"
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+  s3:
+    bucket: ""
+    region: ""
+    prefix: "agentapi-assets/"
+    endpoint: ""
+
 ingress:
   enabled: false
   className: "nginx"
@@ -76,15 +108,12 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: agentapi.example.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: agentapi-proxy-tls
-      hosts:
-        - agentapi.example.com
+  # When empty, global.apiHostname or config.hostname is used.
+  hosts: []
+  tls: []
+  # - secretName: agentapi-proxy-tls
+  #   hosts:
+  #     - agentapi.example.com
 
 resources:
   requests:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -38,6 +38,7 @@ type HandlerRegistry struct {
 	taskController            *controllers.TaskController
 	taskGroupController       *controllers.TaskGroupController
 	fileController            *controllers.FileController
+	assetController           *controllers.AssetController
 	sessionProfileController  *controllers.SessionProfileController
 	provisionerController     *controllers.ProvisionerController
 	customHandlers            []CustomHandler
@@ -149,6 +150,12 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] File controller initialized")
 	}
 
+	var assetController *controllers.AssetController
+	if server.assetStore != nil {
+		assetController = controllers.NewAssetController(server.assetStore)
+		log.Printf("[ROUTER] Asset controller initialized")
+	}
+
 	// Create session profile controller if session profile repository is available
 	var sessionProfileController *controllers.SessionProfileController
 	if server.sessionProfileRepo != nil {
@@ -183,6 +190,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 			taskController:            taskController,
 			taskGroupController:       taskGroupController,
 			fileController:            fileController,
+			assetController:           assetController,
 			sessionProfileController:  sessionProfileController,
 			provisionerController:     provisionerController,
 			customHandlers:            make([]CustomHandler, 0),
@@ -449,6 +457,15 @@ func (r *Router) registerConditionalRoutes() error {
 		log.Printf("[ROUTES] User file endpoints registered")
 	} else {
 		log.Printf("[ROUTES] User file repository not available, skipping file routes")
+	}
+
+	// Add asset upload route if asset storage is available.
+	if r.server.assetStore != nil && r.handlers.assetController != nil {
+		log.Printf("[ROUTES] Registering asset endpoints...")
+		r.echo.POST("/assets", r.handlers.assetController.CreateAsset, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		log.Printf("[ROUTES] Asset endpoints registered")
+	} else {
+		log.Printf("[ROUTES] Asset store not available, skipping asset routes")
 	}
 
 	// Add session profile routes if session profile repository is available (Kubernetes mode only)

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -58,6 +58,7 @@ type Server struct {
 	sessionRouteRepo   portrepos.SessionRouteRepository                // Session route repository for External Session Manager routing
 	userFileRepo       portrepos.UserFileRepository                    // User-managed files repository
 	sessionProfileRepo portrepos.SessionProfileRepository              // Session profile repository
+	assetStore         services.AssetStore                             // Static asset storage backend
 	router             *Router                                         // Router for custom handler registration
 }
 
@@ -112,7 +113,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 			// (at least 3 parts, not starting with "start", "search", "sessions", "oauth", "auth", "notification", or "notifications")
 			if len(pathParts) >= 3 && pathParts[1] != "" {
 				firstSegment := pathParts[1]
-				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files" && firstSegment != "session-profiles" && firstSegment != "sandbox-policies"
+				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "assets" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files" && firstSegment != "session-profiles" && firstSegment != "sandbox-policies"
 			}
 			return false
 		},
@@ -326,6 +327,12 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 	))
 	log.Printf("[SERVER] Session profile repository initialized")
 
+	assetStore, err := services.NewAssetStore(context.Background(), cfg.Asset)
+	if err != nil {
+		log.Fatalf("[SERVER] Failed to initialize asset store: %v", err)
+	}
+	log.Printf("[SERVER] Asset store initialized (backend: %s)", cfg.Asset.Backend)
+
 	s := &Server{
 		config:             cfg,
 		echo:               e,
@@ -345,6 +352,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 		sessionRouteRepo:   sessionRouteRepo,
 		userFileRepo:       userFileRepo,
 		sessionProfileRepo: sessionProfileRepo,
+		assetStore:         assetStore,
 	}
 
 	// Add logging middleware if verbose

--- a/internal/infrastructure/services/asset_store.go
+++ b/internal/infrastructure/services/asset_store.go
@@ -1,0 +1,156 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+// Asset is a stored static asset.
+type Asset struct {
+	ID  string
+	URL string
+}
+
+// AssetStore stores HTML assets and returns externally reachable URLs.
+type AssetStore interface {
+	SaveHTML(ctx context.Context, userID string, html string) (*Asset, error)
+}
+
+// NewAssetStore creates an asset store from configuration.
+func NewAssetStore(ctx context.Context, cfg config.AssetConfig) (AssetStore, error) {
+	switch cfg.Backend {
+	case "", "nginx":
+		return NewFilesystemAssetStore(cfg.StoragePath, cfg.PublicBaseURL), nil
+	case "s3":
+		if cfg.S3 == nil || cfg.S3.Bucket == "" {
+			return nil, fmt.Errorf("asset backend is s3 but asset.s3.bucket is empty")
+		}
+		return NewS3AssetStore(ctx, cfg)
+	default:
+		return nil, fmt.Errorf("unsupported asset backend %q", cfg.Backend)
+	}
+}
+
+// FilesystemAssetStore writes HTML assets to a directory served by nginx.
+type FilesystemAssetStore struct {
+	root          string
+	publicBaseURL string
+}
+
+// NewFilesystemAssetStore creates a filesystem-backed asset store.
+func NewFilesystemAssetStore(root, publicBaseURL string) *FilesystemAssetStore {
+	if root == "" {
+		root = "/var/lib/agentapi-assets"
+	}
+	return &FilesystemAssetStore{
+		root:          root,
+		publicBaseURL: strings.TrimRight(publicBaseURL, "/"),
+	}
+}
+
+// SaveHTML stores HTML as assets/<uuid>/index.html.
+func (s *FilesystemAssetStore) SaveHTML(ctx context.Context, userID string, html string) (*Asset, error) {
+	_ = ctx
+	_ = userID
+
+	id := uuid.New().String()
+	key := assetKey(id)
+	path := filepath.Join(s.root, filepath.FromSlash(key))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, []byte(html), 0o644); err != nil {
+		return nil, err
+	}
+	return &Asset{ID: id, URL: joinURL(s.publicBaseURL, key)}, nil
+}
+
+// S3AssetStore writes HTML assets to S3 or S3-compatible storage.
+type S3AssetStore struct {
+	client        *s3.Client
+	bucket        string
+	prefix        string
+	publicBaseURL string
+}
+
+// NewS3AssetStore creates an S3-backed asset store.
+func NewS3AssetStore(ctx context.Context, cfg config.AssetConfig) (*S3AssetStore, error) {
+	loadOpts := []func(*awsconfig.LoadOptions) error{}
+	if cfg.S3.Region != "" {
+		loadOpts = append(loadOpts, awsconfig.WithRegion(cfg.S3.Region))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		return nil, err
+	}
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		if cfg.S3.Endpoint != "" {
+			o.BaseEndpoint = aws.String(cfg.S3.Endpoint)
+			o.UsePathStyle = true
+		}
+	})
+	publicBaseURL := strings.TrimRight(cfg.PublicBaseURL, "/")
+	if publicBaseURL == "" {
+		if cfg.S3.Endpoint != "" {
+			publicBaseURL = strings.TrimRight(cfg.S3.Endpoint, "/") + "/" + cfg.S3.Bucket
+		} else if cfg.S3.Region != "" {
+			publicBaseURL = fmt.Sprintf("https://%s.s3.%s.amazonaws.com", cfg.S3.Bucket, cfg.S3.Region)
+		} else {
+			publicBaseURL = fmt.Sprintf("https://%s.s3.amazonaws.com", cfg.S3.Bucket)
+		}
+	}
+
+	return &S3AssetStore{
+		client:        client,
+		bucket:        cfg.S3.Bucket,
+		prefix:        strings.Trim(cfg.S3.Prefix, "/"),
+		publicBaseURL: publicBaseURL,
+	}, nil
+}
+
+// SaveHTML uploads HTML as assets/<uuid>/index.html.
+func (s *S3AssetStore) SaveHTML(ctx context.Context, userID string, html string) (*Asset, error) {
+	_ = userID
+
+	id := uuid.New().String()
+	key := assetKey(id)
+	if s.prefix != "" {
+		key = s.prefix + "/" + key
+	}
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucket),
+		Key:         aws.String(key),
+		Body:        strings.NewReader(html),
+		ContentType: aws.String("text/html; charset=utf-8"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Asset{ID: id, URL: joinURL(s.publicBaseURL, key)}, nil
+}
+
+func assetKey(id string) string {
+	return "assets/" + id + "/index.html"
+}
+
+func joinURL(baseURL, key string) string {
+	if baseURL == "" {
+		return "/" + key
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return strings.TrimRight(baseURL, "/") + "/" + key
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/" + strings.TrimLeft(key, "/")
+	return u.String()
+}

--- a/internal/infrastructure/services/asset_store_test.go
+++ b/internal/infrastructure/services/asset_store_test.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFilesystemAssetStoreSaveHTML(t *testing.T) {
+	root := t.TempDir()
+	store := NewFilesystemAssetStore(root, "https://assets.example.com")
+
+	asset, err := store.SaveHTML(context.Background(), "user-1", "<h1>Hello</h1>")
+	if err != nil {
+		t.Fatalf("SaveHTML returned error: %v", err)
+	}
+	if asset.ID == "" {
+		t.Fatal("asset ID is empty")
+	}
+	if !strings.HasPrefix(asset.URL, "https://assets.example.com/assets/") {
+		t.Fatalf("unexpected URL: %s", asset.URL)
+	}
+	if !strings.HasSuffix(asset.URL, "/index.html") {
+		t.Fatalf("unexpected URL suffix: %s", asset.URL)
+	}
+
+	path := filepath.Join(root, "assets", asset.ID, "index.html")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read saved asset: %v", err)
+	}
+	if string(data) != "<h1>Hello</h1>" {
+		t.Fatalf("unexpected saved HTML: %q", string(data))
+	}
+}
+
+func TestJoinURL(t *testing.T) {
+	got := joinURL("https://example.com/base/", "assets/id/index.html")
+	want := "https://example.com/base/assets/id/index.html"
+	if got != want {
+		t.Fatalf("joinURL() = %q, want %q", got, want)
+	}
+}

--- a/internal/interfaces/controllers/asset_controller.go
+++ b/internal/interfaces/controllers/asset_controller.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+// AssetController handles static asset uploads.
+type AssetController struct {
+	store services.AssetStore
+}
+
+// NewAssetController creates a new AssetController.
+func NewAssetController(store services.AssetStore) *AssetController {
+	return &AssetController{store: store}
+}
+
+// CreateAssetRequest is the JSON request body for creating an HTML asset.
+type CreateAssetRequest struct {
+	HTML string `json:"html"`
+}
+
+// AssetResponse is returned after uploading an asset.
+type AssetResponse struct {
+	ID  string `json:"id"`
+	URL string `json:"url"`
+}
+
+// CreateAsset handles POST /assets.
+func (c *AssetController) CreateAsset(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	var html string
+	contentType := ctx.Request().Header.Get(echo.HeaderContentType)
+	if strings.HasPrefix(contentType, "text/html") || strings.HasPrefix(contentType, "text/plain") {
+		body, err := io.ReadAll(ctx.Request().Body)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		}
+		html = string(body)
+	} else {
+		var req CreateAssetRequest
+		if err := ctx.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		}
+		html = req.HTML
+	}
+
+	if html == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "html is required")
+	}
+
+	asset, err := c.store.SaveHTML(ctx.Request().Context(), string(user.ID()), html)
+	if err != nil {
+		log.Printf("[ASSETS] Failed to save asset for user %s: %v", user.ID(), err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to save asset")
+	}
+
+	return ctx.JSON(http.StatusCreated, AssetResponse{ID: asset.ID, URL: asset.URL})
+}

--- a/internal/interfaces/controllers/asset_controller_test.go
+++ b/internal/interfaces/controllers/asset_controller_test.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+)
+
+type mockAssetStore struct {
+	html string
+}
+
+func (m *mockAssetStore) SaveHTML(ctx context.Context, userID string, html string) (*services.Asset, error) {
+	_ = ctx
+	_ = userID
+	m.html = html
+	return &services.Asset{ID: "asset-1", URL: "https://example.com/assets/asset-1/index.html"}, nil
+}
+
+func TestAssetControllerCreateAssetJSON(t *testing.T) {
+	e := echo.New()
+	store := &mockAssetStore{}
+	controller := NewAssetController(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/assets", strings.NewReader(`{"html":"<h1>Hello</h1>"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("internal_user", entities.NewUser(entities.UserID("user-1"), entities.UserTypeRegular, "user-1"))
+
+	if err := controller.CreateAsset(c); err != nil {
+		t.Fatalf("CreateAsset returned error: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+	if store.html != "<h1>Hello</h1>" {
+		t.Fatalf("stored HTML = %q", store.html)
+	}
+
+	var resp AssetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.URL == "" {
+		t.Fatal("response URL is empty")
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -160,6 +160,55 @@ type DeleteResponse struct {
 	SessionID string `json:"session_id"`
 }
 
+// CreateAssetRequest represents the request to upload an HTML asset.
+type CreateAssetRequest struct {
+	HTML string `json:"html"`
+}
+
+// AssetResponse represents an uploaded HTML asset.
+type AssetResponse struct {
+	ID  string `json:"id"`
+	URL string `json:"url"`
+}
+
+// CreateAsset uploads HTML and returns an externally reachable asset URL.
+func (c *Client) CreateAsset(ctx context.Context, req *CreateAssetRequest) (*AssetResponse, error) {
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/assets", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	if err := c.applyMiddlewares(httpReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var assetResp AssetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&assetResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &assetResp, nil
+}
+
 // Start creates a new agentapi session
 func (c *Client) Start(ctx context.Context, req *StartRequest) (*StartResponse, error) {
 	jsonData, err := json.Marshal(req)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -399,6 +399,25 @@ type MemoryS3Config struct {
 	Endpoint string `json:"endpoint" mapstructure:"endpoint"`
 }
 
+// AssetConfig represents static asset upload configuration.
+type AssetConfig struct {
+	// Backend is the storage backend type: "nginx" (default) or "s3".
+	Backend string `json:"backend" mapstructure:"backend"`
+	// PublicBaseURL is the externally reachable base URL used to build asset URLs.
+	PublicBaseURL string `json:"public_base_url" mapstructure:"public_base_url"`
+	// StoragePath is the local directory shared with nginx when Backend is "nginx".
+	StoragePath string `json:"storage_path" mapstructure:"storage_path"`
+	S3          *AssetS3Config `json:"s3,omitempty" mapstructure:"s3"`
+}
+
+// AssetS3Config represents S3 backend configuration for static assets.
+type AssetS3Config struct {
+	Bucket   string `json:"bucket" mapstructure:"bucket"`
+	Region   string `json:"region" mapstructure:"region"`
+	Prefix   string `json:"prefix" mapstructure:"prefix"`
+	Endpoint string `json:"endpoint" mapstructure:"endpoint"`
+}
+
 // SessionManagerConfig holds configuration for the session manager forwarding endpoint.
 // When enabled, External Session Manager (small-cluster mode) accepts pre-built SessionSettings from a
 // trusted upstream proxy (親プロキシ) and creates sessions without requiring local secrets.
@@ -462,6 +481,8 @@ type Config struct {
 	Webhook WebhookConfig `json:"webhook" mapstructure:"webhook"`
 	// Memory is the configuration for memory storage backend
 	Memory MemoryConfig `json:"memory" mapstructure:"memory"`
+	// Asset is the configuration for static asset upload and serving.
+	Asset AssetConfig `json:"asset" mapstructure:"asset"`
 	// Slack is the configuration for Slack bot inbound webhook functionality
 	Slack SlackConfig `json:"slack" mapstructure:"slack"`
 	// SessionManager is the configuration for the session manager forwarding endpoint.
@@ -824,6 +845,40 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 		}
 	}
 
+	if backend := os.Getenv("AGENTAPI_ASSET_BACKEND"); backend != "" {
+		config.Asset.Backend = backend
+	}
+	if publicBaseURL := os.Getenv("AGENTAPI_ASSET_PUBLIC_BASE_URL"); publicBaseURL != "" {
+		config.Asset.PublicBaseURL = publicBaseURL
+	}
+	if storagePath := os.Getenv("AGENTAPI_ASSET_STORAGE_PATH"); storagePath != "" {
+		config.Asset.StoragePath = storagePath
+	}
+	if bucket := os.Getenv("AGENTAPI_ASSET_S3_BUCKET"); bucket != "" {
+		if config.Asset.S3 == nil {
+			config.Asset.S3 = &AssetS3Config{}
+		}
+		config.Asset.S3.Bucket = bucket
+	}
+	if region := os.Getenv("AGENTAPI_ASSET_S3_REGION"); region != "" {
+		if config.Asset.S3 == nil {
+			config.Asset.S3 = &AssetS3Config{}
+		}
+		config.Asset.S3.Region = region
+	}
+	if prefix := os.Getenv("AGENTAPI_ASSET_S3_PREFIX"); prefix != "" {
+		if config.Asset.S3 == nil {
+			config.Asset.S3 = &AssetS3Config{}
+		}
+		config.Asset.S3.Prefix = prefix
+	}
+	if endpoint := os.Getenv("AGENTAPI_ASSET_S3_ENDPOINT"); endpoint != "" {
+		if config.Asset.S3 == nil {
+			config.Asset.S3 = &AssetS3Config{}
+		}
+		config.Asset.S3.Endpoint = endpoint
+	}
+
 	// Override fields if environment variables are set (even if structures already exist)
 	if config.Auth.Static != nil {
 		if v.IsSet("auth.static.keys_file") {
@@ -1013,6 +1068,15 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("memory.s3.prefix", "AGENTAPI_MEMORY_S3_PREFIX")
 	_ = v.BindEnv("memory.s3.endpoint", "AGENTAPI_MEMORY_S3_ENDPOINT")
 
+	// Asset backend configuration
+	_ = v.BindEnv("asset.backend", "AGENTAPI_ASSET_BACKEND")
+	_ = v.BindEnv("asset.public_base_url", "AGENTAPI_ASSET_PUBLIC_BASE_URL")
+	_ = v.BindEnv("asset.storage_path", "AGENTAPI_ASSET_STORAGE_PATH")
+	_ = v.BindEnv("asset.s3.bucket", "AGENTAPI_ASSET_S3_BUCKET")
+	_ = v.BindEnv("asset.s3.region", "AGENTAPI_ASSET_S3_REGION")
+	_ = v.BindEnv("asset.s3.prefix", "AGENTAPI_ASSET_S3_PREFIX")
+	_ = v.BindEnv("asset.s3.endpoint", "AGENTAPI_ASSET_S3_ENDPOINT")
+
 	// External memory-server backend configuration
 	_ = v.BindEnv("memory.external.url", "AGENTAPI_MEMORY_EXTERNAL_URL")
 	_ = v.BindEnv("memory.external.admin_token", "AGENTAPI_MEMORY_EXTERNAL_ADMIN_TOKEN")
@@ -1146,6 +1210,14 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("memory.external.url", "")
 	v.SetDefault("memory.external.admin_token", "")
 
+	// Asset backend defaults
+	v.SetDefault("asset.backend", "nginx")
+	v.SetDefault("asset.public_base_url", "")
+	v.SetDefault("asset.storage_path", "/var/lib/agentapi-assets")
+	v.SetDefault("asset.s3.prefix", "agentapi-assets/")
+	v.SetDefault("asset.s3.region", "")
+	v.SetDefault("asset.s3.endpoint", "")
+
 	// Slack defaults
 	v.SetDefault("slack.dry_run", false)
 
@@ -1192,6 +1264,15 @@ func applyConfigDefaults(config *Config) {
 		if config.Auth.AWS.CacheTTL == "" {
 			config.Auth.AWS.CacheTTL = "1h"
 		}
+	}
+	if config.Asset.Backend == "" {
+		config.Asset.Backend = "nginx"
+	}
+	if config.Asset.StoragePath == "" {
+		config.Asset.StoragePath = "/var/lib/agentapi-assets"
+	}
+	if config.Asset.S3 != nil && config.Asset.S3.Prefix == "" {
+		config.Asset.S3.Prefix = "agentapi-assets/"
 	}
 }
 
@@ -1265,6 +1346,8 @@ func LoadConfigLegacy(filename string) (*Config, error) {
 		return nil, err
 	}
 
+	applyConfigDefaults(&config)
+
 	// Apply post-processing
 	if err := postProcessConfig(&config); err != nil {
 		return nil, err
@@ -1315,6 +1398,13 @@ func DefaultConfig() *Config {
 			LeaseDuration:  "15s",
 			RenewDeadline:  "10s",
 			RetryPeriod:    "2s",
+		},
+		Asset: AssetConfig{
+			Backend:     "nginx",
+			StoragePath: "/var/lib/agentapi-assets",
+			S3: &AssetS3Config{
+				Prefix: "agentapi-assets/",
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- add authenticated POST /assets endpoint and client CLI for uploading HTML
- add nginx-backed filesystem asset store with optional S3 backend configuration
- deploy default nginx asset server, PVC, and /assets ingress path via Helm

## Testing
- git diff --check
- not run locally: go/gofmt/helm are not installed in this session environment