### PR TITLE
Log raw ACP JSON-RPC messages

### DIFF
--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -23,6 +23,7 @@ var (
 	acpSessionFile string
 	acpOutputFile  string
 	acpVerbose     bool
+	acpRawJSONLog  bool
 	acpAutoApprove bool
 )
 
@@ -58,12 +59,18 @@ func init() {
 	AcpServerCmd.Flags().StringVar(&acpSessionFile, "session-file", "", "File to persist ACP session ID for reuse across restarts (defaults to {cwd}/.acp-session-id)")
 	AcpServerCmd.Flags().StringVar(&acpOutputFile, "output-file", "", "File to append conversation history in acp-posts JSONL format (for Slack integration)")
 	AcpServerCmd.Flags().BoolVarP(&acpVerbose, "verbose", "v", false, "Enable verbose logging")
+	AcpServerCmd.Flags().BoolVar(&acpRawJSONLog, "raw-json-log", false, "Log raw ACP JSON-RPC messages sent to and received from the agent")
 	AcpServerCmd.Flags().BoolVar(&acpAutoApprove, "auto-approve", false, "Automatically approve all permission requests without showing a UI modal")
 }
 
 func runAcpServer(cmd *cobra.Command, args []string) error {
 	if acpVerbose {
 		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
+	if acpRawJSONLog {
+		if err := os.Setenv("AGENTAPI_ACP_RAW_LOG", "1"); err != nil {
+			return fmt.Errorf("failed to enable ACP raw JSON logging: %w", err)
+		}
 	}
 
 	// Parse agent command from args (everything after "--" separator or all args).

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -559,10 +559,10 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 	case "cursor":
 		// acp-server bridges Cursor Agent CLI's native ACP server to the agentapi HTTP interface.
 		// https://cursor.com/docs/cli/acp
-		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server --auto-approve -- agent acp]")
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server --auto-approve --raw-json-log -- agent acp]")
 		return sessionsettings.StartupConfig{
 			Command: []string{"agentapi-proxy"},
-			Args:    []string{"acp-server", "--auto-approve", "--", "agent", "acp"},
+			Args:    []string{"acp-server", "--auto-approve", "--raw-json-log", "--", "agent", "acp"},
 		}
 	default:
 		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi server --allowed-hosts * --allowed-origins *]")

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -38,7 +38,7 @@ func TestBuildStartupConfigCursor(t *testing.T) {
 	config := buildStartupConfig("cursor")
 
 	assert.Equal(t, []string{"agentapi-proxy"}, config.Command)
-	assert.Equal(t, []string{"acp-server", "--auto-approve", "--", "agent", "acp"}, config.Args)
+	assert.Equal(t, []string{"acp-server", "--auto-approve", "--raw-json-log", "--", "agent", "acp"}, config.Args)
 }
 
 func TestGenerateTokenFlags(t *testing.T) {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4487,6 +4487,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"acp-server",
 				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
 				"--auto-approve",
+				"--raw-json-log",
 				"--",
 				"agent", "acp",
 			},

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -85,9 +85,10 @@ type Bridge struct {
 	// emits them as a single batched session/update when the kind changes or the
 	// agent turn ends.  This converts the per-chunk stream into a per-comment bulk
 	// delivery so that consumers receive one complete message at a time.
-	chunkMu   sync.Mutex
-	chunkKind acp.SessionUpdateKind
-	chunkText strings.Builder
+	chunkMu              sync.Mutex
+	chunkKind            acp.SessionUpdateKind
+	chunkText            strings.Builder
+	lastAgentMessageText string
 
 	// Status tracking: "running" while a prompt is being processed, "stable" otherwise.
 	// Mirrors the agentapi status convention so the proxy can watch GET /events.
@@ -295,6 +296,7 @@ func (b *Bridge) emitUpdate(update acp.SessionUpdate) {
 
 	// Non-chunk event: flush pending chunks first, then broadcast immediately.
 	b.flushChunkBuffer()
+	update = b.enrichToolCall(update)
 
 	msg := jsonRPCMsg{
 		JSONRPC: "2.0",
@@ -325,6 +327,9 @@ func (b *Bridge) flushChunkBufferLocked() {
 	kind := b.chunkKind
 	b.chunkKind = ""
 	b.chunkText.Reset()
+	if kind == acp.SessionUpdateKindAgentMessageChunk {
+		b.lastAgentMessageText = strings.TrimSpace(text)
+	}
 
 	contentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
 	now := time.Now()
@@ -348,6 +353,35 @@ func (b *Bridge) flushChunkBufferLocked() {
 		b.appendToOutputFile(text)
 	}
 	b.chunkMu.Lock()
+}
+
+func (b *Bridge) enrichToolCall(update acp.SessionUpdate) acp.SessionUpdate {
+	if update.Kind != acp.SessionUpdateKindToolCall || !isEmptyRawInput(update.RawInput) {
+		return update
+	}
+
+	b.chunkMu.Lock()
+	description := b.lastAgentMessageText
+	b.chunkMu.Unlock()
+	if description == "" {
+		return update
+	}
+
+	update.RawInput = map[string]string{"description": description}
+	return update
+}
+
+func isEmptyRawInput(rawInput interface{}) bool {
+	if rawInput == nil {
+		return true
+	}
+	if raw, ok := rawInput.(map[string]interface{}); ok {
+		return len(raw) == 0
+	}
+	if raw, ok := rawInput.(map[string]string); ok {
+		return len(raw) == 0
+	}
+	return false
 }
 
 // handlePermissionRequest emits a session/request_permission request via SSE

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -85,10 +85,9 @@ type Bridge struct {
 	// emits them as a single batched session/update when the kind changes or the
 	// agent turn ends.  This converts the per-chunk stream into a per-comment bulk
 	// delivery so that consumers receive one complete message at a time.
-	chunkMu              sync.Mutex
-	chunkKind            acp.SessionUpdateKind
-	chunkText            strings.Builder
-	lastAgentMessageText string
+	chunkMu   sync.Mutex
+	chunkKind acp.SessionUpdateKind
+	chunkText strings.Builder
 
 	// Status tracking: "running" while a prompt is being processed, "stable" otherwise.
 	// Mirrors the agentapi status convention so the proxy can watch GET /events.
@@ -296,7 +295,6 @@ func (b *Bridge) emitUpdate(update acp.SessionUpdate) {
 
 	// Non-chunk event: flush pending chunks first, then broadcast immediately.
 	b.flushChunkBuffer()
-	update = b.enrichToolCall(update)
 
 	msg := jsonRPCMsg{
 		JSONRPC: "2.0",
@@ -327,9 +325,6 @@ func (b *Bridge) flushChunkBufferLocked() {
 	kind := b.chunkKind
 	b.chunkKind = ""
 	b.chunkText.Reset()
-	if kind == acp.SessionUpdateKindAgentMessageChunk {
-		b.lastAgentMessageText = strings.TrimSpace(text)
-	}
 
 	contentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
 	now := time.Now()
@@ -353,35 +348,6 @@ func (b *Bridge) flushChunkBufferLocked() {
 		b.appendToOutputFile(text)
 	}
 	b.chunkMu.Lock()
-}
-
-func (b *Bridge) enrichToolCall(update acp.SessionUpdate) acp.SessionUpdate {
-	if update.Kind != acp.SessionUpdateKindToolCall || !isEmptyRawInput(update.RawInput) {
-		return update
-	}
-
-	b.chunkMu.Lock()
-	description := b.lastAgentMessageText
-	b.chunkMu.Unlock()
-	if description == "" {
-		return update
-	}
-
-	update.RawInput = map[string]string{"description": description}
-	return update
-}
-
-func isEmptyRawInput(rawInput interface{}) bool {
-	if rawInput == nil {
-		return true
-	}
-	if raw, ok := rawInput.(map[string]interface{}); ok {
-		return len(raw) == 0
-	}
-	if raw, ok := rawInput.(map[string]string); ok {
-		return len(raw) == 0
-	}
-	return false
 }
 
 // handlePermissionRequest emits a session/request_permission request via SSE

--- a/pkg/acp/jsonrpc/client.go
+++ b/pkg/acp/jsonrpc/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"sync"
 	"sync/atomic"
 )
@@ -69,6 +70,7 @@ type Client struct {
 	notifHandlers map[string]NotificationHandler
 
 	verbose bool
+	rawLog  bool
 }
 
 // New creates a new Client.
@@ -80,6 +82,16 @@ func New(r io.Reader, w io.Writer, verbose bool) *Client {
 		reqHandlers:   make(map[string]RequestHandler),
 		notifHandlers: make(map[string]NotificationHandler),
 		verbose:       verbose,
+		rawLog:        verbose || envBool("AGENTAPI_ACP_RAW_LOG"),
+	}
+}
+
+func envBool(name string) bool {
+	switch os.Getenv(name) {
+	case "1", "true", "TRUE", "True", "yes", "YES", "on", "ON":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -173,9 +185,9 @@ func (c *Client) Respond(id json.RawMessage, result interface{}, rpcErr *RPCErro
 func (c *Client) send(msg Message) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.verbose {
-		b, _ := json.Marshal(msg)
-		log.Printf("[jsonrpc] --> %s", b)
+	if c.rawLog {
+		raw, _ := json.Marshal(msg)
+		log.Printf("[acp-raw-json] --> %s", raw)
 	}
 	return c.encoder.Encode(msg)
 }
@@ -191,17 +203,21 @@ func (c *Client) Listen(ctx context.Context) error {
 		default:
 		}
 
-		var msg Message
-		if err := c.decoder.Decode(&msg); err != nil {
+		var raw json.RawMessage
+		if err := c.decoder.Decode(&raw); err != nil {
 			if err == io.EOF {
 				return fmt.Errorf("jsonrpc: connection closed")
 			}
 			return fmt.Errorf("jsonrpc: decode: %w", err)
 		}
 
-		if c.verbose {
-			b, _ := json.Marshal(msg)
-			log.Printf("[jsonrpc] <-- %s", b)
+		if c.rawLog {
+			log.Printf("[acp-raw-json] <-- %s", raw)
+		}
+
+		var msg Message
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			return fmt.Errorf("jsonrpc: unmarshal: %w", err)
 		}
 
 		c.dispatch(ctx, &msg)

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -921,6 +921,7 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 			"acp-server",
 			"--port", agentapiPort,
 			"--auto-approve",
+			"--raw-json-log",
 			"--",
 			"agent", "acp",
 		}

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -47,7 +47,7 @@ func TestBuildAgentCommandCursor(t *testing.T) {
 	if cmd != "agentapi-proxy" {
 		t.Fatalf("command = %q, want agentapi-proxy", cmd)
 	}
-	want := []string{"acp-server", "--port", "9000", "--auto-approve", "--", "agent", "acp"}
+	want := []string{"acp-server", "--port", "9000", "--auto-approve", "--raw-json-log", "--", "agent", "acp"}
 	if !reflect.DeepEqual(args, want) {
 		t.Fatalf("args = %#v, want %#v", args, want)
 	}


### PR DESCRIPTION
## Summary
- add --raw-json-log to acp-server and AGENTAPI_ACP_RAW_LOG support
- log exact JSON-RPC messages sent to and received from ACP agents with [acp-raw-json] direction markers
- enable raw JSON logging for Cursor ACP startup paths so Cursor tool_call payloads can be inspected in pod logs

## Verification
- mise exec -- go test ./pkg/acp/...
- mise exec -- go test ./cmd -run 'TestBuildStartupConfigCursor|TestHelpersCmd|TestHelpersInit'
- mise exec -- go test ./pkg/provisioner -run TestBuildAgentCommandCursor
- mise exec -- go test ./cmd -run TestNonExistent -count=0

Note: a broad cmd package test run still hits existing server-starting tests and was interrupted by signal after initializing Kubernetes session manager; targeted tests and compile check passed.