### PR TITLE
Expose scia integrations metadata

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.5.0" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.9.0" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -260,10 +260,13 @@ spec:
             {{- if and (eq $sciaPublicBaseURL "") $sciaHost }}
               {{- $sciaPublicBaseURL = printf "https://%s" $sciaHost }}
             {{- end }}
+            {{- $sciaService := $scia.service | default dict }}
             - name: AGENTAPI_SCIA_ENABLED
               value: {{ $sciaEnabled | quote }}
             - name: AGENTAPI_SCIA_PUBLIC_BASE_URL
               value: {{ $sciaPublicBaseURL | quote }}
+            - name: AGENTAPI_SCIA_OAUTH_INTERNAL_URL
+              value: {{ $scia.oauthInternalUrl | default (printf "http://%s.%s.svc.cluster.local:%v" (include "agentapi-proxy.sciaServiceName" .) .Release.Namespace ($sciaService.port | default 8081)) | quote }}
             - name: AGENTAPI_SCIA_PROXY_URL
               value: {{ $scia.proxyUrl | default "" | quote }}
             - name: AGENTAPI_SCIA_CREDENTIAL

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.9.0" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.10.0" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT

--- a/helm/agentapi-proxy/templates/ingress.yaml
+++ b/helm/agentapi-proxy/templates/ingress.yaml
@@ -102,6 +102,22 @@ spec:
               serviceName: {{ include "agentapi-proxy.sciaServiceName" $ }}
               servicePort: {{ $sciaService.port | default 8081 }}
               {{- end }}
+          - path: /api/integrations
+            {{- if eq $.Values.ingress.className "gce" }}
+            pathType: ImplementationSpecific
+            {{- else }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "agentapi-proxy.sciaServiceName" $ }}
+                port:
+                  number: {{ $sciaService.port | default 8081 }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.sciaServiceName" $ }}
+              servicePort: {{ $sciaService.port | default 8081 }}
+              {{- end }}
           - path: /_scia
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
@@ -161,6 +177,22 @@ spec:
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "agentapi-proxy.sciaServiceName" . }}
+                port:
+                  number: {{ $sciaService.port | default 8081 }}
+              {{- else }}
+              serviceName: {{ include "agentapi-proxy.sciaServiceName" . }}
+              servicePort: {{ $sciaService.port | default 8081 }}
+              {{- end }}
+          - path: /api/integrations
+            {{- if eq .Values.ingress.className "gce" }}
+            pathType: ImplementationSpecific
+            {{- else }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
               service:
                 name: {{ include "agentapi-proxy.sciaServiceName" . }}
                 port:

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -57,6 +57,15 @@ data:
                 {{- if $scope.desc }}
                 desc: {{ $scope.desc | quote }}
                 {{- end }}
+                {{- if $scope.group }}
+                group: {{ $scope.group | quote }}
+                {{- end }}
+                {{- if $scope.groupName }}
+                groupName: {{ $scope.groupName | quote }}
+                {{- end }}
+                {{- if $scope.groupDesc }}
+                groupDesc: {{ $scope.groupDesc | quote }}
+                {{- end }}
                 enabled: {{ $scope.enabled | default false }}
               {{- end }}
         namespaces:

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -22,6 +22,7 @@
 {{- if and (eq $redirectURL "") $sciaPublicBaseURL }}
   {{- $redirectURL = printf "%s/oauth/google/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
 {{- end }}
+{{- $googleScopes := $google.scopes | default (list (dict "id" ($google.scopeId | default "calendar-read") "value" ($google.scope | default "https://www.googleapis.com/auth/calendar.readonly") "name" ($google.scopeName | default "Google Calendar read-only") "desc" ($google.scopeDesc | default "Read Google Calendar events.") "enabled" true)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -49,11 +50,15 @@ data:
         integrations:
           google:
             scopes:
-              - id: {{ $google.scopeId | default "calendar-read" | quote }}
-                value: {{ $google.scope | default "https://www.googleapis.com/auth/calendar.readonly" | quote }}
-                name: {{ $google.scopeName | default "Google Calendar read-only" | quote }}
-                desc: {{ $google.scopeDesc | default "Read Google Calendar events." | quote }}
-                enabled: true
+              {{- range $scope := $googleScopes }}
+              - id: {{ $scope.id | quote }}
+                value: {{ $scope.value | quote }}
+                name: {{ $scope.name | quote }}
+                {{- if $scope.desc }}
+                desc: {{ $scope.desc | quote }}
+                {{- end }}
+                enabled: {{ $scope.enabled | default false }}
+              {{- end }}
         namespaces:
           {{- range $userID, $_ := $users }}
           {{ $userID | quote }}:

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -46,6 +46,14 @@ data:
       oauth:
         listen: {{ $oauth.listen | default "0.0.0.0:8081" | quote }}
         redirectUrl: {{ $redirectURL | quote }}
+        integrations:
+          google:
+            scopes:
+              - id: {{ $google.scopeId | default "calendar-read" | quote }}
+                value: {{ $google.scope | default "https://www.googleapis.com/auth/calendar.readonly" | quote }}
+                name: {{ $google.scopeName | default "Google Calendar read-only" | quote }}
+                desc: {{ $google.scopeDesc | default "Read Google Calendar events." | quote }}
+                enabled: true
         namespaces:
           {{- range $userID, $_ := $users }}
           {{ $userID | quote }}:

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.9.0" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.10.0" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.5.0" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.9.0" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -101,21 +101,33 @@ scia:
           value: "https://www.googleapis.com/auth/calendar.readonly"
           name: "Google Calendar read-only"
           desc: "Read Google Calendar events."
+          group: calendar
+          groupName: "Google Calendar"
+          groupDesc: "Choose how much Google Calendar access to grant."
           enabled: true
         - id: calendar-write
           value: "https://www.googleapis.com/auth/calendar"
           name: "Google Calendar read/write"
           desc: "Read and write Google Calendar events."
+          group: calendar
+          groupName: "Google Calendar"
+          groupDesc: "Choose how much Google Calendar access to grant."
           enabled: false
         - id: tasks-read
           value: "https://www.googleapis.com/auth/tasks.readonly"
           name: "Google Tasks read-only"
           desc: "Read Google Tasks and task lists."
+          group: tasks
+          groupName: "Google Tasks"
+          groupDesc: "Choose how much Google Tasks access to grant."
           enabled: true
         - id: tasks-write
           value: "https://www.googleapis.com/auth/tasks"
           name: "Google Tasks read/write"
           desc: "Read and write Google Tasks and task lists."
+          group: tasks
+          groupName: "Google Tasks"
+          groupDesc: "Choose how much Google Tasks access to grant."
           enabled: false
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,7 +72,7 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.5.0"
+    tag: "0.9.0"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
@@ -86,7 +86,7 @@ scia:
     - /calendar/v3/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.5.0
+    image: ghcr.io/takutakahashi/scia:0.9.0
     configImage: busybox:1.36
     port: 18081
   oauth:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,7 +72,7 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.9.0"
+    tag: "0.10.0"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
@@ -88,7 +88,7 @@ scia:
     - /tasks/v1/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.9.0
+    image: ghcr.io/takutakahashi/scia:0.10.0
     configImage: busybox:1.36
     port: 18081
   oauth:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -94,6 +94,9 @@ scia:
     redirectUrl: ""
     google:
       scope: "https://www.googleapis.com/auth/calendar.readonly"
+      scopeId: "calendar-read"
+      scopeName: "Google Calendar read-only"
+      scopeDesc: "Read Google Calendar events."
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.
       secret:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -82,8 +82,10 @@ scia:
   noProxy: "localhost,127.0.0.1,.svc,.cluster.local"
   googleHosts:
     - www.googleapis.com
+    - tasks.googleapis.com
   googlePaths:
     - /calendar/v3/*
+    - /tasks/v1/*
   sessionSidecar:
     enabled: true
     image: ghcr.io/takutakahashi/scia:0.9.0
@@ -94,9 +96,27 @@ scia:
     redirectUrl: ""
     google:
       scope: "https://www.googleapis.com/auth/calendar.readonly"
-      scopeId: "calendar-read"
-      scopeName: "Google Calendar read-only"
-      scopeDesc: "Read Google Calendar events."
+      scopes:
+        - id: calendar-read
+          value: "https://www.googleapis.com/auth/calendar.readonly"
+          name: "Google Calendar read-only"
+          desc: "Read Google Calendar events."
+          enabled: true
+        - id: calendar-write
+          value: "https://www.googleapis.com/auth/calendar"
+          name: "Google Calendar read/write"
+          desc: "Read and write Google Calendar events."
+          enabled: false
+        - id: tasks-read
+          value: "https://www.googleapis.com/auth/tasks.readonly"
+          name: "Google Tasks read-only"
+          desc: "Read Google Tasks and task lists."
+          enabled: true
+        - id: tasks-write
+          value: "https://www.googleapis.com/auth/tasks"
+          name: "Google Tasks read/write"
+          desc: "Read and write Google Tasks and task lists."
+          enabled: false
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.
       secret:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -413,9 +413,10 @@ func (r *Router) registerConditionalRoutes() error {
 	}
 
 	if r.handlers.googleOAuthController != nil {
-		log.Printf("[ROUTES] Registering Google OAuth integration endpoints...")
+		log.Printf("[ROUTES] Registering scia integration endpoints...")
+		r.echo.GET("/integrations", r.handlers.googleOAuthController.GetIntegrations, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.GET("/integrations/google-oauth/status", r.handlers.googleOAuthController.GetStatus, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
-		log.Printf("[ROUTES] Google OAuth integration endpoints registered")
+		log.Printf("[ROUTES] scia integration endpoints registered")
 	}
 
 	// Add credentials routes if credentials repository is available (Kubernetes mode only)

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -415,6 +415,7 @@ func (r *Router) registerConditionalRoutes() error {
 	if r.handlers.googleOAuthController != nil {
 		log.Printf("[ROUTES] Registering scia integration endpoints...")
 		r.echo.GET("/integrations", r.handlers.googleOAuthController.GetIntegrations, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.POST("/integrations/:id/authorization-url", r.handlers.googleOAuthController.CreateAuthorizationURL, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.GET("/integrations/google-oauth/status", r.handlers.googleOAuthController.GetStatus, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		log.Printf("[ROUTES] scia integration endpoints registered")
 	}

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -116,7 +116,7 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 			// (at least 3 parts, not starting with "start", "search", "sessions", "oauth", "auth", "notification", or "notifications")
 			if len(pathParts) >= 3 && pathParts[1] != "" {
 				firstSegment := pathParts[1]
-				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "assets" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files" && firstSegment != "session-profiles" && firstSegment != "sandbox-policies"
+				return firstSegment != "start" && firstSegment != "search" && firstSegment != "sessions" && firstSegment != "oauth" && firstSegment != "auth" && firstSegment != "notification" && firstSegment != "notifications" && firstSegment != "memories" && firstSegment != "assets" && firstSegment != "tasks" && firstSegment != "task-groups" && firstSegment != "credentials" && firstSegment != "files" && firstSegment != "session-profiles" && firstSegment != "sandbox-policies" && firstSegment != "integrations"
 			}
 			return false
 		},

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2588,7 +2588,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.9.0"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.10.0"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2588,7 +2588,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.5.0"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.9.0"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.5.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.9.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -241,7 +241,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.5.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.9.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.9.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -241,7 +241,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.9.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -80,6 +81,15 @@ type IntegrationAuthorizationURLResponse struct {
 	AuthURL          string `json:"auth_url,omitempty"`
 	RedirectURI      string `json:"redirect_uri,omitempty"`
 	Scope            string `json:"scope,omitempty"`
+}
+
+type sciaHTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e sciaHTTPError) Error() string {
+	return e.Message
 }
 
 // FrontendIntegration mirrors scia's non-secret frontend metadata with proxy status.
@@ -209,6 +219,10 @@ func (c *GoogleOAuthController) CreateAuthorizationURL(ctx echo.Context) error {
 
 	resp, err := c.createSciaAuthorizationURL(ctx.Request().Context(), integration, input)
 	if err != nil {
+		var upstream sciaHTTPError
+		if errors.As(err, &upstream) {
+			return echo.NewHTTPError(upstream.StatusCode, upstream.Message)
+		}
 		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
 	}
 	resp.Scope = ""
@@ -266,7 +280,10 @@ func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, 
 	}()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 512))
-		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("scia authorization-url returned %s: %s", res.Status, strings.TrimSpace(string(body)))
+		return IntegrationAuthorizationURLResponse{}, sciaHTTPError{
+			StatusCode: res.StatusCode,
+			Message:    strings.TrimSpace(string(body)),
+		}
 	}
 	var output IntegrationAuthorizationURLResponse
 	if err := json.NewDecoder(res.Body).Decode(&output); err != nil {

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -85,10 +85,10 @@ type FrontendIntegration struct {
 
 // FrontendIntegrationScope is one selectable OAuth scope in scia metadata.
 type FrontendIntegrationScope struct {
-	Value       string `json:"value"`
-	Label       string `json:"label,omitempty"`
-	Description string `json:"description,omitempty"`
-	Enabled     bool   `json:"enabled"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Desc    string `json:"desc,omitempty"`
+	Enabled bool   `json:"enabled"`
 }
 
 // GetStatus returns the user's scia Google OAuth integration status.

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -2,7 +2,9 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -55,6 +57,40 @@ type GoogleOAuthStatusResponse struct {
 	ProxyConfigured  bool   `json:"proxy_configured"`
 }
 
+// IntegrationsResponse is returned by GET /integrations.
+type IntegrationsResponse struct {
+	Enabled      bool                  `json:"enabled"`
+	HealthOK     bool                  `json:"health_ok"`
+	HealthStatus string                `json:"health_status,omitempty"`
+	Integrations []FrontendIntegration `json:"integrations"`
+}
+
+// FrontendIntegration mirrors scia's non-secret frontend metadata with proxy status.
+type FrontendIntegration struct {
+	ID                       string                     `json:"id"`
+	Provider                 string                     `json:"provider"`
+	Namespace                string                     `json:"namespace,omitempty"`
+	CredentialID             string                     `json:"credential_id"`
+	Name                     string                     `json:"name"`
+	IconURL                  string                     `json:"icon_url,omitempty"`
+	Description              string                     `json:"description,omitempty"`
+	Released                 bool                       `json:"released"`
+	Source                   string                     `json:"source,omitempty"`
+	StartURL                 string                     `json:"start_url"`
+	AuthorizationURLEndpoint string                     `json:"authorization_url_endpoint,omitempty"`
+	Setup                    map[string]string          `json:"setup,omitempty"`
+	Scopes                   []FrontendIntegrationScope `json:"scopes"`
+	Connected                bool                       `json:"connected"`
+}
+
+// FrontendIntegrationScope is one selectable OAuth scope in scia metadata.
+type FrontendIntegrationScope struct {
+	Value       string `json:"value"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled"`
+}
+
 // GetStatus returns the user's scia Google OAuth integration status.
 func (c *GoogleOAuthController) GetStatus(ctx echo.Context) error {
 	user := auth.GetUserFromContext(ctx)
@@ -84,10 +120,89 @@ func (c *GoogleOAuthController) GetStatus(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, resp)
 }
 
-func (c *GoogleOAuthController) checkHealth(ctx context.Context) (bool, string) {
-	base := strings.TrimRight(c.scia.PublicBaseURL, "/")
+// GetIntegrations returns scia frontend integration metadata for the current user.
+func (c *GoogleOAuthController) GetIntegrations(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+
+	resp := IntegrationsResponse{Enabled: c.scia.Enabled}
+	if !c.scia.Enabled {
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	resp.HealthOK, resp.HealthStatus = c.checkHealth(ctx.Request().Context())
+	integrations, err := c.fetchSciaIntegrations(ctx.Request().Context())
+	if err != nil {
+		resp.HealthStatus = err.Error()
+		return ctx.JSON(http.StatusOK, resp)
+	}
+
+	userID := string(user.ID())
+	defaultNamespace := c.userNamespace(userID)
+	for i := range integrations {
+		namespace := integrations[i].Namespace
+		if namespace == "" {
+			namespace = defaultNamespace
+			integrations[i].Namespace = namespace
+		}
+		integrations[i].StartURL = c.publicURL(integrations[i].StartURL)
+		integrations[i].AuthorizationURLEndpoint = c.publicURL(integrations[i].AuthorizationURLEndpoint)
+		if integrations[i].Setup != nil {
+			for key, value := range integrations[i].Setup {
+				if strings.HasSuffix(key, "_url") {
+					integrations[i].Setup[key] = c.publicURL(value)
+				}
+			}
+		}
+		integrations[i].Connected = c.refreshTokenSecretExists(ctx.Request().Context(), namespace)
+	}
+	resp.Integrations = integrations
+
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+func (c *GoogleOAuthController) fetchSciaIntegrations(ctx context.Context) ([]FrontendIntegration, error) {
+	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
 	if base == "" {
-		return false, "public_base_url_not_configured"
+		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
+	}
+	if base == "" {
+		return nil, fmt.Errorf("scia_oauth_url_not_configured")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/integrations", nil)
+	if err != nil {
+		return nil, fmt.Errorf("invalid_integrations_url")
+	}
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return nil, fmt.Errorf("scia integrations returned %s: %s", res.Status, strings.TrimSpace(string(body)))
+	}
+	var body struct {
+		Integrations []FrontendIntegration `json:"integrations"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("failed to decode scia integrations: %w", err)
+	}
+	return body.Integrations, nil
+}
+
+func (c *GoogleOAuthController) checkHealth(ctx context.Context) (bool, string) {
+	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
+	if base == "" {
+		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
+	}
+	if base == "" {
+		return false, "scia_oauth_url_not_configured"
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/_scia/healthz", nil)
@@ -153,9 +268,22 @@ func (c *GoogleOAuthController) authorizationURLEndpoint(userNamespace string) s
 }
 
 func (c *GoogleOAuthController) withPublicBase(path string) string {
+	return c.publicURL(path)
+}
+
+func (c *GoogleOAuthController) publicURL(path string) string {
+	if path == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(path); err == nil && parsed.IsAbs() {
+		return path
+	}
 	base := strings.TrimRight(c.scia.PublicBaseURL, "/")
 	if base == "" {
 		return path
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
 	}
 	return base + path
 }

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -63,6 +64,22 @@ type IntegrationsResponse struct {
 	HealthOK     bool                  `json:"health_ok"`
 	HealthStatus string                `json:"health_status,omitempty"`
 	Integrations []FrontendIntegration `json:"integrations"`
+}
+
+// IntegrationAuthorizationURLRequest asks scia to build a provider authorization URL.
+type IntegrationAuthorizationURLRequest struct {
+	RedirectURI string   `json:"redirect_uri"`
+	ScopeIDs    []string `json:"scope_ids"`
+	State       string   `json:"state,omitempty"`
+}
+
+// IntegrationAuthorizationURLResponse is returned by scia's authorization-url endpoint.
+type IntegrationAuthorizationURLResponse struct {
+	CredentialID     string `json:"credential_id"`
+	AuthorizationURL string `json:"authorization_url"`
+	AuthURL          string `json:"auth_url,omitempty"`
+	RedirectURI      string `json:"redirect_uri,omitempty"`
+	Scope            string `json:"scope,omitempty"`
 }
 
 // FrontendIntegration mirrors scia's non-secret frontend metadata with proxy status.
@@ -164,6 +181,98 @@ func (c *GoogleOAuthController) GetIntegrations(ctx echo.Context) error {
 	resp.Integrations = integrations
 
 	return ctx.JSON(http.StatusOK, resp)
+}
+
+// CreateAuthorizationURL returns a scia-built OAuth authorization URL for one integration.
+func (c *GoogleOAuthController) CreateAuthorizationURL(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+	if !c.scia.Enabled {
+		return echo.NewHTTPError(http.StatusNotFound, "scia integration is disabled")
+	}
+
+	var input IntegrationAuthorizationURLRequest
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&input); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid json request")
+	}
+
+	integrationID := ctx.Param("id")
+	integration, ok, err := c.integrationForUser(ctx.Request().Context(), string(user.ID()), integrationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, "integration not found")
+	}
+
+	resp, err := c.createSciaAuthorizationURL(ctx.Request().Context(), integration, input)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+	resp.Scope = ""
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+func (c *GoogleOAuthController) integrationForUser(ctx context.Context, userID, integrationID string) (FrontendIntegration, bool, error) {
+	integrations, err := c.fetchSciaIntegrations(ctx)
+	if err != nil {
+		return FrontendIntegration{}, false, err
+	}
+	defaultNamespace := c.userNamespace(userID)
+	for _, integration := range integrations {
+		if integration.ID != integrationID {
+			continue
+		}
+		if integration.Namespace == "" {
+			integration.Namespace = defaultNamespace
+		}
+		return integration, true, nil
+	}
+	return FrontendIntegration{}, false, nil
+}
+
+func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, integration FrontendIntegration, input IntegrationAuthorizationURLRequest) (IntegrationAuthorizationURLResponse, error) {
+	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
+	if base == "" {
+		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
+	}
+	if base == "" {
+		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("scia_oauth_url_not_configured")
+	}
+	if integration.Namespace == "" || integration.Provider == "" {
+		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("integration is missing namespace or provider")
+	}
+
+	path := fmt.Sprintf("/oauth/%s/%s/authorization-url", url.PathEscape(integration.Namespace), url.PathEscape(integration.Provider))
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return IntegrationAuthorizationURLResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+path, bytes.NewReader(payload))
+	if err != nil {
+		return IntegrationAuthorizationURLResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return IntegrationAuthorizationURLResponse{}, err
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("scia authorization-url returned %s: %s", res.Status, strings.TrimSpace(string(body)))
+	}
+	var output IntegrationAuthorizationURLResponse
+	if err := json.NewDecoder(res.Body).Decode(&output); err != nil {
+		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("failed to decode scia authorization-url: %w", err)
+	}
+	return output, nil
 }
 
 func (c *GoogleOAuthController) fetchSciaIntegrations(ctx context.Context) ([]FrontendIntegration, error) {

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -85,10 +85,13 @@ type FrontendIntegration struct {
 
 // FrontendIntegrationScope is one selectable OAuth scope in scia metadata.
 type FrontendIntegrationScope struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Desc    string `json:"desc,omitempty"`
-	Enabled bool   `json:"enabled"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Desc      string `json:"desc,omitempty"`
+	Group     string `json:"group,omitempty"`
+	GroupName string `json:"group_name,omitempty"`
+	GroupDesc string `json:"group_desc,omitempty"`
+	Enabled   bool   `json:"enabled"`
 }
 
 // GetStatus returns the user's scia Google OAuth integration status.

--- a/internal/interfaces/controllers/google_oauth_controller_test.go
+++ b/internal/interfaces/controllers/google_oauth_controller_test.go
@@ -1,0 +1,88 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
+	var gotScopeIDs []string
+	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/integrations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"integrations": []map[string]any{
+					{
+						"id":                         "takutakahashi.google",
+						"provider":                   "google",
+						"namespace":                  "takutakahashi",
+						"credential_id":              "takutakahashi.google",
+						"name":                       "Google",
+						"released":                   true,
+						"start_url":                  "/oauth/takutakahashi/google/start",
+						"authorization_url_endpoint": "/oauth/takutakahashi/google/authorization-url",
+						"scopes":                     []map[string]any{},
+					},
+				},
+			})
+		case "/oauth/takutakahashi/google/authorization-url":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			var req IntegrationAuthorizationURLRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			gotScopeIDs = req.ScopeIDs
+			if req.RedirectURI != "https://app.example.com/api/oauth/google/callback" {
+				t.Fatalf("redirect_uri = %q", req.RedirectURI)
+			}
+			_ = json.NewEncoder(w).Encode(IntegrationAuthorizationURLResponse{
+				CredentialID:     "takutakahashi.google",
+				AuthorizationURL: "https://accounts.google.com/o/oauth2/v2/auth?scope=calendar",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer scia.Close()
+
+	controller := NewGoogleOAuthController(config.SciaConfig{
+		Enabled:          true,
+		OAuthInternalURL: scia.URL,
+	}, nil, "")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/integrations/takutakahashi.google/authorization-url", strings.NewReader(`{"scope_ids":["calendar-write","tasks-write"],"redirect_uri":"https://app.example.com/api/oauth/google/callback"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("takutakahashi.google")
+	ctx.Set("internal_user", entities.NewUser("takutakahashi", entities.UserTypeRegular, "takutakahashi"))
+
+	if err := controller.CreateAuthorizationURL(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Join(gotScopeIDs, ",") != "calendar-write,tasks-write" {
+		t.Fatalf("scope_ids = %#v", gotScopeIDs)
+	}
+	var body IntegrationAuthorizationURLResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.AuthorizationURL != "https://accounts.google.com/o/oauth2/v2/auth?scope=calendar" {
+		t.Fatalf("authorization_url = %q", body.AuthorizationURL)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1313,7 +1313,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.5.0")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.9.0")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1395,7 +1395,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.5.0"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.9.0"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -239,6 +239,8 @@ type SciaConfig struct {
 	// PublicBaseURL is the browser-reachable origin that serves /oauth and /_scia.
 	// When empty, UI clients can still use same-origin relative OAuth URLs.
 	PublicBaseURL string `json:"public_base_url" mapstructure:"public_base_url"`
+	// OAuthInternalURL is the proxy-reachable scia OAuth server origin used for metadata.
+	OAuthInternalURL string `json:"oauth_internal_url" mapstructure:"oauth_internal_url"`
 	// ProxyURL is the forward proxy URL used by session Pods for outbound Google API calls.
 	ProxyURL string `json:"proxy_url" mapstructure:"proxy_url"`
 	// Credential is the scia credential ID used for Google OAuth, e.g. "takutakahashi.google".
@@ -1037,6 +1039,7 @@ func bindEnvVars(v *viper.Viper) {
 	// scia OAuth broker/proxy configuration
 	_ = v.BindEnv("scia.enabled", "AGENTAPI_SCIA_ENABLED")
 	_ = v.BindEnv("scia.public_base_url", "AGENTAPI_SCIA_PUBLIC_BASE_URL")
+	_ = v.BindEnv("scia.oauth_internal_url", "AGENTAPI_SCIA_OAUTH_INTERNAL_URL")
 	_ = v.BindEnv("scia.proxy_url", "AGENTAPI_SCIA_PROXY_URL")
 	_ = v.BindEnv("scia.credential", "AGENTAPI_SCIA_CREDENTIAL")
 	_ = v.BindEnv("scia.user_namespace", "AGENTAPI_SCIA_USER_NAMESPACE")
@@ -1304,6 +1307,7 @@ func setDefaults(v *viper.Viper) {
 	// scia defaults
 	v.SetDefault("scia.enabled", false)
 	v.SetDefault("scia.public_base_url", "")
+	v.SetDefault("scia.oauth_internal_url", "")
 	v.SetDefault("scia.proxy_url", "")
 	v.SetDefault("scia.credential", "")
 	v.SetDefault("scia.user_namespace", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1313,7 +1313,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.9.0")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.10.0")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1395,7 +1395,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.9.0"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.10.0"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"


### PR DESCRIPTION
## Summary
- add authenticated GET /integrations backed by scia /api/integrations
- add scia OAuth internal URL config/env wiring
- route /api/integrations to the scia OAuth service in the Helm ingress

## Verification
- mise exec -- go test ./internal/interfaces/controllers ./pkg/config ./internal/app
- mise exec -- helm template agentapi-proxy helm/agentapi-proxy --namespace agentapi-ui-dev