### PR TITLE
Add MCP tools for webhooks, schedules, and slackbots

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -543,6 +543,7 @@ func registerWebhookHandlers(configData *config.Config, proxyServer *app.Server)
 
 	// Create webhook repository (clean architecture)
 	webhookRepo := repositories.NewKubernetesWebhookRepository(client, namespace)
+	proxyServer.SetWebhookRepository(webhookRepo)
 
 	// Set default GitHub Enterprise host if configured
 	if configData.Webhook.GitHubEnterpriseHost != "" {
@@ -733,6 +734,7 @@ func registerSlackBotHandlers(configData *config.Config, proxyServer *app.Server
 
 	// Create SlackBot repository
 	slackbotRepo := repositories.NewKubernetesSlackBotRepository(client, namespace)
+	proxyServer.SetSlackBotRepository(slackbotRepo)
 
 	// Create and register SlackBot management handlers (no event reception - handled by Socket Mode)
 	slackbotHandlers := slackbot.NewHandlers(slackbotRepo)

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -55,6 +55,8 @@ type Server struct {
 	sandboxDomainRepo  *repositories.KubernetesSandboxDomainRepository // Sandbox domain log repository
 	taskRepo           portrepos.TaskRepository                        // Task repository
 	taskGroupRepo      portrepos.TaskGroupRepository                   // Task group repository
+	webhookRepo        portrepos.WebhookRepository                     // Webhook repository
+	slackBotRepo       portrepos.SlackBotRepository                    // SlackBot repository
 	sessionRouteRepo   portrepos.SessionRouteRepository                // Session route repository for External Session Manager routing
 	userFileRepo       portrepos.UserFileRepository                    // User-managed files repository
 	sessionProfileRepo portrepos.SessionProfileRepository              // Session profile repository
@@ -1101,6 +1103,26 @@ func (s *Server) GetTaskRepository() portrepos.TaskRepository {
 // GetTaskGroupRepository returns the task group repository
 func (s *Server) GetTaskGroupRepository() portrepos.TaskGroupRepository {
 	return s.taskGroupRepo
+}
+
+// GetWebhookRepository returns the webhook repository
+func (s *Server) GetWebhookRepository() portrepos.WebhookRepository {
+	return s.webhookRepo
+}
+
+// SetWebhookRepository allows configuration of a custom webhook repository
+func (s *Server) SetWebhookRepository(repo portrepos.WebhookRepository) {
+	s.webhookRepo = repo
+}
+
+// GetSlackBotRepository returns the SlackBot repository
+func (s *Server) GetSlackBotRepository() portrepos.SlackBotRepository {
+	return s.slackBotRepo
+}
+
+// SetSlackBotRepository allows configuration of a custom SlackBot repository
+func (s *Server) SetSlackBotRepository(repo portrepos.SlackBotRepository) {
+	s.slackBotRepo = repo
 }
 
 // GetSessionProfileRepository returns the session profile repository

--- a/internal/interfaces/mcp/handler.go
+++ b/internal/interfaces/mcp/handler.go
@@ -11,8 +11,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/takutakahashi/agentapi-proxy/internal/app"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	infrarepos "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/repositories"
+	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+	schedulepkg "github.com/takutakahashi/agentapi-proxy/pkg/schedule"
 )
 
 // Context key for authenticated user
@@ -22,12 +25,16 @@ const userContextKey contextKey = "mcp_authenticated_user"
 
 // MCPHandler implements the CustomHandler interface for MCP endpoints
 type MCPHandler struct {
-	sessionManager repositories.SessionManager
-	shareRepo      repositories.ShareRepository
-	taskRepo       repositories.TaskRepository
-	taskGroupRepo  repositories.TaskGroupRepository
-	memoryRepo     repositories.MemoryRepository
-	httpHandler    http.Handler
+	sessionManager     portrepos.SessionManager
+	shareRepo          portrepos.ShareRepository
+	taskRepo           portrepos.TaskRepository
+	taskGroupRepo      portrepos.TaskGroupRepository
+	memoryRepo         portrepos.MemoryRepository
+	webhookRepo        portrepos.WebhookRepository
+	scheduleManager    schedulepkg.Manager
+	slackBotRepo       portrepos.SlackBotRepository
+	sessionProfileRepo portrepos.SessionProfileRepository
+	httpHandler        http.Handler
 }
 
 // NewMCPHandler creates a new MCP handler for the /mcp endpoint
@@ -38,6 +45,22 @@ func NewMCPHandler(server *app.Server) *MCPHandler {
 	taskRepo := server.GetTaskRepository()
 	taskGroupRepo := server.GetTaskGroupRepository()
 	memoryRepo := server.GetMemoryRepository()
+	webhookRepo := server.GetWebhookRepository()
+	slackBotRepo := server.GetSlackBotRepository()
+	sessionProfileRepo := server.GetSessionProfileRepository()
+	var scheduleManager schedulepkg.Manager
+
+	if k8sManager, ok := sessionManager.(*services.KubernetesSessionManager); ok {
+		client := k8sManager.GetClient()
+		namespace := k8sManager.GetNamespace()
+		scheduleManager = schedulepkg.NewKubernetesManager(client, namespace)
+		if webhookRepo == nil {
+			webhookRepo = infrarepos.NewKubernetesWebhookRepository(client, namespace)
+		}
+		if slackBotRepo == nil {
+			slackBotRepo = infrarepos.NewKubernetesSlackBotRepository(client, namespace)
+		}
+	}
 
 	// Create HTTP handler using go-sdk's streamable HTTP handler
 	// Use stateless mode for simpler session management
@@ -47,11 +70,15 @@ func NewMCPHandler(server *app.Server) *MCPHandler {
 	}
 
 	handler := &MCPHandler{
-		sessionManager: sessionManager,
-		shareRepo:      shareRepo,
-		taskRepo:       taskRepo,
-		taskGroupRepo:  taskGroupRepo,
-		memoryRepo:     memoryRepo,
+		sessionManager:     sessionManager,
+		shareRepo:          shareRepo,
+		taskRepo:           taskRepo,
+		taskGroupRepo:      taskGroupRepo,
+		memoryRepo:         memoryRepo,
+		webhookRepo:        webhookRepo,
+		scheduleManager:    scheduleManager,
+		slackBotRepo:       slackBotRepo,
+		sessionProfileRepo: sessionProfileRepo,
 	}
 
 	// Create factory function that creates a new MCP server per request with authenticated user
@@ -90,7 +117,7 @@ func NewMCPHandler(server *app.Server) *MCPHandler {
 		}
 
 		// Create new MCP server instance with authenticated user and repositories
-		mcpServer := NewMCPServer(sessionManager, shareRepo, taskRepo, taskGroupRepo, memoryRepo, authenticatedUserID, authenticatedTeams, authenticatedGithubToken, authenticatedSessionID, opts)
+		mcpServer := NewMCPServer(sessionManager, shareRepo, taskRepo, taskGroupRepo, memoryRepo, webhookRepo, scheduleManager, slackBotRepo, sessionProfileRepo, authenticatedUserID, authenticatedTeams, authenticatedGithubToken, authenticatedSessionID, opts)
 
 		// Register all tools
 		mcpServer.RegisterTools()

--- a/internal/interfaces/mcp/server.go
+++ b/internal/interfaces/mcp/server.go
@@ -14,6 +14,9 @@ type MCPServer struct {
 	useCase                  *mcpusecases.MCPSessionToolsUseCase
 	taskUseCase              *mcpusecases.MCPTaskToolsUseCase
 	memoryUseCase            *mcpusecases.MCPMemoryToolsUseCase
+	webhookUseCase           *mcpusecases.MCPWebhookToolsUseCase
+	scheduleUseCase          *mcpusecases.MCPScheduleToolsUseCase
+	slackBotUseCase          *mcpusecases.MCPSlackBotToolsUseCase
 	authenticatedUserID      string
 	authenticatedTeams       []string // GitHub team slugs (e.g., ["org/team-a"])
 	authenticatedGithubToken string   // GitHub token from Authorization header
@@ -21,7 +24,7 @@ type MCPServer struct {
 }
 
 // NewMCPServer creates a new MCP server instance
-func NewMCPServer(sessionManager repositories.SessionManager, shareRepo repositories.ShareRepository, taskRepo repositories.TaskRepository, taskGroupRepo repositories.TaskGroupRepository, memoryRepo repositories.MemoryRepository, authenticatedUserID string, authenticatedTeams []string, authenticatedGithubToken string, sessionID string, opts *mcp.ServerOptions) *MCPServer {
+func NewMCPServer(sessionManager repositories.SessionManager, shareRepo repositories.ShareRepository, taskRepo repositories.TaskRepository, taskGroupRepo repositories.TaskGroupRepository, memoryRepo repositories.MemoryRepository, webhookRepo repositories.WebhookRepository, scheduleManager mcpusecases.ScheduleManager, slackBotRepo repositories.SlackBotRepository, sessionProfileRepo repositories.SessionProfileRepository, authenticatedUserID string, authenticatedTeams []string, authenticatedGithubToken string, sessionID string, opts *mcp.ServerOptions) *MCPServer {
 	// Create session use case with actual dependencies
 	useCase := mcpusecases.NewMCPSessionToolsUseCase(sessionManager, shareRepo, taskRepo)
 
@@ -37,6 +40,19 @@ func NewMCPServer(sessionManager repositories.SessionManager, shareRepo reposito
 		memoryUseCase = mcpusecases.NewMCPMemoryToolsUseCase(memoryRepo)
 	}
 
+	var webhookUseCase *mcpusecases.MCPWebhookToolsUseCase
+	if webhookRepo != nil {
+		webhookUseCase = mcpusecases.NewMCPWebhookToolsUseCase(webhookRepo, sessionManager, memoryRepo, sessionProfileRepo)
+	}
+	var scheduleUseCase *mcpusecases.MCPScheduleToolsUseCase
+	if scheduleManager != nil {
+		scheduleUseCase = mcpusecases.NewMCPScheduleToolsUseCase(scheduleManager, sessionManager, memoryRepo, sessionProfileRepo)
+	}
+	var slackBotUseCase *mcpusecases.MCPSlackBotToolsUseCase
+	if slackBotRepo != nil {
+		slackBotUseCase = mcpusecases.NewMCPSlackBotToolsUseCase(slackBotRepo)
+	}
+
 	// Create MCP server
 	impl := &mcp.Implementation{
 		Name:    "agentapi-proxy-mcp",
@@ -50,6 +66,9 @@ func NewMCPServer(sessionManager repositories.SessionManager, shareRepo reposito
 		useCase:                  useCase,
 		taskUseCase:              taskUseCase,
 		memoryUseCase:            memoryUseCase,
+		webhookUseCase:           webhookUseCase,
+		scheduleUseCase:          scheduleUseCase,
+		slackBotUseCase:          slackBotUseCase,
 		authenticatedUserID:      authenticatedUserID,
 		authenticatedTeams:       authenticatedTeams,
 		authenticatedGithubToken: authenticatedGithubToken,
@@ -70,6 +89,18 @@ func (s *MCPServer) RegisterTools() {
 	// Register memory tools if available
 	if s.memoryUseCase != nil {
 		s.registerMemoryTools()
+	}
+
+	if s.webhookUseCase != nil {
+		s.registerWebhookTools()
+	}
+
+	if s.scheduleUseCase != nil {
+		s.registerScheduleTools()
+	}
+
+	if s.slackBotUseCase != nil {
+		s.registerSlackBotTools()
 	}
 }
 

--- a/internal/interfaces/mcp/webhook_schedule_slackbot_tools.go
+++ b/internal/interfaces/mcp/webhook_schedule_slackbot_tools.go
@@ -1,0 +1,235 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	mcpusecases "github.com/takutakahashi/agentapi-proxy/internal/usecases/mcp"
+)
+
+type GetWebhookToolInput struct {
+	WebhookID string `json:"webhook_id"`
+}
+
+type ListWebhooksToolOutput struct {
+	Webhooks []mcpusecases.WebhookInfo `json:"webhooks"`
+	Total    int                       `json:"total"`
+}
+
+type GetWebhookToolOutput struct {
+	Webhook mcpusecases.WebhookInfo `json:"webhook"`
+}
+
+type TriggerWebhookToolOutput struct {
+	Result mcpusecases.TriggerWebhookResult `json:"result"`
+}
+
+type GetScheduleToolInput struct {
+	ScheduleID string `json:"schedule_id"`
+}
+
+type TriggerScheduleToolInput struct {
+	ScheduleID string `json:"schedule_id"`
+}
+
+type ListSchedulesToolOutput struct {
+	Schedules []mcpusecases.ScheduleInfo `json:"schedules"`
+	Total     int                        `json:"total"`
+}
+
+type GetScheduleToolOutput struct {
+	Schedule mcpusecases.ScheduleInfo `json:"schedule"`
+}
+
+type TriggerScheduleToolOutput struct {
+	Result mcpusecases.TriggerScheduleResult `json:"result"`
+}
+
+type GetSlackBotToolInput struct {
+	SlackBotID string `json:"slackbot_id"`
+}
+
+type ListSlackBotsToolOutput struct {
+	SlackBots []mcpusecases.SlackBotInfo `json:"slackbots"`
+	Total     int                        `json:"total"`
+}
+
+type GetSlackBotToolOutput struct {
+	SlackBot mcpusecases.SlackBotInfo `json:"slackbot"`
+}
+
+func (s *MCPServer) registerWebhookTools() {
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "list_webhooks",
+		Description: "List webhooks with optional filters (scope, team_id, type, status). Secrets are never returned.",
+	}, s.handleListWebhooks)
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "get_webhook",
+		Description: "Get a webhook by ID. The webhook secret is never returned.",
+	}, s.handleGetWebhook)
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "trigger_webhook",
+		Description: "Manually trigger a webhook. GitHub webhooks require event; dry_run evaluates without creating a session.",
+	}, s.handleTriggerWebhook)
+	slog.Info("[MCP] Registered 3 webhook tools: list_webhooks, get_webhook, trigger_webhook")
+}
+
+func (s *MCPServer) registerScheduleTools() {
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "list_schedules",
+		Description: "List schedules with optional filters (scope, team_id, status).",
+	}, s.handleListSchedules)
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "get_schedule",
+		Description: "Get a schedule by ID.",
+	}, s.handleGetSchedule)
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "trigger_schedule",
+		Description: "Manually trigger a schedule and create or reuse a session.",
+	}, s.handleTriggerSchedule)
+	slog.Info("[MCP] Registered 3 schedule tools: list_schedules, get_schedule, trigger_schedule")
+}
+
+func (s *MCPServer) registerSlackBotTools() {
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "list_slackbots",
+		Description: "List SlackBots with optional filters (scope, team_id, status). Token values are never returned.",
+	}, s.handleListSlackBots)
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "get_slackbot",
+		Description: "Get a SlackBot by ID. Token values are never returned.",
+	}, s.handleGetSlackBot)
+	slog.Info("[MCP] Registered 2 slackbot tools: list_slackbots, get_slackbot")
+}
+
+func (s *MCPServer) handleListWebhooks(ctx context.Context, req *mcp.CallToolRequest, input mcpusecases.ListWebhooksInput) (*mcp.CallToolResult, ListWebhooksToolOutput, error) {
+	if err := s.requireWebhookAuth(); err != nil {
+		return nil, ListWebhooksToolOutput{}, err
+	}
+	webhooks, err := s.webhookUseCase.ListWebhooks(ctx, input, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, ListWebhooksToolOutput{}, fmt.Errorf("failed to list webhooks: %w", err)
+	}
+	return nil, ListWebhooksToolOutput{Webhooks: webhooks, Total: len(webhooks)}, nil
+}
+
+func (s *MCPServer) handleGetWebhook(ctx context.Context, req *mcp.CallToolRequest, input GetWebhookToolInput) (*mcp.CallToolResult, GetWebhookToolOutput, error) {
+	if err := s.requireWebhookAuth(); err != nil {
+		return nil, GetWebhookToolOutput{}, err
+	}
+	if input.WebhookID == "" {
+		return nil, GetWebhookToolOutput{}, fmt.Errorf("webhook_id is required")
+	}
+	webhook, err := s.webhookUseCase.GetWebhook(ctx, input.WebhookID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, GetWebhookToolOutput{}, fmt.Errorf("failed to get webhook: %w", err)
+	}
+	return nil, GetWebhookToolOutput{Webhook: *webhook}, nil
+}
+
+func (s *MCPServer) handleTriggerWebhook(ctx context.Context, req *mcp.CallToolRequest, input mcpusecases.TriggerWebhookInput) (*mcp.CallToolResult, TriggerWebhookToolOutput, error) {
+	if err := s.requireWebhookAuth(); err != nil {
+		return nil, TriggerWebhookToolOutput{}, err
+	}
+	result, err := s.webhookUseCase.TriggerWebhook(ctx, input, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, TriggerWebhookToolOutput{}, fmt.Errorf("failed to trigger webhook: %w", err)
+	}
+	return nil, TriggerWebhookToolOutput{Result: *result}, nil
+}
+
+func (s *MCPServer) handleListSchedules(ctx context.Context, req *mcp.CallToolRequest, input mcpusecases.ListSchedulesInput) (*mcp.CallToolResult, ListSchedulesToolOutput, error) {
+	if err := s.requireScheduleAuth(); err != nil {
+		return nil, ListSchedulesToolOutput{}, err
+	}
+	schedules, err := s.scheduleUseCase.ListSchedules(ctx, input, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, ListSchedulesToolOutput{}, fmt.Errorf("failed to list schedules: %w", err)
+	}
+	return nil, ListSchedulesToolOutput{Schedules: schedules, Total: len(schedules)}, nil
+}
+
+func (s *MCPServer) handleGetSchedule(ctx context.Context, req *mcp.CallToolRequest, input GetScheduleToolInput) (*mcp.CallToolResult, GetScheduleToolOutput, error) {
+	if err := s.requireScheduleAuth(); err != nil {
+		return nil, GetScheduleToolOutput{}, err
+	}
+	if input.ScheduleID == "" {
+		return nil, GetScheduleToolOutput{}, fmt.Errorf("schedule_id is required")
+	}
+	scheduleInfo, err := s.scheduleUseCase.GetSchedule(ctx, input.ScheduleID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, GetScheduleToolOutput{}, fmt.Errorf("failed to get schedule: %w", err)
+	}
+	return nil, GetScheduleToolOutput{Schedule: *scheduleInfo}, nil
+}
+
+func (s *MCPServer) handleTriggerSchedule(ctx context.Context, req *mcp.CallToolRequest, input TriggerScheduleToolInput) (*mcp.CallToolResult, TriggerScheduleToolOutput, error) {
+	if err := s.requireScheduleAuth(); err != nil {
+		return nil, TriggerScheduleToolOutput{}, err
+	}
+	if input.ScheduleID == "" {
+		return nil, TriggerScheduleToolOutput{}, fmt.Errorf("schedule_id is required")
+	}
+	result, err := s.scheduleUseCase.TriggerSchedule(ctx, input.ScheduleID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, TriggerScheduleToolOutput{}, fmt.Errorf("failed to trigger schedule: %w", err)
+	}
+	return nil, TriggerScheduleToolOutput{Result: *result}, nil
+}
+
+func (s *MCPServer) handleListSlackBots(ctx context.Context, req *mcp.CallToolRequest, input mcpusecases.ListSlackBotsInput) (*mcp.CallToolResult, ListSlackBotsToolOutput, error) {
+	if err := s.requireSlackBotAuth(); err != nil {
+		return nil, ListSlackBotsToolOutput{}, err
+	}
+	bots, err := s.slackBotUseCase.ListSlackBots(ctx, input, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, ListSlackBotsToolOutput{}, fmt.Errorf("failed to list slackbots: %w", err)
+	}
+	return nil, ListSlackBotsToolOutput{SlackBots: bots, Total: len(bots)}, nil
+}
+
+func (s *MCPServer) handleGetSlackBot(ctx context.Context, req *mcp.CallToolRequest, input GetSlackBotToolInput) (*mcp.CallToolResult, GetSlackBotToolOutput, error) {
+	if err := s.requireSlackBotAuth(); err != nil {
+		return nil, GetSlackBotToolOutput{}, err
+	}
+	if input.SlackBotID == "" {
+		return nil, GetSlackBotToolOutput{}, fmt.Errorf("slackbot_id is required")
+	}
+	bot, err := s.slackBotUseCase.GetSlackBot(ctx, input.SlackBotID, s.authenticatedUserID, s.authenticatedTeams)
+	if err != nil {
+		return nil, GetSlackBotToolOutput{}, fmt.Errorf("failed to get slackbot: %w", err)
+	}
+	return nil, GetSlackBotToolOutput{SlackBot: *bot}, nil
+}
+
+func (s *MCPServer) requireWebhookAuth() error {
+	if s.webhookUseCase == nil {
+		return fmt.Errorf("webhook tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return fmt.Errorf("authentication required")
+	}
+	return nil
+}
+
+func (s *MCPServer) requireScheduleAuth() error {
+	if s.scheduleUseCase == nil {
+		return fmt.Errorf("schedule tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return fmt.Errorf("authentication required")
+	}
+	return nil
+}
+
+func (s *MCPServer) requireSlackBotAuth() error {
+	if s.slackBotUseCase == nil {
+		return fmt.Errorf("slackbot tools not available")
+	}
+	if s.authenticatedUserID == "" {
+		return fmt.Errorf("authentication required")
+	}
+	return nil
+}

--- a/internal/usecases/mcp/webhook_schedule_slackbot_tools.go
+++ b/internal/usecases/mcp/webhook_schedule_slackbot_tools.go
@@ -1,0 +1,670 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/takutakahashi/agentapi-proxy/internal/app"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	sessionuc "github.com/takutakahashi/agentapi-proxy/internal/usecases/session"
+	"github.com/takutakahashi/agentapi-proxy/pkg/schedule"
+)
+
+type ScheduleManager = schedule.Manager
+
+// MCPWebhookToolsUseCase provides MCP access to webhook resources.
+type MCPWebhookToolsUseCase struct {
+	repo             portrepos.WebhookRepository
+	githubController *controllers.WebhookGitHubController
+	customController *controllers.WebhookCustomController
+}
+
+func NewMCPWebhookToolsUseCase(repo portrepos.WebhookRepository, sessionManager portrepos.SessionManager, memoryRepo portrepos.MemoryRepository, sessionProfileRepo portrepos.SessionProfileRepository) *MCPWebhookToolsUseCase {
+	return &MCPWebhookToolsUseCase{
+		repo:             repo,
+		githubController: controllers.NewWebhookGitHubController(repo, sessionManager, memoryRepo, sessionProfileRepo),
+		customController: controllers.NewWebhookCustomController(repo, sessionManager, memoryRepo, sessionProfileRepo),
+	}
+}
+
+// MCPScheduleToolsUseCase provides MCP access to schedule resources.
+type MCPScheduleToolsUseCase struct {
+	manager  schedule.Manager
+	launcher *sessionuc.LaunchUseCase
+}
+
+func NewMCPScheduleToolsUseCase(manager schedule.Manager, sessionManager portrepos.SessionManager, memoryRepo portrepos.MemoryRepository, sessionProfileRepo portrepos.SessionProfileRepository) *MCPScheduleToolsUseCase {
+	return &MCPScheduleToolsUseCase{
+		manager: manager,
+		launcher: sessionuc.NewLaunchUseCase(sessionManager).
+			WithMemoryRepository(memoryRepo).
+			WithSessionProfileRepository(sessionProfileRepo),
+	}
+}
+
+// MCPSlackBotToolsUseCase provides MCP access to SlackBot resources.
+type MCPSlackBotToolsUseCase struct {
+	repo portrepos.SlackBotRepository
+}
+
+func NewMCPSlackBotToolsUseCase(repo portrepos.SlackBotRepository) *MCPSlackBotToolsUseCase {
+	return &MCPSlackBotToolsUseCase{repo: repo}
+}
+
+type ListWebhooksInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type TriggerWebhookInput struct {
+	WebhookID string                 `json:"webhook_id"`
+	Event     string                 `json:"event,omitempty"`
+	Payload   map[string]interface{} `json:"payload"`
+	DryRun    bool                   `json:"dry_run,omitempty"`
+}
+
+type WebhookInfo struct {
+	ID              string               `json:"id"`
+	Name            string               `json:"name"`
+	UserID          string               `json:"user_id"`
+	Scope           string               `json:"scope"`
+	TeamID          string               `json:"team_id,omitempty"`
+	Status          string               `json:"status"`
+	Type            string               `json:"type"`
+	SignatureHeader string               `json:"signature_header,omitempty"`
+	SignatureType   string               `json:"signature_type,omitempty"`
+	SignaturePrefix string               `json:"signature_prefix,omitempty"`
+	GitHub          *GitHubConfigInfo    `json:"github,omitempty"`
+	Triggers        []WebhookTriggerInfo `json:"triggers"`
+	SessionConfig   *SessionConfigInfo   `json:"session_config,omitempty"`
+	MaxSessions     int                  `json:"max_sessions"`
+	CreatedAt       time.Time            `json:"created_at"`
+	UpdatedAt       time.Time            `json:"updated_at"`
+	LastDelivery    *DeliveryInfo        `json:"last_delivery,omitempty"`
+	DeliveryCount   int64                `json:"delivery_count"`
+}
+
+type GitHubConfigInfo struct {
+	EnterpriseURL       string   `json:"enterprise_url,omitempty"`
+	AllowedEvents       []string `json:"allowed_events,omitempty"`
+	AllowedRepositories []string `json:"allowed_repositories,omitempty"`
+}
+
+type WebhookTriggerInfo struct {
+	ID            string                `json:"id"`
+	Name          string                `json:"name"`
+	Priority      int                   `json:"priority"`
+	Enabled       bool                  `json:"enabled"`
+	Conditions    WebhookConditionsInfo `json:"conditions"`
+	SessionConfig *SessionConfigInfo    `json:"session_config,omitempty"`
+	StopOnMatch   bool                  `json:"stop_on_match"`
+}
+
+type WebhookConditionsInfo struct {
+	GitHub     *GitHubConditionsInfo `json:"github,omitempty"`
+	GoTemplate string                `json:"go_template,omitempty"`
+}
+
+type GitHubConditionsInfo struct {
+	Events       []string `json:"events,omitempty"`
+	Actions      []string `json:"actions,omitempty"`
+	Branches     []string `json:"branches,omitempty"`
+	Repositories []string `json:"repositories,omitempty"`
+	Labels       []string `json:"labels,omitempty"`
+	Paths        []string `json:"paths,omitempty"`
+	BaseBranches []string `json:"base_branches,omitempty"`
+	Draft        *bool    `json:"draft,omitempty"`
+	Sender       []string `json:"sender,omitempty"`
+}
+
+type SessionConfigInfo struct {
+	Environment            map[string]string  `json:"environment,omitempty"`
+	Tags                   map[string]string  `json:"tags,omitempty"`
+	InitialMessageTemplate string             `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string             `json:"reuse_message_template,omitempty"`
+	Params                 *SessionParamsInfo `json:"params,omitempty"`
+	ReuseSession           bool               `json:"reuse_session,omitempty"`
+	MountPayload           bool               `json:"mount_payload,omitempty"`
+	MemoryKey              map[string]string  `json:"memory_key,omitempty"`
+	SessionProfileID       string             `json:"session_profile_id,omitempty"`
+}
+
+type SessionParamsInfo struct {
+	AgentType    string `json:"agent_type,omitempty"`
+	Oneshot      bool   `json:"oneshot,omitempty"`
+	RepoFullName string `json:"repo_full_name,omitempty"`
+}
+
+type DeliveryInfo struct {
+	ID             string    `json:"id"`
+	ReceivedAt     time.Time `json:"received_at"`
+	Status         string    `json:"status"`
+	MatchedTrigger string    `json:"matched_trigger,omitempty"`
+	SessionID      string    `json:"session_id,omitempty"`
+	Error          string    `json:"error,omitempty"`
+	SessionReused  bool      `json:"session_reused,omitempty"`
+}
+
+type TriggerWebhookResult struct {
+	Matched        bool                       `json:"matched"`
+	MatchedTrigger *TriggerMatchedTriggerInfo `json:"matched_trigger,omitempty"`
+	SessionID      string                     `json:"session_id,omitempty"`
+	SessionReused  bool                       `json:"session_reused,omitempty"`
+	DryRun         bool                       `json:"dry_run"`
+	InitialMessage string                     `json:"initial_message,omitempty"`
+	Tags           map[string]string          `json:"tags,omitempty"`
+	Environment    map[string]string          `json:"environment,omitempty"`
+	Error          string                     `json:"error,omitempty"`
+}
+
+type TriggerMatchedTriggerInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (uc *MCPWebhookToolsUseCase) ListWebhooks(ctx context.Context, input ListWebhooksInput, userID string, teamIDs []string) ([]WebhookInfo, error) {
+	filter := portrepos.WebhookFilter{
+		Scope:   entities.ResourceScope(input.Scope),
+		TeamID:  input.TeamID,
+		TeamIDs: teamIDs,
+		Type:    entities.WebhookType(input.Type),
+		Status:  entities.WebhookStatus(input.Status),
+	}
+	if input.Scope != string(entities.ScopeTeam) && input.TeamID == "" {
+		filter.UserID = userID
+	}
+
+	webhooks, err := uc.repo.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]WebhookInfo, 0, len(webhooks))
+	for _, webhook := range webhooks {
+		if !visibleInScope(input.Scope, webhook.Scope()) || !canAccessOwnedResource(webhook.Scope(), webhook.UserID(), webhook.TeamID(), userID, teamIDs) {
+			continue
+		}
+		result = append(result, toWebhookInfo(webhook))
+	}
+	return result, nil
+}
+
+func (uc *MCPWebhookToolsUseCase) GetWebhook(ctx context.Context, webhookID, userID string, teamIDs []string) (*WebhookInfo, error) {
+	webhook, err := uc.repo.Get(ctx, webhookID)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccessOwnedResource(webhook.Scope(), webhook.UserID(), webhook.TeamID(), userID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+	info := toWebhookInfo(webhook)
+	return &info, nil
+}
+
+func (uc *MCPWebhookToolsUseCase) TriggerWebhook(ctx context.Context, input TriggerWebhookInput, userID string, teamIDs []string) (*TriggerWebhookResult, error) {
+	if input.WebhookID == "" {
+		return nil, fmt.Errorf("webhook_id is required")
+	}
+	if input.Payload == nil {
+		return nil, fmt.Errorf("payload is required")
+	}
+
+	webhook, err := uc.repo.Get(ctx, input.WebhookID)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccessOwnedResource(webhook.Scope(), webhook.UserID(), webhook.TeamID(), userID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	switch webhook.WebhookType() {
+	case entities.WebhookTypeGitHub:
+		return uc.triggerGitHubWebhook(ctx, webhook, input)
+	case entities.WebhookTypeCustom:
+		return uc.triggerCustomWebhook(ctx, webhook, input)
+	default:
+		return nil, fmt.Errorf("unsupported webhook type")
+	}
+}
+
+func (uc *MCPWebhookToolsUseCase) triggerGitHubWebhook(ctx context.Context, webhook *entities.Webhook, input TriggerWebhookInput) (*TriggerWebhookResult, error) {
+	if input.Event == "" {
+		return nil, fmt.Errorf("event is required for GitHub webhooks")
+	}
+
+	payloadBytes, _ := json.Marshal(input.Payload)
+	var payload controllers.GitHubPayload
+	_ = json.Unmarshal(payloadBytes, &payload)
+	payload.Raw = input.Payload
+
+	match := uc.githubController.MatchTriggersForTest(webhook.Triggers(), input.Event, &payload)
+	result := &TriggerWebhookResult{DryRun: input.DryRun, Matched: match != nil}
+	if match == nil {
+		return result, nil
+	}
+	result.MatchedTrigger = &TriggerMatchedTriggerInfo{ID: match.ID(), Name: match.Name()}
+
+	tags := uc.githubController.BuildGitHubTagsForTest(webhook, match, input.Event, &payload)
+	defaultMessage := uc.githubController.BuildDefaultInitialMessageForTest(input.Event, &payload)
+	if input.DryRun {
+		dryResult, err := uc.githubController.SessionService().DryRunSessionConfig(controllers.SessionCreationParams{
+			Webhook: webhook, Trigger: match, Payload: input.Payload, Tags: tags, DefaultMessage: defaultMessage,
+		})
+		applyDryRunResult(result, dryResult, err)
+		return result, nil
+	}
+
+	sessionID, reused, err := uc.githubController.SessionService().CreateSessionFromWebhook(ctx, controllers.SessionCreationParams{
+		Webhook: webhook, Trigger: match, Payload: input.Payload, Tags: tags, DefaultMessage: defaultMessage,
+	})
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+	result.SessionID = sessionID
+	result.SessionReused = reused
+	return result, nil
+}
+
+func (uc *MCPWebhookToolsUseCase) triggerCustomWebhook(ctx context.Context, webhook *entities.Webhook, input TriggerWebhookInput) (*TriggerWebhookResult, error) {
+	match := uc.customController.MatchTriggersForTest(webhook.Triggers(), input.Payload)
+	result := &TriggerWebhookResult{DryRun: input.DryRun, Matched: match != nil}
+	if match == nil {
+		return result, nil
+	}
+	result.MatchedTrigger = &TriggerMatchedTriggerInfo{ID: match.ID(), Name: match.Name()}
+
+	tags := uc.customController.BuildCustomTagsForTest(webhook, match)
+	defaultMessage := uc.customController.BuildDefaultMessageForTest(input.Payload)
+	if input.DryRun {
+		dryResult, err := uc.customController.SessionService().DryRunSessionConfig(controllers.SessionCreationParams{
+			Webhook: webhook, Trigger: match, Payload: input.Payload, Tags: tags, DefaultMessage: defaultMessage,
+		})
+		applyDryRunResult(result, dryResult, err)
+		return result, nil
+	}
+
+	sessionID, reused, err := uc.customController.SessionService().CreateSessionFromWebhook(ctx, controllers.SessionCreationParams{
+		Webhook: webhook, Trigger: match, Payload: input.Payload, Tags: tags, DefaultMessage: defaultMessage,
+	})
+	if err != nil {
+		result.Error = err.Error()
+		return result, nil
+	}
+	result.SessionID = sessionID
+	result.SessionReused = reused
+	return result, nil
+}
+
+func applyDryRunResult(result *TriggerWebhookResult, dryResult *controllers.DryRunResult, err error) {
+	if err != nil {
+		result.Error = err.Error()
+		return
+	}
+	if dryResult.Error != "" {
+		result.Error = dryResult.Error
+		return
+	}
+	result.InitialMessage = dryResult.InitialMessage
+	result.Tags = dryResult.Tags
+	result.Environment = dryResult.Environment
+}
+
+type ListSchedulesInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type ScheduleInfo struct {
+	ID              string                    `json:"id"`
+	Name            string                    `json:"name"`
+	UserID          string                    `json:"user_id"`
+	Scope           string                    `json:"scope"`
+	TeamID          string                    `json:"team_id,omitempty"`
+	Status          string                    `json:"status"`
+	ScheduledAt     *time.Time                `json:"scheduled_at,omitempty"`
+	CronExpr        string                    `json:"cron_expr,omitempty"`
+	Timezone        string                    `json:"timezone,omitempty"`
+	SessionConfig   schedule.SessionConfig    `json:"session_config"`
+	LastExecution   *schedule.ExecutionRecord `json:"last_execution,omitempty"`
+	NextExecutionAt *time.Time                `json:"next_execution_at,omitempty"`
+	ExecutionCount  int                       `json:"execution_count"`
+	CreatedAt       time.Time                 `json:"created_at"`
+	UpdatedAt       time.Time                 `json:"updated_at"`
+}
+
+type TriggerScheduleResult struct {
+	SessionID     string    `json:"session_id"`
+	TriggeredAt   time.Time `json:"triggered_at"`
+	SessionReused bool      `json:"session_reused"`
+}
+
+func (uc *MCPScheduleToolsUseCase) ListSchedules(ctx context.Context, input ListSchedulesInput, userID string, teamIDs []string) ([]ScheduleInfo, error) {
+	filter := schedule.ScheduleFilter{
+		Scope:   entities.ResourceScope(input.Scope),
+		TeamID:  input.TeamID,
+		TeamIDs: teamIDs,
+		Status:  schedule.ScheduleStatus(input.Status),
+	}
+	if input.Scope != string(entities.ScopeTeam) && input.TeamID == "" {
+		filter.UserID = userID
+	}
+
+	schedules, err := uc.manager.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]ScheduleInfo, 0, len(schedules))
+	for _, item := range schedules {
+		if !visibleInScope(input.Scope, item.GetScope()) || !canAccessOwnedResource(item.GetScope(), item.UserID, item.TeamID, userID, teamIDs) {
+			continue
+		}
+		result = append(result, toScheduleInfo(item))
+	}
+	return result, nil
+}
+
+func (uc *MCPScheduleToolsUseCase) GetSchedule(ctx context.Context, scheduleID, userID string, teamIDs []string) (*ScheduleInfo, error) {
+	item, err := uc.manager.Get(ctx, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccessOwnedResource(item.GetScope(), item.UserID, item.TeamID, userID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+	info := toScheduleInfo(item)
+	return &info, nil
+}
+
+func (uc *MCPScheduleToolsUseCase) TriggerSchedule(ctx context.Context, scheduleID, userID string, teamIDs []string) (*TriggerScheduleResult, error) {
+	item, err := uc.manager.Get(ctx, scheduleID)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccessOwnedResource(item.GetScope(), item.UserID, item.TeamID, userID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+
+	sessionID := uuid.New().String()
+	scope := item.GetScope()
+	teams := sessionuc.ResolveTeams(scope, item.TeamID, teamIDs)
+	if len(teams) == 0 {
+		teams = sessionuc.ResolveTeams(scope, item.TeamID, item.UserTeams)
+	}
+
+	tags := item.SessionConfig.Tags
+	if tags == nil {
+		tags = make(map[string]string)
+	}
+	tags["schedule_id"] = item.ID
+	tags["schedule_name"] = item.Name
+
+	req := sessionuc.LaunchRequest{
+		UserID:           item.UserID,
+		Scope:            scope,
+		TeamID:           item.TeamID,
+		Teams:            teams,
+		Environment:      item.SessionConfig.Environment,
+		Tags:             tags,
+		MemoryKey:        item.SessionConfig.MemoryKey,
+		RepoInfo:         app.ExtractRepositoryInfo(tags, sessionID),
+		SessionProfileID: item.SessionConfig.SessionProfileID,
+		ReuseSession:     item.SessionConfig.ReuseSession,
+		ReuseMatchTags:   map[string]string{"schedule_id": item.ID},
+		ReuseMessage:     item.SessionConfig.ReuseMessage,
+	}
+	if item.SessionConfig.Params != nil {
+		req.InitialMessage = item.SessionConfig.Params.Message
+		if scope != entities.ScopeTeam {
+			req.GithubToken = item.SessionConfig.Params.GithubToken
+		}
+		req.AgentType = item.SessionConfig.Params.AgentType
+		req.SlackParams = item.SessionConfig.Params.Slack
+		req.Sandbox = item.SessionConfig.Params.Sandbox
+		req.Docker = item.SessionConfig.Params.Docker
+		req.Oneshot = item.SessionConfig.Params.Oneshot
+		req.InitialMessageWaitSecond = item.SessionConfig.Params.InitialMessageWaitSecond
+		req.CycleMessage = item.SessionConfig.Params.CycleMessage
+		req.CycleMaxCount = item.SessionConfig.Params.CycleMaxCount
+		req.SessionTTL = item.SessionConfig.Params.SessionTTL
+	}
+
+	launchResult, err := uc.launcher.Launch(ctx, sessionID, req)
+	record := schedule.ExecutionRecord{ExecutedAt: time.Now()}
+	if err != nil {
+		record.Status = "failed"
+		record.Error = err.Error()
+		_ = uc.manager.RecordExecution(ctx, scheduleID, record)
+		return nil, err
+	}
+
+	record.Status = "success"
+	record.SessionID = launchResult.SessionID
+	record.SessionReused = launchResult.SessionReused
+	_ = uc.manager.RecordExecution(ctx, scheduleID, record)
+	return &TriggerScheduleResult{SessionID: launchResult.SessionID, TriggeredAt: record.ExecutedAt, SessionReused: launchResult.SessionReused}, nil
+}
+
+type ListSlackBotsInput struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type SlackBotInfo struct {
+	ID                     string             `json:"id"`
+	Name                   string             `json:"name"`
+	UserID                 string             `json:"user_id"`
+	Scope                  string             `json:"scope"`
+	TeamID                 string             `json:"team_id,omitempty"`
+	Teams                  []string           `json:"teams,omitempty"`
+	Status                 string             `json:"status"`
+	BotTokenSecretName     string             `json:"bot_token_secret_name,omitempty"`
+	BotTokenSecretKey      string             `json:"bot_token_secret_key,omitempty"`
+	AppTokenSecretKey      string             `json:"app_token_secret_key,omitempty"`
+	AllowedEventTypes      []string           `json:"allowed_event_types,omitempty"`
+	AllowedChannelNames    []string           `json:"allowed_channel_names,omitempty"`
+	AllowedUserIDs         []string           `json:"allowed_user_ids,omitempty"`
+	SessionConfig          *SessionConfigInfo `json:"session_config,omitempty"`
+	MaxSessions            int                `json:"max_sessions"`
+	NotifyOnSessionCreated bool               `json:"notify_on_session_created"`
+	AllowBotMessages       bool               `json:"allow_bot_messages"`
+	CreatedAt              time.Time          `json:"created_at"`
+	UpdatedAt              time.Time          `json:"updated_at"`
+}
+
+func (uc *MCPSlackBotToolsUseCase) ListSlackBots(ctx context.Context, input ListSlackBotsInput, userID string, teamIDs []string) ([]SlackBotInfo, error) {
+	bots, err := uc.repo.List(ctx, portrepos.SlackBotFilter{
+		UserID:  userID,
+		TeamIDs: teamIDs,
+		Scope:   entities.ResourceScope(input.Scope),
+		TeamID:  input.TeamID,
+		Status:  entities.SlackBotStatus(input.Status),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]SlackBotInfo, 0, len(bots))
+	for _, bot := range bots {
+		if !canAccessOwnedResource(bot.Scope(), bot.UserID(), bot.TeamID(), userID, teamIDs) {
+			continue
+		}
+		result = append(result, toSlackBotInfo(bot))
+	}
+	return result, nil
+}
+
+func (uc *MCPSlackBotToolsUseCase) GetSlackBot(ctx context.Context, botID, userID string, teamIDs []string) (*SlackBotInfo, error) {
+	bot, err := uc.repo.Get(ctx, botID)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccessOwnedResource(bot.Scope(), bot.UserID(), bot.TeamID(), userID, teamIDs) {
+		return nil, fmt.Errorf("access denied")
+	}
+	info := toSlackBotInfo(bot)
+	return &info, nil
+}
+
+func visibleInScope(requestedScope string, resourceScope entities.ResourceScope) bool {
+	if requestedScope == string(entities.ScopeTeam) {
+		return resourceScope == entities.ScopeTeam
+	}
+	return resourceScope != entities.ScopeTeam
+}
+
+func canAccessOwnedResource(scope entities.ResourceScope, ownerID, teamID, userID string, teamIDs []string) bool {
+	switch scope {
+	case entities.ScopeTeam:
+		return containsTeam(teamIDs, teamID)
+	default:
+		return ownerID == userID
+	}
+}
+
+func toWebhookInfo(webhook *entities.Webhook) WebhookInfo {
+	info := WebhookInfo{
+		ID:              webhook.ID(),
+		Name:            webhook.Name(),
+		UserID:          webhook.UserID(),
+		Scope:           string(webhook.Scope()),
+		TeamID:          webhook.TeamID(),
+		Status:          string(webhook.Status()),
+		Type:            string(webhook.WebhookType()),
+		SignatureHeader: webhook.SignatureHeader(),
+		SignatureType:   string(webhook.SignatureType()),
+		SignaturePrefix: webhook.SignaturePrefix(),
+		SessionConfig:   toSessionConfigInfo(webhook.SessionConfig()),
+		MaxSessions:     webhook.MaxSessions(),
+		CreatedAt:       webhook.CreatedAt(),
+		UpdatedAt:       webhook.UpdatedAt(),
+		DeliveryCount:   webhook.DeliveryCount(),
+	}
+	if github := webhook.GitHub(); github != nil {
+		info.GitHub = &GitHubConfigInfo{
+			EnterpriseURL:       github.EnterpriseURL(),
+			AllowedEvents:       github.AllowedEvents(),
+			AllowedRepositories: github.AllowedRepositories(),
+		}
+	}
+	for _, trigger := range webhook.Triggers() {
+		info.Triggers = append(info.Triggers, toWebhookTriggerInfo(trigger))
+	}
+	if delivery := webhook.LastDelivery(); delivery != nil {
+		info.LastDelivery = &DeliveryInfo{
+			ID:             delivery.ID(),
+			ReceivedAt:     delivery.ReceivedAt(),
+			Status:         string(delivery.Status()),
+			MatchedTrigger: delivery.MatchedTrigger(),
+			SessionID:      delivery.SessionID(),
+			Error:          delivery.Error(),
+			SessionReused:  delivery.SessionReused(),
+		}
+	}
+	return info
+}
+
+func toWebhookTriggerInfo(trigger entities.WebhookTrigger) WebhookTriggerInfo {
+	conditions := trigger.Conditions()
+	info := WebhookTriggerInfo{
+		ID:            trigger.ID(),
+		Name:          trigger.Name(),
+		Priority:      trigger.Priority(),
+		Enabled:       trigger.Enabled(),
+		Conditions:    WebhookConditionsInfo{GoTemplate: conditions.GoTemplate()},
+		SessionConfig: toSessionConfigInfo(trigger.SessionConfig()),
+		StopOnMatch:   trigger.StopOnMatch(),
+	}
+	if github := conditions.GitHub(); github != nil {
+		info.Conditions.GitHub = &GitHubConditionsInfo{
+			Events:       github.Events(),
+			Actions:      github.Actions(),
+			Branches:     github.Branches(),
+			Repositories: github.Repositories(),
+			Labels:       github.Labels(),
+			Paths:        github.Paths(),
+			BaseBranches: github.BaseBranches(),
+			Draft:        github.Draft(),
+			Sender:       github.Sender(),
+		}
+	}
+	return info
+}
+
+func toSessionConfigInfo(config *entities.WebhookSessionConfig) *SessionConfigInfo {
+	if config == nil {
+		return nil
+	}
+	info := &SessionConfigInfo{
+		Environment:            config.Environment(),
+		Tags:                   config.Tags(),
+		InitialMessageTemplate: config.InitialMessageTemplate(),
+		ReuseMessageTemplate:   config.ReuseMessageTemplate(),
+		ReuseSession:           config.ReuseSession(),
+		MountPayload:           config.MountPayload(),
+		MemoryKey:              config.MemoryKey(),
+		SessionProfileID:       config.SessionProfileID(),
+	}
+	if params := config.Params(); params != nil {
+		info.Params = &SessionParamsInfo{
+			AgentType:    params.AgentType,
+			Oneshot:      params.Oneshot,
+			RepoFullName: params.RepoFullName,
+		}
+	}
+	return info
+}
+
+func toScheduleInfo(item *schedule.Schedule) ScheduleInfo {
+	return ScheduleInfo{
+		ID:              item.ID,
+		Name:            item.Name,
+		UserID:          item.UserID,
+		Scope:           string(item.GetScope()),
+		TeamID:          item.TeamID,
+		Status:          string(item.Status),
+		ScheduledAt:     item.ScheduledAt,
+		CronExpr:        item.CronExpr,
+		Timezone:        item.Timezone,
+		SessionConfig:   item.SessionConfig,
+		LastExecution:   item.LastExecution,
+		NextExecutionAt: item.NextExecutionAt,
+		ExecutionCount:  item.ExecutionCount,
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       item.UpdatedAt,
+	}
+}
+
+func toSlackBotInfo(bot *entities.SlackBot) SlackBotInfo {
+	return SlackBotInfo{
+		ID:                     bot.ID(),
+		Name:                   bot.Name(),
+		UserID:                 bot.UserID(),
+		Scope:                  string(bot.Scope()),
+		TeamID:                 bot.TeamID(),
+		Teams:                  bot.Teams(),
+		Status:                 string(bot.Status()),
+		BotTokenSecretName:     bot.BotTokenSecretName(),
+		BotTokenSecretKey:      bot.BotTokenSecretKey(),
+		AppTokenSecretKey:      bot.AppTokenSecretKey(),
+		AllowedEventTypes:      bot.AllowedEventTypes(),
+		AllowedChannelNames:    bot.AllowedChannelNames(),
+		AllowedUserIDs:         bot.AllowedUserIDs(),
+		SessionConfig:          toSessionConfigInfo(bot.SessionConfig()),
+		MaxSessions:            bot.MaxSessions(),
+		NotifyOnSessionCreated: bot.NotifyOnSessionCreated(),
+		AllowBotMessages:       bot.AllowBotMessages(),
+		CreatedAt:              bot.CreatedAt(),
+		UpdatedAt:              bot.UpdatedAt(),
+	}
+}

--- a/internal/usecases/mcp/webhook_schedule_slackbot_tools_test.go
+++ b/internal/usecases/mcp/webhook_schedule_slackbot_tools_test.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+func TestWebhookInfoDoesNotExposeSecret(t *testing.T) {
+	webhook := entities.NewWebhook("webhook-1", "test webhook", "user-1", entities.WebhookTypeGitHub)
+	webhook.SetSecret("super-secret-value")
+
+	data, err := json.Marshal(toWebhookInfo(webhook))
+	if err != nil {
+		t.Fatalf("marshal webhook info: %v", err)
+	}
+
+	body := string(data)
+	if strings.Contains(body, "super-secret-value") || strings.Contains(body, `"secret"`) {
+		t.Fatalf("webhook info exposed secret: %s", body)
+	}
+}
+
+func TestSlackBotInfoDoesNotExposeTokenValues(t *testing.T) {
+	bot := entities.NewSlackBot("bot-1", "test bot", "user-1")
+	bot.SetBotToken("xoxb-secret")
+	bot.SetAppToken("xapp-secret")
+
+	data, err := json.Marshal(toSlackBotInfo(bot))
+	if err != nil {
+		t.Fatalf("marshal slackbot info: %v", err)
+	}
+
+	body := string(data)
+	if strings.Contains(body, "xoxb-secret") || strings.Contains(body, "xapp-secret") {
+		t.Fatalf("slackbot info exposed token value: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary
- add MCP tools for webhook list/get/trigger with secret-free responses
- add MCP tools for schedule list/get/trigger using the existing schedule manager and launch path
- add MCP tools for slackbot list/get with token values excluded from responses
- wire webhook/slackbot repositories and schedule manager into the MCP server setup

## Tests
- mise exec -- go test ./internal/usecases/mcp ./internal/interfaces/mcp ./pkg/schedule ./pkg/webhook ./pkg/slackbot
- mise exec -- go test ./... -run '^$'

Closes #835