### PR TITLE
Fix asset persistence disabled Helm rendering

### DIFF
--- a/helm/agentapi-proxy/templates/asset-nginx.yaml
+++ b/helm/agentapi-proxy/templates/asset-nginx.yaml
@@ -1,7 +1,14 @@
 {{- $asset := .Values.asset | default dict -}}
 {{- $assetBackend := $asset.backend | default "nginx" -}}
-{{- $assetEnabled := $asset.enabled | default true -}}
+{{- $assetEnabled := true -}}
+{{- if hasKey $asset "enabled" -}}
+{{- $assetEnabled = $asset.enabled -}}
+{{- end -}}
 {{- $assetPersistence := $asset.persistence | default dict -}}
+{{- $assetPersistenceEnabled := true -}}
+{{- if hasKey $assetPersistence "enabled" -}}
+{{- $assetPersistenceEnabled = $assetPersistence.enabled -}}
+{{- end -}}
 {{- $assetNginx := $asset.nginx | default dict -}}
 {{- $assetNginxImage := $assetNginx.image | default dict -}}
 {{- $assetNginxService := $assetNginx.service | default dict -}}
@@ -68,7 +75,7 @@ spec:
             {{- toYaml $assetNginxResources | nindent 12 }}
       volumes:
         - name: asset-storage
-          {{ if $assetPersistence.enabled | default true }}
+          {{ if $assetPersistenceEnabled }}
           persistentVolumeClaim:
             claimName: {{ include "agentapi-proxy.fullname" . }}-assets
           {{ else }}

--- a/helm/agentapi-proxy/templates/asset-pvc.yaml
+++ b/helm/agentapi-proxy/templates/asset-pvc.yaml
@@ -1,8 +1,15 @@
 {{- $asset := .Values.asset | default dict -}}
 {{- $assetBackend := $asset.backend | default "nginx" -}}
-{{- $assetEnabled := $asset.enabled | default true -}}
+{{- $assetEnabled := true -}}
+{{- if hasKey $asset "enabled" -}}
+{{- $assetEnabled = $asset.enabled -}}
+{{- end -}}
 {{- $assetPersistence := $asset.persistence | default dict -}}
-{{- if and $assetEnabled (eq $assetBackend "nginx") ($assetPersistence.enabled | default true) -}}
+{{- $assetPersistenceEnabled := true -}}
+{{- if hasKey $assetPersistence "enabled" -}}
+{{- $assetPersistenceEnabled = $assetPersistence.enabled -}}
+{{- end -}}
+{{- if and $assetEnabled (eq $assetBackend "nginx") $assetPersistenceEnabled -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -1,9 +1,15 @@
 {{- $asset := .Values.asset | default dict }}
 {{- $assetBackend := $asset.backend | default "nginx" }}
-{{- $assetEnabled := $asset.enabled | default true }}
+{{- $assetEnabled := true }}
+{{- if hasKey $asset "enabled" }}
+{{- $assetEnabled = $asset.enabled }}
+{{- end }}
 {{- $assetStoragePath := $asset.storagePath | default "/var/lib/agentapi-assets" }}
 {{- $assetPersistence := $asset.persistence | default dict }}
-{{- $assetPersistenceEnabled := $assetPersistence.enabled | default true }}
+{{- $assetPersistenceEnabled := true }}
+{{- if hasKey $assetPersistence "enabled" }}
+{{- $assetPersistenceEnabled = $assetPersistence.enabled }}
+{{- end }}
 {{- $assetS3 := $asset.s3 | default dict }}
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/agentapi-proxy/templates/ingress.yaml
+++ b/helm/agentapi-proxy/templates/ingress.yaml
@@ -1,7 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $asset := .Values.asset | default dict }}
 {{- $assetBackend := $asset.backend | default "nginx" }}
-{{- $assetEnabled := $asset.enabled | default true }}
+{{- $assetEnabled := true }}
+{{- if hasKey $asset "enabled" }}
+{{- $assetEnabled = $asset.enabled }}
+{{- end }}
 {{- $assetNginx := $asset.nginx | default dict }}
 {{- $assetNginxService := $assetNginx.service | default dict }}
 {{- $assetNginxServicePort := $assetNginxService.port | default 80 }}


### PR DESCRIPTION
## Summary
- Preserve explicit false values for asset.enabled and asset.persistence.enabled in Helm templates
- Render emptyDir instead of PVC mounts when asset.persistence.enabled=false
- Keep default behavior unchanged when asset persistence is unspecified

## Verification
- helm lint helm/agentapi-proxy
- helm template test helm/agentapi-proxy --set asset.persistence.enabled=false
- helm template test helm/agentapi-proxy
