### PR TITLE
Add Cursor ACP agent type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -173,8 +173,8 @@ RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | 
     printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/node > /dev/null && \
     sudo chmod +x /usr/local/bin/node
 
-# Set combined PATH environment variable (including /opt/claude/bin for claude CLI)
-ENV PATH="/opt/claude/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:/home/agentapi/.bun/bin:/home/agentapi/.bun/bin:$PATH"
+# Set combined PATH environment variable (including /opt/claude/bin for claude CLI and /opt/cursor/bin for Cursor CLI)
+ENV PATH="/opt/claude/bin:/opt/cursor/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:/home/agentapi/.bun/bin:/home/agentapi/.bun/bin:$PATH"
 
 # install claude-agentapi
 RUN bun install -g @takutakahashi/claude-agentapi
@@ -187,6 +187,20 @@ RUN bun install -g @openai/codex && \
     printf '#!/bin/bash\nexec bun /home/agentapi/.bun/bin/codex "$@"\n' | \
     sudo tee /opt/claude/bin/codex > /dev/null && \
     sudo chmod +x /opt/claude/bin/codex
+
+# Install Cursor Agent CLI and place stable wrappers in /opt/cursor/bin.
+# Official install docs: https://cursor.com/docs/cli/installation
+RUN curl https://cursor.com/install -fsS | bash && \
+    sudo mkdir -p /opt/cursor/bin /opt/cursor/agent && \
+    CURSOR_AGENT_TARGET="$(readlink -f /home/agentapi/.local/bin/agent)" && \
+    sudo cp -a "$(dirname "$CURSOR_AGENT_TARGET")/." /opt/cursor/agent/ && \
+    sudo ln -sf /opt/cursor/agent/cursor-agent /opt/cursor/bin/agent && \
+    sudo ln -sf /opt/cursor/agent/cursor-agent /opt/cursor/bin/cursor-agent && \
+    sudo chown -R agentapi:agentapi /opt/cursor && \
+    sudo chmod +x /opt/cursor/agent/cursor-agent && \
+    rm -rf /home/agentapi/.local/share/cursor-agent /home/agentapi/.local/bin/agent /home/agentapi/.local/bin/cursor-agent 2>/dev/null || true && \
+    ln -sf /opt/cursor/bin/agent /home/agentapi/.local/bin/agent && \
+    ln -sf /opt/cursor/bin/cursor-agent /home/agentapi/.local/bin/cursor-agent
 
 # Install claude-agent-sdk CLI and create arch-agnostic symlink
 RUN bun install -g @anthropic-ai/claude-agent-sdk && \

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -556,6 +556,14 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 			Command: []string{"agentapi-proxy"},
 			Args:    []string{"acp-server", "--", "npx", "@zed-industries/codex-acp"},
 		}
+	case "cursor":
+		// acp-server bridges Cursor Agent CLI's native ACP server to the agentapi HTTP interface.
+		// https://cursor.com/docs/cli/acp
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server --auto-approve -- agent acp]")
+		return sessionsettings.StartupConfig{
+			Command: []string{"agentapi-proxy"},
+			Args:    []string{"acp-server", "--auto-approve", "--", "agent", "acp"},
+		}
 	default:
 		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi server --allowed-hosts * --allowed-origins *]")
 		return sessionsettings.StartupConfig{

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -34,6 +34,13 @@ func TestHelpersInit(t *testing.T) {
 	assert.Contains(t, commandNames, "compile-settings")
 }
 
+func TestBuildStartupConfigCursor(t *testing.T) {
+	config := buildStartupConfig("cursor")
+
+	assert.Equal(t, []string{"agentapi-proxy"}, config.Command)
+	assert.Equal(t, []string{"acp-server", "--auto-approve", "--", "agent", "acp"}, config.Args)
+}
+
 func TestGenerateTokenFlags(t *testing.T) {
 	// Test required flags
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1547,7 +1547,7 @@ func (m *KubernetesSessionManager) Shutdown(timeout time.Duration) error {
 }
 
 // SendMessage sends a message to an existing session.
-// For ACP sessions (claude-acp, codex-acp) it uses the ACP JSON-RPC 2.0
+// For ACP sessions (claude-acp, codex-acp, cursor) it uses the ACP JSON-RPC 2.0
 // POST /rpc endpoint with session/prompt; for standard agentapi sessions it
 // uses the agentapi-compatible POST /message endpoint.
 func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, message string) error {
@@ -1771,7 +1771,7 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 }
 
 func isACPAgentType(agentType string) bool {
-	return agentType == "claude-acp" || agentType == "codex-acp"
+	return agentType == "claude-acp" || agentType == "codex-acp" || agentType == "cursor"
 }
 
 func restoreAgentTypeFromService(svc *corev1.Service) string {
@@ -4475,6 +4475,20 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"--auto-approve",
 				"--",
 				"npx", "@zed-industries/codex-acp",
+			},
+		}
+	case "cursor":
+		// acp-server bridges Cursor Agent CLI's native ACP server to the agentapi HTTP interface.
+		// https://cursor.com/docs/cli/acp
+		// --auto-approve bypasses the UI permission modal at the ACP bridge layer.
+		settings.Startup = sessionsettings.StartupConfig{
+			Command: []string{"agentapi-proxy"},
+			Args: []string{
+				"acp-server",
+				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
+				"--auto-approve",
+				"--",
+				"agent", "acp",
 			},
 		}
 	default:

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -45,6 +45,12 @@ func TestBroadcastMessageUpdate_UpdatesLastMessageAt(t *testing.T) {
 	}
 }
 
+func TestIsACPAgentTypeIncludesCursor(t *testing.T) {
+	if !isACPAgentType("cursor") {
+		t.Fatal("expected cursor to be treated as an ACP agent type")
+	}
+}
+
 // TestSubscribeMessageEvents_ReceivesBroadcast verifies that a subscriber
 // registered before broadcastMessageUpdate is called receives the event.
 func TestSubscribeMessageEvents_ReceivesBroadcast(t *testing.T) {

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -913,6 +913,18 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 			"npx", "@zed-industries/codex-acp",
 		}
 
+	case "cursor":
+		// Start the acp-server bridge that wraps Cursor Agent CLI's native ACP server via stdio.
+		// https://cursor.com/docs/cli/acp
+		// --auto-approve bypasses the UI permission modal at the ACP bridge layer.
+		return "agentapi-proxy", []string{
+			"acp-server",
+			"--port", agentapiPort,
+			"--auto-approve",
+			"--",
+			"agent", "acp",
+		}
+
 	default:
 		// Default: agentapi server wrapping claude
 		claudeCmd := "claude"
@@ -986,7 +998,7 @@ type acpMessagesResponse struct {
 // started, replicating the logic of initialMessageSenderScript.
 func sendInitialMessage(ctx context.Context, agentapiURL, message, agentType string, waitSec int) {
 	// ACP sessions use a different transport (JSON-RPC 2.0 over POST /rpc).
-	if agentType == "claude-acp" || agentType == "codex-acp" {
+	if agentType == "claude-acp" || agentType == "codex-acp" || agentType == "cursor" {
 		sendACPInitialMessage(ctx, agentapiURL, message, waitSec)
 		return
 	}

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
 // TestWriteWebhookPayloadFile_WritesWhenAbsent verifies that
@@ -31,6 +34,22 @@ func TestWriteWebhookPayloadFile_WritesWhenAbsent(t *testing.T) {
 	}
 	if string(got) != `{"event":"push"}` {
 		t.Errorf("expected payload %q, got %q", `{"event":"push"}`, string(got))
+	}
+}
+
+func TestBuildAgentCommandCursor(t *testing.T) {
+	t.Setenv("AGENTAPI_PORT", "9000")
+
+	cmd, args := (&Server{}).buildAgentCommand(&sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{AgentType: "cursor"},
+	}, nil)
+
+	if cmd != "agentapi-proxy" {
+		t.Fatalf("command = %q, want agentapi-proxy", cmd)
+	}
+	want := []string{"acp-server", "--port", "9000", "--auto-approve", "--", "agent", "acp"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- install Cursor Agent CLI in the runtime image and expose stable agent/cursor-agent wrappers
- add agent_type=cursor using agentapi-proxy acp-server -- agent acp
- include cursor in ACP message handling and provisioner startup paths

## Verification
- mise exec -- go test ./cmd -run 'TestBuildStartupConfigCursor|TestHelpersCmd|TestHelpersInit'
- mise exec -- go test ./pkg/provisioner ./internal/infrastructure/services
- mise exec -- go build -o /tmp/agentapi-proxy-cursor-test main.go
- dev Helm chart 0.3.0-dev.20260618033922.2e4a7e3 deployed to agentapi-ui-dev
- created dev session with agent_type=cursor; Cursor ACP replied: cursor acp ok