### PR TITLE
Add profile tag selectors and resource transfer API

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -461,8 +461,8 @@ func startStockInventoryWorker(configData *config.Config, proxyServer *app.Serve
 			Sandbox: configData.StockInventoryWorker.SandboxEnabled,
 			DinD:    configData.StockInventoryWorker.DockerEnabled,
 		},
-		Pools:         pools,
-		Enabled:       true,
+		Pools:   pools,
+		Enabled: true,
 	}
 
 	leaseDuration, err := time.ParseDuration(configData.StockInventoryWorker.LeaseDuration)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/personal_api_key"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/resource_transfer"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 	"github.com/takutakahashi/agentapi-proxy/spec"
 )
@@ -23,25 +24,26 @@ type Router struct {
 
 // HandlerRegistry contains all handlers
 type HandlerRegistry struct {
-	notificationHandlers      *controllers.NotificationHandlers
-	healthController          *controllers.HealthController
-	sessionController         *controllers.SessionController
-	acpController             *controllers.ACPController
-	settingsController        *controllers.SettingsController
-	credentialsController     *controllers.CredentialsController
-	codexDeviceAuthController *controllers.CodexDeviceAuthController
-	userController            *controllers.UserController
-	shareController           *controllers.ShareController
-	personalAPIKeyController  *controllers.PersonalAPIKeyController
-	memoryController          *controllers.MemoryController
-	sandboxPolicyController   *controllers.SandboxPolicyController
-	taskController            *controllers.TaskController
-	taskGroupController       *controllers.TaskGroupController
-	fileController            *controllers.FileController
-	assetController           *controllers.AssetController
-	sessionProfileController  *controllers.SessionProfileController
-	provisionerController     *controllers.ProvisionerController
-	customHandlers            []CustomHandler
+	notificationHandlers       *controllers.NotificationHandlers
+	healthController           *controllers.HealthController
+	sessionController          *controllers.SessionController
+	acpController              *controllers.ACPController
+	settingsController         *controllers.SettingsController
+	credentialsController      *controllers.CredentialsController
+	codexDeviceAuthController  *controllers.CodexDeviceAuthController
+	userController             *controllers.UserController
+	shareController            *controllers.ShareController
+	personalAPIKeyController   *controllers.PersonalAPIKeyController
+	memoryController           *controllers.MemoryController
+	sandboxPolicyController    *controllers.SandboxPolicyController
+	taskController             *controllers.TaskController
+	taskGroupController        *controllers.TaskGroupController
+	resourceTransferController *controllers.ResourceTransferController
+	fileController             *controllers.FileController
+	assetController            *controllers.AssetController
+	sessionProfileController   *controllers.SessionProfileController
+	provisionerController      *controllers.ProvisionerController
+	customHandlers             []CustomHandler
 }
 
 // CustomHandler interface for adding custom routes
@@ -143,6 +145,24 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] Task group controller initialized")
 	}
 
+	resourceTransferOptions := []resource_transfer.Option{
+		resource_transfer.WithMemoryRepository(server.memoryRepo),
+		resource_transfer.WithTaskRepository(server.taskRepo),
+		resource_transfer.WithTaskGroupRepository(server.taskGroupRepo),
+		resource_transfer.WithSessionProfileRepository(server.sessionProfileRepo),
+		resource_transfer.WithSandboxPolicyRepository(server.sandboxPolicyRepo),
+	}
+	if k8sManager, ok := server.sessionManager.(*services.KubernetesSessionManager); ok {
+		client := k8sManager.GetClient()
+		namespace := k8sManager.GetNamespace()
+		resourceTransferOptions = append(resourceTransferOptions,
+			resource_transfer.WithWebhookRepository(repositories.NewKubernetesWebhookRepository(client, namespace)),
+			resource_transfer.WithSlackBotRepository(repositories.NewKubernetesSlackBotRepository(client, namespace)),
+		)
+	}
+	resourceTransferController := controllers.NewResourceTransferController(resource_transfer.New(resourceTransferOptions...))
+	log.Printf("[ROUTER] Resource transfer controller initialized")
+
 	// Create file controller if user file repository is available
 	var fileController *controllers.FileController
 	if server.userFileRepo != nil {
@@ -175,25 +195,26 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		echo:   e,
 		server: server,
 		handlers: &HandlerRegistry{
-			notificationHandlers:      controllers.NewNotificationHandlers(server.notificationSvc, server.sessionManager),
-			healthController:          controllers.NewHealthController(),
-			sessionController:         sessionController,
-			acpController:             acpController,
-			settingsController:        settingsController,
-			credentialsController:     credentialsController,
-			codexDeviceAuthController: codexDeviceAuthController,
-			userController:            controllers.NewUserController(),
-			shareController:           shareController,
-			personalAPIKeyController:  personalAPIKeyController,
-			memoryController:          memoryController,
-			sandboxPolicyController:   sandboxPolicyController,
-			taskController:            taskController,
-			taskGroupController:       taskGroupController,
-			fileController:            fileController,
-			assetController:           assetController,
-			sessionProfileController:  sessionProfileController,
-			provisionerController:     provisionerController,
-			customHandlers:            make([]CustomHandler, 0),
+			notificationHandlers:       controllers.NewNotificationHandlers(server.notificationSvc, server.sessionManager),
+			healthController:           controllers.NewHealthController(),
+			sessionController:          sessionController,
+			acpController:              acpController,
+			settingsController:         settingsController,
+			credentialsController:      credentialsController,
+			codexDeviceAuthController:  codexDeviceAuthController,
+			userController:             controllers.NewUserController(),
+			shareController:            shareController,
+			personalAPIKeyController:   personalAPIKeyController,
+			memoryController:           memoryController,
+			sandboxPolicyController:    sandboxPolicyController,
+			taskController:             taskController,
+			taskGroupController:        taskGroupController,
+			resourceTransferController: resourceTransferController,
+			fileController:             fileController,
+			assetController:            assetController,
+			sessionProfileController:   sessionProfileController,
+			provisionerController:      provisionerController,
+			customHandlers:             make([]CustomHandler, 0),
 		},
 	}
 }
@@ -220,6 +241,8 @@ func (r *Router) RegisterRoutes() error {
 	if err := r.registerCustomHandlers(); err != nil {
 		return err
 	}
+
+	r.registerSessionProxyRoutes()
 
 	return nil
 }
@@ -263,6 +286,18 @@ func (r *Router) registerCoreRoutes() error {
 		auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 	log.Printf("[ROUTES] Session status/message push endpoints registered (SSE + long-poll)")
 
+	if r.handlers.resourceTransferController != nil {
+		log.Printf("[ROUTES] Registering resource transfer endpoint...")
+		r.echo.POST("/resources/transfer", r.handlers.resourceTransferController.TransferResource, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.POST("/resources/*", func(c echo.Context) error {
+			if c.Param("*") != "transfer" {
+				return echo.NewHTTPError(http.StatusNotFound, "resource endpoint not found")
+			}
+			return r.handlers.resourceTransferController.TransferResource(c)
+		}, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		log.Printf("[ROUTES] Resource transfer endpoint registered")
+	}
+
 	if r.handlers.provisionerController != nil {
 		r.echo.POST("/internal/session-provisioners/connect", r.handlers.provisionerController.Connect)
 		r.echo.GET("/internal/session-provisioners/:sessionId/provision-requests", r.handlers.provisionerController.GetProvisionRequest)
@@ -302,14 +337,20 @@ func (r *Router) registerCoreRoutes() error {
 		log.Printf("[ROUTES] Session sharing endpoints registered")
 	}
 
-	// Session proxy route
-	r.echo.Any("/:sessionId/*", r.handlers.sessionController.RouteToSession)
-	log.Printf("[ROUTES] Session management endpoints registered")
-
 	// Add explicit OPTIONS handler for DELETE endpoint to ensure CORS preflight works
 	r.echo.OPTIONS("/sessions/:sessionId", func(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	})
+
+	log.Printf("[ROUTES] Session management endpoints registered")
+
+	return nil
+}
+
+func (r *Router) registerSessionProxyRoutes() {
+	// Session proxy route must be registered after all proxy-level routes so
+	// paths such as /resources/transfer are not treated as session IDs.
+	r.echo.Any("/:sessionId/*", r.handlers.sessionController.RouteToSession)
 
 	// Add explicit OPTIONS handler for session proxy routes to ensure CORS preflight works
 	r.echo.OPTIONS("/:sessionId/*", func(c echo.Context) error {
@@ -321,8 +362,6 @@ func (r *Router) registerCoreRoutes() error {
 		c.Response().Header().Set("Access-Control-Max-Age", "86400")
 		return c.NoContent(http.StatusNoContent)
 	})
-
-	return nil
 }
 
 // registerConditionalRoutes registers routes based on server configuration

--- a/internal/domain/entities/memory.go
+++ b/internal/domain/entities/memory.go
@@ -135,6 +135,18 @@ func (m *Memory) SetTags(tags map[string]string) {
 	m.updatedAt = time.Now()
 }
 
+// SetOwnership updates the resource ownership metadata.
+func (m *Memory) SetOwnership(scope ResourceScope, ownerID, teamID string) {
+	m.scope = scope
+	m.ownerID = ownerID
+	if scope == ScopeTeam {
+		m.teamID = teamID
+	} else {
+		m.teamID = ""
+	}
+	m.updatedAt = time.Now()
+}
+
 // SetID overwrites the memory ID. Used by external repository adapters that
 // receive a server-assigned ID after persisting (e.g. memory-server generates
 // its own UUID which must replace the caller-supplied placeholder).

--- a/internal/domain/entities/sandbox_policy.go
+++ b/internal/domain/entities/sandbox_policy.go
@@ -85,6 +85,18 @@ func (p *SandboxPolicy) SetCountMode(v bool) {
 	p.updatedAt = time.Now()
 }
 
+// SetOwnership updates the resource ownership metadata.
+func (p *SandboxPolicy) SetOwnership(scope ResourceScope, ownerID, teamID string) {
+	p.scope = scope
+	p.ownerID = ownerID
+	if scope == ScopeTeam {
+		p.teamID = teamID
+	} else {
+		p.teamID = ""
+	}
+	p.updatedAt = time.Now()
+}
+
 func (p *SandboxPolicy) SetCreatedAt(t time.Time) { p.createdAt = t }
 func (p *SandboxPolicy) SetUpdatedAt(t time.Time) { p.updatedAt = t }
 

--- a/internal/domain/entities/session_profile.go
+++ b/internal/domain/entities/session_profile.go
@@ -6,16 +6,17 @@ import (
 
 // SessionProfile represents a named, reusable session configuration for a tenant
 type SessionProfile struct {
-	id          string
-	name        string
-	description string
-	userID      string
-	scope       ResourceScope
-	teamID      string
-	isDefault   bool
-	config      SessionProfileConfig
-	createdAt   time.Time
-	updatedAt   time.Time
+	id           string
+	name         string
+	description  string
+	userID       string
+	scope        ResourceScope
+	teamID       string
+	isDefault    bool
+	selectorTags map[string]string
+	config       SessionProfileConfig
+	createdAt    time.Time
+	updatedAt    time.Time
 }
 
 // SessionProfileConfig contains the reusable session configuration fields
@@ -96,6 +97,18 @@ func (p *SessionProfile) SetTeamID(teamID string) {
 	p.updatedAt = time.Now()
 }
 
+// SetOwnership updates the resource ownership metadata.
+func (p *SessionProfile) SetOwnership(scope ResourceScope, userID, teamID string) {
+	p.scope = scope
+	p.userID = userID
+	if scope == ScopeTeam {
+		p.teamID = teamID
+	} else {
+		p.teamID = ""
+	}
+	p.updatedAt = time.Now()
+}
+
 // IsDefault returns whether this profile is the tenant's default
 func (p *SessionProfile) IsDefault() bool { return p.isDefault }
 
@@ -103,6 +116,35 @@ func (p *SessionProfile) IsDefault() bool { return p.isDefault }
 func (p *SessionProfile) SetIsDefault(isDefault bool) {
 	p.isDefault = isDefault
 	p.updatedAt = time.Now()
+}
+
+// SelectorTags returns the tag selector used to choose this profile at launch time.
+func (p *SessionProfile) SelectorTags() map[string]string {
+	return copyStringMap(p.selectorTags)
+}
+
+// SetSelectorTags sets the tag selector used to choose this profile at launch time.
+func (p *SessionProfile) SetSelectorTags(tags map[string]string) {
+	p.selectorTags = copyStringMap(tags)
+	p.updatedAt = time.Now()
+}
+
+// MatchesSelectorTags returns true when requestTags contains all selector tags.
+func (p *SessionProfile) MatchesSelectorTags(requestTags map[string]string) bool {
+	if len(p.selectorTags) == 0 {
+		return false
+	}
+	for k, v := range p.selectorTags {
+		if requestTags[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// SelectorSpecificity returns the number of selector tags.
+func (p *SessionProfile) SelectorSpecificity() int {
+	return len(p.selectorTags)
 }
 
 // Config returns the session profile configuration
@@ -223,4 +265,15 @@ type ErrSessionProfileNotFound struct {
 
 func (e ErrSessionProfileNotFound) Error() string {
 	return "session profile not found: " + e.ID
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/internal/domain/entities/session_profile_test.go
+++ b/internal/domain/entities/session_profile_test.go
@@ -1,0 +1,38 @@
+package entities
+
+import "testing"
+
+func TestSessionProfileMatchesSelectorTags(t *testing.T) {
+	profile := NewSessionProfile("profile-1", "selected", "user-1")
+
+	if profile.MatchesSelectorTags(map[string]string{"env": "dev"}) {
+		t.Fatal("empty selector should not match")
+	}
+
+	profile.SetSelectorTags(map[string]string{"env": "dev", "repo": "owner/repo"})
+	if !profile.MatchesSelectorTags(map[string]string{
+		"env":   "dev",
+		"repo":  "owner/repo",
+		"extra": "kept",
+	}) {
+		t.Fatal("expected all selector tags to match")
+	}
+	if profile.MatchesSelectorTags(map[string]string{"env": "dev"}) {
+		t.Fatal("missing selector tag should not match")
+	}
+	if profile.MatchesSelectorTags(map[string]string{"env": "prod", "repo": "owner/repo"}) {
+		t.Fatal("different selector value should not match")
+	}
+}
+
+func TestSessionProfileSelectorTagsReturnsCopy(t *testing.T) {
+	profile := NewSessionProfile("profile-1", "selected", "user-1")
+	profile.SetSelectorTags(map[string]string{"env": "dev"})
+
+	tags := profile.SelectorTags()
+	tags["env"] = "prod"
+
+	if profile.SelectorTags()["env"] != "dev" {
+		t.Fatal("SelectorTags should return a copy")
+	}
+}

--- a/internal/domain/entities/slackbot.go
+++ b/internal/domain/entities/slackbot.go
@@ -98,6 +98,18 @@ func (s *SlackBot) SetTeamID(teamID string) {
 	s.updatedAt = time.Now()
 }
 
+// SetOwnership updates the resource ownership metadata.
+func (s *SlackBot) SetOwnership(scope ResourceScope, userID, teamID string) {
+	s.scope = scope
+	s.userID = userID
+	if scope == ScopeTeam {
+		s.teamID = teamID
+	} else {
+		s.teamID = ""
+	}
+	s.updatedAt = time.Now()
+}
+
 // Teams returns the GitHub team slugs stored at bot creation/update time.
 // These are used to merge team-level settings (MCP servers, env vars, etc.)
 // into sessions created by this bot.

--- a/internal/domain/entities/task.go
+++ b/internal/domain/entities/task.go
@@ -193,6 +193,18 @@ func (t *Task) SetLinks(links []*TaskLink) {
 	t.updatedAt = time.Now()
 }
 
+// SetOwnership updates the resource ownership metadata.
+func (t *Task) SetOwnership(scope ResourceScope, ownerID, teamID string) {
+	t.scope = scope
+	t.ownerID = ownerID
+	if scope == ScopeTeam {
+		t.teamID = teamID
+	} else {
+		t.teamID = ""
+	}
+	t.updatedAt = time.Now()
+}
+
 // SetCreatedAt sets the createdAt field (for deserialization only)
 func (t *Task) SetCreatedAt(ts time.Time) { t.createdAt = ts }
 
@@ -286,6 +298,18 @@ func (g *TaskGroup) SetName(name string) {
 // SetDescription sets the description and updates the updatedAt timestamp
 func (g *TaskGroup) SetDescription(description string) {
 	g.description = description
+	g.updatedAt = time.Now()
+}
+
+// SetOwnership updates the resource ownership metadata.
+func (g *TaskGroup) SetOwnership(scope ResourceScope, ownerID, teamID string) {
+	g.scope = scope
+	g.ownerID = ownerID
+	if scope == ScopeTeam {
+		g.teamID = teamID
+	} else {
+		g.teamID = ""
+	}
 	g.updatedAt = time.Now()
 }
 

--- a/internal/domain/entities/webhook.go
+++ b/internal/domain/entities/webhook.go
@@ -128,6 +128,18 @@ func (w *Webhook) SetTeamID(teamID string) {
 	w.updatedAt = time.Now()
 }
 
+// SetOwnership updates the resource ownership metadata.
+func (w *Webhook) SetOwnership(scope ResourceScope, userID, teamID string) {
+	w.scope = scope
+	w.userID = userID
+	if scope == ScopeTeam {
+		w.teamID = teamID
+	} else {
+		w.teamID = ""
+	}
+	w.updatedAt = time.Now()
+}
+
 // UserTeams returns the GitHub team slugs captured at webhook creation/update time.
 // These are used to inject team-level settings into sessions spawned by this webhook.
 func (w *Webhook) UserTeams() []string {

--- a/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
@@ -34,16 +34,17 @@ const (
 
 // sessionProfileJSON is the JSON representation for storage
 type sessionProfileJSON struct {
-	ID          string                   `json:"id"`
-	Name        string                   `json:"name"`
-	Description string                   `json:"description,omitempty"`
-	UserID      string                   `json:"user_id"`
-	Scope       entities.ResourceScope   `json:"scope,omitempty"`
-	TeamID      string                   `json:"team_id,omitempty"`
-	IsDefault   bool                     `json:"is_default,omitempty"`
-	Config      sessionProfileConfigJSON `json:"config"`
-	CreatedAt   time.Time                `json:"created_at"`
-	UpdatedAt   time.Time                `json:"updated_at"`
+	ID           string                   `json:"id"`
+	Name         string                   `json:"name"`
+	Description  string                   `json:"description,omitempty"`
+	UserID       string                   `json:"user_id"`
+	Scope        entities.ResourceScope   `json:"scope,omitempty"`
+	TeamID       string                   `json:"team_id,omitempty"`
+	IsDefault    bool                     `json:"is_default,omitempty"`
+	SelectorTags map[string]string        `json:"selector_tags,omitempty"`
+	Config       sessionProfileConfigJSON `json:"config"`
+	CreatedAt    time.Time                `json:"created_at"`
+	UpdatedAt    time.Time                `json:"updated_at"`
 }
 
 type sessionProfileConfigJSON struct {
@@ -306,6 +307,7 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 	profile.SetScope(pj.Scope)
 	profile.SetTeamID(pj.TeamID)
 	profile.SetIsDefault(pj.IsDefault)
+	profile.SetSelectorTags(pj.SelectorTags)
 	profile.SetCreatedAt(pj.CreatedAt)
 	profile.SetUpdatedAt(pj.UpdatedAt)
 
@@ -327,13 +329,14 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 func (r *KubernetesSessionProfileRepository) entityToJSON(profile *entities.SessionProfile) *sessionProfileJSON {
 	cfg := profile.Config()
 	return &sessionProfileJSON{
-		ID:          profile.ID(),
-		Name:        profile.Name(),
-		Description: profile.Description(),
-		UserID:      profile.UserID(),
-		Scope:       profile.Scope(),
-		TeamID:      profile.TeamID(),
-		IsDefault:   profile.IsDefault(),
+		ID:           profile.ID(),
+		Name:         profile.Name(),
+		Description:  profile.Description(),
+		UserID:       profile.UserID(),
+		Scope:        profile.Scope(),
+		TeamID:       profile.TeamID(),
+		IsDefault:    profile.IsDefault(),
+		SelectorTags: profile.SelectorTags(),
 		Config: sessionProfileConfigJSON{
 			Environment:            cfg.Environment(),
 			Tags:                   cfg.Tags(),

--- a/internal/interfaces/controllers/resource_transfer_controller.go
+++ b/internal/interfaces/controllers/resource_transfer_controller.go
@@ -1,0 +1,78 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/resource_transfer"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+type ResourceTransferController struct {
+	uc *resource_transfer.UseCase
+}
+
+func NewResourceTransferController(uc *resource_transfer.UseCase) *ResourceTransferController {
+	return &ResourceTransferController{uc: uc}
+}
+
+func (c *ResourceTransferController) GetName() string { return "ResourceTransferController" }
+
+type TransferResourceRequest struct {
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+	TargetScope  string `json:"target_scope"`
+	TargetUserID string `json:"target_user_id,omitempty"`
+	TargetTeamID string `json:"target_team_id,omitempty"`
+	DryRun       bool   `json:"dry_run,omitempty"`
+}
+
+func (c *ResourceTransferController) TransferResource(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+
+	var req TransferResourceRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+	if req.ResourceType == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "resource_type is required")
+	}
+	if req.ResourceID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "resource_id is required")
+	}
+
+	result, err := c.uc.Transfer(ctx.Request().Context(), resource_transfer.Request{
+		ResourceType: resource_transfer.ResourceType(req.ResourceType),
+		ResourceID:   req.ResourceID,
+		TargetScope:  entities.ResourceScope(req.TargetScope),
+		TargetUserID: req.TargetUserID,
+		TargetTeamID: req.TargetTeamID,
+		DryRun:       req.DryRun,
+		Actor:        user,
+	})
+	if err != nil {
+		return transferError(err)
+	}
+	return ctx.JSON(http.StatusOK, result)
+}
+
+func transferError(err error) error {
+	msg := err.Error()
+	switch {
+	case msg == "authentication required":
+		return echo.NewHTTPError(http.StatusUnauthorized, msg)
+	case strings.Contains(msg, "access denied"), strings.Contains(msg, "cannot transfer"), strings.Contains(msg, "not a member"):
+		return echo.NewHTTPError(http.StatusForbidden, msg)
+	case strings.Contains(msg, "not found"):
+		return echo.NewHTTPError(http.StatusNotFound, msg)
+	case strings.Contains(msg, "required"), strings.Contains(msg, "must be"), strings.Contains(msg, "unsupported"):
+		return echo.NewHTTPError(http.StatusBadRequest, msg)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, msg)
+	}
+}

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -176,7 +176,7 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 	// When SessionProfileID is set, use that profile. Otherwise fall back to the
 	// user/team's default profile. The profile is the base; explicit request fields override.
 	if c.sessionProfileRepo != nil {
-		profile := c.resolveSessionProfile(ctx.Request().Context(), startReq.SessionProfileID, userID, startReq.Scope, startReq.TeamID)
+		profile := c.resolveSessionProfile(ctx.Request().Context(), startReq.SessionProfileID, userID, startReq.Scope, startReq.TeamID, startReq.Tags)
 		if profile != nil {
 			cfg := profile.Config()
 
@@ -960,8 +960,8 @@ func (c *SessionController) GetSessionSandboxDomains(ctx echo.Context) error {
 
 // resolveSessionProfile returns the session profile to apply for a session creation request.
 // If profileID is set, it fetches that profile directly.
-// Otherwise it searches for the default profile scoped to the user or team.
-func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID, userID string, scope entities.ResourceScope, teamID string) *entities.SessionProfile {
+// Otherwise it searches for a selector_tags match before falling back to the default profile.
+func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID, userID string, scope entities.ResourceScope, teamID string, tags map[string]string) *entities.SessionProfile {
 	if profileID != "" {
 		profile, err := c.sessionProfileRepo.Get(ctx, profileID)
 		if err != nil {
@@ -971,7 +971,6 @@ func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID
 		return profile
 	}
 
-	// No explicit ID — look for the default profile for this user/team scope.
 	filter := repositories.SessionProfileFilter{
 		UserID: userID,
 		Scope:  scope,
@@ -984,6 +983,10 @@ func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID
 		log.Printf("[SESSION] Warning: could not list session profiles for default lookup: %v", err)
 		return nil
 	}
+	if profile := selectSessionProfileByTags(profiles, tags); profile != nil {
+		log.Printf("[SESSION] Applying tag-selected session profile %q (%s) for user %s", profile.ID(), profile.Name(), userID)
+		return profile
+	}
 	for _, p := range profiles {
 		if p.IsDefault() {
 			log.Printf("[SESSION] Applying default session profile %q (%s) for user %s", p.ID(), p.Name(), userID)
@@ -991,4 +994,29 @@ func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID
 		}
 	}
 	return nil
+}
+
+func selectSessionProfileByTags(profiles []*entities.SessionProfile, tags map[string]string) *entities.SessionProfile {
+	var matches []*entities.SessionProfile
+	for _, p := range profiles {
+		if p.MatchesSelectorTags(tags) {
+			matches = append(matches, p)
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].SelectorSpecificity() != matches[j].SelectorSpecificity() {
+			return matches[i].SelectorSpecificity() > matches[j].SelectorSpecificity()
+		}
+		if matches[i].IsDefault() != matches[j].IsDefault() {
+			return matches[i].IsDefault()
+		}
+		if matches[i].Name() != matches[j].Name() {
+			return matches[i].Name() < matches[j].Name()
+		}
+		return matches[i].ID() < matches[j].ID()
+	})
+	return matches[0]
 }

--- a/internal/interfaces/controllers/session_profile_controller.go
+++ b/internal/interfaces/controllers/session_profile_controller.go
@@ -44,34 +44,37 @@ type SessionProfileConfigRequest struct {
 
 // CreateSessionProfileRequest is the request body for creating a session profile
 type CreateSessionProfileRequest struct {
-	Name        string                      `json:"name"`
-	Description string                      `json:"description,omitempty"`
-	Scope       entities.ResourceScope      `json:"scope,omitempty"`
-	TeamID      string                      `json:"team_id,omitempty"`
-	IsDefault   bool                        `json:"is_default,omitempty"`
-	Config      SessionProfileConfigRequest `json:"config"`
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description,omitempty"`
+	Scope        entities.ResourceScope      `json:"scope,omitempty"`
+	TeamID       string                      `json:"team_id,omitempty"`
+	IsDefault    bool                        `json:"is_default,omitempty"`
+	SelectorTags map[string]string           `json:"selector_tags,omitempty"`
+	Config       SessionProfileConfigRequest `json:"config"`
 }
 
 // UpdateSessionProfileRequest is the request body for updating a session profile
 type UpdateSessionProfileRequest struct {
-	Name        *string                      `json:"name,omitempty"`
-	Description *string                      `json:"description,omitempty"`
-	IsDefault   *bool                        `json:"is_default,omitempty"`
-	Config      *SessionProfileConfigRequest `json:"config,omitempty"`
+	Name         *string                      `json:"name,omitempty"`
+	Description  *string                      `json:"description,omitempty"`
+	IsDefault    *bool                        `json:"is_default,omitempty"`
+	SelectorTags map[string]string            `json:"selector_tags,omitempty"`
+	Config       *SessionProfileConfigRequest `json:"config,omitempty"`
 }
 
 // SessionProfileResponse is the response for a session profile
 type SessionProfileResponse struct {
-	ID          string                       `json:"id"`
-	Name        string                       `json:"name"`
-	Description string                       `json:"description,omitempty"`
-	UserID      string                       `json:"user_id"`
-	Scope       entities.ResourceScope       `json:"scope,omitempty"`
-	TeamID      string                       `json:"team_id,omitempty"`
-	IsDefault   bool                         `json:"is_default,omitempty"`
-	Config      SessionProfileConfigResponse `json:"config"`
-	CreatedAt   string                       `json:"created_at"`
-	UpdatedAt   string                       `json:"updated_at"`
+	ID           string                       `json:"id"`
+	Name         string                       `json:"name"`
+	Description  string                       `json:"description,omitempty"`
+	UserID       string                       `json:"user_id"`
+	Scope        entities.ResourceScope       `json:"scope,omitempty"`
+	TeamID       string                       `json:"team_id,omitempty"`
+	IsDefault    bool                         `json:"is_default,omitempty"`
+	SelectorTags map[string]string            `json:"selector_tags,omitempty"`
+	Config       SessionProfileConfigResponse `json:"config"`
+	CreatedAt    string                       `json:"created_at"`
+	UpdatedAt    string                       `json:"updated_at"`
 }
 
 // SessionProfileConfigResponse represents session profile config in responses
@@ -125,6 +128,7 @@ func (c *SessionProfileController) CreateSessionProfile(ctx echo.Context) error 
 	profile.SetScope(req.Scope)
 	profile.SetTeamID(req.TeamID)
 	profile.SetIsDefault(req.IsDefault)
+	profile.SetSelectorTags(req.SelectorTags)
 	profile.SetConfig(c.requestToConfig(req.Config))
 
 	if err := c.repo.Create(ctx.Request().Context(), profile); err != nil {
@@ -242,6 +246,9 @@ func (c *SessionProfileController) UpdateSessionProfile(ctx echo.Context) error 
 	if req.IsDefault != nil {
 		profile.SetIsDefault(*req.IsDefault)
 	}
+	if req.SelectorTags != nil {
+		profile.SetSelectorTags(req.SelectorTags)
+	}
 	if req.Config != nil {
 		profile.SetConfig(c.requestToConfig(*req.Config))
 	}
@@ -327,13 +334,14 @@ func (c *SessionProfileController) requestToConfig(req SessionProfileConfigReque
 func (c *SessionProfileController) toResponse(p *entities.SessionProfile) SessionProfileResponse {
 	cfg := p.Config()
 	return SessionProfileResponse{
-		ID:          p.ID(),
-		Name:        p.Name(),
-		Description: p.Description(),
-		UserID:      p.UserID(),
-		Scope:       p.Scope(),
-		TeamID:      p.TeamID(),
-		IsDefault:   p.IsDefault(),
+		ID:           p.ID(),
+		Name:         p.Name(),
+		Description:  p.Description(),
+		UserID:       p.UserID(),
+		Scope:        p.Scope(),
+		TeamID:       p.TeamID(),
+		IsDefault:    p.IsDefault(),
+		SelectorTags: p.SelectorTags(),
 		Config: SessionProfileConfigResponse{
 			Environment:            cfg.Environment(),
 			Tags:                   cfg.Tags(),

--- a/internal/usecases/resource_transfer/transfer.go
+++ b/internal/usecases/resource_transfer/transfer.go
@@ -1,0 +1,380 @@
+package resource_transfer
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+type ResourceType string
+
+const (
+	ResourceMemory         ResourceType = "memory"
+	ResourceTask           ResourceType = "task"
+	ResourceTaskGroup      ResourceType = "task_group"
+	ResourceWebhook        ResourceType = "webhook"
+	ResourceSlackBot       ResourceType = "slackbot"
+	ResourceSessionProfile ResourceType = "session_profile"
+	ResourceSandboxPolicy  ResourceType = "sandbox_policy"
+)
+
+type Request struct {
+	ResourceType ResourceType
+	ResourceID   string
+	TargetScope  entities.ResourceScope
+	TargetUserID string
+	TargetTeamID string
+	DryRun       bool
+	Actor        *entities.User
+}
+
+type Endpoint struct {
+	Scope  entities.ResourceScope `json:"scope"`
+	UserID string                 `json:"user_id,omitempty"`
+	TeamID string                 `json:"team_id,omitempty"`
+}
+
+type Result struct {
+	ResourceType ResourceType `json:"resource_type"`
+	ResourceID   string       `json:"resource_id"`
+	From         Endpoint     `json:"from"`
+	To           Endpoint     `json:"to"`
+	Status       string       `json:"status"`
+	DryRun       bool         `json:"dry_run"`
+	Warnings     []string     `json:"warnings,omitempty"`
+}
+
+type UseCase struct {
+	memoryRepo         portrepos.MemoryRepository
+	taskRepo           portrepos.TaskRepository
+	taskGroupRepo      portrepos.TaskGroupRepository
+	webhookRepo        portrepos.WebhookRepository
+	slackBotRepo       portrepos.SlackBotRepository
+	sessionProfileRepo portrepos.SessionProfileRepository
+	sandboxPolicyRepo  portrepos.SandboxPolicyRepository
+}
+
+type Option func(*UseCase)
+
+func New(opts ...Option) *UseCase {
+	uc := &UseCase{}
+	for _, opt := range opts {
+		opt(uc)
+	}
+	return uc
+}
+
+func WithMemoryRepository(repo portrepos.MemoryRepository) Option {
+	return func(uc *UseCase) { uc.memoryRepo = repo }
+}
+
+func WithTaskRepository(repo portrepos.TaskRepository) Option {
+	return func(uc *UseCase) { uc.taskRepo = repo }
+}
+
+func WithTaskGroupRepository(repo portrepos.TaskGroupRepository) Option {
+	return func(uc *UseCase) { uc.taskGroupRepo = repo }
+}
+
+func WithWebhookRepository(repo portrepos.WebhookRepository) Option {
+	return func(uc *UseCase) { uc.webhookRepo = repo }
+}
+
+func WithSlackBotRepository(repo portrepos.SlackBotRepository) Option {
+	return func(uc *UseCase) { uc.slackBotRepo = repo }
+}
+
+func WithSessionProfileRepository(repo portrepos.SessionProfileRepository) Option {
+	return func(uc *UseCase) { uc.sessionProfileRepo = repo }
+}
+
+func WithSandboxPolicyRepository(repo portrepos.SandboxPolicyRepository) Option {
+	return func(uc *UseCase) { uc.sandboxPolicyRepo = repo }
+}
+
+func (uc *UseCase) Transfer(ctx context.Context, req Request) (Result, error) {
+	if req.Actor == nil {
+		return Result{}, fmt.Errorf("authentication required")
+	}
+	if req.ResourceID == "" {
+		return Result{}, fmt.Errorf("resource_id is required")
+	}
+	if req.TargetScope == "" {
+		req.TargetScope = entities.ScopeUser
+	}
+	targetUserID := req.TargetUserID
+	if req.TargetScope == entities.ScopeUser && targetUserID == "" {
+		targetUserID = string(req.Actor.ID())
+	}
+	if req.TargetScope == entities.ScopeTeam && targetUserID == "" {
+		targetUserID = string(req.Actor.ID())
+	}
+	if err := authorizeTarget(req.Actor, req.TargetScope, targetUserID, req.TargetTeamID); err != nil {
+		return Result{}, err
+	}
+
+	switch req.ResourceType {
+	case ResourceMemory:
+		return uc.transferMemory(ctx, req, targetUserID)
+	case ResourceTask:
+		return uc.transferTask(ctx, req, targetUserID)
+	case ResourceTaskGroup:
+		return uc.transferTaskGroup(ctx, req, targetUserID)
+	case ResourceWebhook:
+		return uc.transferWebhook(ctx, req, targetUserID)
+	case ResourceSlackBot:
+		return uc.transferSlackBot(ctx, req, targetUserID)
+	case ResourceSessionProfile:
+		return uc.transferSessionProfile(ctx, req, targetUserID)
+	case ResourceSandboxPolicy:
+		return uc.transferSandboxPolicy(ctx, req, targetUserID)
+	default:
+		return Result{}, fmt.Errorf("unsupported resource_type: %s", req.ResourceType)
+	}
+}
+
+func authorizeTarget(actor *entities.User, scope entities.ResourceScope, userID, teamID string) error {
+	switch scope {
+	case entities.ScopeUser:
+		if userID == "" {
+			return fmt.Errorf("target_user_id is required when target_scope is user")
+		}
+		if !actor.IsAdmin() && userID != string(actor.ID()) {
+			return fmt.Errorf("cannot transfer to another user")
+		}
+	case entities.ScopeTeam:
+		if teamID == "" {
+			return fmt.Errorf("target_team_id is required when target_scope is team")
+		}
+		if !actor.IsAdmin() && !actor.IsMemberOfTeam(teamID) {
+			return fmt.Errorf("you are not a member of target team")
+		}
+	default:
+		return fmt.Errorf("target_scope must be user or team")
+	}
+	return nil
+}
+
+func canModify(actor *entities.User, ownerID string, scope entities.ResourceScope, teamID string) bool {
+	if actor.IsAdmin() {
+		return true
+	}
+	if scope == entities.ScopeTeam {
+		return actor.IsMemberOfTeam(teamID)
+	}
+	return ownerID == string(actor.ID())
+}
+
+func endpoint(scope entities.ResourceScope, ownerID, teamID string) Endpoint {
+	if scope == "" {
+		scope = entities.ScopeUser
+	}
+	if scope == entities.ScopeTeam {
+		return Endpoint{Scope: scope, TeamID: teamID}
+	}
+	return Endpoint{Scope: scope, UserID: ownerID}
+}
+
+func result(req Request, from Endpoint, targetUserID string) Result {
+	to := endpoint(req.TargetScope, targetUserID, req.TargetTeamID)
+	status := "transferred"
+	if req.DryRun {
+		status = "dry_run"
+	}
+	return Result{
+		ResourceType: req.ResourceType,
+		ResourceID:   req.ResourceID,
+		From:         from,
+		To:           to,
+		Status:       status,
+		DryRun:       req.DryRun,
+	}
+}
+
+func (uc *UseCase) transferMemory(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.memoryRepo == nil {
+		return Result{}, fmt.Errorf("memory repository is not configured")
+	}
+	m, err := uc.memoryRepo.GetByID(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, m.OwnerID(), m.Scope(), m.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(m.Scope(), m.OwnerID(), m.TeamID()), targetUserID)
+	if req.DryRun {
+		return res, nil
+	}
+	m.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.memoryRepo.Update(ctx, m); err != nil {
+		return Result{}, err
+	}
+	updated, err := uc.memoryRepo.GetByID(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !sameOwnership(updated.Scope(), updated.OwnerID(), updated.TeamID(), req.TargetScope, targetUserID, req.TargetTeamID) {
+		return Result{}, fmt.Errorf("memory ownership transfer was not persisted")
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}
+
+func sameOwnership(actualScope entities.ResourceScope, actualOwnerID, actualTeamID string, targetScope entities.ResourceScope, targetOwnerID, targetTeamID string) bool {
+	if actualScope != targetScope {
+		return false
+	}
+	if targetScope == entities.ScopeTeam {
+		return actualTeamID == targetTeamID
+	}
+	return actualOwnerID == targetOwnerID
+}
+
+func (uc *UseCase) transferTask(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.taskRepo == nil {
+		return Result{}, fmt.Errorf("task repository is not configured")
+	}
+	t, err := uc.taskRepo.GetByID(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, t.OwnerID(), t.Scope(), t.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(t.Scope(), t.OwnerID(), t.TeamID()), targetUserID)
+	if t.GroupID() != "" {
+		res.Warnings = append(res.Warnings, "task group ownership is not changed automatically")
+	}
+	if req.DryRun {
+		return res, nil
+	}
+	t.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.taskRepo.Update(ctx, t); err != nil {
+		return Result{}, err
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}
+
+func (uc *UseCase) transferTaskGroup(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.taskGroupRepo == nil {
+		return Result{}, fmt.Errorf("task group repository is not configured")
+	}
+	g, err := uc.taskGroupRepo.GetByID(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, g.OwnerID(), g.Scope(), g.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(g.Scope(), g.OwnerID(), g.TeamID()), targetUserID)
+	res.Warnings = append(res.Warnings, "tasks in this group are not transferred automatically")
+	if req.DryRun {
+		return res, nil
+	}
+	g.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.taskGroupRepo.Update(ctx, g); err != nil {
+		return Result{}, err
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}
+
+func (uc *UseCase) transferWebhook(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.webhookRepo == nil {
+		return Result{}, fmt.Errorf("webhook repository is not configured")
+	}
+	w, err := uc.webhookRepo.Get(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, w.UserID(), w.Scope(), w.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(w.Scope(), w.UserID(), w.TeamID()), targetUserID)
+	res.Warnings = append(res.Warnings, "resources referenced by this webhook are not transferred automatically")
+	if req.DryRun {
+		return res, nil
+	}
+	w.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.webhookRepo.Update(ctx, w); err != nil {
+		return Result{}, err
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}
+
+func (uc *UseCase) transferSlackBot(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.slackBotRepo == nil {
+		return Result{}, fmt.Errorf("slackbot repository is not configured")
+	}
+	b, err := uc.slackBotRepo.Get(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, b.UserID(), b.Scope(), b.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(b.Scope(), b.UserID(), b.TeamID()), targetUserID)
+	res.Warnings = append(res.Warnings, "resources referenced by this slackbot are not transferred automatically")
+	if req.DryRun {
+		return res, nil
+	}
+	b.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.slackBotRepo.Update(ctx, b); err != nil {
+		return Result{}, err
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}
+
+func (uc *UseCase) transferSessionProfile(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.sessionProfileRepo == nil {
+		return Result{}, fmt.Errorf("session profile repository is not configured")
+	}
+	p, err := uc.sessionProfileRepo.Get(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, p.UserID(), p.Scope(), p.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(p.Scope(), p.UserID(), p.TeamID()), targetUserID)
+	if req.DryRun {
+		return res, nil
+	}
+	p.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.sessionProfileRepo.Update(ctx, p); err != nil {
+		return Result{}, err
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}
+
+func (uc *UseCase) transferSandboxPolicy(ctx context.Context, req Request, targetUserID string) (Result, error) {
+	if uc.sandboxPolicyRepo == nil {
+		return Result{}, fmt.Errorf("sandbox policy repository is not configured")
+	}
+	p, err := uc.sandboxPolicyRepo.GetByID(ctx, req.ResourceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if !canModify(req.Actor, p.OwnerID(), p.Scope(), p.TeamID()) {
+		return Result{}, fmt.Errorf("access denied")
+	}
+	res := result(req, endpoint(p.Scope(), p.OwnerID(), p.TeamID()), targetUserID)
+	res.Warnings = append(res.Warnings, "resources referencing this sandbox policy are not transferred automatically")
+	if req.DryRun {
+		return res, nil
+	}
+	p.SetOwnership(req.TargetScope, targetUserID, req.TargetTeamID)
+	if err := uc.sandboxPolicyRepo.Update(ctx, p); err != nil {
+		return Result{}, err
+	}
+	log.Printf("[RESOURCE_TRANSFER] actor=%s type=%s id=%s from=%+v to=%+v", req.Actor.ID(), req.ResourceType, req.ResourceID, res.From, res.To)
+	return res, nil
+}

--- a/internal/usecases/resource_transfer/transfer_test.go
+++ b/internal/usecases/resource_transfer/transfer_test.go
@@ -1,0 +1,140 @@
+package resource_transfer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+type fakeMemoryRepo struct {
+	memory          *entities.Memory
+	updated         bool
+	ignoreOwnership bool
+}
+
+func (r *fakeMemoryRepo) Create(context.Context, *entities.Memory) error { return nil }
+func (r *fakeMemoryRepo) GetByID(context.Context, string) (*entities.Memory, error) {
+	return cloneMemory(r.memory), nil
+}
+func (r *fakeMemoryRepo) List(context.Context, portrepos.MemoryFilter) ([]*entities.Memory, error) {
+	return nil, nil
+}
+func (r *fakeMemoryRepo) Update(_ context.Context, memory *entities.Memory) error {
+	if r.ignoreOwnership {
+		r.updated = true
+		return nil
+	}
+	r.memory = memory
+	r.updated = true
+	return nil
+}
+func (r *fakeMemoryRepo) Delete(context.Context, string) error { return nil }
+
+func cloneMemory(m *entities.Memory) *entities.Memory {
+	if m == nil {
+		return nil
+	}
+	clone := entities.NewMemoryWithTags(m.ID(), m.Title(), m.Content(), m.Scope(), m.OwnerID(), m.TeamID(), m.Tags())
+	clone.SetCreatedAt(m.CreatedAt())
+	clone.SetUpdatedAt(m.UpdatedAt())
+	return clone
+}
+
+func TestTransferMemoryDryRunDoesNotUpdate(t *testing.T) {
+	repo := &fakeMemoryRepo{memory: entities.NewMemory("mem-1", "title", "content", entities.ScopeUser, "user-1", "")}
+	uc := New(WithMemoryRepository(repo))
+
+	res, err := uc.Transfer(context.Background(), Request{
+		ResourceType: ResourceMemory,
+		ResourceID:   "mem-1",
+		TargetScope:  entities.ScopeTeam,
+		TargetTeamID: "org/team-a",
+		DryRun:       true,
+		Actor:        teamMember("user-1", "org/team-a"),
+	})
+	if err != nil {
+		t.Fatalf("Transfer() error = %v", err)
+	}
+	if res.Status != "dry_run" {
+		t.Fatalf("expected dry_run status, got %q", res.Status)
+	}
+	if repo.updated {
+		t.Fatal("dry_run should not update repository")
+	}
+	if repo.memory.Scope() != entities.ScopeUser {
+		t.Fatalf("dry_run changed memory scope to %q", repo.memory.Scope())
+	}
+}
+
+func TestTransferMemoryToAnotherUserRequiresAdmin(t *testing.T) {
+	repo := &fakeMemoryRepo{memory: entities.NewMemory("mem-1", "title", "content", entities.ScopeUser, "user-1", "")}
+	uc := New(WithMemoryRepository(repo))
+
+	_, err := uc.Transfer(context.Background(), Request{
+		ResourceType: ResourceMemory,
+		ResourceID:   "mem-1",
+		TargetScope:  entities.ScopeUser,
+		TargetUserID: "user-2",
+		Actor:        entities.NewUser("user-1", entities.UserTypeRegular, "user-1"),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if repo.updated {
+		t.Fatal("forbidden transfer should not update repository")
+	}
+}
+
+func TestTransferMemoryToTeamUpdatesOwnership(t *testing.T) {
+	repo := &fakeMemoryRepo{memory: entities.NewMemory("mem-1", "title", "content", entities.ScopeUser, "user-1", "")}
+	uc := New(WithMemoryRepository(repo))
+
+	_, err := uc.Transfer(context.Background(), Request{
+		ResourceType: ResourceMemory,
+		ResourceID:   "mem-1",
+		TargetScope:  entities.ScopeTeam,
+		TargetTeamID: "org/team-a",
+		Actor:        teamMember("user-1", "org/team-a"),
+	})
+	if err != nil {
+		t.Fatalf("Transfer() error = %v", err)
+	}
+	if !repo.updated {
+		t.Fatal("expected repository update")
+	}
+	if repo.memory.Scope() != entities.ScopeTeam || repo.memory.TeamID() != "org/team-a" || repo.memory.OwnerID() != "user-1" {
+		t.Fatalf("unexpected ownership: scope=%q owner=%q team=%q", repo.memory.Scope(), repo.memory.OwnerID(), repo.memory.TeamID())
+	}
+}
+
+func TestTransferMemoryErrorsWhenOwnershipIsNotPersisted(t *testing.T) {
+	repo := &fakeMemoryRepo{
+		memory:          entities.NewMemory("mem-1", "title", "content", entities.ScopeUser, "user-1", ""),
+		ignoreOwnership: true,
+	}
+	uc := New(WithMemoryRepository(repo))
+
+	_, err := uc.Transfer(context.Background(), Request{
+		ResourceType: ResourceMemory,
+		ResourceID:   "mem-1",
+		TargetScope:  entities.ScopeTeam,
+		TargetTeamID: "org/team-a",
+		Actor:        teamMember("user-1", "org/team-a"),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "ownership transfer was not persisted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func teamMember(userID, teamID string) *entities.User {
+	user := entities.NewGitHubUser(entities.UserID(userID), userID, "", entities.NewGitHubUserInfo(1, userID, userID, "", "", "", ""))
+	parts := strings.SplitN(teamID, "/", 2)
+	user.SetGitHubInfo(user.GitHubInfo(), []entities.GitHubTeamMembership{{Organization: parts[0], TeamSlug: parts[1]}})
+	return user
+}

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -262,7 +262,7 @@ func (uc *LaunchUseCase) ensureMemoryExists(ctx context.Context, req LaunchReque
 
 // resolveSessionProfile returns the session profile to apply for the given request.
 // If SessionProfileID is set, it fetches that profile directly.
-// Otherwise it searches for the default profile scoped to the user or team.
+// Otherwise it searches for a selector_tags match before falling back to the default profile.
 func (uc *LaunchUseCase) resolveSessionProfile(ctx context.Context, req LaunchRequest) *entities.SessionProfile {
 	if req.SessionProfileID != "" {
 		profile, err := uc.sessionProfileRepo.Get(ctx, req.SessionProfileID)
@@ -273,7 +273,6 @@ func (uc *LaunchUseCase) resolveSessionProfile(ctx context.Context, req LaunchRe
 		return profile
 	}
 
-	// No explicit ID — look for the default profile for this user/team scope.
 	scope := req.Scope
 	if scope == "" {
 		scope = entities.ScopeUser
@@ -290,6 +289,10 @@ func (uc *LaunchUseCase) resolveSessionProfile(ctx context.Context, req LaunchRe
 		log.Printf("[LAUNCH] Warning: could not list session profiles for default lookup: %v", err)
 		return nil
 	}
+	if profile := selectProfileByTags(profiles, req.Tags); profile != nil {
+		log.Printf("[LAUNCH] Applying tag-selected session profile %q (%s) for user %s", profile.ID(), profile.Name(), req.UserID)
+		return profile
+	}
 	for _, p := range profiles {
 		if p.IsDefault() {
 			log.Printf("[LAUNCH] Applying default session profile %q (%s) for user %s", p.ID(), p.Name(), req.UserID)
@@ -297,6 +300,31 @@ func (uc *LaunchUseCase) resolveSessionProfile(ctx context.Context, req LaunchRe
 		}
 	}
 	return nil
+}
+
+func selectProfileByTags(profiles []*entities.SessionProfile, tags map[string]string) *entities.SessionProfile {
+	var matches []*entities.SessionProfile
+	for _, p := range profiles {
+		if p.MatchesSelectorTags(tags) {
+			matches = append(matches, p)
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].SelectorSpecificity() != matches[j].SelectorSpecificity() {
+			return matches[i].SelectorSpecificity() > matches[j].SelectorSpecificity()
+		}
+		if matches[i].IsDefault() != matches[j].IsDefault() {
+			return matches[i].IsDefault()
+		}
+		if matches[i].Name() != matches[j].Name() {
+			return matches[i].Name() < matches[j].Name()
+		}
+		return matches[i].ID() < matches[j].ID()
+	})
+	return matches[0]
 }
 
 // applyProfileToLaunchRequest merges a SessionProfileConfig into a LaunchRequest.

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -163,6 +163,109 @@ func TestLaunchExplicitDockerOverridesProfileDocker(t *testing.T) {
 	}
 }
 
+func TestLaunchAppliesProfileSelectedByTags(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	defaultProfile := entities.NewSessionProfile("profile-default", "default", "user-1")
+	defaultProfile.SetIsDefault(true)
+	defaultCfg := entities.NewSessionProfileConfig()
+	defaultCfg.SetParams(&entities.SessionParams{AgentType: "claude"})
+	defaultProfile.SetConfig(defaultCfg)
+
+	selectedProfile := entities.NewSessionProfile("profile-selected", "selected", "user-1")
+	selectedProfile.SetSelectorTags(map[string]string{"env": "dev"})
+	selectedCfg := entities.NewSessionProfileConfig()
+	selectedCfg.SetParams(&entities.SessionParams{AgentType: "codex"})
+	selectedCfg.SetTags(map[string]string{"profile": "selected", "env": "profile"})
+	selectedProfile.SetConfig(selectedCfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{
+			defaultProfile,
+			selectedProfile,
+		}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+		Tags:   map[string]string{"env": "dev", "request": "kept"},
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req.AgentType != "codex" {
+		t.Fatalf("expected tag-selected profile agent type, got %q", sessionManager.req.AgentType)
+	}
+	if sessionManager.req.Tags["env"] != "dev" || sessionManager.req.Tags["profile"] != "selected" || sessionManager.req.Tags["request"] != "kept" {
+		t.Fatalf("unexpected merged tags: %#v", sessionManager.req.Tags)
+	}
+}
+
+func TestLaunchExplicitProfileIDOverridesTagSelector(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	explicitProfile := entities.NewSessionProfile("profile-explicit", "explicit", "user-1")
+	explicitCfg := entities.NewSessionProfileConfig()
+	explicitCfg.SetParams(&entities.SessionParams{AgentType: "claude"})
+	explicitProfile.SetConfig(explicitCfg)
+
+	selectedProfile := entities.NewSessionProfile("profile-selected", "selected", "user-1")
+	selectedProfile.SetSelectorTags(map[string]string{"env": "dev"})
+	selectedCfg := entities.NewSessionProfileConfig()
+	selectedCfg.SetParams(&entities.SessionParams{AgentType: "codex"})
+	selectedProfile.SetConfig(selectedCfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{
+			explicitProfile,
+			selectedProfile,
+		}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID:           "user-1",
+		Scope:            entities.ScopeUser,
+		Tags:             map[string]string{"env": "dev"},
+		SessionProfileID: "profile-explicit",
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req.AgentType != "claude" {
+		t.Fatalf("expected explicit profile agent type, got %q", sessionManager.req.AgentType)
+	}
+}
+
+func TestLaunchChoosesMostSpecificTagSelectedProfile(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	genericProfile := entities.NewSessionProfile("profile-generic", "generic", "user-1")
+	genericProfile.SetSelectorTags(map[string]string{"env": "dev"})
+	genericCfg := entities.NewSessionProfileConfig()
+	genericCfg.SetParams(&entities.SessionParams{AgentType: "claude"})
+	genericProfile.SetConfig(genericCfg)
+
+	specificProfile := entities.NewSessionProfile("profile-specific", "specific", "user-1")
+	specificProfile.SetSelectorTags(map[string]string{"env": "dev", "repo": "owner/repo"})
+	specificCfg := entities.NewSessionProfileConfig()
+	specificCfg.SetParams(&entities.SessionParams{AgentType: "codex"})
+	specificProfile.SetConfig(specificCfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{
+			genericProfile,
+			specificProfile,
+		}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+		Tags:   map[string]string{"env": "dev", "repo": "owner/repo"},
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req.AgentType != "codex" {
+		t.Fatalf("expected most specific selected profile, got %q", sessionManager.req.AgentType)
+	}
+}
+
 func TestLaunchReuseRoutesMessageToExistingSession(t *testing.T) {
 	sessionManager := &recordingSessionManager{
 		existing: []entities.Session{&launchTestSession{id: "existing-1", userID: "user-1", status: "active"}},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -406,7 +406,7 @@ type AssetConfig struct {
 	// PublicBaseURL is the externally reachable base URL used to build asset URLs.
 	PublicBaseURL string `json:"public_base_url" mapstructure:"public_base_url"`
 	// StoragePath is the local directory shared with nginx when Backend is "nginx".
-	StoragePath string `json:"storage_path" mapstructure:"storage_path"`
+	StoragePath string         `json:"storage_path" mapstructure:"storage_path"`
 	S3          *AssetS3Config `json:"s3,omitempty" mapstructure:"s3"`
 }
 

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1416,6 +1416,7 @@ type sessionProfileRecord struct {
 	Scope                  string                      `yaml:"scope"`
 	TeamID                 string                      `yaml:"team_id,omitempty"`
 	IsDefault              bool                        `yaml:"is_default,omitempty"`
+	SelectorTags           map[string]string           `yaml:"selector_tags,omitempty"`
 	Environment            map[string]string           `yaml:"environment,omitempty"`
 	Tags                   map[string]string           `yaml:"tags,omitempty"`
 	InitialMessageTemplate string                      `yaml:"initial_message_template,omitempty"`
@@ -1478,6 +1479,7 @@ func sessionProfileToRecord(p *entities.SessionProfile, dek []byte) (sessionProf
 		Scope:                  string(p.Scope()),
 		TeamID:                 p.TeamID(),
 		IsDefault:              p.IsDefault(),
+		SelectorTags:           p.SelectorTags(),
 		Environment:            env,
 		Tags:                   cfg.Tags(),
 		InitialMessageTemplate: cfg.InitialMessageTemplate(),
@@ -1692,6 +1694,7 @@ func (s *Syncer) importSessionProfileFile(ctx context.Context, data []byte, scop
 	p.SetScope(scope)
 	p.SetTeamID(teamID)
 	p.SetIsDefault(rec.IsDefault)
+	p.SetSelectorTags(rec.SelectorTags)
 
 	cfg := entities.NewSessionProfileConfig()
 	if len(env) > 0 {

--- a/pkg/import/types.go
+++ b/pkg/import/types.go
@@ -239,11 +239,12 @@ type MarketplaceImport struct {
 
 // SessionProfileImport represents a session profile for import/export
 type SessionProfileImport struct {
-	ID          string                     `yaml:"id" toml:"id" json:"id"`
-	Name        string                     `yaml:"name" toml:"name" json:"name"`
-	Description string                     `yaml:"description,omitempty" toml:"description,omitempty" json:"description,omitempty"`
-	IsDefault   bool                       `yaml:"is_default,omitempty" toml:"is_default,omitempty" json:"is_default,omitempty"`
-	Config      SessionProfileConfigImport `yaml:"config" toml:"config" json:"config"`
+	ID           string                     `yaml:"id" toml:"id" json:"id"`
+	Name         string                     `yaml:"name" toml:"name" json:"name"`
+	Description  string                     `yaml:"description,omitempty" toml:"description,omitempty" json:"description,omitempty"`
+	IsDefault    bool                       `yaml:"is_default,omitempty" toml:"is_default,omitempty" json:"is_default,omitempty"`
+	SelectorTags map[string]string          `yaml:"selector_tags,omitempty" toml:"selector_tags,omitempty" json:"selector_tags,omitempty"`
+	Config       SessionProfileConfigImport `yaml:"config" toml:"config" json:"config"`
 }
 
 // SessionProfileConfigImport represents session profile config for import/export

--- a/pkg/stock_inventory/worker.go
+++ b/pkg/stock_inventory/worker.go
@@ -22,8 +22,8 @@ type StockRepository interface {
 
 // StockRequirements captures the pod capabilities a stock session is prepared for.
 type StockRequirements struct {
-	Sandbox   bool
-	DinD      bool
+	Sandbox bool
+	DinD    bool
 }
 
 // StockPool captures one stock inventory target for a capability set.

--- a/pkg/stock_inventory/worker_test.go
+++ b/pkg/stock_inventory/worker_test.go
@@ -83,7 +83,7 @@ type recordingStockRepo struct {
 	counts              map[StockRequirements]int
 	countRequirements   StockRequirements
 	countedRequirements []StockRequirements
-	createRequirements []StockRequirements
+	createRequirements  []StockRequirements
 }
 
 func (r *recordingStockRepo) CreateStockSession(_ context.Context, sandbox, dind bool) error {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4051,6 +4051,58 @@
         }
       }
     },
+    "/resources/transfer": {
+      "post": {
+        "summary": "Transfer a resource",
+        "description": "Transfers ownership of a user- or team-scoped resource. Supports dry-run validation.",
+        "operationId": "transferResource",
+        "tags": [
+          "Resources"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferResourceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transfer result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferResourceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Resource not found"
+          }
+        }
+      }
+    },
     "/files": {
       "post": {
         "summary": "Create a user file",
@@ -7516,6 +7568,13 @@
           "type": "boolean",
           "description": "Whether this is the default profile for the tenant"
         },
+        "selector_tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Tag selector used to choose this profile when launching a session"
+        },
         "config": {
           "$ref": "#/components/schemas/SessionProfileConfig"
         }
@@ -7535,6 +7594,13 @@
         "is_default": {
           "type": "boolean",
           "description": "Whether this is the default profile for the tenant"
+        },
+        "selector_tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Tag selector used to choose this profile when launching a session"
         },
         "config": {
           "$ref": "#/components/schemas/SessionProfileConfig"
@@ -7571,6 +7637,13 @@
           "type": "boolean",
           "description": "Whether this is the default profile for the tenant"
         },
+        "selector_tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Tag selector used to choose this profile when launching a session"
+        },
         "config": {
           "$ref": "#/components/schemas/SessionProfileConfig"
         },
@@ -7581,6 +7654,93 @@
         "updated_at": {
           "type": "string",
           "format": "date-time"
+        }
+      }
+    },
+    "TransferResourceRequest": {
+      "type": "object",
+      "required": [
+        "resource_type",
+        "resource_id",
+        "target_scope"
+      ],
+      "properties": {
+        "resource_type": {
+          "type": "string",
+          "enum": [
+            "memory",
+            "task",
+            "task_group",
+            "webhook",
+            "slackbot",
+            "session_profile",
+            "sandbox_policy"
+          ]
+        },
+        "resource_id": {
+          "type": "string"
+        },
+        "target_scope": {
+          "$ref": "#/components/schemas/ResourceScope"
+        },
+        "target_user_id": {
+          "type": "string",
+          "description": "Target user ID when target_scope is user. Defaults to current user."
+        },
+        "target_team_id": {
+          "type": "string",
+          "description": "Target team ID when target_scope is team."
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "Validate the transfer without mutating the resource."
+        }
+      }
+    },
+    "TransferEndpoint": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/components/schemas/ResourceScope"
+        },
+        "user_id": {
+          "type": "string"
+        },
+        "team_id": {
+          "type": "string"
+        }
+      }
+    },
+    "TransferResourceResponse": {
+      "type": "object",
+      "properties": {
+        "resource_type": {
+          "type": "string"
+        },
+        "resource_id": {
+          "type": "string"
+        },
+        "from": {
+          "$ref": "#/components/schemas/TransferEndpoint"
+        },
+        "to": {
+          "$ref": "#/components/schemas/TransferEndpoint"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "transferred",
+            "dry_run"
+          ]
+        },
+        "dry_run": {
+          "type": "boolean"
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- add session profile selector_tags and resolve profiles by launch tags before default fallback
- persist selector_tags through API, Kubernetes storage, GitHub sync, import/export types, and OpenAPI
- add POST /resources/transfer for user/team ownership transfer with dry_run and auth checks
- support memory, task, task_group, webhook, slackbot, session_profile, and sandbox_policy transfer

## Tests
- make lint
- env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT CGO_ENABLED=1 CC='zig cc' mise exec zig@0.16.0 -- make test

Note: plain make test needs a C compiler for -race; this environment lacks gcc, so zig cc was used.