### PR TITLE
fix(helm): roll scia pods on config changes

### DIFF
--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -23,16 +23,17 @@ spec:
       app.kubernetes.io/component: scia-oauth
   template:
     metadata:
+      annotations:
+        checksum/scia-config: {{ include (print $.Template.BasePath "/scia-configmap.yaml") . | sha256sum }}
+        {{- with $scia.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "agentapi-proxy.labels" . | nindent 8 }}
         app.kubernetes.io/component: scia-oauth
         {{- with $scia.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $scia.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
     spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:


### PR DESCRIPTION
## Summary
- add a checksum annotation for the rendered scia ConfigMap to the scia Deployment pod template
- keep existing scia podAnnotations support
- ensure Helm config changes roll scia pods so OAuth state/scope config is not left stale

## Production follow-up
- production was manually rolled via scia.podAnnotations in Helm revision 568
- verified /_scia/healthz returns 204
- verified a newly generated OAuth state is accepted by callback validation; random state still returns 400
- reset default enabled OAuth scopes back to Calendar/Tasks read-only while keeping expanded scopes selectable

## Tests
- git diff --check
- helm template not run: helm CLI is not installed in this session