### PR TITLE
Protect adopted sessions from stock purge

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -590,6 +590,12 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 	if err != nil {
 		return fmt.Errorf("failed to list stock services for purge: %w", err)
 	}
+	allSessionSvcs, err := m.client.CoreV1().Services(m.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/managed-by=agentapi-proxy,app.kubernetes.io/name=agentapi-session",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list session services for purge protection: %w", err)
+	}
 	deployments, err := m.client.AppsV1().Deployments(m.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})
@@ -614,6 +620,18 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 
 	var purgeErrs []string
 	sessionIDs := make(map[string]struct{})
+	adoptedSessionIDs := make(map[string]struct{})
+	for i := range allSessionSvcs.Items {
+		svc := &allSessionSvcs.Items[i]
+		sessionID := svc.Labels["agentapi.proxy/session-id"]
+		if sessionID == "" || svc.DeletionTimestamp != nil {
+			continue
+		}
+		stockState := svc.Labels["agentapi.proxy/stock"]
+		if stockState != "true" && stockState != "claiming" {
+			adoptedSessionIDs[sessionID] = struct{}{}
+		}
+	}
 	for i := range svcs.Items {
 		svc := &svcs.Items[i]
 		sessionID := svc.Labels["agentapi.proxy/session-id"]
@@ -628,16 +646,28 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 	}
 	for i := range deployments.Items {
 		if sessionID := deployments.Items[i].Labels["agentapi.proxy/session-id"]; sessionID != "" {
+			if _, adopted := adoptedSessionIDs[sessionID]; adopted {
+				log.Printf("[STOCK_INVENTORY] Skipping adopted session %s during stock purge (matched stale deployment label)", sessionID)
+				continue
+			}
 			sessionIDs[sessionID] = struct{}{}
 		}
 	}
 	for i := range pods.Items {
 		if sessionID := pods.Items[i].Labels["agentapi.proxy/session-id"]; sessionID != "" {
+			if _, adopted := adoptedSessionIDs[sessionID]; adopted {
+				log.Printf("[STOCK_INVENTORY] Skipping adopted session %s during stock purge (matched stale pod label)", sessionID)
+				continue
+			}
 			sessionIDs[sessionID] = struct{}{}
 		}
 	}
 	for i := range pvcs.Items {
 		if sessionID := pvcs.Items[i].Labels["agentapi.proxy/session-id"]; sessionID != "" {
+			if _, adopted := adoptedSessionIDs[sessionID]; adopted {
+				log.Printf("[STOCK_INVENTORY] Skipping adopted session %s during stock purge (matched stale pvc label)", sessionID)
+				continue
+			}
 			sessionIDs[sessionID] = struct{}{}
 		}
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager_workload_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_workload_test.go
@@ -234,3 +234,92 @@ func TestPurgeStockSessionsDeletesMixedWorkloadKindsAndPVC(t *testing.T) {
 		t.Fatalf("Expected orphaned PVC to be deleted, got err=%v", err)
 	}
 }
+
+func TestPurgeStockSessionsKeepsAdoptedSessionWithStaleStockWorkloadLabels(t *testing.T) {
+	manager := newWorkloadTestManager(t, true)
+	ctx := context.Background()
+	sessionID := "adopted-stock-session"
+	name := "agentapi-session-" + sessionID
+
+	adoptedServiceLabels := map[string]string{
+		"app.kubernetes.io/name":       "agentapi-session",
+		"app.kubernetes.io/managed-by": "agentapi-proxy",
+		"agentapi.proxy/session-id":    sessionID,
+		"agentapi.proxy/user-id":       "test-user",
+		"agentapi.proxy/scope":         "user",
+	}
+	staleStockLabels := map[string]string{
+		"app.kubernetes.io/name":            "agentapi-session",
+		"app.kubernetes.io/managed-by":      "agentapi-proxy",
+		"agentapi.proxy/session-id":         sessionID,
+		"agentapi.proxy/stock":              "true",
+		"agentapi.proxy/capability-sandbox": "false",
+		"agentapi.proxy/capability-dind":    "false",
+	}
+
+	_, err := manager.client.CoreV1().Services("test-ns").Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-svc",
+			Namespace: "test-ns",
+			Labels:    adoptedServiceLabels,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create adopted service: %v", err)
+	}
+	_, err = manager.client.AppsV1().Deployments("test-ns").Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+			Labels:    staleStockLabels,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create stale-labeled deployment: %v", err)
+	}
+	_, err = manager.client.CoreV1().Pods("test-ns").Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+			Labels:    staleStockLabels,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create stale-labeled pod: %v", err)
+	}
+	_, err = manager.client.CoreV1().PersistentVolumeClaims("test-ns").Create(ctx, &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-pvc",
+			Namespace: "test-ns",
+			Labels:    staleStockLabels,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create stale-labeled PVC: %v", err)
+	}
+
+	if err := manager.PurgeStockSessions(ctx); err != nil {
+		t.Fatalf("PurgeStockSessions failed: %v", err)
+	}
+
+	if _, err := manager.client.CoreV1().Services("test-ns").Get(ctx, name+"-svc", metav1.GetOptions{}); err != nil {
+		t.Fatalf("Expected adopted service to remain, got err=%v", err)
+	}
+	if _, err := manager.client.AppsV1().Deployments("test-ns").Get(ctx, name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("Expected stale-labeled deployment to remain, got err=%v", err)
+	}
+	if _, err := manager.client.CoreV1().Pods("test-ns").Get(ctx, name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("Expected stale-labeled pod to remain, got err=%v", err)
+	}
+	if _, err := manager.client.CoreV1().PersistentVolumeClaims("test-ns").Get(ctx, name+"-pvc", metav1.GetOptions{}); err != nil {
+		t.Fatalf("Expected stale-labeled PVC to remain, got err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- prevent stock inventory purge from deleting workloads for sessions that already have an adopted non-stock Service
- keep purge behavior for real stock and orphaned stock resources
- add regression coverage for stale stock labels left on adopted session workloads

## Why
A stock session can be adopted while stale stock labels remain on workload-side resources. On proxy startup, the stock inventory worker purges resources matching stock=true. If it collects the session ID from a stale workload label, it can delete the adopted session's Deployment/PVC while leaving the non-stock Service and settings Secrets behind.

## Test
- mise exec -- go test ./internal/infrastructure/services -run 'TestPurgeStockSessions|TestCreateSessionWorkload'
- mise exec -- go test ./internal/infrastructure/services