### PR TITLE
Support ACP session config updates

### DIFF
--- a/internal/interfaces/controllers/acp_controller.go
+++ b/internal/interfaces/controllers/acp_controller.go
@@ -109,7 +109,7 @@ func (c *ACPController) HandleRPC(ctx echo.Context) error {
 		return c.handleSessionResume(ctx, req)
 	case "session/load":
 		return c.handleSessionLoad(ctx, req)
-	case "session/prompt", "session/cancel":
+	case "session/prompt", "session/cancel", "session/set_config_option":
 		return c.proxyToBridge(ctx, req)
 	default:
 		return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32601, "Method not found: "+req.Method))
@@ -417,7 +417,7 @@ func (c *ACPController) getBridgeSessionID(addr, proxySessionID string) (string,
 	return bridgeSession.SessionId, nil
 }
 
-// proxyToBridge forwards session/prompt and session/cancel to the ACP bridge's
+// proxyToBridge forwards session/prompt, session/cancel, and session/set_config_option to the ACP bridge's
 // /rpc endpoint. Requires the session to run with an ACP-native agent (e.g. claude-acp).
 func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 	var baseParams struct {
@@ -481,6 +481,13 @@ func (c *ACPController) proxyToBridge(ctx echo.Context, req acpRequest) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if req.Method == "session/set_config_option" {
+			var rpcResp acpResponse
+			if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+				return ctx.JSON(http.StatusOK, acpErrResp(req.ID, -32603, "failed to decode bridge response: "+err.Error()))
+			}
+			return ctx.JSON(http.StatusOK, rpcResp)
+		}
 		return ctx.JSON(http.StatusOK, acpSuccessResp(req.ID, struct{}{}))
 	}
 

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -483,6 +483,31 @@ func (b *Bridge) HandleReply(id int64, result json.RawMessage) error {
 	return nil
 }
 
+// SetSessionConfigOption forwards a session/set_config_option request to the ACP agent.
+// The result is also emitted as a config_option_update notification so live UI clients
+// observe the same configuration state that the HTTP caller receives.
+func (b *Bridge) SetSessionConfigOption(ctx context.Context, configId, value string) (acp.SessionSetConfigOptionResult, error) {
+	result, err := b.acp.SetSessionConfigOption(ctx, configId, value)
+	if err != nil {
+		return acp.SessionSetConfigOptionResult{}, err
+	}
+
+	b.broadcast(jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: b.sessionId,
+			Update: acp.SessionUpdate{
+				Kind:          acp.SessionUpdateKindConfigOptionUpdate,
+				ConfigOptions: result.ConfigOptions,
+			},
+			Time: time.Now(),
+		},
+	})
+
+	return result, nil
+}
+
 // Cancel cancels the current agent turn.
 func (b *Bridge) Cancel(ctx context.Context) error {
 	return b.acp.Cancel(ctx)

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -168,6 +168,7 @@ type rpcEnvelope struct {
 //  1. Client-initiated requests (id + method):
 //     - "session/prompt"  → forwards text to ACP agent; result comes via SSE
 //     - "session/cancel"  → cancels the current agent turn
+//     - "session/set_config_option" → changes an ACP session config option
 //
 //  2. Client-initiated notifications (no id, method set):
 //     - "session/cancel"  → same as above, no response expected
@@ -236,6 +237,39 @@ func (s *Server) handleRPC(c echo.Context) error {
 		_ = s.bridge.Cancel(c.Request().Context())
 		// Notifications don't require a response; requests get a simple ack.
 		return c.JSON(http.StatusOK, map[string]bool{"ok": true})
+
+	case "session/set_config_option":
+		if env.ID == nil {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(nil, -32600, "id is required for session/set_config_option"))
+		}
+		var params acp.SessionSetConfigOptionParams
+		if err := json.Unmarshal(env.Params, &params); err != nil {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32602, "invalid params: "+err.Error()))
+		}
+		if params.ConfigId == "" {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32602, "configId is required"))
+		}
+		if params.SessionId != "" && params.SessionId != s.bridge.SessionID() {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32602, "sessionId does not match active ACP session"))
+		}
+		if params.Value == "" {
+			return c.JSON(http.StatusBadRequest,
+				rpcErrorResp(env.ID, -32602, "value is required"))
+		}
+		result, err := s.bridge.SetSessionConfigOption(c.Request().Context(), params.ConfigId, params.Value)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError,
+				rpcErrorResp(env.ID, -32000, err.Error()))
+		}
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      env.ID,
+			"result":  result,
+		})
 
 	default:
 		return c.JSON(http.StatusBadRequest,

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -63,6 +63,9 @@ func (c *Client) registerHandlers() {
 			log.Printf("[acp] session/update parse error: %v", err)
 			return
 		}
+		if n.Update.Kind == SessionUpdateKindConfigOptionUpdate {
+			c.updateSessionConfigOptions(n.Update.ConfigOptions)
+		}
 		select {
 		case c.updateCh <- n.Update:
 		default:
@@ -302,13 +305,24 @@ func (c *Client) setSessionRuntimeInfo(sessionId string, modes *SessionModeState
 	}
 }
 
+func (c *Client) updateSessionConfigOptions(configOptions []ConfigOption) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sessionInfo.ConfigOptions = configOptions
+	c.sessionInfo.Model = ExtractModelFromConfigOptions(configOptions)
+}
+
 // ExtractModelFromConfigOptions returns the most likely active model value from ACP config options.
 func ExtractModelFromConfigOptions(configOptions []ConfigOption) string {
 	for _, option := range configOptions {
+		id := strings.ToLower(strings.TrimSpace(option.ID))
 		key := strings.ToLower(strings.TrimSpace(option.Key))
 		name := strings.ToLower(strings.TrimSpace(option.Name))
+		category := strings.ToLower(strings.TrimSpace(option.Category))
 		description := strings.ToLower(option.Description)
-		if key != "model" && key != "modelid" && key != "model_id" &&
+		if category != "model" &&
+			id != "model" && id != "modelid" && id != "model_id" &&
+			key != "model" && key != "modelid" && key != "model_id" &&
 			name != "model" && name != "modelid" && name != "model_id" &&
 			!strings.Contains(description, "model") {
 			continue
@@ -363,6 +377,29 @@ func (c *Client) Prompt(ctx context.Context, text string) (StopReason, error) {
 		return "", fmt.Errorf("acp session/prompt: parse result: %w", err)
 	}
 	return result.StopReason, nil
+}
+
+// SetSessionConfigOption changes a runtime session configuration option.
+func (c *Client) SetSessionConfigOption(ctx context.Context, configId, value string) (SessionSetConfigOptionResult, error) {
+	sessionId := c.SessionID()
+	if sessionId == "" {
+		return SessionSetConfigOptionResult{}, fmt.Errorf("acp: no active session; call NewSession first")
+	}
+	params := SessionSetConfigOptionParams{
+		SessionId: sessionId,
+		ConfigId:  configId,
+		Value:     value,
+	}
+	raw, err := c.rpc.Call(ctx, "session/set_config_option", params)
+	if err != nil {
+		return SessionSetConfigOptionResult{}, fmt.Errorf("acp session/set_config_option: %w", err)
+	}
+	var result SessionSetConfigOptionResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return SessionSetConfigOptionResult{}, fmt.Errorf("acp session/set_config_option: parse result: %w", err)
+	}
+	c.updateSessionConfigOptions(result.ConfigOptions)
+	return result, nil
 }
 
 // Cancel sends a session/cancel notification to abort the current turn.

--- a/pkg/acp/client_test.go
+++ b/pkg/acp/client_test.go
@@ -37,6 +37,21 @@ func TestExtractModelFromConfigOptions(t *testing.T) {
 			want: "gpt-5.1-codex",
 		},
 		{
+			name: "v1 model category with id",
+			options: []ConfigOption{
+				{
+					ID:           "model",
+					Category:     "model",
+					Type:         "select",
+					CurrentValue: "gpt-5.1-codex",
+					Options: []interface{}{
+						map[string]interface{}{"value": "gpt-5.1-codex", "name": "GPT-5.1 Codex"},
+					},
+				},
+			},
+			want: "gpt-5.1-codex",
+		},
+		{
 			name: "non model option ignored",
 			options: []ConfigOption{
 				{Key: "cwd", Default: "/workspace"},

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -104,12 +104,16 @@ type SessionModeState struct {
 
 // ConfigOption is a runtime config option offered by the agent.
 type ConfigOption struct {
-	Key          string      `json:"key"`
+	ID           string      `json:"id,omitempty"`
+	Key          string      `json:"key,omitempty"`
 	Name         string      `json:"name,omitempty"`
 	Description  string      `json:"description,omitempty"`
+	Category     string      `json:"category,omitempty"`
+	Type         string      `json:"type,omitempty"`
 	Value        interface{} `json:"value,omitempty"`
 	CurrentValue interface{} `json:"currentValue,omitempty"`
 	Default      interface{} `json:"default,omitempty"`
+	Options      interface{} `json:"options,omitempty"`
 }
 
 // SessionRuntimeInfo is the session metadata reported by ACP session/new or session/load.
@@ -157,6 +161,18 @@ type SessionLoadResult struct {
 type SessionSetModeParams struct {
 	SessionId string `json:"sessionId"`
 	Mode      string `json:"mode"`
+}
+
+// SessionSetConfigOptionParams is the params for "session/set_config_option".
+type SessionSetConfigOptionParams struct {
+	SessionId string `json:"sessionId"`
+	ConfigId  string `json:"configId"`
+	Value     string `json:"value"`
+}
+
+// SessionSetConfigOptionResult is the response to "session/set_config_option".
+type SessionSetConfigOptionResult struct {
+	ConfigOptions []ConfigOption `json:"configOptions"`
 }
 
 // ----------------------------------------------------------------------------
@@ -234,6 +250,7 @@ const (
 	SessionUpdateKindAvailableCommandsUpdate SessionUpdateKind = "available_commands_update"
 	SessionUpdateKindSessionInfoUpdate       SessionUpdateKind = "session_info_update"
 	SessionUpdateKindCurrentModeUpdate       SessionUpdateKind = "current_mode_update"
+	SessionUpdateKindConfigOptionUpdate      SessionUpdateKind = "config_option_update"
 )
 
 // ToolCallStatus describes the lifecycle state of a tool call.
@@ -280,6 +297,9 @@ type SessionUpdate struct {
 
 	// current_mode_update
 	Mode string `json:"mode,omitempty"`
+
+	// config_option_update
+	ConfigOptions []ConfigOption `json:"configOptions,omitempty"`
 }
 
 // SessionUpdateNotification is the params for the "session/update" notification


### PR DESCRIPTION
## Summary
- add ACP `session/set_config_option` params/results and config option fields for `id/category/type/options`
- forward `session/set_config_option` through both the per-session bridge `/rpc` and global `/acp` controller
- update ACP runtime info from set-config results and `config_option_update` notifications, and emit config updates over SSE
- extend model extraction coverage for ACP v1 model config options

## Verification
- `mise exec -- go test ./pkg/acp/... ./internal/interfaces/controllers`
- `mise exec -- go test ./pkg/acp/...`

## Notes
- `mise exec -- go test ./...` currently fails in `./cmd` in this in-cluster environment with `signal: interrupt` after initializing the Kubernetes session manager from ambient cluster env; targeted packages for this change pass.