### PR TITLE
Remove legacy AgentAPI agent types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,9 +176,6 @@ RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | 
 # Set combined PATH environment variable (including /opt/claude/bin for claude CLI and /opt/cursor/bin for Cursor CLI)
 ENV PATH="/opt/claude/bin:/opt/cursor/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:/home/agentapi/.bun/bin:/home/agentapi/.bun/bin:$PATH"
 
-# install claude-agentapi
-RUN bun install -g @takutakahashi/claude-agentapi
-
 # Install codex CLI and place a wrapper in /opt/claude/bin (first in PATH).
 # The bun-installed codex script uses "#!/usr/bin/env node", but /usr/local/bin/node is a
 # claude wrapper. The wrapper here explicitly invokes bun so codex works reliably in the proxy.

--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -27,14 +27,14 @@ var (
 )
 
 // AcpServerCmd starts an ACP agent over stdio and exposes it as an
-// agentapi-compatible HTTP server (compatible with takutakahashi/claude-agentapi).
+// agentapi-compatible HTTP server.
 var AcpServerCmd = &cobra.Command{
 	Use:   "acp-server [flags] -- <agent-command> [agent-args...]",
 	Short: "Run an ACP agent over stdio and expose it as an agentapi-compatible HTTP server",
 	Long: `acp-server launches an ACP-compatible agent as a subprocess via stdio (stdin/stdout)
 and exposes its interface as an agentapi-compatible HTTP API.
 
-The HTTP interface is compatible with takutakahashi/claude-agentapi and coder/agentapi.
+The HTTP interface is compatible with coder/agentapi.
 
 Endpoints exposed:
   GET  /health    - health check

--- a/cmd/agent_provisioner.go
+++ b/cmd/agent_provisioner.go
@@ -15,7 +15,7 @@ import (
 // provision requests from the proxy internal API. The provisioner then:
 //
 //  1. Runs the full setup sequence (write-pem, clone-repo, compile, sync-extra)
-//  2. Starts agentapi (or claude-agentapi / codex-agentapi) as a subprocess
+//  2. Starts agentapi (or an ACP bridge) as a subprocess
 //  3. Waits for agentapi to become ready
 //  4. Sends the initial message (if any)
 //

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -154,7 +154,7 @@ session settings を組み立て、その過程をログに出しながら最終
       "environment": { "MY_VAR": "value" },
       "tags": { "repo": "myorg/myrepo" },
       "params": {
-        "agent_type": "claude-agentapi",
+        "agent_type": "claude-acp",
         "message": "Run daily checks",
         "oneshot": true
       }
@@ -174,7 +174,7 @@ session settings を組み立て、その過程をログに出しながら最終
       "session_config": {
         "environment": { "MY_VAR": "value" },
         "initial_message_template": "Hello!",
-        "params": { "agent_type": "claude-agentapi", "oneshot": false }
+        "params": { "agent_type": "claude-acp", "oneshot": false }
       }
     },
     "settings": [...]
@@ -535,11 +535,6 @@ func applySessionEnv(env map[string]string, sessionEnv map[string]string) {
 // buildStartupConfig returns the startup command config for the given agent type.
 func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 	switch agentType {
-	case "claude-agentapi":
-		log.Printf("[GENERATE-SETTING]   startup.command: [claude-agentapi]")
-		return sessionsettings.StartupConfig{
-			Command: []string{"claude-agentapi"},
-		}
 	case "claude-acp":
 		// acp-server bridges claude-agent-acp (ACP over stdio) to the agentapi HTTP interface.
 		// Port is determined at runtime via AGENTAPI_PORT env var.

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -490,7 +490,7 @@ kubernetesSession:
 
   # Slack Integration
   # claude-posts runs as a subprocess inside the agentapi container (not as a sidecar).
-  # Requires agent_type=claude-agentapi to produce the history file.
+  # ACP agent types produce the history file used for Slack forwarding.
   slackIntegration:
     # Kubernetes Secret containing the Slack credentials (bot token + signing secret).
     # The bot token and signing secret are a pair belonging to the same Slack App,

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -342,6 +342,8 @@ func (m *KubernetesSessionManager) StopStatusSubscriber() {
 // It first attempts to use a pre-warmed stock session (labeled agentapi.proxy/stock=true).
 // If no stock is available, a new session is created from scratch.
 func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error) {
+	req.AgentType = supportedAgentTypeOrDefault(req.AgentType)
+
 	// Attempt to adopt a stock session matching the requested pod capabilities
 	// before creating a new one.
 	if stockSvc, err := m.findStockSession(ctx, sessionRequirements(req)); err != nil {
@@ -1703,7 +1705,7 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 		return fmt.Errorf("session is not active: status=%s", status)
 	}
 
-	// Build service name and endpoint URL for the claude-agentapi /action endpoint
+	// Build service name and endpoint URL for the agentapi /action endpoint
 	serviceName := fmt.Sprintf("agentapi-session-%s-svc", id)
 	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/action",
 		serviceName,
@@ -1772,6 +1774,15 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 
 func isACPAgentType(agentType string) bool {
 	return agentType == "claude-acp" || agentType == "codex-acp" || agentType == "cursor"
+}
+
+func supportedAgentTypeOrDefault(agentType string) string {
+	switch agentType {
+	case "claude-acp", "codex-acp", "cursor":
+		return agentType
+	default:
+		return ""
+	}
 }
 
 func restoreAgentTypeFromService(svc *corev1.Service) string {
@@ -2696,14 +2707,6 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 	// No otelcol ConfigMap volume needed: otelcol runs as an in-process subprocess
 	// and generates its config file at /tmp/otelcol-config.yaml at provisioning time.
 
-	// Add EmptyDir for claude-agentapi history output
-	volumes = append(volumes, corev1.Volume{
-		Name: "claude-agentapi-history",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	})
-
 	return volumes
 }
 
@@ -3046,12 +3049,6 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 	// Add Agent Type if specified
 	if req.AgentType != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_AGENT_TYPE", Value: req.AgentType})
-
-		// Add claude-agentapi / codex-agentapi specific environment variables
-		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" {
-			envVars = append(envVars, corev1.EnvVar{Name: "HOST", Value: "0.0.0.0"})
-			envVars = append(envVars, corev1.EnvVar{Name: "PORT", Value: fmt.Sprintf("%d", m.k8sConfig.BasePort)})
-		}
 	}
 
 	proxyURL := m.k8sConfig.ProvisionerProxyURL
@@ -3625,12 +3622,6 @@ func (m *KubernetesSessionManager) buildMainContainerVolumeMounts(session *Kuber
 		})
 	}
 
-	// Add claude-agentapi history volume mount
-	volumeMounts = append(volumeMounts, corev1.VolumeMount{
-		Name:      "claude-agentapi-history",
-		MountPath: "/opt/claude-agentapi",
-	})
-
 	return volumeMounts
 }
 
@@ -4166,12 +4157,6 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	// Add Agent Type if specified
 	if req.AgentType != "" {
 		env["AGENTAPI_AGENT_TYPE"] = req.AgentType
-
-		// Add claude-agentapi / codex-agentapi specific environment variables
-		if req.AgentType == "claude-agentapi" || req.AgentType == "codex-agentapi" {
-			env["HOST"] = "0.0.0.0"
-			env["PORT"] = fmt.Sprintf("%d", m.k8sConfig.BasePort)
-		}
 	}
 
 	// Add CLAUDE_ARGS from request environment or proxy's environment
@@ -4391,7 +4376,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		MCPServers:   materialized.MCPServers,
 	}
 
-	// For codex sessions, populate Codex-specific config.
+	// For Codex ACP sessions, populate Codex-specific config.
 	switch req.AgentType {
 	case "codex-acp":
 		settings.Codex = sessionsettings.CodexConfig{
@@ -4403,10 +4388,6 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			MCPServers: materialized.MCPServers,
 		}
 		log.Printf("[K8S_SESSION] Injected Codex hooks and set approval-mode=full-auto, sandbox_mode=danger-full-access for session %s", session.id)
-	case "codex-agentapi":
-		settings.Codex = sessionsettings.CodexConfig{
-			MCPServers: materialized.MCPServers,
-		}
 	}
 
 	// Repository info
@@ -4440,10 +4421,6 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 
 	// Startup command (simplified version for now - full command logic in pod)
 	switch req.AgentType {
-	case "claude-agentapi":
-		settings.Startup = sessionsettings.StartupConfig{
-			Command: []string{"claude-agentapi"},
-		}
 	case "claude-acp":
 		// acp-server bridges claude-agent-acp (ACP over stdio) to the agentapi HTTP interface.
 		settings.Startup = sessionsettings.StartupConfig{

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -191,11 +191,11 @@ func TestRestoreSessionFromServiceRestoresAgentType(t *testing.T) {
 	}
 }
 
-func TestStopAgentUsesActionForAgentAPISessions(t *testing.T) {
+func TestStopAgentUsesActionForDefaultAgentAPISessions(t *testing.T) {
 	m := newTestManagerForCycle(t)
 	session := NewKubernetesSession(
 		"test-session",
-		&entities.RunServerRequest{UserID: "user1", AgentType: "claude-agentapi"},
+		&entities.RunServerRequest{UserID: "user1"},
 		"test-deploy", "test-svc", "test-pvc", "test-ns",
 		9000, nil, nil,
 	)
@@ -224,6 +224,28 @@ func TestStopAgentUsesActionForAgentAPISessions(t *testing.T) {
 	}
 	if !strings.Contains(body, `"type":"stop_agent"`) {
 		t.Fatalf("unexpected action payload: %s", body)
+	}
+}
+
+func TestSupportedAgentTypeOrDefault(t *testing.T) {
+	tests := []struct {
+		name      string
+		agentType string
+		want      string
+	}{
+		{name: "default", agentType: "", want: ""},
+		{name: "claude acp", agentType: "claude-acp", want: "claude-acp"},
+		{name: "codex acp", agentType: "codex-acp", want: "codex-acp"},
+		{name: "cursor", agentType: "cursor", want: "cursor"},
+		{name: "unknown", agentType: "unknown-agent", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportedAgentTypeOrDefault(tt.agentType); got != tt.want {
+				t.Fatalf("supportedAgentTypeOrDefault(%q) = %q, want %q", tt.agentType, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/interfaces/controllers/slackbot_event_handler_test.go
+++ b/internal/interfaces/controllers/slackbot_event_handler_test.go
@@ -1668,7 +1668,7 @@ func TestProcessEvent_NoConfiguredRepo_FallsBackToMessageDetection(t *testing.T)
 	// Configure session params WITHOUT repo_full_name.
 	sc := entities.NewWebhookSessionConfig()
 	sc.SetParams(&entities.SessionParams{
-		AgentType: "claude-agentapi",
+		AgentType: "claude-acp",
 	})
 	bot.SetSessionConfig(sc)
 	repo.bots[botID] = bot

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -50,7 +50,7 @@ const (
 //  3. Load the generated session env file
 //  4. Fetch memory from the proxy and inject into CLAUDE.md
 //  5. cd into the cloned repo if present
-//  6. Start agentapi (or claude-agentapi / codex-agentapi) as a subprocess
+//  6. Start agentapi (or an ACP bridge) as a subprocess
 //  7. Wait for agentapi to become ready
 //  8. Send the initial message if specified in settings
 //  9. Set status to "ready"; supervise the subprocess
@@ -319,19 +319,14 @@ func (s *Server) runPreScript(ctx context.Context, script string, envMap map[str
 }
 
 // runAcpPosts starts the acp-posts binary as a subprocess, forwarding
-// agent output (history.jsonl) to Slack. It waits for the history file to
-// appear before launching. The history file path depends on the agent type:
-//   - claude-acp: /opt/acp-posts/history.jsonl (written by the acp-server bridge)
-//   - others:     /opt/claude-agentapi/history.jsonl (written by claude-agentapi)
+// agent output (history.jsonl) to Slack. It waits for the ACP bridge history
+// file to appear before launching.
 //
 // The subprocess is tied to ctx: when ctx is cancelled the goroutine exits.
 func (s *Server) runAcpPosts(ctx context.Context, params *sessionsettings.SlackParams, agentType string) {
 	const acpPostsBin = "/usr/local/bin/acp-posts"
 
-	historyFile := "/opt/claude-agentapi/history.jsonl"
-	if agentType == "claude-acp" {
-		historyFile = "/opt/acp-posts/history.jsonl"
-	}
+	historyFile := "/opt/acp-posts/history.jsonl"
 
 	log.Printf("[ACP_POSTS] Waiting for history file %s", historyFile)
 	for {
@@ -867,7 +862,7 @@ service:
 }
 
 // buildAgentCommand returns the executable and arguments for the agent
-// process, mirroring the logic in buildClaudeStartCommand().
+// process, mirroring the logic in BuildRemoteProvisionSettings().
 func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, envMap map[string]string) (string, []string) {
 	agentType := settings.Session.AgentType
 
@@ -877,16 +872,6 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 	}
 
 	switch agentType {
-	case "claude-agentapi":
-		args := []string{"--output-file", "/opt/claude-agentapi/history.jsonl"}
-		if claudeArgs := os.Getenv("CLAUDE_ARGS"); claudeArgs != "" {
-			args = append(args, strings.Fields(claudeArgs)...)
-		}
-		return "claude-agentapi", args
-
-	case "codex-agentapi":
-		return "bunx", []string{"@takutakahashi/codex-agentapi"}
-
 	case "claude-acp":
 		// Start the acp-server bridge that wraps claude-agent-acp (ACP agent) via stdio.
 		// The bridge exposes an agentapi-compatible HTTP server on AGENTAPI_PORT.
@@ -1016,7 +1001,7 @@ func sendInitialMessage(ctx context.Context, agentapiURL, message, agentType str
 		// Default agentapi: wait for running→stable transition OR stable + non-empty message.
 		waitForDefaultAgentReady(ctx, client, agentapiURL)
 	} else {
-		// claude-agentapi / codex-agentapi: just wait for stable.
+		// Non-default agents: wait for stable.
 		waitForStable(ctx, client, agentapiURL, 60)
 	}
 

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -22,7 +22,7 @@ func TestCompile_FullSettings(t *testing.T) {
 			ID:        "test-123",
 			UserID:    "user-456",
 			Scope:     "user",
-			AgentType: "claude-agentapi",
+			AgentType: "claude-acp",
 		},
 		Env: map[string]string{
 			"AGENTAPI_PORT":       "9000",
@@ -550,7 +550,7 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 				ID:        "test-codex-mcp",
 				UserID:    "user-codex-mcp",
 				Scope:     "user",
-				AgentType: "codex-agentapi",
+				AgentType: "codex-acp",
 			},
 			Codex: CodexConfig{
 				MCPServers: map[string]interface{}{

--- a/pkg/sessionsettings/types_test.go
+++ b/pkg/sessionsettings/types_test.go
@@ -17,7 +17,7 @@ func TestMarshalYAML_FullSettings(t *testing.T) {
 			UserID:    "user-456",
 			Scope:     "user",
 			TeamID:    "org/team",
-			AgentType: "claude-agentapi",
+			AgentType: "claude-acp",
 			Oneshot:   true,
 			Teams:     []string{"org/team1", "org/team2"},
 		},

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5462,8 +5462,8 @@
           },
           "agent_type": {
             "type": "string",
-            "description": "Agent type for the session. Supported values: 'claude-agentapi' (uses claude-agentapi command with HOST=0.0.0.0 and PORT=9000), 'codex-agentapi' (uses codex-agentapi command with HOST=0.0.0.0 and PORT=9000, configured via environment variables). If not specified, uses default agentapi.",
-            "example": "claude-agentapi"
+            "description": "Agent type for the session. Supported values: 'claude-acp', 'codex-acp', and 'cursor'. If not specified, uses default agentapi.",
+            "example": "claude-acp"
           },
           "slack": {
             "$ref": "#/components/schemas/SlackParams"
@@ -7196,8 +7196,8 @@
       "properties": {
         "agent_type": {
           "type": "string",
-          "description": "Agent type to use (default: 'claude-agentapi')",
-          "example": "claude-agentapi"
+          "description": "Agent type to use. Supported values: 'claude-acp', 'codex-acp', and 'cursor'. If omitted, the default agentapi is used.",
+          "example": "claude-acp"
         },
         "oneshot": {
           "type": "boolean",


### PR DESCRIPTION
## Summary
- remove claude-agentapi/codex-agentapi startup command handling, env wiring, Codex config branch, and legacy history volume mounts
- keep only current supported agent types (claude-acp, codex-acp, cursor); any other agent_type is treated the same as omitted/default
- remove @takutakahashi/claude-agentapi from the proxy image and update OpenAPI/docs/tests to ACP/default agent types

## Verification
- mise exec -- make lint
- env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT mise exec -- go test ./...
- env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT mise exec -- go test ./cmd

## Note
- make test invokes go test -race and cannot complete in this container because gcc is not installed: cgo: C compiler "gcc" not found.