### PR TITLE
Expose ACP session model info

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -180,6 +180,11 @@ func (b *Bridge) Messages() []json.RawMessage {
 // SessionID returns the ACP session ID.
 func (b *Bridge) SessionID() string { return b.sessionId }
 
+// SessionRuntimeInfo returns the runtime information reported by the ACP agent.
+func (b *Bridge) SessionRuntimeInfo() acp.SessionRuntimeInfo {
+	return b.acp.SessionRuntimeInfo()
+}
+
 // Status returns the current agent status ("running" or "stable").
 func (b *Bridge) Status() string {
 	b.statusMu.RLock()

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -131,11 +131,23 @@ func (s *Server) handleGetMessages(c echo.Context) error {
 // Returns the session ID and current status so clients know what ID to use in RPC calls.
 func (s *Server) handleGetSession(c echo.Context) error {
 	sessionId := s.bridge.SessionID()
+	info := s.bridge.SessionRuntimeInfo()
 	log.Printf("[acp-server] GET /session -> sessionId=%s (remoteAddr=%s)", sessionId, c.RealIP())
-	return c.JSON(http.StatusOK, map[string]string{
-		"sessionId": sessionId,
-		"status":    "ready",
+	return c.JSON(http.StatusOK, acpSessionResponse{
+		SessionId:     sessionId,
+		Status:        "ready",
+		Model:         info.Model,
+		Modes:         info.Modes,
+		ConfigOptions: info.ConfigOptions,
 	})
+}
+
+type acpSessionResponse struct {
+	SessionId     string                `json:"sessionId"`
+	Status        string                `json:"status"`
+	Model         string                `json:"model,omitempty"`
+	Modes         *acp.SessionModeState `json:"modes,omitempty"`
+	ConfigOptions []acp.ConfigOption    `json:"configOptions,omitempty"`
 }
 
 // rpcEnvelope is the JSON-RPC 2.0 message envelope received on POST /rpc.

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
+	"sync"
 
 	"github.com/takutakahashi/agentapi-proxy/pkg/acp/jsonrpc"
 )
@@ -28,8 +30,10 @@ type Client struct {
 	rpc     *jsonrpc.Client
 	verbose bool
 
-	sessionId string
-	agentCaps AgentCapabilities
+	sessionId   string
+	agentCaps   AgentCapabilities
+	mu          sync.RWMutex
+	sessionInfo SessionRuntimeInfo
 
 	// updateCh is closed when the client is stopped.
 	updateCh chan SessionUpdate
@@ -244,16 +248,25 @@ func (c *Client) NewSession(ctx context.Context, cwd string, mcpServers []McpSer
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return fmt.Errorf("acp session/new: parse result: %w", err)
 	}
-	c.sessionId = result.SessionId
+	c.setSessionRuntimeInfo(result.SessionId, result.Modes, result.ConfigOptions)
 	if c.verbose {
-		log.Printf("[acp] session created: id=%s modes=%v", result.SessionId, result.Modes)
+		log.Printf("[acp] session created: id=%s modes=%v configOptions=%d", result.SessionId, result.Modes, len(result.ConfigOptions))
 	}
 	return nil
 }
 
 // SessionID returns the current session ID (set after NewSession).
 func (c *Client) SessionID() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.sessionId
+}
+
+// SessionRuntimeInfo returns the runtime information reported by session/new or session/load.
+func (c *Client) SessionRuntimeInfo() SessionRuntimeInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sessionInfo
 }
 
 // LoadSession restores a previously created ACP session by its ID.
@@ -270,22 +283,73 @@ func (c *Client) LoadSession(ctx context.Context, sessionId string) error {
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return fmt.Errorf("acp session/load: parse result: %w", err)
 	}
-	c.sessionId = result.SessionId
+	c.setSessionRuntimeInfo(result.SessionId, result.Modes, result.ConfigOptions)
 	if c.verbose {
-		log.Printf("[acp] session loaded: id=%s", result.SessionId)
+		log.Printf("[acp] session loaded: id=%s configOptions=%d", result.SessionId, len(result.ConfigOptions))
 	}
 	return nil
+}
+
+func (c *Client) setSessionRuntimeInfo(sessionId string, modes *SessionModeState, configOptions []ConfigOption) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessionId = sessionId
+	c.sessionInfo = SessionRuntimeInfo{
+		SessionId:     sessionId,
+		Modes:         modes,
+		ConfigOptions: configOptions,
+		Model:         ExtractModelFromConfigOptions(configOptions),
+	}
+}
+
+// ExtractModelFromConfigOptions returns the most likely active model value from ACP config options.
+func ExtractModelFromConfigOptions(configOptions []ConfigOption) string {
+	for _, option := range configOptions {
+		key := strings.ToLower(strings.TrimSpace(option.Key))
+		name := strings.ToLower(strings.TrimSpace(option.Name))
+		description := strings.ToLower(option.Description)
+		if key != "model" && key != "modelid" && key != "model_id" &&
+			name != "model" && name != "modelid" && name != "model_id" &&
+			!strings.Contains(description, "model") {
+			continue
+		}
+		for _, value := range []interface{}{option.Value, option.CurrentValue, option.Default} {
+			if model := modelValueToString(value); model != "" {
+				return model
+			}
+		}
+	}
+	return ""
+}
+
+func modelValueToString(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case map[string]interface{}:
+		for _, key := range []string{"id", "model", "modelId", "name", "displayName", "value", "default"} {
+			if model := modelValueToString(v[key]); model != "" {
+				return model
+			}
+		}
+	case []interface{}:
+		if len(v) == 1 {
+			return modelValueToString(v[0])
+		}
+	}
+	return ""
 }
 
 // Prompt sends a user message and returns when the agent has finished the turn.
 // While the agent is working, session/update notifications are dispatched to
 // the channel returned by Updates().
 func (c *Client) Prompt(ctx context.Context, text string) (StopReason, error) {
-	if c.sessionId == "" {
+	sessionId := c.SessionID()
+	if sessionId == "" {
 		return "", fmt.Errorf("acp: no active session; call NewSession first")
 	}
 	params := PromptParams{
-		SessionId: c.sessionId,
+		SessionId: sessionId,
 		Prompt: []ContentBlock{
 			{Type: ContentBlockTypeText, Text: text},
 		},
@@ -303,10 +367,11 @@ func (c *Client) Prompt(ctx context.Context, text string) (StopReason, error) {
 
 // Cancel sends a session/cancel notification to abort the current turn.
 func (c *Client) Cancel(ctx context.Context) error {
-	if c.sessionId == "" {
+	sessionId := c.SessionID()
+	if sessionId == "" {
 		return nil
 	}
-	return c.rpc.Notify("session/cancel", SessionCancelParams{SessionId: c.sessionId})
+	return c.rpc.Notify("session/cancel", SessionCancelParams{SessionId: sessionId})
 }
 
 // Updates returns a channel that receives session/update notifications from

--- a/pkg/acp/client_test.go
+++ b/pkg/acp/client_test.go
@@ -1,0 +1,55 @@
+package acp
+
+import "testing"
+
+func TestExtractModelFromConfigOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []ConfigOption
+		want    string
+	}{
+		{
+			name: "string model default",
+			options: []ConfigOption{
+				{Key: "model", Default: "gpt-5.1-codex"},
+			},
+			want: "gpt-5.1-codex",
+		},
+		{
+			name: "model id object default",
+			options: []ConfigOption{
+				{Key: "model", Default: map[string]interface{}{"id": "claude-sonnet-4.5"}},
+			},
+			want: "claude-sonnet-4.5",
+		},
+		{
+			name: "description fallback",
+			options: []ConfigOption{
+				{Key: "provider_default", Description: "Current model", Default: "o4-mini"},
+			},
+			want: "o4-mini",
+		},
+		{
+			name: "current value preferred over default",
+			options: []ConfigOption{
+				{Key: "model", CurrentValue: "gpt-5.1-codex", Default: "gpt-4.1"},
+			},
+			want: "gpt-5.1-codex",
+		},
+		{
+			name: "non model option ignored",
+			options: []ConfigOption{
+				{Key: "cwd", Default: "/workspace"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractModelFromConfigOptions(tt.options); got != tt.want {
+				t.Fatalf("ExtractModelFromConfigOptions() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -104,9 +104,20 @@ type SessionModeState struct {
 
 // ConfigOption is a runtime config option offered by the agent.
 type ConfigOption struct {
-	Key         string      `json:"key"`
-	Description string      `json:"description,omitempty"`
-	Default     interface{} `json:"default,omitempty"`
+	Key          string      `json:"key"`
+	Name         string      `json:"name,omitempty"`
+	Description  string      `json:"description,omitempty"`
+	Value        interface{} `json:"value,omitempty"`
+	CurrentValue interface{} `json:"currentValue,omitempty"`
+	Default      interface{} `json:"default,omitempty"`
+}
+
+// SessionRuntimeInfo is the session metadata reported by ACP session/new or session/load.
+type SessionRuntimeInfo struct {
+	SessionId     string            `json:"sessionId"`
+	Modes         *SessionModeState `json:"modes,omitempty"`
+	ConfigOptions []ConfigOption    `json:"configOptions,omitempty"`
+	Model         string            `json:"model,omitempty"`
 }
 
 // SessionNewResult is the response to "session/new".


### PR DESCRIPTION
## Summary
- preserve ACP session runtime info from session/new and session/load
- expose model, modes, and configOptions from the ACP bridge /session endpoint
- derive model from model-related ACP config options

## Tests
- mise exec -- go test ./pkg/acp/...
- mise exec -- go test ./... (fails in cmd with signal: interrupt while initializing local Kubernetes-backed server state; unrelated packages pass)