### PR TITLE
Restrict GitHub App tokens by repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,6 +141,7 @@ ENV GOCACHE=/home/agentapi/.cache/go-build
 
 # Install mise
 RUN curl https://mise.run | sh && \
+    /home/agentapi/.local/bin/mise --version && \
     echo 'export PATH="/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:$PATH"' >> /home/agentapi/.bashrc
 
 # Install claude code and move to /opt/claude for persistence across volume mounts

--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -288,6 +288,18 @@ This creates files in `/etc/role-env-files/`:
 
 See [values-role-env-example.yaml](values-role-env-example.yaml) for a complete example with all secrets.
 
+### GitHub App Repository Restriction
+
+GitHub App installation tokens can be restricted to the repository being cloned or synced:
+
+```yaml
+github:
+  app:
+    repositoryRestriction: true
+```
+
+The default is `false`. When enabled, token generation requires a repository full name and sends the repository name in the GitHub installation token request body.
+
 ### Create Required Secrets
 
 ```bash

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -169,6 +169,8 @@ spec:
             - name: GITHUB_INSTALLATION_ID
               value: {{ .Values.github.app.installationId | quote }}
             {{- end }}
+            - name: REPOSITORY_RESTRICTION
+              value: {{ .Values.github.app.repositoryRestriction | default false | quote }}
             {{- if and .Values.github.app.privateKey.secretName .Values.github.app.privateKey.key }}
             - name: GITHUB_APP_PEM
               valueFrom:

--- a/helm/agentapi-proxy/templates/github-session-secret.yaml
+++ b/helm/agentapi-proxy/templates/github-session-secret.yaml
@@ -49,6 +49,7 @@ stringData:
   {{- if .Values.github.app.installationId }}
   GITHUB_INSTALLATION_ID: {{ .Values.github.app.installationId | quote }}
   {{- end }}
+  REPOSITORY_RESTRICTION: {{ .Values.github.app.repositoryRestriction | default false | quote }}
 {{- end }}
 ---
 {{- /*

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -145,6 +145,8 @@ github:
     # GitHub App Installation ID (必須)
     # 組織にインストール後のURLから取得: /settings/installations/12345678 -> 12345678
     installationId: ""
+    # GitHub App installation token を対象リポジトリに限定する場合は true
+    repositoryRestriction: false
     # GitHub App の秘密鍵（PEM形式）を含む Secret (必須)
     # kubectl create secret generic github-app-private-key --from-file=private-key=/path/to/app.private-key.pem
     privateKey:

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -84,7 +84,7 @@ func isPersonalSync(settingsName, userID string) bool {
 // GITHUB_APP_ID / GITHUB_APP_PEM env vars and the installation ID resolved as follows:
 //  1. The proxy-level git_sync.github_app.installation_id config value
 //  2. The GITHUB_INSTALLATION_ID environment variable (set by Helm from github.app.installationId)
-func (s *Syncer) resolveToken(personalToken string) (string, error) {
+func (s *Syncer) resolveToken(personalToken, repoFullName string) (string, error) {
 	if personalToken != "" {
 		return personalToken, nil
 	}
@@ -103,7 +103,7 @@ func (s *Syncer) resolveToken(personalToken string) (string, error) {
 		return "", fmt.Errorf("github_token is not configured and GITHUB_APP_ID env var is not set")
 	}
 	pemPath := os.Getenv("GITHUB_APP_PEM_PATH")
-	token, err := startup.GenerateGitHubAppToken(appID, installID, pemPath)
+	token, err := startup.GenerateGitHubAppTokenForRepository(appID, installID, pemPath, repoFullName)
 	if err != nil {
 		return "", fmt.Errorf("github_token is not configured; GitHub App token generation failed: %w", err)
 	}
@@ -123,7 +123,7 @@ func (s *Syncer) Push(ctx context.Context, settingsName, userID string, commitMe
 		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
 	}
 
-	token, err := s.resolveToken(cfg.GitHubToken)
+	token, err := s.resolveToken(cfg.GitHubToken, cfg.RepoFullName)
 	if err != nil {
 		return nil, fmt.Errorf("no GitHub token for %q: %w", settingsName, err)
 	}
@@ -255,7 +255,7 @@ func (s *Syncer) Pull(ctx context.Context, settingsName, userID string, deleteOr
 		return nil, fmt.Errorf("GitHub sync is not enabled for %q", settingsName)
 	}
 
-	token, err := s.resolveToken(cfg.GitHubToken)
+	token, err := s.resolveToken(cfg.GitHubToken, cfg.RepoFullName)
 	if err != nil {
 		return nil, fmt.Errorf("no GitHub token for %q: %w", settingsName, err)
 	}
@@ -362,7 +362,7 @@ func (s *Syncer) importFileByPath(ctx context.Context, filePath string, content 
 // the remote .sync-meta.yaml syncedAt timestamp with the local LastPushedAt.
 // Returns "pull" when GitHub is newer, "push" otherwise.
 func (s *Syncer) resolveSyncDirection(ctx context.Context, cfg *entities.GitSyncConfig, settingsName string) (string, error) {
-	token, err := s.resolveToken(cfg.GitHubToken)
+	token, err := s.resolveToken(cfg.GitHubToken, cfg.RepoFullName)
 	if err != nil {
 		return "", err
 	}
@@ -467,7 +467,7 @@ func (s *Syncer) RotateKey(ctx context.Context, settingsName, userID string) (*R
 		return nil, fmt.Errorf("failed to decrypt old DEK: %w", err)
 	}
 
-	rotateToken, err := s.resolveToken(cfg.GitHubToken)
+	rotateToken, err := s.resolveToken(cfg.GitHubToken, cfg.RepoFullName)
 	if err != nil {
 		return nil, fmt.Errorf("no GitHub token for %q: %w", settingsName, err)
 	}

--- a/pkg/github_sync/worker.go
+++ b/pkg/github_sync/worker.go
@@ -157,7 +157,7 @@ func (w *Worker) syncOne(ctx context.Context, settingsName string) error {
 		return nil
 	}
 
-	token, err := w.syncer.resolveToken(cfg.GitHubToken)
+	token, err := w.syncer.resolveToken(cfg.GitHubToken, cfg.RepoFullName)
 	if err != nil {
 		return err
 	}

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -316,7 +316,7 @@ func GetGitHubToken(repoFullName string) (string, error) {
 
 		// If we have installation ID (manual or auto-discovered), proceed with token generation
 		if installationID != "" {
-			return GenerateGitHubAppToken(appID, installationID, pemPath)
+			return GenerateGitHubAppTokenForRepository(appID, installationID, pemPath, repoFullName)
 		}
 	}
 
@@ -330,6 +330,17 @@ func GetGitHubToken(repoFullName string) (string, error) {
 
 // GenerateGitHubAppToken generates a GitHub App installation token
 func GenerateGitHubAppToken(appIDStr, installationIDStr, pemPath string) (string, error) {
+	return GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, "")
+}
+
+// GenerateGitHubAppTokenForRepository generates a GitHub App installation token,
+// optionally restricted to a single repository.
+func GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, repoFullName string) (string, error) {
+	repositories, err := installationTokenRepositories(repoFullName)
+	if err != nil {
+		return "", err
+	}
+
 	// Parse app ID
 	appID, err := strconv.ParseInt(appIDStr, 10, 64)
 	if err != nil {
@@ -391,13 +402,36 @@ func GenerateGitHubAppToken(appIDStr, installationIDStr, pemPath string) (string
 	token, _, err := client.Apps.CreateInstallationToken(
 		ctx,
 		installationID,
-		&github.InstallationTokenOptions{},
+		&github.InstallationTokenOptions{
+			Repositories: repositories,
+		},
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create installation token: %w", err)
 	}
 
 	return token.GetToken(), nil
+}
+
+func installationTokenRepositories(repoFullName string) ([]string, error) {
+	repoFullName = strings.TrimSpace(repoFullName)
+	if repoFullName == "" {
+		if repositoryRestrictionEnabled() {
+			return nil, fmt.Errorf("repository restriction is enabled; repository fullname is required for GitHub App installation token generation")
+		}
+		return nil, nil
+	}
+
+	parts := strings.Split(repoFullName, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return nil, fmt.Errorf("invalid repository fullname %q: expected owner/repo", repoFullName)
+	}
+
+	return []string{strings.TrimSuffix(strings.TrimSpace(parts[1]), ".git")}, nil
+}
+
+func repositoryRestrictionEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("REPOSITORY_RESTRICTION")), "true")
 }
 
 // AutoDiscoverInstallationID discovers the installation ID for a given repository using cache

--- a/pkg/startup/startup_test.go
+++ b/pkg/startup/startup_test.go
@@ -605,6 +605,50 @@ func TestGenerateGitHubAppToken(t *testing.T) {
 	}
 }
 
+func TestInstallationTokenRepositories(t *testing.T) {
+	t.Run("no repository without restriction", func(t *testing.T) {
+		t.Setenv("REPOSITORY_RESTRICTION", "")
+
+		repositories, err := installationTokenRepositories("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if repositories != nil {
+			t.Fatalf("expected nil repositories, got %#v", repositories)
+		}
+	})
+
+	t.Run("no repository with restriction", func(t *testing.T) {
+		t.Setenv("REPOSITORY_RESTRICTION", "true")
+
+		_, err := installationTokenRepositories("")
+		if err == nil {
+			t.Fatal("expected error when repository restriction is enabled")
+		}
+	})
+
+	t.Run("repository fullname becomes token repository name", func(t *testing.T) {
+		t.Setenv("REPOSITORY_RESTRICTION", "true")
+
+		repositories, err := installationTokenRepositories("owner/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(repositories, []string{"repo"}) {
+			t.Fatalf("expected repository name, got %#v", repositories)
+		}
+	})
+
+	t.Run("invalid repository fullname", func(t *testing.T) {
+		t.Setenv("REPOSITORY_RESTRICTION", "")
+
+		_, err := installationTokenRepositories("repo")
+		if err == nil {
+			t.Fatal("expected error for invalid repository fullname")
+		}
+	})
+}
+
 func TestAutoDiscoverInstallationID(t *testing.T) {
 	// Test case 1: Invalid repository format
 	_, err := AutoDiscoverInstallationID("123", "/path/to/pem", "invalid-repo-format")


### PR DESCRIPTION
## Summary
- require repository context for GitHub App token generation when REPOSITORY_RESTRICTION=true
- pass resolved repository names into setup-gh/startup token generation and GitHub sync fallback token generation
- send repository-scoped installation token requests with the repository name in InstallationTokenOptions.Repositories

## Tests
- mise exec -- gofmt -w pkg/startup/startup.go pkg/startup/startup_test.go pkg/github_sync/syncer.go pkg/github_sync/worker.go
- mise exec -- go test ./pkg/startup ./pkg/github_sync