### PR TITLE
Set service owner references on session resources

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -390,9 +390,20 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 
 	log.Printf("[K8S_SESSION] Creating session %s in namespace %s", id, m.namespace)
 
+	// Create Service first so session-owned resources can point at it as their
+	// garbage-collection owner.
+	if err := m.createService(ctx, session); err != nil {
+		m.cleanupSession(id)
+		return nil, fmt.Errorf("failed to create Service: %w", err)
+	}
+	log.Printf("[K8S_SESSION] Created Service %s for session %s", serviceName, id)
+
 	// Create PVC if enabled
 	if m.isPVCEnabled() {
 		if err := m.createPVC(ctx, session); err != nil {
+			if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+				log.Printf("[K8S_SESSION] Failed to cleanup resources after PVC creation failure: %v", delErr)
+			}
 			m.cleanupSession(id)
 			return nil, fmt.Errorf("failed to create PVC: %w", err)
 		}
@@ -442,6 +453,9 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 
 	session.SetProvisionSettings(sessionSettings)
 	if err := m.CreateProvisionRequest(ctx, session); err != nil {
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after provision request creation failure: %v", delErr)
+		}
 		m.cleanupSession(id)
 		return nil, fmt.Errorf("failed to create provision request: %w", err)
 	}
@@ -449,30 +463,13 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 	// Create workload. PVC-backed sessions use a Deployment for restart recovery;
 	// ephemeral EmptyDir sessions use a Pod with restartPolicy=Never.
 	if err := m.createSessionWorkload(ctx, session, req); err != nil {
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after workload creation failure: %v", delErr)
-			}
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after workload creation failure: %v", delErr)
 		}
 		m.cleanupSession(id)
 		return nil, fmt.Errorf("failed to create session workload: %w", err)
 	}
 	log.Printf("[K8S_SESSION] Created workload %s for session %s", deploymentName, id)
-
-	// Create Service
-	if err := m.createService(ctx, session); err != nil {
-		if delErr := m.deleteSessionWorkload(ctx, session); delErr != nil {
-			log.Printf("[K8S_SESSION] Failed to cleanup workload after service creation failure: %v", delErr)
-		}
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after service creation failure: %v", delErr)
-			}
-		}
-		m.cleanupSession(id)
-		return nil, fmt.Errorf("failed to create Service: %w", err)
-	}
-	log.Printf("[K8S_SESSION] Created Service %s for session %s", serviceName, id)
 
 	// Start watching session in background
 	go m.watchSession(sessionCtx, session)
@@ -521,34 +518,28 @@ func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, sandb
 		m.namespace, m.k8sConfig.BasePort, cancel, nil)
 	session.SetIsStock(true)
 
+	if err := m.createService(ctx, session); err != nil {
+		cancel()
+		return fmt.Errorf("failed to create stock service: %w", err)
+	}
+
 	// Create PVC if enabled (required for Deployment volume mounts).
 	if m.isPVCEnabled() {
 		if err := m.createPVC(ctx, session); err != nil {
+			if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+				log.Printf("[K8S_SESSION] Failed to cleanup resources after stock PVC creation failure: %v", delErr)
+			}
 			cancel()
 			return fmt.Errorf("failed to create stock PVC: %w", err)
 		}
 	}
 
 	if err := m.createSessionWorkload(ctx, session, minimalReq); err != nil {
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after stock workload creation failure: %v", delErr)
-			}
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after stock workload creation failure: %v", delErr)
 		}
 		cancel()
 		return fmt.Errorf("failed to create stock workload: %w", err)
-	}
-	if err := m.createService(ctx, session); err != nil {
-		if delErr := m.deleteSessionWorkload(ctx, session); delErr != nil {
-			log.Printf("[K8S_SESSION] Failed to cleanup workload after stock service creation failure: %v", delErr)
-		}
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after stock service creation failure: %v", delErr)
-			}
-		}
-		cancel()
-		return fmt.Errorf("failed to create stock service: %w", err)
 	}
 	log.Printf("[K8S_SESSION] Stock session %s created successfully (sandbox=%t, dind=%t)",
 		id, sandbox, dind)
@@ -907,6 +898,10 @@ func (m *KubernetesSessionManager) adoptStockSession(
 				log.Printf("[K8S_SESSION] Warning: failed to update stock pod labels for session %s: %v", stockID, err)
 			}
 		}
+	}
+
+	if err := m.applySessionOwnerReferences(ctx, session); err != nil {
+		log.Printf("[K8S_SESSION] Warning: failed to apply owner references for stock session %s: %v", stockID, err)
 	}
 
 	// Start background watch. The Pod is already running and will claim the provision request.
@@ -1855,6 +1850,104 @@ func (m *KubernetesSessionManager) GetMessages(ctx context.Context, id string) (
 	return response.Messages, nil
 }
 
+func (m *KubernetesSessionManager) sessionOwnerReferences(ctx context.Context, session *KubernetesSession) ([]metav1.OwnerReference, error) {
+	svc, err := m.client.CoreV1().Services(m.namespace).Get(ctx, session.ServiceName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return []metav1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "Service",
+			Name:       svc.Name,
+			UID:        svc.UID,
+		},
+	}, nil
+}
+
+func (m *KubernetesSessionManager) setSessionOwnerReferences(ctx context.Context, session *KubernetesSession, meta *metav1.ObjectMeta) error {
+	ownerRefs, err := m.sessionOwnerReferences(ctx, session)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get owner service %s: %w", session.ServiceName(), err)
+	}
+	meta.OwnerReferences = ownerRefs
+	return nil
+}
+
+func upsertOwnerReference(ownerRefs []metav1.OwnerReference, ownerRef metav1.OwnerReference) []metav1.OwnerReference {
+	for i := range ownerRefs {
+		existing := ownerRefs[i]
+		if existing.APIVersion == ownerRef.APIVersion && existing.Kind == ownerRef.Kind && existing.Name == ownerRef.Name {
+			ownerRefs[i] = ownerRef
+			return ownerRefs
+		}
+	}
+	return append(ownerRefs, ownerRef)
+}
+
+func (m *KubernetesSessionManager) applySessionOwnerReferences(ctx context.Context, session *KubernetesSession) error {
+	ownerRefs, err := m.sessionOwnerReferences(ctx, session)
+	if err != nil {
+		return fmt.Errorf("failed to get owner service %s: %w", session.ServiceName(), err)
+	}
+	if len(ownerRefs) == 0 {
+		return nil
+	}
+	ownerRef := ownerRefs[0]
+
+	if pvc, err := m.client.CoreV1().PersistentVolumeClaims(m.namespace).Get(ctx, session.PVCName(), metav1.GetOptions{}); err == nil {
+		pvc.OwnerReferences = upsertOwnerReference(pvc.OwnerReferences, ownerRef)
+		if _, err := m.client.CoreV1().PersistentVolumeClaims(m.namespace).Update(ctx, pvc, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("update PVC owner references: %w", err)
+		}
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("get PVC for owner references: %w", err)
+	}
+
+	if dep, err := m.client.AppsV1().Deployments(m.namespace).Get(ctx, session.DeploymentName(), metav1.GetOptions{}); err == nil {
+		dep.OwnerReferences = upsertOwnerReference(dep.OwnerReferences, ownerRef)
+		if _, err := m.client.AppsV1().Deployments(m.namespace).Update(ctx, dep, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("update Deployment owner references: %w", err)
+		}
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("get Deployment for owner references: %w", err)
+	}
+
+	if pod, err := m.client.CoreV1().Pods(m.namespace).Get(ctx, session.DeploymentName(), metav1.GetOptions{}); err == nil {
+		pod.OwnerReferences = upsertOwnerReference(pod.OwnerReferences, ownerRef)
+		if _, err := m.client.CoreV1().Pods(m.namespace).Update(ctx, pod, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("update Pod owner references: %w", err)
+		}
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("get Pod for owner references: %w", err)
+	}
+
+	secretNames := []string{
+		fmt.Sprintf("%s-webhook-payload", session.ServiceName()),
+		fmt.Sprintf("%s-oneshot-settings", session.ServiceName()),
+		fmt.Sprintf("agentapi-session-%s-settings", session.id),
+		provisionRequestSecretName(session.id),
+	}
+	for _, secretName := range secretNames {
+		secret, err := m.client.CoreV1().Secrets(m.namespace).Get(ctx, secretName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("get Secret %s for owner references: %w", secretName, err)
+		}
+		secret.OwnerReferences = upsertOwnerReference(secret.OwnerReferences, ownerRef)
+		if _, err := m.client.CoreV1().Secrets(m.namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("update Secret %s owner references: %w", secretName, err)
+		}
+	}
+
+	return nil
+}
+
 // createPVC creates a PersistentVolumeClaim for the session
 func (m *KubernetesSessionManager) createPVC(ctx context.Context, session *KubernetesSession) error {
 	storageSize := resource.MustParse(m.k8sConfig.PVCStorageSize)
@@ -1875,6 +1968,9 @@ func (m *KubernetesSessionManager) createPVC(ctx context.Context, session *Kuber
 				},
 			},
 		},
+	}
+	if err := m.setSessionOwnerReferences(ctx, session, &pvc.ObjectMeta); err != nil {
+		return err
 	}
 
 	// Set storage class if specified
@@ -1916,6 +2012,9 @@ func (m *KubernetesSessionManager) createPod(ctx context.Context, session *Kuber
 			Annotations: podTemplate.Annotations,
 		},
 		Spec: podTemplate.Spec,
+	}
+	if err := m.setSessionOwnerReferences(ctx, session, &pod.ObjectMeta); err != nil {
+		return err
 	}
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 
@@ -2191,6 +2290,9 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 			},
 		},
 	}
+	if err := m.setSessionOwnerReferences(ctx, session, &deployment.ObjectMeta); err != nil {
+		log.Printf("[K8S_SESSION] Warning: failed to set owner reference on Deployment %s: %v", session.DeploymentName(), err)
+	}
 	return deployment
 }
 
@@ -2233,6 +2335,9 @@ func (m *KubernetesSessionManager) createWebhookPayloadSecret(
 		Data: map[string][]byte{
 			"payload.json": payload,
 		},
+	}
+	if err := m.setSessionOwnerReferences(ctx, session, &secret.ObjectMeta); err != nil {
+		return err
 	}
 
 	_, err := m.client.CoreV1().Secrets(m.namespace).Create(ctx, secret, metav1.CreateOptions{})
@@ -2351,6 +2456,9 @@ func (m *KubernetesSessionManager) createOneshotSettingsSecret(
 		Data: map[string][]byte{
 			"settings.json": settingsData,
 		},
+	}
+	if err := m.setSessionOwnerReferences(ctx, session, &secret.ObjectMeta); err != nil {
+		return err
 	}
 
 	_, err = m.client.CoreV1().Secrets(m.namespace).Create(ctx, secret, metav1.CreateOptions{})
@@ -4685,6 +4793,9 @@ func (m *KubernetesSessionManager) createSessionSettingsSecretFromSettings(
 		Data: map[string][]byte{
 			"settings.yaml": yamlData,
 		},
+	}
+	if err := m.setSessionOwnerReferences(ctx, session, &secret.ObjectMeta); err != nil {
+		return err
 	}
 
 	_, err = m.client.CoreV1().Secrets(m.namespace).Create(ctx, secret, metav1.CreateOptions{})

--- a/internal/infrastructure/services/kubernetes_session_manager_initial_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_initial_message_test.go
@@ -19,6 +19,16 @@ func boolPtrForTest(b bool) *bool {
 	return &b
 }
 
+func assertServiceOwnerReference(t *testing.T, ownerRefs []metav1.OwnerReference, serviceName string) {
+	t.Helper()
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.APIVersion == "v1" && ownerRef.Kind == "Service" && ownerRef.Name == serviceName {
+			return
+		}
+	}
+	t.Fatalf("expected owner reference to Service %q, got %#v", serviceName, ownerRefs)
+}
+
 // TestInitialMessageStoredInSettingsYAML verifies that the initial message is embedded
 // inside settings.yaml (not as a separate "initial-message" key) when the settings
 // Secret is created.
@@ -275,4 +285,130 @@ func TestCreateSessionWithInitialMessage(t *testing.T) {
 			t.Error("initial-message-state volume should NOT be present (sidecar removed)")
 		}
 	}
+}
+
+func TestCreateSessionSetsServiceOwnerReferences(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-owner-ref-ns",
+		},
+	}
+	k8sClient := fake.NewSimpleClientset(ns)
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:     ns.Name,
+			Image:         "test-image:latest",
+			BasePort:      9000,
+			PVCEnabled:    boolPtrForTest(false),
+			CPURequest:    "100m",
+			CPULimit:      "1",
+			MemoryRequest: "128Mi",
+			MemoryLimit:   "512Mi",
+		},
+	}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	ctx := context.Background()
+	sessionID := "owner-ref-test"
+	req := &entities.RunServerRequest{
+		UserID:  "test-user",
+		Oneshot: true,
+	}
+	_, err = manager.CreateSession(ctx, sessionID, req, []byte(`{"event":"test"}`))
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer func() {
+		_ = manager.DeleteSession(sessionID)
+	}()
+
+	serviceName := fmt.Sprintf("agentapi-session-%s-svc", sessionID)
+	workloadName := fmt.Sprintf("agentapi-session-%s", sessionID)
+
+	pod, err := k8sClient.CoreV1().Pods(ns.Name).Get(ctx, workloadName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get session pod: %v", err)
+	}
+	assertServiceOwnerReference(t, pod.OwnerReferences, serviceName)
+
+	provisionSecret, err := k8sClient.CoreV1().Secrets(ns.Name).Get(ctx, provisionRequestSecretName(sessionID), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get provision request secret: %v", err)
+	}
+	assertServiceOwnerReference(t, provisionSecret.OwnerReferences, serviceName)
+
+	webhookSecret, err := k8sClient.CoreV1().Secrets(ns.Name).Get(ctx, serviceName+"-webhook-payload", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get webhook payload secret: %v", err)
+	}
+	assertServiceOwnerReference(t, webhookSecret.OwnerReferences, serviceName)
+
+	oneshotSecret, err := k8sClient.CoreV1().Secrets(ns.Name).Get(ctx, serviceName+"-oneshot-settings", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get oneshot settings secret: %v", err)
+	}
+	assertServiceOwnerReference(t, oneshotSecret.OwnerReferences, serviceName)
+}
+
+func TestCreateSessionWithPVCSetsServiceOwnerReferences(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-owner-ref-pvc-ns",
+		},
+	}
+	k8sClient := fake.NewSimpleClientset(ns)
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:       ns.Name,
+			Image:           "test-image:latest",
+			BasePort:        9000,
+			PVCEnabled:      boolPtrForTest(true),
+			PVCStorageSize:  "1Gi",
+			CPURequest:      "100m",
+			CPULimit:        "1",
+			MemoryRequest:   "128Mi",
+			MemoryLimit:     "512Mi",
+		},
+	}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+
+	ctx := context.Background()
+	sessionID := "owner-ref-pvc-test"
+	req := &entities.RunServerRequest{
+		UserID: "test-user",
+	}
+	_, err = manager.CreateSession(ctx, sessionID, req, nil)
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+	defer func() {
+		_ = manager.DeleteSession(sessionID)
+	}()
+
+	serviceName := fmt.Sprintf("agentapi-session-%s-svc", sessionID)
+	resourceName := fmt.Sprintf("agentapi-session-%s", sessionID)
+
+	pvc, err := k8sClient.CoreV1().PersistentVolumeClaims(ns.Name).Get(ctx, resourceName+"-pvc", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PVC: %v", err)
+	}
+	assertServiceOwnerReference(t, pvc.OwnerReferences, serviceName)
+
+	deployment, err := k8sClient.AppsV1().Deployments(ns.Name).Get(ctx, resourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get deployment: %v", err)
+	}
+	assertServiceOwnerReference(t, deployment.OwnerReferences, serviceName)
+
+	provisionSecret, err := k8sClient.CoreV1().Secrets(ns.Name).Get(ctx, provisionRequestSecretName(sessionID), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get provision request secret: %v", err)
+	}
+	assertServiceOwnerReference(t, provisionSecret.OwnerReferences, serviceName)
 }

--- a/internal/infrastructure/services/provisioner_requests.go
+++ b/internal/infrastructure/services/provisioner_requests.go
@@ -138,7 +138,15 @@ func (m *KubernetesSessionManager) CreateProvisionRequest(ctx context.Context, s
 		Status:    "pending",
 		UpdatedAt: time.Now().UTC(),
 	}
-	return m.saveProvisionRequest(ctx, req)
+	ownerRefs, err := m.sessionOwnerReferences(ctx, session)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			ownerRefs = nil
+		} else {
+			return fmt.Errorf("failed to get owner service %s: %w", session.ServiceName(), err)
+		}
+	}
+	return m.saveProvisionRequest(ctx, req, ownerRefs)
 }
 
 func (m *KubernetesSessionManager) ConnectProvisioner(ctx context.Context, req ProvisionerConnectRequest) error {
@@ -148,7 +156,7 @@ func (m *KubernetesSessionManager) ConnectProvisioner(ctx context.Context, req P
 	}
 	provisionReq.ClaimedBy = req.PodName
 	provisionReq.UpdatedAt = time.Now().UTC()
-	return m.saveProvisionRequest(ctx, provisionReq)
+	return m.saveProvisionRequest(ctx, provisionReq, nil)
 }
 
 func (m *KubernetesSessionManager) ClaimProvisionRequest(ctx context.Context, sessionID, podName string) (*ProvisionRequest, bool, error) {
@@ -165,7 +173,7 @@ func (m *KubernetesSessionManager) ClaimProvisionRequest(ctx context.Context, se
 	provisionReq.Status = "claimed"
 	provisionReq.ClaimedBy = podName
 	provisionReq.UpdatedAt = time.Now().UTC()
-	if err := m.saveProvisionRequest(ctx, provisionReq); err != nil {
+	if err := m.saveProvisionRequest(ctx, provisionReq, nil); err != nil {
 		return nil, false, err
 	}
 	return provisionReq, true, nil
@@ -185,7 +193,7 @@ func (m *KubernetesSessionManager) UpdateProvisionRequestStatus(ctx context.Cont
 		provisionReq.ClaimedBy = req.PodName
 	}
 	provisionReq.UpdatedAt = time.Now().UTC()
-	if err := m.saveProvisionRequest(ctx, provisionReq); err != nil {
+	if err := m.saveProvisionRequest(ctx, provisionReq, nil); err != nil {
 		return err
 	}
 
@@ -248,7 +256,7 @@ func (m *KubernetesSessionManager) getProvisionRequest(ctx context.Context, sess
 	return &req, nil
 }
 
-func (m *KubernetesSessionManager) saveProvisionRequest(ctx context.Context, req *ProvisionRequest) error {
+func (m *KubernetesSessionManager) saveProvisionRequest(ctx context.Context, req *ProvisionRequest, ownerRefs []metav1.OwnerReference) error {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("encode provision request: %w", err)
@@ -263,9 +271,10 @@ func (m *KubernetesSessionManager) saveProvisionRequest(ctx context.Context, req
 	if apierrors.IsNotFound(err) {
 		sec = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: m.namespace,
-				Labels:    labels,
+				Name:            name,
+				Namespace:       m.namespace,
+				Labels:          labels,
+				OwnerReferences: ownerRefs,
 			},
 			Type: corev1.SecretTypeOpaque,
 			Data: map[string][]byte{"request.json": data},
@@ -277,6 +286,9 @@ func (m *KubernetesSessionManager) saveProvisionRequest(ctx context.Context, req
 		return err
 	}
 	sec.Labels = labels
+	if len(ownerRefs) > 0 {
+		sec.OwnerReferences = ownerRefs
+	}
 	if sec.Data == nil {
 		sec.Data = make(map[string][]byte)
 	}


### PR DESCRIPTION
## Summary
- create session Services before dependent resources so the Service can be used as the owner
- set Service ownerReferences on session Pods/Deployments, PVCs, and session-scoped Secrets
- backfill ownerReferences when adopting stock sessions
- add fake-client tests for PVC and non-PVC session resource ownership

## Tests
- git diff --check
- not run: go test ./internal/infrastructure/services (go/gofmt are not installed in this environment)