### PR TITLE
Fix setup-gh step execution

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -107,9 +107,18 @@ Optional settings:
 - GITHUB_API: GitHub API URL for Enterprise Server (e.g., https://github.enterprise.com/api/v3)
 - GITHUB_REPO_FULLNAME: Repository full name for installation ID discovery (auto-detected from git remote if not provided)
 
+Steps:
+- all: Run get-token, auth-login, and setup-git behavior (default)
+- get-token: Resolve and print the GitHub token
+- auth-login: Run gh auth login --with-token
+- setup-git: Run gh auth setup-git
+
 Usage:
   agentapi-proxy helpers setup-gh                    # Auto-detect repository from git remote
   agentapi-proxy helpers setup-gh --repo-fullname owner/repo
+  agentapi-proxy helpers setup-gh --step get-token
+  agentapi-proxy helpers setup-gh --step auth-login
+  agentapi-proxy helpers setup-gh --step setup-git
   
 Examples:
   # Using personal access token
@@ -139,6 +148,7 @@ var githubAppPEM string
 var githubAPI string
 var githubToken string
 var githubPersonalAccessToken string
+var setupGHStep string
 
 func init() {
 	generateTokenCmd.Flags().StringVar(&outputPath, "output-path", "", "Path to JSON file where API keys will be saved (required)")
@@ -164,6 +174,7 @@ func init() {
 	setupGHCmd.Flags().StringVar(&githubAPI, "github-api", "", "GitHub API URL for Enterprise Server (can also be set via GITHUB_API env var)")
 	setupGHCmd.Flags().StringVar(&githubToken, "github-token", "", "GitHub personal access token (can also be set via GITHUB_TOKEN env var)")
 	setupGHCmd.Flags().StringVar(&githubPersonalAccessToken, "github-personal-access-token", "", "GitHub personal access token (can also be set via GITHUB_PERSONAL_ACCESS_TOKEN env var)")
+	setupGHCmd.Flags().StringVar(&setupGHStep, "step", "all", "Setup step to run: all, get-token, auth-login, setup-git")
 
 	// send-notification command flags
 	sendNotificationCmd.Flags().StringVar(&notifyUserID, "user-id", "", "Target specific user ID")
@@ -385,11 +396,14 @@ func runSetupGH(cmd *cobra.Command, args []string) error {
 	}
 
 	// Call the startup package function
-	if err := startup.SetupGitHubAuth(repo); err != nil {
+	if err := startup.SetupGitHubAuthStep(repo, setupGHStep); err != nil {
 		return fmt.Errorf("failed to setup GitHub authentication: %w", err)
 	}
 
-	fmt.Println("GitHub authentication setup completed successfully!")
+	normalizedStep := strings.ToLower(strings.TrimSpace(setupGHStep))
+	if normalizedStep != "get-token" && normalizedStep != "token" {
+		fmt.Println("GitHub authentication setup completed successfully!")
+	}
 	return nil
 }
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -322,6 +322,10 @@ func TestSetupGHFlags(t *testing.T) {
 
 	patFlag := setupGHCmd.LocalFlags().Lookup("github-personal-access-token")
 	assert.NotNil(t, patFlag)
+
+	stepFlag := setupGHCmd.LocalFlags().Lookup("step")
+	assert.NotNil(t, stepFlag)
+	assert.Equal(t, "all", stepFlag.DefValue)
 }
 
 func TestSetGitHubEnvFromFlags(t *testing.T) {

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -567,14 +567,55 @@ func getGitHubURL() string {
 
 // SetupGitHubAuth sets up GitHub authentication using gh CLI
 func SetupGitHubAuth(repoFullName string) error {
+	return SetupGitHubAuthStep(repoFullName, "all")
+}
+
+// SetupGitHubAuthStep runs one GitHub authentication setup step.
+func SetupGitHubAuthStep(repoFullName, step string) error {
+	requestedStep := step
+	step = normalizeGitHubAuthStep(step)
+	if step == "" {
+		return fmt.Errorf("invalid GitHub auth setup step %q (valid: all, get-token, auth-login, setup-git)", requestedStep)
+	}
+
 	log.Printf("Setting up GitHub authentication for repository: %s", repoFullName)
 
 	// Determine GitHub host
-	githubHost := "github.com"
-	if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" && githubAPI != "https://api.github.com" {
-		githubHost = strings.TrimPrefix(githubAPI, "https://")
-		githubHost = strings.TrimPrefix(githubHost, "http://")
-		githubHost = strings.TrimSuffix(githubHost, "/api/v3")
+	githubHost := getGitHubAuthHost()
+
+	switch step {
+	case "get-token":
+		token, err := GetGitHubToken(repoFullName)
+		if err != nil {
+			return fmt.Errorf("failed to get GitHub token: %w", err)
+		}
+		fmt.Println(token)
+		return nil
+	case "auth-login":
+		token, err := GetGitHubToken(repoFullName)
+		if err != nil {
+			return fmt.Errorf("failed to get GitHub token: %w", err)
+		}
+
+		env := os.Environ()
+		if githubHost != "github.com" {
+			env = append(env, fmt.Sprintf("GH_HOST=%s", githubHost))
+		}
+
+		if err := performGHAuthLogin(githubHost, token, env); err != nil {
+			return fmt.Errorf("failed to authenticate gh CLI: %w", err)
+		}
+		return nil
+	case "setup-git":
+		env := os.Environ()
+		if githubHost != "github.com" {
+			env = append(env, fmt.Sprintf("GH_HOST=%s", githubHost))
+		}
+
+		if err := performGHAuthSetupGit(githubHost, env); err != nil {
+			return fmt.Errorf("failed to setup git authentication: %w", err)
+		}
+		return nil
 	}
 
 	// Check if GITHUB_TOKEN is already set in the environment
@@ -638,6 +679,31 @@ func SetupGitHubAuth(repoFullName string) error {
 	return nil
 }
 
+func normalizeGitHubAuthStep(step string) string {
+	switch strings.ToLower(strings.TrimSpace(step)) {
+	case "", "all":
+		return "all"
+	case "token", "get-token":
+		return "get-token"
+	case "login", "auth-login":
+		return "auth-login"
+	case "git", "setup-git":
+		return "setup-git"
+	default:
+		return ""
+	}
+}
+
+func getGitHubAuthHost() string {
+	githubHost := "github.com"
+	if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" && githubAPI != "https://api.github.com" {
+		githubHost = strings.TrimPrefix(githubAPI, "https://")
+		githubHost = strings.TrimPrefix(githubHost, "http://")
+		githubHost = strings.TrimSuffix(githubHost, "/api/v3")
+	}
+	return githubHost
+}
+
 // performGHAuthLogin performs gh auth login
 func performGHAuthLogin(githubHost, token string, env []string) error {
 	log.Printf("Performing gh auth login for host: %s", githubHost)
@@ -652,7 +718,7 @@ func performGHAuthLogin(githubHost, token string, env []string) error {
 	}
 
 	cmd.Stdin = strings.NewReader(token)
-	cmd.Env = env
+	cmd.Env = withoutGitHubTokenEnv(env)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -663,6 +729,17 @@ func performGHAuthLogin(githubHost, token string, env []string) error {
 
 	log.Printf("Successfully authenticated gh CLI for %s", githubHost)
 	return nil
+}
+
+func withoutGitHubTokenEnv(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "GITHUB_TOKEN=") || strings.HasPrefix(entry, "GH_TOKEN=") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
 // performGHAuthSetupGit performs gh auth setup-git

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -653,6 +653,54 @@ func TestAuthenticateGHCLI(t *testing.T) {
 	}
 }
 
+func TestWithoutGitHubTokenEnv(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin:/bin",
+		"GITHUB_TOKEN=github-token",
+		"GH_TOKEN=gh-token",
+		"GITHUB_APP_ID=12345",
+		"HOME=/tmp",
+	}
+
+	filtered := withoutGitHubTokenEnv(env)
+
+	expected := []string{
+		"PATH=/usr/bin:/bin",
+		"GITHUB_APP_ID=12345",
+		"HOME=/tmp",
+	}
+	if !reflect.DeepEqual(filtered, expected) {
+		t.Fatalf("unexpected filtered env: got %#v, want %#v", filtered, expected)
+	}
+}
+
+func TestNormalizeGitHubAuthStep(t *testing.T) {
+	tests := []struct {
+		name string
+		step string
+		want string
+	}{
+		{name: "empty defaults to all", step: "", want: "all"},
+		{name: "all", step: "all", want: "all"},
+		{name: "get token", step: "get-token", want: "get-token"},
+		{name: "token alias", step: "token", want: "get-token"},
+		{name: "auth login", step: "auth-login", want: "auth-login"},
+		{name: "login alias", step: "login", want: "auth-login"},
+		{name: "setup git", step: "setup-git", want: "setup-git"},
+		{name: "git alias", step: "git", want: "setup-git"},
+		{name: "trims and lowercases", step: " SETUP-GIT ", want: "setup-git"},
+		{name: "invalid", step: "unknown", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeGitHubAuthStep(tt.step); got != tt.want {
+				t.Fatalf("normalizeGitHubAuthStep(%q) = %q, want %q", tt.step, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSetupRepository(t *testing.T) {
 	// Test case 1: Invalid repository URL
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Add a --step flag to helpers setup-gh for get-token, auth-login, setup-git, or all
- Keep the existing all-in-one setup-gh behavior as the default
- Avoid passing GITHUB_TOKEN/GH_TOKEN into gh auth login so GitHub CLI accepts --with-token input

## Testing
- mise exec -- gofmt -w cmd/helpers.go cmd/helpers_test.go pkg/startup/startup.go pkg/startup/startup_test.go
- mise exec -- go test ./cmd -run 'TestSetupGH'
- mise exec -- go test ./pkg/startup
- git diff --check

Note: mise exec -- go test ./cmd ./pkg/startup was attempted first; ./pkg/startup passed, but ./cmd package-wide tests entered existing server/session initialization paths and were interrupted by the command timeout.