### PR TITLE
Configure scia from Helm values

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -85,6 +85,21 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.hosts`            | An array with hosts and paths                      | `[{"host": "agentapi.example.com", "paths": [{"path": "/", "pathType": "Prefix"}]}]` |
 | `ingress.tls`              | TLS configuration for ingress                      | `[]`                     |
 
+### scia parameters
+
+| Name                                               | Description                                      | Value |
+| -------------------------------------------------- | ------------------------------------------------ | ----- |
+| `scia.enabled`                                     | Deploy scia OAuth broker and configure sessions | `true` |
+| `scia.publicBaseUrl`                               | Browser-facing scia base URL                    | `""` |
+| `scia.credential`                                  | Google credential ID injected into sessions     | `default.google` |
+| `scia.userNamespace`                               | scia user namespace used by default             | `default` |
+| `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `true` |
+| `scia.oauth.google.secret.existingSecret`          | Existing Secret containing Google OAuth values  | `""` |
+| `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |
+| `scia.oauth.google.secret.clientSecretKey`         | Secret key for the Google OAuth client secret   | `client-secret` |
+| `scia.users`                                       | scia user-to-refresh-token Secret mapping       | `{default: {secretName: scia-oauth-default}}` |
+| `scia.sessionRefreshTokenSecretNames`              | Refresh-token Secrets readable by session pods  | `[scia-oauth-default]` |
+
 ### Application Configuration
 
 | Name                                    | Description                               | Value     |
@@ -173,6 +188,34 @@ helm install agentapi-proxy ./helm/agentapi-proxy -f values.yaml
 # From OCI registry
 helm install agentapi-proxy oci://ghcr.io/takutakahashi/charts/agentapi-proxy --version 0.1.0 -f values.yaml
 ```
+
+### With scia Google OAuth
+
+```yaml
+# values.yaml
+config:
+  hostname: agentapi.yourdomain.com
+
+scia:
+  enabled: true
+  publicBaseUrl: https://agentapi.yourdomain.com
+  credential: default.google
+  userNamespace: default
+  oauth:
+    google:
+      secret:
+        create: false
+        existingSecret: scia-google-oauth
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+  users:
+    default:
+      secretName: scia-oauth-default
+  sessionRefreshTokenSecretNames:
+    - scia-oauth-default
+```
+
+The `scia-google-oauth` Secret must contain the Google OAuth client ID and client secret. When `ingress.enabled=true`, the chart routes `/oauth` and `/_scia` to the scia OAuth broker on the same host.
 
 ### With Environment Variables
 

--- a/helm/agentapi-proxy/templates/_helpers.tpl
+++ b/helm/agentapi-proxy/templates/_helpers.tpl
@@ -60,3 +60,22 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+scia OAuth broker resource names.
+*/}}
+{{- define "agentapi-proxy.sciaName" -}}
+{{- printf "%s-scia-oauth" (include "agentapi-proxy.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "agentapi-proxy.sciaServiceName" -}}
+scia-oauth
+{{- end }}
+
+{{- define "agentapi-proxy.sciaSecretName" -}}
+{{- $scia := .Values.scia | default dict }}
+{{- $oauth := $scia.oauth | default dict }}
+{{- $google := $oauth.google | default dict }}
+{{- $secret := $google.secret | default dict }}
+{{- default (include "agentapi-proxy.sciaName" .) $secret.existingSecret }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       {{- end }}
       labels:
         {{- include "agentapi-proxy.labels" . | nindent 8 }}
+        app.kubernetes.io/component: proxy
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -242,6 +243,47 @@ spec:
             - name: AGENTAPI_WEBHOOK_GITHUB_ENTERPRISE_HOST
               value: {{ .Values.github.enterprise.baseUrl | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/" | quote }}
             {{- end }}
+            # scia Google OAuth broker/proxy integration
+            {{- $scia := .Values.scia | default dict }}
+            {{- $sciaEnabled := true }}
+            {{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+              {{- $sciaEnabled = $scia.enabled }}
+            {{- end }}
+            {{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
+            {{- $sciaHost := .Values.config.hostname | default "" }}
+            {{- if .Values.global }}
+              {{- $sciaHost = .Values.global.apiHostname | default $sciaHost }}
+            {{- end }}
+            {{- if and (eq $sciaHost "") .Values.ingress.hosts }}
+              {{- $sciaHost = (index .Values.ingress.hosts 0).host }}
+            {{- end }}
+            {{- if and (eq $sciaPublicBaseURL "") $sciaHost }}
+              {{- $sciaPublicBaseURL = printf "https://%s" $sciaHost }}
+            {{- end }}
+            - name: AGENTAPI_SCIA_ENABLED
+              value: {{ $sciaEnabled | quote }}
+            - name: AGENTAPI_SCIA_PUBLIC_BASE_URL
+              value: {{ $sciaPublicBaseURL | quote }}
+            - name: AGENTAPI_SCIA_PROXY_URL
+              value: {{ $scia.proxyUrl | default "" | quote }}
+            - name: AGENTAPI_SCIA_CREDENTIAL
+              value: {{ $scia.credential | default "default.google" | quote }}
+            - name: AGENTAPI_SCIA_USER_NAMESPACE
+              value: {{ $scia.userNamespace | default "default" | quote }}
+            - name: AGENTAPI_SCIA_NO_PROXY
+              value: {{ $scia.noProxy | default "localhost,127.0.0.1,.svc,.cluster.local" | quote }}
+            - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
+              value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
+            - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.5.0" $scia | quote }}
+            - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
+              value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
+            - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT
+              value: {{ dig "sessionSidecar" "port" 18081 $scia | quote }}
+            - name: AGENTAPI_SCIA_GOOGLE_HOSTS
+              value: {{ $scia.googleHosts | default (list "www.googleapis.com") | join "," | quote }}
+            - name: AGENTAPI_SCIA_GOOGLE_PATHS
+              value: {{ $scia.googlePaths | default (list "/calendar/v3/*") | join "," | quote }}
             # Kubernetes Session Management configuration
             - name: AGENTAPI_K8S_SESSION_ENABLED
               value: "true"
@@ -504,8 +546,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- range .Values.env }}
+            {{- if not (hasPrefix "AGENTAPI_SCIA_" .name) }}
             - name: {{ .name }}
               value: {{ .value | quote }}
+            {{- end }}
             {{- end }}
           {{- with .Values.envFrom }}
           envFrom:

--- a/helm/agentapi-proxy/templates/ingress.yaml
+++ b/helm/agentapi-proxy/templates/ingress.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $asset := .Values.asset | default dict }}
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaService := $scia.service | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
 {{- $assetBackend := $asset.backend | default "nginx" }}
 {{- $assetEnabled := true }}
 {{- if hasKey $asset "enabled" }}
@@ -81,6 +87,36 @@ spec:
               servicePort: {{ $assetNginxServicePort }}
               {{- end }}
           {{- end }}
+          {{- if $sciaEnabled }}
+          - path: /oauth
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.sciaServiceName" $ }}
+                port:
+                  number: {{ $sciaService.port | default 8081 }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.sciaServiceName" $ }}
+              servicePort: {{ $sciaService.port | default 8081 }}
+              {{- end }}
+          - path: /_scia
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.sciaServiceName" $ }}
+                port:
+                  number: {{ $sciaService.port | default 8081 }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.sciaServiceName" $ }}
+              servicePort: {{ $sciaService.port | default 8081 }}
+              {{- end }}
+          {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
@@ -116,6 +152,36 @@ spec:
               {{- else }}
               serviceName: {{ include "agentapi-proxy.fullname" . }}-assets
               servicePort: {{ $assetNginxServicePort }}
+              {{- end }}
+          {{- end }}
+          {{- if $sciaEnabled }}
+          - path: /oauth
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.sciaServiceName" . }}
+                port:
+                  number: {{ $sciaService.port | default 8081 }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.sciaServiceName" . }}
+              servicePort: {{ $sciaService.port | default 8081 }}
+              {{- end }}
+          - path: /_scia
+            {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.sciaServiceName" . }}
+                port:
+                  number: {{ $sciaService.port | default 8081 }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.sciaServiceName" . }}
+              servicePort: {{ $sciaService.port | default 8081 }}
               {{- end }}
           {{- end }}
           - path: /

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -1,0 +1,62 @@
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
+{{- if $sciaEnabled }}
+{{- $oauth := $scia.oauth | default dict }}
+{{- $google := $oauth.google | default dict }}
+{{- $users := $scia.users | default (dict "default" (dict "secretName" "scia-oauth-default")) }}
+{{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
+{{- $sciaHost := .Values.config.hostname | default "" }}
+{{- if .Values.global }}
+  {{- $sciaHost = .Values.global.apiHostname | default $sciaHost }}
+{{- end }}
+{{- if and (eq $sciaHost "") .Values.ingress.hosts }}
+  {{- $sciaHost = (index .Values.ingress.hosts 0).host }}
+{{- end }}
+{{- if and (eq $sciaPublicBaseURL "") $sciaHost }}
+  {{- $sciaPublicBaseURL = printf "https://%s" $sciaHost }}
+{{- end }}
+{{- $redirectURL := $oauth.redirectUrl | default "" }}
+{{- if and (eq $redirectURL "") $sciaPublicBaseURL }}
+  {{- $redirectURL = printf "%s/oauth/google/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentapi-proxy.sciaName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+data:
+  config.yaml: |
+    server:
+      mode: "oauth"
+      listen: {{ $oauth.listen | default "0.0.0.0:8081" | quote }}
+      secrets:
+        mode: kubernetes
+        kubernetes:
+          namespace: {{ .Release.Namespace | quote }}
+      users:
+        {{- range $userID, $user := $users }}
+        {{ $userID | quote }}:
+          secretName: {{ $user.secretName | quote }}
+        {{- end }}
+      oauth:
+        listen: {{ $oauth.listen | default "0.0.0.0:8081" | quote }}
+        redirectUrl: {{ $redirectURL | quote }}
+        namespaces:
+          {{- range $userID, $_ := $users }}
+          {{ $userID | quote }}:
+            google:
+              clientId: "env:GOOGLE_OAUTH_CLIENT_ID"
+              clientSecret: "env:GOOGLE_OAUTH_CLIENT_SECRET"
+              scope: {{ $google.scope | default "https://www.googleapis.com/auth/calendar.readonly" | quote }}
+              {{- if $redirectURL }}
+              redirectUrl: {{ $redirectURL | quote }}
+              {{- end }}
+          {{- end }}
+    credentials: []
+    rules: []
+{{- end }}

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -1,0 +1,100 @@
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
+{{- if $sciaEnabled }}
+{{- $image := $scia.image | default dict }}
+{{- $oauth := $scia.oauth | default dict }}
+{{- $google := $oauth.google | default dict }}
+{{- $secret := $google.secret | default dict }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentapi-proxy.sciaName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+spec:
+  replicas: {{ $scia.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "agentapi-proxy.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: scia-oauth
+  template:
+    metadata:
+      labels:
+        {{- include "agentapi-proxy.labels" . | nindent 8 }}
+        app.kubernetes.io/component: scia-oauth
+        {{- with $scia.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $scia.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
+      containers:
+        - name: scia-oauth
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.5.0" }}"
+          imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - -config
+            - /etc/scia/config.yaml
+          ports:
+            - name: http
+              containerPort: {{ regexFind "[0-9]+$" ($oauth.listen | default "0.0.0.0:8081") }}
+              protocol: TCP
+          env:
+            - name: GOOGLE_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentapi-proxy.sciaSecretName" . }}
+                  key: {{ $secret.clientIdKey | default "client-id" | quote }}
+                  optional: true
+            - name: GOOGLE_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentapi-proxy.sciaSecretName" . }}
+                  key: {{ $secret.clientSecretKey | default "client-secret" | quote }}
+                  optional: true
+          volumeMounts:
+            - name: scia-config
+              mountPath: /etc/scia
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /_scia/healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /_scia/healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml $scia.resources | nindent 12 }}
+      volumes:
+        - name: scia-config
+          configMap:
+            name: {{ include "agentapi-proxy.sciaName" . }}
+      {{- with $scia.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $scia.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $scia.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/scia-rbac.yaml
+++ b/helm/agentapi-proxy/templates/scia-rbac.yaml
@@ -1,0 +1,41 @@
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
+{{- if $sciaEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentapi-proxy.sciaName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agentapi-proxy.sciaName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agentapi-proxy.sciaName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentapi-proxy.sciaName" . }}
+roleRef:
+  kind: Role
+  name: {{ include "agentapi-proxy.sciaName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/agentapi-proxy/templates/scia-secret.yaml
+++ b/helm/agentapi-proxy/templates/scia-secret.yaml
@@ -1,0 +1,21 @@
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
+{{- $oauth := $scia.oauth | default dict }}
+{{- $google := $oauth.google | default dict }}
+{{- $secret := $google.secret | default dict }}
+{{- if and $sciaEnabled ($secret.create | default true) (not $secret.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentapi-proxy.sciaSecretName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+type: Opaque
+stringData:
+  {{ $secret.clientIdKey | default "client-id" }}: {{ $secret.clientId | default "" | quote }}
+  {{ $secret.clientSecretKey | default "client-secret" }}: {{ $secret.clientSecret | default "" | quote }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/scia-service.yaml
+++ b/helm/agentapi-proxy/templates/scia-service.yaml
@@ -1,0 +1,25 @@
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
+{{- if $sciaEnabled }}
+{{- $sciaService := $scia.service | default dict }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentapi-proxy.sciaServiceName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $sciaService.port | default 8081 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agentapi-proxy.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+{{- end }}

--- a/helm/agentapi-proxy/templates/service.yaml
+++ b/helm/agentapi-proxy/templates/service.yaml
@@ -17,3 +17,4 @@ spec:
       name: agentapi-base
   selector:
     {{- include "agentapi-proxy.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy

--- a/helm/agentapi-proxy/templates/session-role.yaml
+++ b/helm/agentapi-proxy/templates/session-role.yaml
@@ -1,4 +1,13 @@
 {{- if and .Values.kubernetesSession .Values.kubernetesSession.enabled }}
+{{- $scia := .Values.scia | default dict }}
+{{- $sciaEnabled := true }}
+{{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
+{{- $sciaEnabled = $scia.enabled }}
+{{- end }}
+{{- $sciaRefreshSecretNames := list }}
+{{- if $sciaEnabled }}
+{{- $sciaRefreshSecretNames = $scia.sessionRefreshTokenSecretNames | default (list "scia-oauth-default") }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -21,7 +30,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update"]
-  {{- with .Values.scia.sessionRefreshTokenSecretNames }}
+  {{- with $sciaRefreshSecretNames }}
   # Permissions for the scia session sidecar to read only the per-user refresh
   # token Secrets explicitly listed by the operator. OAuth client Secrets must
   # remain readable only by the scia OAuth broker.

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -68,9 +68,62 @@ service:
   agentapiPort: 9000
 
 scia:
+  # Deploy and configure scia Google OAuth broker/proxy integration.
+  enabled: true
+  image:
+    repository: ghcr.io/takutakahashi/scia
+    tag: "0.5.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  publicBaseUrl: ""
+  proxyUrl: ""
+  credential: "default.google"
+  userNamespace: "default"
+  noProxy: "localhost,127.0.0.1,.svc,.cluster.local"
+  googleHosts:
+    - www.googleapis.com
+  googlePaths:
+    - /calendar/v3/*
+  sessionSidecar:
+    enabled: true
+    image: ghcr.io/takutakahashi/scia:0.5.0
+    configImage: busybox:1.36
+    port: 18081
+  oauth:
+    listen: "0.0.0.0:8081"
+    redirectUrl: ""
+    google:
+      scope: "https://www.googleapis.com/auth/calendar.readonly"
+      # Secret-backed Google OAuth client credentials. Set create=false and
+      # existingSecret to use a Secret managed outside Helm.
+      secret:
+        create: true
+        existingSecret: ""
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+        clientId: ""
+        clientSecret: ""
+  service:
+    port: 8081
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "250m"
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  users:
+    default:
+      secretName: scia-oauth-default
   # Per-user refresh-token Secret names that session Pods may read when scia
   # runs as a session sidecar. Do not include OAuth client-secret Secrets here.
-  sessionRefreshTokenSecretNames: []
+  sessionRefreshTokenSecretNames:
+    - scia-oauth-default
 
 asset:
   enabled: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -748,6 +748,21 @@ func jsonValue(values map[string]interface{}, keys ...string) (interface{}, bool
 	return nil, false
 }
 
+func commaSeparatedList(value string) []string {
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}
+
 // initializeConfigStructsFromEnv initializes config structs from environment variables
 func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	// Initialize Auth.Static if environment variables are set
@@ -908,6 +923,45 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 			config.Asset.S3 = &AssetS3Config{}
 		}
 		config.Asset.S3.Endpoint = endpoint
+	}
+
+	if enabled, ok := os.LookupEnv("AGENTAPI_SCIA_ENABLED"); ok {
+		config.Scia.Enabled = strings.EqualFold(enabled, "true")
+	}
+	if publicBaseURL := os.Getenv("AGENTAPI_SCIA_PUBLIC_BASE_URL"); publicBaseURL != "" {
+		config.Scia.PublicBaseURL = publicBaseURL
+	}
+	if proxyURL := os.Getenv("AGENTAPI_SCIA_PROXY_URL"); proxyURL != "" {
+		config.Scia.ProxyURL = proxyURL
+	}
+	if credential := os.Getenv("AGENTAPI_SCIA_CREDENTIAL"); credential != "" {
+		config.Scia.Credential = credential
+	}
+	if userNamespace := os.Getenv("AGENTAPI_SCIA_USER_NAMESPACE"); userNamespace != "" {
+		config.Scia.UserNamespace = userNamespace
+	}
+	if noProxy := os.Getenv("AGENTAPI_SCIA_NO_PROXY"); noProxy != "" {
+		config.Scia.NoProxy = noProxy
+	}
+	if enabled, ok := os.LookupEnv("AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED"); ok {
+		config.Scia.SessionSidecarEnabled = strings.EqualFold(enabled, "true")
+	}
+	if image := os.Getenv("AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE"); image != "" {
+		config.Scia.SessionSidecarImage = image
+	}
+	if image := os.Getenv("AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE"); image != "" {
+		config.Scia.SessionSidecarConfigImage = image
+	}
+	if port := os.Getenv("AGENTAPI_SCIA_SESSION_SIDECAR_PORT"); port != "" {
+		if parsed, err := strconv.Atoi(port); err == nil {
+			config.Scia.SessionSidecarPort = parsed
+		}
+	}
+	if hosts := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_GOOGLE_HOSTS")); len(hosts) > 0 {
+		config.Scia.GoogleHosts = hosts
+	}
+	if paths := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_GOOGLE_PATHS")); len(paths) > 0 {
+		config.Scia.GooglePaths = paths
 	}
 
 	// Override fields if environment variables are set (even if structures already exist)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -455,6 +455,33 @@ func TestLoadConfigWithStockInventoryPoolsEnv(t *testing.T) {
 	}, loadedConfig.StockInventoryWorker.Pools)
 }
 
+func TestLoadConfigWithSciaEnvironmentVariables(t *testing.T) {
+	clearAGENTAPIEnvVars(t)
+
+	_ = os.Setenv("AGENTAPI_SCIA_ENABLED", "true")
+	_ = os.Setenv("AGENTAPI_SCIA_PUBLIC_BASE_URL", "https://agentapi.example.com")
+	_ = os.Setenv("AGENTAPI_SCIA_CREDENTIAL", "default.google")
+	_ = os.Setenv("AGENTAPI_SCIA_USER_NAMESPACE", "default")
+	_ = os.Setenv("AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED", "true")
+	_ = os.Setenv("AGENTAPI_SCIA_SESSION_SIDECAR_PORT", "18082")
+	_ = os.Setenv("AGENTAPI_SCIA_GOOGLE_HOSTS", "www.googleapis.com,content.googleapis.com")
+	_ = os.Setenv("AGENTAPI_SCIA_GOOGLE_PATHS", "/calendar/v3/*,/drive/v3/*")
+
+	loadedConfig, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	assert.True(t, loadedConfig.Scia.Enabled)
+	assert.Equal(t, "https://agentapi.example.com", loadedConfig.Scia.PublicBaseURL)
+	assert.Equal(t, "default.google", loadedConfig.Scia.Credential)
+	assert.Equal(t, "default", loadedConfig.Scia.UserNamespace)
+	assert.True(t, loadedConfig.Scia.SessionSidecarEnabled)
+	assert.Equal(t, 18082, loadedConfig.Scia.SessionSidecarPort)
+	assert.Equal(t, []string{"www.googleapis.com", "content.googleapis.com"}, loadedConfig.Scia.GoogleHosts)
+	assert.Equal(t, []string{"/calendar/v3/*", "/drive/v3/*"}, loadedConfig.Scia.GooglePaths)
+}
+
 func TestLoadConfigNetworkFilterResourceDefaults(t *testing.T) {
 	clearAGENTAPIEnvVars(t)
 


### PR DESCRIPTION
## Summary
- add default-enabled scia OAuth broker resources to the Helm chart
- expose scia broker/proxy/session-sidecar settings through values.yaml
- store Google OAuth client values through a Kubernetes Secret or existing Secret reference
- route /oauth and /_scia to scia when ingress is enabled
- make scia env-only config loading explicit, including comma-separated Google hosts/paths
- keep main agentapi-proxy Service endpoints separate from the scia broker via component labels

## Verification
- helm lint helm/agentapi-proxy --strict
- helm template agentapi-proxy helm/agentapi-proxy --namespace agentapi-ui-dev
- helm template with ingress hostname, scia disabled, scia missing, and existing Secret settings
- go test ./pkg/config ./internal/infrastructure/services ./internal/interfaces/controllers
- GitHub PR checks: CI, E2E Tests, Test Helm Chart all passed

## Dev deploy
- Built dev chart: 0.3.0-dev.20260619113314.b8fd332
- Deployed to agentapi-ui-dev: agentapi-proxy revision 1060
- Verified rollouts for agentapi-proxy and agentapi-proxy-scia-oauth
- Verified scia /_scia/healthz returns 204
- Verified /integrations/google-oauth/status returns enabled=true, health_ok=true, client_configured=true, connected=true
- Verified /memories returns 200