### PR TITLE
Refactor session allocation protocol boundaries

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,17 +15,20 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/takutakahashi/agentapi-proxy/internal/app"
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/repositories"
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	infrasessionallocation "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/sessionallocation"
 	mcpiface "github.com/takutakahashi/agentapi-proxy/internal/interfaces/mcp"
 	"github.com/takutakahashi/agentapi-proxy/internal/modules/schedule"
+	sessionallocationworker "github.com/takutakahashi/agentapi-proxy/internal/modules/sessionallocation"
+	"github.com/takutakahashi/agentapi-proxy/internal/modules/sessionmanager"
 	"github.com/takutakahashi/agentapi-proxy/internal/modules/slackbot"
 	"github.com/takutakahashi/agentapi-proxy/internal/modules/webhook"
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	githubsync "github.com/takutakahashi/agentapi-proxy/pkg/github_sync"
 	importexport "github.com/takutakahashi/agentapi-proxy/pkg/import"
-	"github.com/takutakahashi/agentapi-proxy/internal/modules/sessionmanager"
 	slackbotcleanup "github.com/takutakahashi/agentapi-proxy/pkg/slackbot_cleanup"
 	stock_inventory "github.com/takutakahashi/agentapi-proxy/pkg/stock_inventory"
 	"k8s.io/client-go/kubernetes"
@@ -564,7 +567,7 @@ func registerWebhookHandlers(configData *config.Config, proxyServer *app.Server)
 // startSessionAllocator starts the leader-elected SessionAllocator. API requests
 // can land on any proxy replica, but only the elected leader consumes allocation
 // requests and creates/adopts session Pods.
-func startSessionAllocator(configData *config.Config, proxyServer *app.Server) *services.SessionAllocator {
+func startSessionAllocator(configData *config.Config, proxyServer *app.Server) *sessionallocationworker.Worker {
 	log.Printf("[SESSION_ALLOCATOR] Initializing session allocator...")
 
 	restConfig, err := ctrl.GetConfig()
@@ -601,7 +604,8 @@ func startSessionAllocator(configData *config.Config, proxyServer *app.Server) *
 	}
 
 	manager.SetSessionAllocatorEnabled(true)
-	allocator := services.NewSessionAllocator(manager)
+	allocationClient := infrasessionallocation.NewClient(manager.AllocationProxyURL(), configData.KubernetesSession.ProvisionerToken)
+	allocator := sessionallocationworker.NewWorker(manager, allocationClient)
 	electorConfig := schedule.LeaderElectionConfig{
 		LeaseDuration: leaseDuration,
 		RenewDeadline: renewDeadline,
@@ -626,10 +630,10 @@ func startSessionAllocator(configData *config.Config, proxyServer *app.Server) *
 	return allocator
 }
 
-func buildSessionAllocationNotifier(configData *config.Config) services.SessionAllocationNotifier {
+func buildSessionAllocationNotifier(configData *config.Config) sessionallocation.Notifier {
 	if configData.Redis.Addr == "" {
 		log.Printf("[SESSION_ALLOCATOR] Redis not configured; using local allocation notifier")
-		return services.NewLocalSessionAllocationNotifier()
+		return infrasessionallocation.NewLocalNotifier()
 	}
 	opts := &redis.Options{
 		Addr:     configData.Redis.Addr,
@@ -654,10 +658,10 @@ func buildSessionAllocationNotifier(configData *config.Config) services.SessionA
 	if err := client.Ping(ctx).Err(); err != nil {
 		log.Printf("[SESSION_ALLOCATOR] Warning: Redis ping failed (%s); using local allocation notifier: %v", configData.Redis.Addr, err)
 		_ = client.Close()
-		return services.NewLocalSessionAllocationNotifier()
+		return infrasessionallocation.NewLocalNotifier()
 	}
 	log.Printf("[SESSION_ALLOCATOR] Redis allocation notifier connected: addr=%s", configData.Redis.Addr)
-	return services.NewRedisSessionAllocationNotifier(client)
+	return infrasessionallocation.NewRedisNotifier(client)
 }
 
 // registerImportExportHandlers registers import/export REST API handlers

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -185,7 +185,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 
 	var provisionerController *controllers.ProvisionerController
 	if k8sManager, ok := server.sessionManager.(*services.KubernetesSessionManager); ok {
-		provisionerController = controllers.NewProvisionerController(k8sManager, server.settingsRepo, server.sessionRouteRepo)
+		provisionerController = controllers.NewProvisionerController(k8sManager, k8sManager, server.settingsRepo, server.sessionRouteRepo)
 		log.Printf("[ROUTER] Provisioner controller initialized")
 	}
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/redis/go-redis/v9"
 	corerepo "github.com/takutakahashi/agentapi-proxy/internal/core/repository"
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/di"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/repositories"
@@ -794,11 +795,11 @@ func (s *Server) createRemoteSession(ctx context.Context, sessionID string, star
 		}
 	}
 
-	k8sManager, ok := s.sessionManager.(*services.KubernetesSessionManager)
+	allocationQueue, ok := s.sessionManager.(sessionallocation.Queue)
 	if !ok {
-		return nil, fmt.Errorf("external session manager allocator requires KubernetesSessionManager")
+		return nil, fmt.Errorf("external session manager allocator requires allocation queue")
 	}
-	if err := k8sManager.SubmitExternalSessionAllocation(ctx, managerID, sessionID, settings, runReq); err != nil {
+	if err := allocationQueue.SubmitExternalSessionAllocation(ctx, managerID, sessionID, settings, runReq); err != nil {
 		return nil, err
 	}
 	startedAt := time.Now()

--- a/internal/core/sessionallocation/ports.go
+++ b/internal/core/sessionallocation/ports.go
@@ -1,0 +1,32 @@
+package sessionallocation
+
+import (
+	"context"
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
+)
+
+type InternalAllocatorClient interface {
+	Next(ctx context.Context, wait time.Duration) (*AllocationRequest, bool, error)
+	Complete(ctx context.Context, sessionID string, result AllocationResult) error
+}
+
+type ExternalAllocatorClient interface {
+	NextExternal(ctx context.Context, wait time.Duration) (*AllocationRequest, bool, error)
+	CompleteExternal(ctx context.Context, sessionID string, result AllocationResult) error
+}
+
+type Queue interface {
+	SubmitExternalSessionAllocation(ctx context.Context, managerID, sessionID string, settings *sessionsettings.SessionSettings, req *entities.RunServerRequest) error
+	NextSessionAllocation(ctx context.Context, wait time.Duration) (*AllocationRequest, bool, error)
+	CompleteSessionAllocation(ctx context.Context, sessionID string, result AllocationResult) error
+	NextExternalSessionAllocation(ctx context.Context, managerID string, wait time.Duration) (*AllocationRequest, bool, error)
+	CompleteExternalSessionAllocation(ctx context.Context, sessionID string, result AllocationResult) (*AllocationRequest, error)
+}
+
+type Notifier interface {
+	Notify(ctx context.Context) error
+	Subscribe(ctx context.Context) (<-chan struct{}, func(), error)
+}

--- a/internal/core/sessionallocation/types.go
+++ b/internal/core/sessionallocation/types.go
@@ -1,0 +1,56 @@
+package sessionallocation
+
+import (
+	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
+)
+
+type Status string
+
+const (
+	StatusPending    Status = "pending"
+	StatusAllocating Status = "allocating"
+	StatusAssigned   Status = "assigned"
+	StatusError      Status = "error"
+)
+
+// AllocationRequest is the cluster-visible request consumed by allocator workers.
+type AllocationRequest struct {
+	SessionID          string                           `json:"session_id"`
+	ManagerID          string                           `json:"manager_id,omitempty"`
+	Request            *entities.RunServerRequest       `json:"request"`
+	ProvisionSettings  *sessionsettings.SessionSettings `json:"provision_settings,omitempty"`
+	WebhookPayload     []byte                           `json:"webhook_payload,omitempty"`
+	Status             Status                           `json:"status"`
+	Message            string                           `json:"message,omitempty"`
+	AllocatedSessionID string                           `json:"allocated_session_id,omitempty"`
+	Requirements       Requirements                     `json:"requirements"`
+	UpdatedAt          time.Time                        `json:"updated_at"`
+}
+
+type AllocationResult struct {
+	Status             Status `json:"status"`
+	Message            string `json:"message,omitempty"`
+	AllocatedSessionID string `json:"allocated_session_id,omitempty"`
+	ProxyURL           string `json:"proxy_url,omitempty"`
+}
+
+// Requirements captures pod capabilities used for stock matching.
+type Requirements struct {
+	AgentType string `json:"agent_type,omitempty"`
+	Sandbox   bool   `json:"sandbox"`
+	DinD      bool   `json:"dind"`
+}
+
+func RequirementsFromRunServerRequest(req *entities.RunServerRequest) Requirements {
+	if req == nil {
+		return Requirements{}
+	}
+	return Requirements{
+		AgentType: req.AgentType,
+		Sandbox:   req.Sandbox != nil && req.Sandbox.Enabled,
+		DinD:      req.Docker != nil && req.Docker.Enabled,
+	}
+}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -30,7 +30,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	coreallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	infrasessionallocation "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/sessionallocation"
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
@@ -141,7 +143,7 @@ type KubernetesSessionManager struct {
 	// SessionAllocator when the server has started that worker.
 	sessionAllocatorEnabled bool
 
-	sessionAllocationNotifier SessionAllocationNotifier
+	sessionAllocationNotifier coreallocation.Notifier
 }
 
 // NewKubernetesSessionManager creates a new KubernetesSessionManager
@@ -200,7 +202,7 @@ func NewKubernetesSessionManagerWithClient(
 		podID:                     podID,
 		statusSubCtx:              subCtx,
 		statusSubCancel:           subCancel,
-		sessionAllocationNotifier: NewLocalSessionAllocationNotifier(),
+		sessionAllocationNotifier: infrasessionallocation.NewLocalNotifier(),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -707,7 +709,7 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 // oldest available one (by CreationTimestamp, ascending). Oldest sessions have been
 // warmed up the longest and are the most ready to serve.
 // Returns (nil, nil) when no stock is available.
-func (m *KubernetesSessionManager) findStockSession(ctx context.Context, requirements SessionRequirements) (*corev1.Service, error) {
+func (m *KubernetesSessionManager) findStockSession(ctx context.Context, requirements coreallocation.Requirements) (*corev1.Service, error) {
 	selector := fmt.Sprintf(
 		"agentapi.proxy/stock=true,app.kubernetes.io/managed-by=agentapi-proxy,agentapi.proxy/capability-sandbox=%t,agentapi.proxy/capability-dind=%t",
 		requirements.Sandbox,
@@ -1197,7 +1199,7 @@ func (m *KubernetesSessionManager) fetchSessionAllocationsFromK8s(ctx context.Co
 		if len(data) == 0 {
 			continue
 		}
-		var allocation SessionAllocationRequest
+		var allocation coreallocation.AllocationRequest
 		if err := json.Unmarshal(data, &allocation); err != nil {
 			log.Printf("[K8S_SESSION] Failed to decode session allocation %s: %v", sec.Name, err)
 			continue
@@ -1216,7 +1218,7 @@ func (m *KubernetesSessionManager) fetchSessionAllocationsFromK8s(ctx context.Co
 			allocation.Request.TeamID,
 			allocation.Request.Tags,
 			allocation.UpdatedAt,
-			allocation.Status,
+			string(allocation.Status),
 		)
 		if len(m.applySessionListFilters([]entities.Session{session}, filter)) == 0 {
 			continue

--- a/internal/infrastructure/services/session_allocator.go
+++ b/internal/infrastructure/services/session_allocator.go
@@ -1,19 +1,14 @@
 package services
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"net/url"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/redis/go-redis/v9"
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 	corev1 "k8s.io/api/core/v1"
@@ -24,37 +19,7 @@ import (
 const (
 	sessionAllocationSecretPrefix = "agentapi-session-allocation-"
 	sessionAllocationDataKey      = "request.json"
-	sessionAllocationNotifyTopic  = "agentapi:session-allocation:notify"
 )
-
-// SessionAllocationRequest is the cluster-visible request consumed by the
-// leader-elected SessionAllocator.
-type SessionAllocationRequest struct {
-	SessionID          string                           `json:"session_id"`
-	ManagerID          string                           `json:"manager_id,omitempty"`
-	Request            *entities.RunServerRequest       `json:"request"`
-	ProvisionSettings  *sessionsettings.SessionSettings `json:"provision_settings,omitempty"`
-	WebhookPayload     []byte                           `json:"webhook_payload,omitempty"`
-	Status             string                           `json:"status"`
-	Message            string                           `json:"message,omitempty"`
-	AllocatedSessionID string                           `json:"allocated_session_id,omitempty"`
-	Requirements       SessionRequirements              `json:"requirements"`
-	UpdatedAt          time.Time                        `json:"updated_at"`
-}
-
-type SessionAllocationResult struct {
-	Status             string `json:"status"`
-	Message            string `json:"message,omitempty"`
-	AllocatedSessionID string `json:"allocated_session_id,omitempty"`
-	ProxyURL           string `json:"proxy_url,omitempty"`
-}
-
-// SessionRequirements captures pod capabilities used for stock matching.
-type SessionRequirements struct {
-	AgentType string `json:"agent_type,omitempty"`
-	Sandbox   bool   `json:"sandbox"`
-	DinD      bool   `json:"dind"`
-}
 
 // CreateSession creates a session by submitting a SessionAllocationRequest when
 // the leader-elected allocator is enabled. Tests and non-server usage fall back
@@ -74,11 +39,11 @@ func (m *KubernetesSessionManager) CreateSessionDirect(ctx context.Context, id s
 }
 
 func (m *KubernetesSessionManager) submitSessionAllocation(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error) {
-	allocation := &SessionAllocationRequest{
+	allocation := &sessionallocation.AllocationRequest{
 		SessionID:      id,
 		Request:        req,
 		WebhookPayload: webhookPayload,
-		Status:         "pending",
+		Status:         sessionallocation.StatusPending,
 		Requirements:   sessionRequirements(req),
 		UpdatedAt:      time.Now().UTC(),
 	}
@@ -108,7 +73,7 @@ func (m *KubernetesSessionManager) SetSessionAllocatorEnabled(enabled bool) {
 	m.setSessionAllocatorEnabled(enabled)
 }
 
-func (m *KubernetesSessionManager) SetSessionAllocationNotifier(notifier SessionAllocationNotifier) {
+func (m *KubernetesSessionManager) SetSessionAllocationNotifier(notifier sessionallocation.Notifier) {
 	if notifier == nil {
 		return
 	}
@@ -117,19 +82,15 @@ func (m *KubernetesSessionManager) SetSessionAllocationNotifier(notifier Session
 	m.sessionAllocationNotifier = notifier
 }
 
-func sessionRequirements(req *entities.RunServerRequest) SessionRequirements {
-	return SessionRequirements{
-		AgentType: req.AgentType,
-		Sandbox:   req.Sandbox != nil && req.Sandbox.Enabled,
-		DinD:      req.Docker != nil && req.Docker.Enabled,
-	}
+func sessionRequirements(req *entities.RunServerRequest) sessionallocation.Requirements {
+	return sessionallocation.RequirementsFromRunServerRequest(req)
 }
 
 func sessionAllocationSecretName(sessionID string) string {
 	return sessionAllocationSecretPrefix + sessionID
 }
 
-func (m *KubernetesSessionManager) getSessionAllocation(ctx context.Context, sessionID string) (*SessionAllocationRequest, error) {
+func (m *KubernetesSessionManager) getSessionAllocation(ctx context.Context, sessionID string) (*sessionallocation.AllocationRequest, error) {
 	sec, err := m.client.CoreV1().Secrets(m.namespace).Get(ctx, sessionAllocationSecretName(sessionID), metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -138,14 +99,14 @@ func (m *KubernetesSessionManager) getSessionAllocation(ctx context.Context, ses
 	if len(data) == 0 {
 		return nil, fmt.Errorf("session allocation Secret %s has no %s", sec.Name, sessionAllocationDataKey)
 	}
-	var req SessionAllocationRequest
+	var req sessionallocation.AllocationRequest
 	if err := json.Unmarshal(data, &req); err != nil {
 		return nil, fmt.Errorf("decode session allocation: %w", err)
 	}
 	return &req, nil
 }
 
-func (m *KubernetesSessionManager) saveSessionAllocation(ctx context.Context, req *SessionAllocationRequest) error {
+func (m *KubernetesSessionManager) saveSessionAllocation(ctx context.Context, req *sessionallocation.AllocationRequest) error {
 	req.UpdatedAt = time.Now().UTC()
 	data, err := json.Marshal(req)
 	if err != nil {
@@ -158,7 +119,7 @@ func (m *KubernetesSessionManager) saveSessionAllocation(ctx context.Context, re
 		"agentapi.proxy/session-allocation":        "true",
 		"agentapi.proxy/requirement-sandbox":       fmt.Sprintf("%t", req.Requirements.Sandbox),
 		"agentapi.proxy/requirement-dind":          fmt.Sprintf("%t", req.Requirements.DinD),
-		"agentapi.proxy/session-allocation-status": req.Status,
+		"agentapi.proxy/session-allocation-status": string(req.Status),
 	}
 	if req.ManagerID != "" {
 		labels["agentapi.proxy/external-session-manager-id"] = "true"
@@ -210,7 +171,7 @@ func (m *KubernetesSessionManager) deleteSessionAllocation(ctx context.Context, 
 	return err
 }
 
-func (m *KubernetesSessionManager) NextSessionAllocation(ctx context.Context, wait time.Duration) (*SessionAllocationRequest, bool, error) {
+func (m *KubernetesSessionManager) NextSessionAllocation(ctx context.Context, wait time.Duration) (*sessionallocation.AllocationRequest, bool, error) {
 	deadline := time.Now().Add(wait)
 	for {
 		req, ok, err := m.claimNextSessionAllocation(ctx)
@@ -247,7 +208,7 @@ func (m *KubernetesSessionManager) NextSessionAllocation(ctx context.Context, wa
 	}
 }
 
-func (m *KubernetesSessionManager) claimNextSessionAllocation(ctx context.Context) (*SessionAllocationRequest, bool, error) {
+func (m *KubernetesSessionManager) claimNextSessionAllocation(ctx context.Context) (*sessionallocation.AllocationRequest, bool, error) {
 	secrets, err := m.client.CoreV1().Secrets(m.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "agentapi.proxy/session-allocation=true,!agentapi.proxy/external-session-manager-id,agentapi.proxy/session-allocation-status in (pending,allocating)",
 	})
@@ -265,7 +226,7 @@ func (m *KubernetesSessionManager) claimNextSessionAllocation(ctx context.Contex
 			log.Printf("[SESSION_ALLOCATOR] Failed to read allocation %s: %v", sec.Name, err)
 			continue
 		}
-		req.Status = "allocating"
+		req.Status = sessionallocation.StatusAllocating
 		if err := m.saveSessionAllocation(ctx, req); err != nil {
 			log.Printf("[SESSION_ALLOCATOR] Failed to claim allocation %s: %v", req.SessionID, err)
 			continue
@@ -276,12 +237,12 @@ func (m *KubernetesSessionManager) claimNextSessionAllocation(ctx context.Contex
 }
 
 func (m *KubernetesSessionManager) SubmitExternalSessionAllocation(ctx context.Context, managerID, sessionID string, settings *sessionsettings.SessionSettings, req *entities.RunServerRequest) error {
-	allocation := &SessionAllocationRequest{
+	allocation := &sessionallocation.AllocationRequest{
 		SessionID:         sessionID,
 		ManagerID:         managerID,
 		Request:           req,
 		ProvisionSettings: settings,
-		Status:            "pending",
+		Status:            sessionallocation.StatusPending,
 		Requirements:      sessionRequirements(req),
 		UpdatedAt:         time.Now().UTC(),
 	}
@@ -294,7 +255,7 @@ func (m *KubernetesSessionManager) SubmitExternalSessionAllocation(ctx context.C
 	return nil
 }
 
-func (m *KubernetesSessionManager) NextExternalSessionAllocation(ctx context.Context, managerID string, wait time.Duration) (*SessionAllocationRequest, bool, error) {
+func (m *KubernetesSessionManager) NextExternalSessionAllocation(ctx context.Context, managerID string, wait time.Duration) (*sessionallocation.AllocationRequest, bool, error) {
 	deadline := time.Now().Add(wait)
 	for {
 		req, ok, err := m.claimNextExternalSessionAllocation(ctx, managerID)
@@ -331,7 +292,7 @@ func (m *KubernetesSessionManager) NextExternalSessionAllocation(ctx context.Con
 	}
 }
 
-func (m *KubernetesSessionManager) claimNextExternalSessionAllocation(ctx context.Context, managerID string) (*SessionAllocationRequest, bool, error) {
+func (m *KubernetesSessionManager) claimNextExternalSessionAllocation(ctx context.Context, managerID string) (*sessionallocation.AllocationRequest, bool, error) {
 	if managerID == "" {
 		return nil, false, fmt.Errorf("managerID is required")
 	}
@@ -355,7 +316,7 @@ func (m *KubernetesSessionManager) claimNextExternalSessionAllocation(ctx contex
 		if req.ManagerID != managerID {
 			continue
 		}
-		req.Status = "allocating"
+		req.Status = sessionallocation.StatusAllocating
 		if err := m.saveSessionAllocation(ctx, req); err != nil {
 			log.Printf("[EXTERNAL_SESSION_ALLOCATOR] Failed to claim allocation %s: %v", req.SessionID, err)
 			continue
@@ -365,7 +326,7 @@ func (m *KubernetesSessionManager) claimNextExternalSessionAllocation(ctx contex
 	return nil, false, nil
 }
 
-func (m *KubernetesSessionManager) CompleteExternalSessionAllocation(ctx context.Context, sessionID string, result SessionAllocationResult) (*SessionAllocationRequest, error) {
+func (m *KubernetesSessionManager) CompleteExternalSessionAllocation(ctx context.Context, sessionID string, result sessionallocation.AllocationResult) (*sessionallocation.AllocationRequest, error) {
 	req, err := m.getSessionAllocation(ctx, sessionID)
 	if err != nil {
 		return nil, err
@@ -385,7 +346,7 @@ func (m *KubernetesSessionManager) CompleteExternalSessionAllocation(ctx context
 	return req, nil
 }
 
-func (m *KubernetesSessionManager) CompleteSessionAllocation(ctx context.Context, sessionID string, result SessionAllocationResult) error {
+func (m *KubernetesSessionManager) CompleteSessionAllocation(ctx context.Context, sessionID string, result sessionallocation.AllocationResult) error {
 	req, err := m.getSessionAllocation(ctx, sessionID)
 	if err != nil {
 		return err
@@ -426,199 +387,6 @@ func (m *KubernetesSessionManager) subscribeSessionAllocation(ctx context.Contex
 	return notifier.Subscribe(ctx)
 }
 
-type SessionAllocationNotifier interface {
-	Notify(ctx context.Context) error
-	Subscribe(ctx context.Context) (<-chan struct{}, func(), error)
-}
-
-type LocalSessionAllocationNotifier struct {
-	mu   sync.Mutex
-	subs map[chan struct{}]struct{}
-}
-
-func NewLocalSessionAllocationNotifier() *LocalSessionAllocationNotifier {
-	return &LocalSessionAllocationNotifier{subs: make(map[chan struct{}]struct{})}
-}
-
-func (n *LocalSessionAllocationNotifier) Notify(context.Context) error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	for ch := range n.subs {
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
-	}
-	return nil
-}
-
-func (n *LocalSessionAllocationNotifier) Subscribe(context.Context) (<-chan struct{}, func(), error) {
-	ch := make(chan struct{}, 1)
-	n.mu.Lock()
-	n.subs[ch] = struct{}{}
-	n.mu.Unlock()
-	cancel := func() {
-		n.mu.Lock()
-		if _, ok := n.subs[ch]; ok {
-			delete(n.subs, ch)
-			close(ch)
-		}
-		n.mu.Unlock()
-	}
-	return ch, cancel, nil
-}
-
-type RedisSessionAllocationNotifier struct {
-	client *redis.Client
-	local  *LocalSessionAllocationNotifier
-}
-
-func NewRedisSessionAllocationNotifier(client *redis.Client) *RedisSessionAllocationNotifier {
-	return &RedisSessionAllocationNotifier{client: client, local: NewLocalSessionAllocationNotifier()}
-}
-
-func (n *RedisSessionAllocationNotifier) Notify(ctx context.Context) error {
-	_ = n.local.Notify(ctx)
-	if n.client == nil {
-		return nil
-	}
-	return n.client.Publish(ctx, sessionAllocationNotifyTopic, "ping").Err()
-}
-
-func (n *RedisSessionAllocationNotifier) Subscribe(ctx context.Context) (<-chan struct{}, func(), error) {
-	if n.client == nil {
-		return n.local.Subscribe(ctx)
-	}
-	localCh, localCancel, _ := n.local.Subscribe(ctx)
-	pubsub := n.client.Subscribe(ctx, sessionAllocationNotifyTopic)
-	if _, err := pubsub.Receive(ctx); err != nil {
-		localCancel()
-		_ = pubsub.Close()
-		return nil, nil, err
-	}
-	out := make(chan struct{}, 1)
-	done := make(chan struct{})
-	go func() {
-		defer close(out)
-		redisCh := pubsub.Channel()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ctx.Done():
-				return
-			case _, ok := <-localCh:
-				if !ok {
-					localCh = nil
-					continue
-				}
-				select {
-				case out <- struct{}{}:
-				default:
-				}
-			case _, ok := <-redisCh:
-				if !ok {
-					return
-				}
-				select {
-				case out <- struct{}{}:
-				default:
-				}
-			}
-		}
-	}()
-	cancel := func() {
-		close(done)
-		localCancel()
-		_ = pubsub.Close()
-	}
-	return out, cancel, nil
-}
-
-// SessionAllocator is a leader-only worker that binds a session allocation
-// request to either matching stock capacity or a newly created session Pod.
-type SessionAllocator struct {
-	manager *KubernetesSessionManager
-	client  *SessionAllocatorClient
-
-	mu      sync.Mutex
-	running bool
-	stopCh  chan struct{}
-}
-
-func NewSessionAllocator(manager *KubernetesSessionManager) *SessionAllocator {
-	return &SessionAllocator{
-		manager: manager,
-		client:  NewSessionAllocatorClient(manager.allocationProxyURL(), manager.k8sConfig.ProvisionerToken),
-		stopCh:  make(chan struct{}),
-	}
-}
-
-func (a *SessionAllocator) Start(ctx context.Context) error {
-	a.mu.Lock()
-	if a.running {
-		a.mu.Unlock()
-		return nil
-	}
-	a.running = true
-	a.stopCh = make(chan struct{})
-	a.mu.Unlock()
-
-	go a.run(ctx)
-	log.Printf("[SESSION_ALLOCATOR] Started")
-	return nil
-}
-
-func (a *SessionAllocator) Stop() {
-	a.mu.Lock()
-	if !a.running {
-		a.mu.Unlock()
-		return
-	}
-	close(a.stopCh)
-	a.running = false
-	a.mu.Unlock()
-	log.Printf("[SESSION_ALLOCATOR] Stopped")
-}
-
-func (a *SessionAllocator) run(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-a.stopCh:
-			return
-		default:
-		}
-		req, ok, err := a.client.Next(ctx, 30*time.Second)
-		if err != nil {
-			log.Printf("[SESSION_ALLOCATOR] Failed to receive allocation request: %v", err)
-			sleepOrContextDone(ctx, 2*time.Second)
-			continue
-		}
-		if !ok {
-			continue
-		}
-		a.processOne(ctx, req)
-	}
-}
-
-func (a *SessionAllocator) processOne(ctx context.Context, req *SessionAllocationRequest) {
-	log.Printf("[SESSION_ALLOCATOR] Allocating session %s (sandbox=%t dind=%t agent_type=%s)",
-		req.SessionID, req.Requirements.Sandbox, req.Requirements.DinD, req.Requirements.AgentType)
-	sess, err := a.manager.allocateSessionDirect(ctx, req.SessionID, req.Request, req.WebhookPayload)
-	if err != nil {
-		_ = a.client.Complete(context.Background(), req.SessionID, SessionAllocationResult{Status: "error", Message: err.Error()})
-		log.Printf("[SESSION_ALLOCATOR] Allocation failed for %s: %v", req.SessionID, err)
-		return
-	}
-	if err := a.client.Complete(context.Background(), req.SessionID, SessionAllocationResult{Status: "assigned", AllocatedSessionID: sess.ID()}); err != nil {
-		log.Printf("[SESSION_ALLOCATOR] Failed to mark allocation %s assigned: %v", req.SessionID, err)
-		return
-	}
-	log.Printf("[SESSION_ALLOCATOR] Allocated session %s as %s", req.SessionID, sess.ID())
-}
-
 func (m *KubernetesSessionManager) allocationProxyURL() string {
 	proxyURL := strings.TrimRight(m.k8sConfig.ProvisionerProxyURL, "/")
 	if proxyURL != "" {
@@ -627,94 +395,6 @@ func (m *KubernetesSessionManager) allocationProxyURL() string {
 	return fmt.Sprintf("http://agentapi-proxy.%s.svc.cluster.local:8080", m.namespace)
 }
 
-type SessionAllocatorClient struct {
-	baseURL string
-	token   string
-	client  *http.Client
-}
-
-func NewSessionAllocatorClient(baseURL, token string) *SessionAllocatorClient {
-	return &SessionAllocatorClient{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		token:   token,
-		client:  &http.Client{Timeout: 35 * time.Second},
-	}
-}
-
-func (c *SessionAllocatorClient) Next(ctx context.Context, wait time.Duration) (*SessionAllocationRequest, bool, error) {
-	return c.next(ctx, "/internal/session-allocations/next", wait)
-}
-
-func (c *SessionAllocatorClient) NextExternal(ctx context.Context, wait time.Duration) (*SessionAllocationRequest, bool, error) {
-	return c.next(ctx, "/internal/external-session-manager/allocations/next", wait)
-}
-
-func (c *SessionAllocatorClient) next(ctx context.Context, path string, wait time.Duration) (*SessionAllocationRequest, bool, error) {
-	u, err := url.Parse(c.baseURL + path)
-	if err != nil {
-		return nil, false, err
-	}
-	q := u.Query()
-	q.Set("wait", wait.String())
-	u.RawQuery = q.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, false, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, false, err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, false, nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, false, fmt.Errorf("GET allocation next returned HTTP %d: %s", resp.StatusCode, string(body))
-	}
-	var allocation SessionAllocationRequest
-	if err := json.NewDecoder(resp.Body).Decode(&allocation); err != nil {
-		return nil, false, err
-	}
-	return &allocation, true, nil
-}
-
-func (c *SessionAllocatorClient) Complete(ctx context.Context, sessionID string, result SessionAllocationResult) error {
-	return c.complete(ctx, "/internal/session-allocations/"+url.PathEscape(sessionID)+"/result", result)
-}
-
-func (c *SessionAllocatorClient) CompleteExternal(ctx context.Context, sessionID string, result SessionAllocationResult) error {
-	return c.complete(ctx, "/internal/external-session-manager/allocations/"+url.PathEscape(sessionID)+"/result", result)
-}
-
-func (c *SessionAllocatorClient) complete(ctx context.Context, path string, result SessionAllocationResult) error {
-	data, err := json.Marshal(result)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("POST allocation result returned HTTP %d: %s", resp.StatusCode, string(body))
-	}
-	return nil
-}
-
-func sleepOrContextDone(ctx context.Context, d time.Duration) {
-	select {
-	case <-ctx.Done():
-	case <-time.After(d):
-	}
+func (m *KubernetesSessionManager) AllocationProxyURL() string {
+	return m.allocationProxyURL()
 }

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
@@ -109,10 +110,10 @@ func TestNextSessionAllocationClaimsRequestCreatedWhileSubscribing(t *testing.T)
 	}
 	manager.SetSessionAllocationNotifier(&subscribeHookNotifier{
 		onSubscribe: func() {
-			if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+			if err := manager.saveSessionAllocation(context.Background(), &sessionallocation.AllocationRequest{
 				SessionID: "test-session",
 				Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
-				Status:    "pending",
+				Status:    sessionallocation.StatusPending,
 			}); err != nil {
 				t.Fatalf("saveSessionAllocation() error = %v", err)
 			}
@@ -129,7 +130,7 @@ func TestNextSessionAllocationClaimsRequestCreatedWhileSubscribing(t *testing.T)
 	if allocation.SessionID != "test-session" {
 		t.Fatalf("allocation.SessionID = %q, want test-session", allocation.SessionID)
 	}
-	if allocation.Status != "allocating" {
+	if allocation.Status != sessionallocation.StatusAllocating {
 		t.Fatalf("allocation.Status = %q, want allocating", allocation.Status)
 	}
 }
@@ -146,11 +147,11 @@ func TestNextExternalSessionAllocationClaimsRequestCreatedWhileSubscribing(t *te
 	}
 	manager.SetSessionAllocationNotifier(&subscribeHookNotifier{
 		onSubscribe: func() {
-			if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+			if err := manager.saveSessionAllocation(context.Background(), &sessionallocation.AllocationRequest{
 				SessionID: "test-session",
 				ManagerID: "manager-a",
 				Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
-				Status:    "pending",
+				Status:    sessionallocation.StatusPending,
 			}); err != nil {
 				t.Fatalf("saveSessionAllocation() error = %v", err)
 			}
@@ -167,7 +168,7 @@ func TestNextExternalSessionAllocationClaimsRequestCreatedWhileSubscribing(t *te
 	if allocation.SessionID != "test-session" {
 		t.Fatalf("allocation.SessionID = %q, want test-session", allocation.SessionID)
 	}
-	if allocation.Status != "allocating" {
+	if allocation.Status != sessionallocation.StatusAllocating {
 		t.Fatalf("allocation.Status = %q, want allocating", allocation.Status)
 	}
 }
@@ -183,16 +184,16 @@ func TestCompleteSessionAllocationDeletesAllocationSecret(t *testing.T) {
 		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
 	}
 
-	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+	if err := manager.saveSessionAllocation(context.Background(), &sessionallocation.AllocationRequest{
 		SessionID: "test-session",
 		Request:   &entities.RunServerRequest{UserID: "test-user"},
-		Status:    "allocating",
+		Status:    sessionallocation.StatusAllocating,
 	}); err != nil {
 		t.Fatalf("saveSessionAllocation() error = %v", err)
 	}
 
-	if err := manager.CompleteSessionAllocation(context.Background(), "test-session", SessionAllocationResult{
-		Status:             "assigned",
+	if err := manager.CompleteSessionAllocation(context.Background(), "test-session", sessionallocation.AllocationResult{
+		Status:             sessionallocation.StatusAssigned,
 		AllocatedSessionID: "test-session",
 	}); err != nil {
 		t.Fatalf("CompleteSessionAllocation() error = %v", err)
@@ -215,14 +216,14 @@ func TestListSessionsIncludesAllocatingSessionAllocation(t *testing.T) {
 		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
 	}
 
-	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+	if err := manager.saveSessionAllocation(context.Background(), &sessionallocation.AllocationRequest{
 		SessionID: "test-session",
 		Request: &entities.RunServerRequest{
 			UserID: "test-user",
 			Scope:  entities.ScopeUser,
 			Tags:   map[string]string{"purpose": "test"},
 		},
-		Status: "allocating",
+		Status: sessionallocation.StatusAllocating,
 	}); err != nil {
 		t.Fatalf("saveSessionAllocation() error = %v", err)
 	}
@@ -258,10 +259,10 @@ func TestSessionAllocationInvalidatesSessionListCache(t *testing.T) {
 	cache := &recordingSessionListCacheRepo{}
 	manager.SetSessionListCacheRepository(cache)
 
-	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+	if err := manager.saveSessionAllocation(context.Background(), &sessionallocation.AllocationRequest{
 		SessionID: "test-session",
 		Request:   &entities.RunServerRequest{UserID: "test-user", Scope: entities.ScopeUser},
-		Status:    "pending",
+		Status:    sessionallocation.StatusPending,
 	}); err != nil {
 		t.Fatalf("saveSessionAllocation() error = %v", err)
 	}
@@ -290,14 +291,14 @@ func TestListSessionsDoesNotPopulateCacheWhileAllocationExists(t *testing.T) {
 	cache := &recordingSessionListCacheRepo{}
 	manager.SetSessionListCacheRepository(cache)
 
-	if err := manager.saveSessionAllocation(context.Background(), &SessionAllocationRequest{
+	if err := manager.saveSessionAllocation(context.Background(), &sessionallocation.AllocationRequest{
 		SessionID: "test-session",
 		Request: &entities.RunServerRequest{
 			UserID: "test-user",
 			Scope:  entities.ScopeUser,
 			Tags:   map[string]string{"purpose": "test"},
 		},
-		Status: "pending",
+		Status: sessionallocation.StatusPending,
 	}); err != nil {
 		t.Fatalf("saveSessionAllocation() error = %v", err)
 	}

--- a/internal/infrastructure/sessionallocation/http_client.go
+++ b/internal/infrastructure/sessionallocation/http_client.go
@@ -1,0 +1,100 @@
+package sessionallocation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	core "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
+)
+
+type Client struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func NewClient(baseURL, token string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		client:  &http.Client{Timeout: 35 * time.Second},
+	}
+}
+
+func (c *Client) Next(ctx context.Context, wait time.Duration) (*core.AllocationRequest, bool, error) {
+	return c.next(ctx, "/internal/session-allocations/next", wait)
+}
+
+func (c *Client) NextExternal(ctx context.Context, wait time.Duration) (*core.AllocationRequest, bool, error) {
+	return c.next(ctx, "/internal/external-session-manager/allocations/next", wait)
+}
+
+func (c *Client) next(ctx context.Context, path string, wait time.Duration) (*core.AllocationRequest, bool, error) {
+	u, err := url.Parse(c.baseURL + path)
+	if err != nil {
+		return nil, false, err
+	}
+	q := u.Query()
+	q.Set("wait", wait.String())
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, false, fmt.Errorf("GET allocation next returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	var allocation core.AllocationRequest
+	if err := json.NewDecoder(resp.Body).Decode(&allocation); err != nil {
+		return nil, false, err
+	}
+	return &allocation, true, nil
+}
+
+func (c *Client) Complete(ctx context.Context, sessionID string, result core.AllocationResult) error {
+	return c.complete(ctx, "/internal/session-allocations/"+url.PathEscape(sessionID)+"/result", result)
+}
+
+func (c *Client) CompleteExternal(ctx context.Context, sessionID string, result core.AllocationResult) error {
+	return c.complete(ctx, "/internal/external-session-manager/allocations/"+url.PathEscape(sessionID)+"/result", result)
+}
+
+func (c *Client) complete(ctx context.Context, path string, result core.AllocationResult) error {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("POST allocation result returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/internal/infrastructure/sessionallocation/notifier.go
+++ b/internal/infrastructure/sessionallocation/notifier.go
@@ -1,0 +1,114 @@
+package sessionallocation
+
+import (
+	"context"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const notifyTopic = "agentapi:session-allocation:notify"
+
+type LocalNotifier struct {
+	mu   sync.Mutex
+	subs map[chan struct{}]struct{}
+}
+
+func NewLocalNotifier() *LocalNotifier {
+	return &LocalNotifier{subs: make(map[chan struct{}]struct{})}
+}
+
+func (n *LocalNotifier) Notify(context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for ch := range n.subs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (n *LocalNotifier) Subscribe(context.Context) (<-chan struct{}, func(), error) {
+	ch := make(chan struct{}, 1)
+	n.mu.Lock()
+	n.subs[ch] = struct{}{}
+	n.mu.Unlock()
+	cancel := func() {
+		n.mu.Lock()
+		if _, ok := n.subs[ch]; ok {
+			delete(n.subs, ch)
+			close(ch)
+		}
+		n.mu.Unlock()
+	}
+	return ch, cancel, nil
+}
+
+type RedisNotifier struct {
+	client *redis.Client
+	local  *LocalNotifier
+}
+
+func NewRedisNotifier(client *redis.Client) *RedisNotifier {
+	return &RedisNotifier{client: client, local: NewLocalNotifier()}
+}
+
+func (n *RedisNotifier) Notify(ctx context.Context) error {
+	_ = n.local.Notify(ctx)
+	if n.client == nil {
+		return nil
+	}
+	return n.client.Publish(ctx, notifyTopic, "ping").Err()
+}
+
+func (n *RedisNotifier) Subscribe(ctx context.Context) (<-chan struct{}, func(), error) {
+	if n.client == nil {
+		return n.local.Subscribe(ctx)
+	}
+	localCh, localCancel, _ := n.local.Subscribe(ctx)
+	pubsub := n.client.Subscribe(ctx, notifyTopic)
+	if _, err := pubsub.Receive(ctx); err != nil {
+		localCancel()
+		_ = pubsub.Close()
+		return nil, nil, err
+	}
+	out := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(out)
+		redisCh := pubsub.Channel()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case _, ok := <-localCh:
+				if !ok {
+					localCh = nil
+					continue
+				}
+				select {
+				case out <- struct{}{}:
+				default:
+				}
+			case _, ok := <-redisCh:
+				if !ok {
+					return
+				}
+				select {
+				case out <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+	cancel := func() {
+		close(done)
+		localCancel()
+		_ = pubsub.Close()
+	}
+	return out, cancel, nil
+}

--- a/internal/interfaces/controllers/provisioner_controller.go
+++ b/internal/interfaces/controllers/provisioner_controller.go
@@ -8,18 +8,20 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 )
 
 type ProvisionerController struct {
 	manager          *services.KubernetesSessionManager
+	allocationQueue  sessionallocation.Queue
 	settingsRepo     repositories.SettingsRepository
 	sessionRouteRepo repositories.SessionRouteRepository
 }
 
-func NewProvisionerController(manager *services.KubernetesSessionManager, settingsRepo repositories.SettingsRepository, sessionRouteRepo repositories.SessionRouteRepository) *ProvisionerController {
-	return &ProvisionerController{manager: manager, settingsRepo: settingsRepo, sessionRouteRepo: sessionRouteRepo}
+func NewProvisionerController(manager *services.KubernetesSessionManager, allocationQueue sessionallocation.Queue, settingsRepo repositories.SettingsRepository, sessionRouteRepo repositories.SessionRouteRepository) *ProvisionerController {
+	return &ProvisionerController{manager: manager, allocationQueue: allocationQueue, settingsRepo: settingsRepo, sessionRouteRepo: sessionRouteRepo}
 }
 
 func (pc *ProvisionerController) Connect(c echo.Context) error {
@@ -89,7 +91,7 @@ func (pc *ProvisionerController) GetNextSessionAllocation(c echo.Context) error 
 		return c.NoContent(http.StatusUnauthorized)
 	}
 	wait := parseWait(c.QueryParam("wait"))
-	req, ok, err := pc.manager.NextSessionAllocation(c.Request().Context(), wait)
+	req, ok, err := pc.allocationQueue.NextSessionAllocation(c.Request().Context(), wait)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -103,14 +105,14 @@ func (pc *ProvisionerController) CompleteSessionAllocation(c echo.Context) error
 	if !pc.authorized(c) {
 		return c.NoContent(http.StatusUnauthorized)
 	}
-	var result services.SessionAllocationResult
+	var result sessionallocation.AllocationResult
 	if err := c.Bind(&result); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	if result.Status == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "status is required"})
 	}
-	if err := pc.manager.CompleteSessionAllocation(c.Request().Context(), c.Param("sessionId"), result); err != nil {
+	if err := pc.allocationQueue.CompleteSessionAllocation(c.Request().Context(), c.Param("sessionId"), result); err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -122,7 +124,7 @@ func (pc *ProvisionerController) GetNextExternalSessionAllocation(c echo.Context
 		return c.NoContent(http.StatusUnauthorized)
 	}
 	wait := parseWait(c.QueryParam("wait"))
-	req, found, err := pc.manager.NextExternalSessionAllocation(c.Request().Context(), managerID, wait)
+	req, found, err := pc.allocationQueue.NextExternalSessionAllocation(c.Request().Context(), managerID, wait)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
@@ -137,21 +139,21 @@ func (pc *ProvisionerController) CompleteExternalSessionAllocation(c echo.Contex
 	if !ok {
 		return c.NoContent(http.StatusUnauthorized)
 	}
-	var result services.SessionAllocationResult
+	var result sessionallocation.AllocationResult
 	if err := c.Bind(&result); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 	if result.Status == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "status is required"})
 	}
-	if result.Status == "assigned" && result.AllocatedSessionID == "" {
+	if result.Status == sessionallocation.StatusAssigned && result.AllocatedSessionID == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "allocated_session_id is required when status is assigned"})
 	}
-	allocation, err := pc.manager.CompleteExternalSessionAllocation(c.Request().Context(), c.Param("sessionId"), result)
+	allocation, err := pc.allocationQueue.CompleteExternalSessionAllocation(c.Request().Context(), c.Param("sessionId"), result)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
-	if result.Status != "assigned" {
+	if result.Status != sessionallocation.StatusAssigned {
 		if pc.sessionRouteRepo != nil {
 			_ = pc.sessionRouteRepo.Delete(c.Request().Context(), allocation.SessionID)
 		}

--- a/internal/modules/sessionallocation/worker.go
+++ b/internal/modules/sessionallocation/worker.go
@@ -1,0 +1,105 @@
+package sessionallocation
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	core "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+type SessionCreator interface {
+	CreateSessionDirect(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error)
+}
+
+// Worker is a leader-only loop that binds queued allocation requests to sessions.
+type Worker struct {
+	creator SessionCreator
+	client  core.InternalAllocatorClient
+
+	mu      sync.Mutex
+	running bool
+	stopCh  chan struct{}
+}
+
+func NewWorker(creator SessionCreator, client core.InternalAllocatorClient) *Worker {
+	return &Worker{
+		creator: creator,
+		client:  client,
+		stopCh:  make(chan struct{}),
+	}
+}
+
+func (w *Worker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	w.running = true
+	w.stopCh = make(chan struct{})
+	w.mu.Unlock()
+
+	go w.run(ctx)
+	log.Printf("[SESSION_ALLOCATOR] Started")
+	return nil
+}
+
+func (w *Worker) Stop() {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return
+	}
+	close(w.stopCh)
+	w.running = false
+	w.mu.Unlock()
+	log.Printf("[SESSION_ALLOCATOR] Stopped")
+}
+
+func (w *Worker) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		default:
+		}
+		req, ok, err := w.client.Next(ctx, 30*time.Second)
+		if err != nil {
+			log.Printf("[SESSION_ALLOCATOR] Failed to receive allocation request: %v", err)
+			sleepOrContextDone(ctx, 2*time.Second)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		w.processOne(ctx, req)
+	}
+}
+
+func (w *Worker) processOne(ctx context.Context, req *core.AllocationRequest) {
+	log.Printf("[SESSION_ALLOCATOR] Allocating session %s (sandbox=%t dind=%t agent_type=%s)",
+		req.SessionID, req.Requirements.Sandbox, req.Requirements.DinD, req.Requirements.AgentType)
+	sess, err := w.creator.CreateSessionDirect(ctx, req.SessionID, req.Request, req.WebhookPayload)
+	if err != nil {
+		_ = w.client.Complete(context.Background(), req.SessionID, core.AllocationResult{Status: core.StatusError, Message: err.Error()})
+		log.Printf("[SESSION_ALLOCATOR] Allocation failed for %s: %v", req.SessionID, err)
+		return
+	}
+	if err := w.client.Complete(context.Background(), req.SessionID, core.AllocationResult{Status: core.StatusAssigned, AllocatedSessionID: sess.ID()}); err != nil {
+		log.Printf("[SESSION_ALLOCATOR] Failed to mark allocation %s assigned: %v", req.SessionID, err)
+		return
+	}
+	log.Printf("[SESSION_ALLOCATOR] Allocated session %s as %s", req.SessionID, sess.ID())
+}
+
+func sleepOrContextDone(ctx context.Context, d time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
+}

--- a/internal/modules/sessionmanager/allocator_worker.go
+++ b/internal/modules/sessionmanager/allocator_worker.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
+	infrasessionallocation "github.com/takutakahashi/agentapi-proxy/internal/infrastructure/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
 type AllocatorWorker struct {
 	sessionManager repositories.SessionManager
-	client         *services.SessionAllocatorClient
+	client         sessionallocation.ExternalAllocatorClient
 	publicURL      string
 }
 
@@ -23,9 +24,13 @@ type directSessionManager interface {
 }
 
 func NewAllocatorWorker(sessionManager repositories.SessionManager, upstreamURL, token, publicURL string) *AllocatorWorker {
+	return NewAllocatorWorkerWithClient(sessionManager, infrasessionallocation.NewClient(upstreamURL, token), publicURL)
+}
+
+func NewAllocatorWorkerWithClient(sessionManager repositories.SessionManager, client sessionallocation.ExternalAllocatorClient, publicURL string) *AllocatorWorker {
 	return &AllocatorWorker{
 		sessionManager: sessionManager,
-		client:         services.NewSessionAllocatorClient(upstreamURL, token),
+		client:         client,
 		publicURL:      publicURL,
 	}
 }
@@ -51,14 +56,14 @@ func (w *AllocatorWorker) Start(ctx context.Context) {
 	}
 }
 
-func (w *AllocatorWorker) process(ctx context.Context, allocation *services.SessionAllocationRequest) {
+func (w *AllocatorWorker) process(ctx context.Context, allocation *sessionallocation.AllocationRequest) {
 	settings := allocation.ProvisionSettings
 	if settings == nil && allocation.Request != nil {
 		settings = allocation.Request.ProvisionSettings
 	}
 	if settings == nil {
-		_ = w.client.CompleteExternal(context.Background(), allocation.SessionID, services.SessionAllocationResult{
-			Status:  "error",
+		_ = w.client.CompleteExternal(context.Background(), allocation.SessionID, sessionallocation.AllocationResult{
+			Status:  sessionallocation.StatusError,
 			Message: "provision_settings is required",
 		})
 		return
@@ -69,15 +74,15 @@ func (w *AllocatorWorker) process(ctx context.Context, allocation *services.Sess
 	session, err := w.createLocalSession(ctx, sessionID, req)
 	if err != nil {
 		log.Printf("[SESSION_MANAGER_ALLOCATOR] Failed to create session for allocation %s: %v", allocation.SessionID, err)
-		_ = w.client.CompleteExternal(context.Background(), allocation.SessionID, services.SessionAllocationResult{
-			Status:  "error",
+		_ = w.client.CompleteExternal(context.Background(), allocation.SessionID, sessionallocation.AllocationResult{
+			Status:  sessionallocation.StatusError,
 			Message: err.Error(),
 		})
 		return
 	}
 
-	if err := w.client.CompleteExternal(context.Background(), allocation.SessionID, services.SessionAllocationResult{
-		Status:             "assigned",
+	if err := w.client.CompleteExternal(context.Background(), allocation.SessionID, sessionallocation.AllocationResult{
+		Status:             sessionallocation.StatusAssigned,
 		AllocatedSessionID: session.ID(),
 		ProxyURL:           w.publicURL,
 	}); err != nil {

--- a/internal/modules/sessionmanager/allocator_worker_test.go
+++ b/internal/modules/sessionmanager/allocator_worker_test.go
@@ -1,0 +1,141 @@
+package sessionmanager
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sessionallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
+)
+
+func TestAllocatorWorkerCompletesAssignedAllocation(t *testing.T) {
+	client := &fakeExternalAllocatorClient{}
+	manager := &fakeAllocatorSessionManager{}
+	worker := NewAllocatorWorkerWithClient(manager, client, "https://esm.example")
+
+	worker.process(context.Background(), &sessionallocation.AllocationRequest{
+		SessionID: "parent-session",
+		ProvisionSettings: &sessionsettings.SessionSettings{
+			Session: sessionsettings.SessionMeta{
+				UserID:    "user-1",
+				Scope:     string(entities.ScopeUser),
+				AgentType: "codex",
+			},
+		},
+	})
+
+	if len(client.completed) != 1 {
+		t.Fatalf("completed results = %d, want 1", len(client.completed))
+	}
+	result := client.completed[0]
+	if result.sessionID != "parent-session" {
+		t.Fatalf("completed sessionID = %q, want parent-session", result.sessionID)
+	}
+	if result.result.Status != sessionallocation.StatusAssigned {
+		t.Fatalf("status = %q, want assigned", result.result.Status)
+	}
+	if result.result.AllocatedSessionID == "" {
+		t.Fatalf("allocated_session_id is empty")
+	}
+	if result.result.ProxyURL != "https://esm.example" {
+		t.Fatalf("proxy_url = %q, want https://esm.example", result.result.ProxyURL)
+	}
+	if manager.created == 0 {
+		t.Fatalf("local session was not created")
+	}
+}
+
+func TestAllocatorWorkerCompletesErrorWhenProvisionSettingsMissing(t *testing.T) {
+	client := &fakeExternalAllocatorClient{}
+	worker := NewAllocatorWorkerWithClient(&fakeAllocatorSessionManager{}, client, "https://esm.example")
+
+	worker.process(context.Background(), &sessionallocation.AllocationRequest{SessionID: "parent-session"})
+
+	if len(client.completed) != 1 {
+		t.Fatalf("completed results = %d, want 1", len(client.completed))
+	}
+	result := client.completed[0].result
+	if result.Status != sessionallocation.StatusError {
+		t.Fatalf("status = %q, want error", result.Status)
+	}
+	if result.Message != "provision_settings is required" {
+		t.Fatalf("message = %q, want provision_settings is required", result.Message)
+	}
+}
+
+func TestAllocatorWorkerCompletesErrorWhenLocalSessionCreationFails(t *testing.T) {
+	client := &fakeExternalAllocatorClient{}
+	manager := &fakeAllocatorSessionManager{createErr: errors.New("create failed")}
+	worker := NewAllocatorWorkerWithClient(manager, client, "https://esm.example")
+
+	worker.process(context.Background(), &sessionallocation.AllocationRequest{
+		SessionID: "parent-session",
+		ProvisionSettings: &sessionsettings.SessionSettings{
+			Session: sessionsettings.SessionMeta{UserID: "user-1", Scope: string(entities.ScopeUser)},
+		},
+	})
+
+	if len(client.completed) != 1 {
+		t.Fatalf("completed results = %d, want 1", len(client.completed))
+	}
+	result := client.completed[0].result
+	if result.Status != sessionallocation.StatusError {
+		t.Fatalf("status = %q, want error", result.Status)
+	}
+	if result.Message != "create failed" {
+		t.Fatalf("message = %q, want create failed", result.Message)
+	}
+}
+
+type fakeExternalAllocatorClient struct {
+	completed []completedAllocation
+}
+
+type completedAllocation struct {
+	sessionID string
+	result    sessionallocation.AllocationResult
+}
+
+func (c *fakeExternalAllocatorClient) NextExternal(context.Context, time.Duration) (*sessionallocation.AllocationRequest, bool, error) {
+	return nil, false, nil
+}
+
+func (c *fakeExternalAllocatorClient) CompleteExternal(_ context.Context, sessionID string, result sessionallocation.AllocationResult) error {
+	c.completed = append(c.completed, completedAllocation{sessionID: sessionID, result: result})
+	return nil
+}
+
+type fakeAllocatorSessionManager struct {
+	created   int
+	createErr error
+}
+
+func (m *fakeAllocatorSessionManager) CreateSession(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error) {
+	return m.CreateSessionDirect(ctx, id, req, webhookPayload)
+}
+
+func (m *fakeAllocatorSessionManager) CreateSessionDirect(_ context.Context, id string, req *entities.RunServerRequest, _ []byte) (entities.Session, error) {
+	m.created++
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	return entities.NewProxySession(id, req.UserID, req.Scope, req.TeamID, req.Tags, time.Now()), nil
+}
+
+func (m *fakeAllocatorSessionManager) GetSession(string) entities.Session { return nil }
+func (m *fakeAllocatorSessionManager) ListSessions(entities.SessionFilter) []entities.Session {
+	return nil
+}
+func (m *fakeAllocatorSessionManager) DeleteSession(string) error { return nil }
+func (m *fakeAllocatorSessionManager) SendMessage(context.Context, string, string) error {
+	return nil
+}
+func (m *fakeAllocatorSessionManager) StopAgent(context.Context, string) error { return nil }
+func (m *fakeAllocatorSessionManager) GetMessages(context.Context, string) ([]portrepos.Message, error) {
+	return nil, nil
+}
+func (m *fakeAllocatorSessionManager) Shutdown(time.Duration) error { return nil }


### PR DESCRIPTION
## Summary
- Move allocation request/result/requirements/status and allocator ports into internal/core/sessionallocation
- Move allocator HTTP client and Redis/local notifier adapters into internal/infrastructure/sessionallocation
- Move the leader allocator loop into internal/modules/sessionallocation and wire it from cmd/server.go
- Remove internal/modules/sessionmanager dependency on internal/infrastructure/services and add fake-client worker tests
- Route parent ESM allocation submission and provisioner allocation endpoints through the core queue port

## Verification
- /tmp/go-toolchain/go/bin/go test ./internal/infrastructure/services ./internal/interfaces/controllers ./internal/modules/sessionmanager ./internal/modules/sessionallocation ./internal/infrastructure/sessionallocation ./internal/app
- /tmp/go-toolchain/go/bin/go list ./... | grep -v '/cmd$' | xargs /tmp/go-toolchain/go/bin/go test
- /tmp/go-toolchain/go/bin/go test ./cmd -run 'TestServerCmd|TestServerCmdFlags'
- /tmp/go-toolchain/go/bin/go test ./cmd -run TestClient
- grep boundary checks: internal/modules/sessionmanager has no internal/infrastructure/services import; internal/core has no app/interfaces/modules/infrastructure imports

Note: /tmp/go-toolchain/go/bin/go test ./... reaches the existing cmd TestRunProxy* tests, which send os.Interrupt to the whole test process. In this dev-cluster environment they fail independently of this change with signal: interrupt while real Kubernetes-backed server startup is still initializing.