### PR TITLE
Add scia Todoist OAuth support

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -234,7 +234,7 @@ scia:
     todoist:
       enabled: true
       scope: data:read_write
-      redirectUrl: https://agentapi.yourdomain.com/oauth/todoist/callback
+      redirectUrl: https://agentapi.yourdomain.com/api/oauth/todoist/callback
       omitRedirectUrl: false
       secret:
         create: false

--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -92,11 +92,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scia.enabled`                                     | Deploy scia OAuth broker and configure sessions | `true` |
 | `scia.publicBaseUrl`                               | Browser-facing scia base URL                    | `""` |
 | `scia.credential`                                  | Google credential ID injected into sessions     | `default.google` |
+| `scia.todoistCredential`                           | Todoist credential ID injected into sessions    | `default.todoist` |
 | `scia.userNamespace`                               | scia user namespace used by default             | `default` |
 | `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `true` |
 | `scia.oauth.google.secret.existingSecret`          | Existing Secret containing Google OAuth values  | `""` |
 | `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |
 | `scia.oauth.google.secret.clientSecretKey`         | Secret key for the Google OAuth client secret   | `client-secret` |
+| `scia.oauth.todoist.enabled`                       | Enable Todoist OAuth in scia                    | `false` |
+| `scia.oauth.todoist.secret.create`                 | Create a Kubernetes Secret for Todoist OAuth    | `true` |
+| `scia.oauth.todoist.secret.existingSecret`         | Existing Secret containing Todoist OAuth values | `""` |
 | `scia.users`                                       | scia user-to-refresh-token Secret mapping       | `{default: {secretName: scia-oauth-default}}` |
 | `scia.sessionRefreshTokenSecretNames`              | Refresh-token Secrets readable by session pods  | `[scia-oauth-default]` |
 
@@ -216,6 +220,28 @@ scia:
 ```
 
 The `scia-google-oauth` Secret must contain the Google OAuth client ID and client secret. When `ingress.enabled=true`, the chart routes `/oauth` and `/_scia` to the scia OAuth broker on the same host.
+
+### With scia Todoist OAuth
+
+```yaml
+scia:
+  enabled: true
+  publicBaseUrl: https://agentapi.yourdomain.com
+  userNamespace: default
+  todoistCredential: default.todoist
+  oauth:
+    todoist:
+      enabled: true
+      scope: data:read_write
+      redirectUrl: https://agentapi.yourdomain.com/oauth/todoist/callback
+      secret:
+        create: false
+        existingSecret: scia-todoist-oauth
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+```
+
+The `scia-todoist-oauth` Secret must contain the Todoist OAuth client ID and client secret. Register the same `redirectUrl` in the Todoist app console. The session sidecar injects the Todoist token for `api.todoist.com/api/v1/*` requests by default.
 
 ### With Environment Variables
 

--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -99,6 +99,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |
 | `scia.oauth.google.secret.clientSecretKey`         | Secret key for the Google OAuth client secret   | `client-secret` |
 | `scia.oauth.todoist.enabled`                       | Enable Todoist OAuth in scia                    | `false` |
+| `scia.oauth.todoist.omitRedirectUrl`               | Omit Todoist redirect_uri from OAuth requests   | `false` |
 | `scia.oauth.todoist.secret.create`                 | Create a Kubernetes Secret for Todoist OAuth    | `true` |
 | `scia.oauth.todoist.secret.existingSecret`         | Existing Secret containing Todoist OAuth values | `""` |
 | `scia.users`                                       | scia user-to-refresh-token Secret mapping       | `{default: {secretName: scia-oauth-default}}` |
@@ -234,6 +235,7 @@ scia:
       enabled: true
       scope: data:read_write
       redirectUrl: https://agentapi.yourdomain.com/oauth/todoist/callback
+      omitRedirectUrl: false
       secret:
         create: false
         existingSecret: scia-todoist-oauth

--- a/helm/agentapi-proxy/templates/_helpers.tpl
+++ b/helm/agentapi-proxy/templates/_helpers.tpl
@@ -79,3 +79,11 @@ scia-oauth
 {{- $secret := $google.secret | default dict }}
 {{- default (include "agentapi-proxy.sciaName" .) $secret.existingSecret }}
 {{- end }}
+
+{{- define "agentapi-proxy.sciaTodoistSecretName" -}}
+{{- $scia := .Values.scia | default dict }}
+{{- $oauth := $scia.oauth | default dict }}
+{{- $todoist := $oauth.todoist | default dict }}
+{{- $secret := $todoist.secret | default dict }}
+{{- default (printf "%s-todoist" (include "agentapi-proxy.sciaName" .) | trunc 63 | trimSuffix "-") $secret.existingSecret }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -287,6 +287,12 @@ spec:
               value: {{ $scia.googleHosts | default (list "www.googleapis.com") | join "," | quote }}
             - name: AGENTAPI_SCIA_GOOGLE_PATHS
               value: {{ $scia.googlePaths | default (list "/calendar/v3/*") | join "," | quote }}
+            - name: AGENTAPI_SCIA_TODOIST_CREDENTIAL
+              value: {{ $scia.todoistCredential | default (printf "%s.todoist" ($scia.userNamespace | default "default")) | quote }}
+            - name: AGENTAPI_SCIA_TODOIST_HOSTS
+              value: {{ $scia.todoistHosts | default (list "api.todoist.com") | join "," | quote }}
+            - name: AGENTAPI_SCIA_TODOIST_PATHS
+              value: {{ $scia.todoistPaths | default (list "/api/v1/*") | join "," | quote }}
             # Kubernetes Session Management configuration
             - name: AGENTAPI_K8S_SESSION_ENABLED
               value: "true"

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -26,7 +26,7 @@
 {{- end }}
 {{- $todoistRedirectURL := $todoist.redirectUrl | default "" }}
 {{- if and (eq $todoistRedirectURL "") $sciaPublicBaseURL }}
-  {{- $todoistRedirectURL = printf "%s/oauth/todoist/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
+  {{- $todoistRedirectURL = printf "%s/api/oauth/todoist/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
 {{- end }}
 {{- if $todoist.omitRedirectUrl }}
   {{- $todoistRedirectURL = "" }}

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -28,6 +28,9 @@
 {{- if and (eq $todoistRedirectURL "") $sciaPublicBaseURL }}
   {{- $todoistRedirectURL = printf "%s/oauth/todoist/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
 {{- end }}
+{{- if $todoist.omitRedirectUrl }}
+  {{- $todoistRedirectURL = "" }}
+{{- end }}
 {{- $googleScopes := $google.scopes | default (list (dict "id" ($google.scopeId | default "calendar-read") "value" ($google.scope | default "https://www.googleapis.com/auth/calendar.readonly") "name" ($google.scopeName | default "Google Calendar read-only") "desc" ($google.scopeDesc | default "Read Google Calendar events.") "enabled" true)) }}
 {{- $todoistScopes := $todoist.scopes | default (list (dict "id" "read-write" "value" ($todoist.scope | default "data:read_write") "name" "Todoist read/write" "desc" "Read and write Todoist tasks and projects." "enabled" true)) }}
 apiVersion: v1

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -6,6 +6,8 @@
 {{- if $sciaEnabled }}
 {{- $oauth := $scia.oauth | default dict }}
 {{- $google := $oauth.google | default dict }}
+{{- $todoist := $oauth.todoist | default dict }}
+{{- $todoistEnabled := $todoist.enabled | default false }}
 {{- $users := $scia.users | default (dict "default" (dict "secretName" "scia-oauth-default")) }}
 {{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
 {{- $sciaHost := .Values.config.hostname | default "" }}
@@ -22,7 +24,12 @@
 {{- if and (eq $redirectURL "") $sciaPublicBaseURL }}
   {{- $redirectURL = printf "%s/oauth/google/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
 {{- end }}
+{{- $todoistRedirectURL := $todoist.redirectUrl | default "" }}
+{{- if and (eq $todoistRedirectURL "") $sciaPublicBaseURL }}
+  {{- $todoistRedirectURL = printf "%s/oauth/todoist/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
+{{- end }}
 {{- $googleScopes := $google.scopes | default (list (dict "id" ($google.scopeId | default "calendar-read") "value" ($google.scope | default "https://www.googleapis.com/auth/calendar.readonly") "name" ($google.scopeName | default "Google Calendar read-only") "desc" ($google.scopeDesc | default "Read Google Calendar events.") "enabled" true)) }}
+{{- $todoistScopes := $todoist.scopes | default (list (dict "id" "read-write" "value" ($todoist.scope | default "data:read_write") "name" "Todoist read/write" "desc" "Read and write Todoist tasks and projects." "enabled" true)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -49,6 +56,15 @@ data:
         redirectUrl: {{ $redirectURL | quote }}
         integrations:
           google:
+            name: {{ $google.name | default "Google" | quote }}
+            {{- if $google.iconUrl }}
+            iconUrl: {{ $google.iconUrl | quote }}
+            {{- end }}
+            {{- if $google.description }}
+            description: {{ $google.description | quote }}
+            {{- end }}
+            setup:
+              callback_url: {{ $redirectURL | quote }}
             scopes:
               {{- range $scope := $googleScopes }}
               - id: {{ $scope.id | quote }}
@@ -68,6 +84,33 @@ data:
                 {{- end }}
                 enabled: {{ $scope.enabled | default false }}
               {{- end }}
+          {{- if $todoistEnabled }}
+          todoist:
+            name: {{ $todoist.name | default "Todoist" | quote }}
+            iconUrl: {{ $todoist.iconUrl | default "https://todoist.com/favicon.ico" | quote }}
+            description: {{ $todoist.description | default "Connect Todoist tasks and projects." | quote }}
+            setup:
+              callback_url: {{ $todoistRedirectURL | quote }}
+            scopes:
+              {{- range $scope := $todoistScopes }}
+              - id: {{ $scope.id | quote }}
+                value: {{ $scope.value | quote }}
+                name: {{ $scope.name | quote }}
+                {{- if $scope.desc }}
+                desc: {{ $scope.desc | quote }}
+                {{- end }}
+                {{- if $scope.group }}
+                group: {{ $scope.group | quote }}
+                {{- end }}
+                {{- if $scope.groupName }}
+                groupName: {{ $scope.groupName | quote }}
+                {{- end }}
+                {{- if $scope.groupDesc }}
+                groupDesc: {{ $scope.groupDesc | quote }}
+                {{- end }}
+                enabled: {{ $scope.enabled | default false }}
+              {{- end }}
+          {{- end }}
         namespaces:
           {{- range $userID, $_ := $users }}
           {{ $userID | quote }}:
@@ -78,6 +121,15 @@ data:
               {{- if $redirectURL }}
               redirectUrl: {{ $redirectURL | quote }}
               {{- end }}
+            {{- if $todoistEnabled }}
+            todoist:
+              clientId: "env:TODOIST_OAUTH_CLIENT_ID"
+              clientSecret: "env:TODOIST_OAUTH_CLIENT_SECRET"
+              scope: {{ $todoist.scope | default "data:read_write" | quote }}
+              {{- if $todoistRedirectURL }}
+              redirectUrl: {{ $todoistRedirectURL | quote }}
+              {{- end }}
+            {{- end }}
           {{- end }}
     credentials: []
     rules: []

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -8,6 +8,8 @@
 {{- $oauth := $scia.oauth | default dict }}
 {{- $google := $oauth.google | default dict }}
 {{- $secret := $google.secret | default dict }}
+{{- $todoist := $oauth.todoist | default dict }}
+{{- $todoistSecret := $todoist.secret | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,6 +61,18 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentapi-proxy.sciaSecretName" . }}
                   key: {{ $secret.clientSecretKey | default "client-secret" | quote }}
+                  optional: true
+            - name: TODOIST_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentapi-proxy.sciaTodoistSecretName" . }}
+                  key: {{ $todoistSecret.clientIdKey | default "client-id" | quote }}
+                  optional: true
+            - name: TODOIST_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentapi-proxy.sciaTodoistSecretName" . }}
+                  key: {{ $todoistSecret.clientSecretKey | default "client-secret" | quote }}
                   optional: true
           volumeMounts:
             - name: scia-config

--- a/helm/agentapi-proxy/templates/scia-secret.yaml
+++ b/helm/agentapi-proxy/templates/scia-secret.yaml
@@ -6,6 +6,8 @@
 {{- $oauth := $scia.oauth | default dict }}
 {{- $google := $oauth.google | default dict }}
 {{- $secret := $google.secret | default dict }}
+{{- $todoist := $oauth.todoist | default dict }}
+{{- $todoistSecret := $todoist.secret | default dict }}
 {{- if and $sciaEnabled ($secret.create | default true) (not $secret.existingSecret) }}
 apiVersion: v1
 kind: Secret
@@ -18,4 +20,18 @@ type: Opaque
 stringData:
   {{ $secret.clientIdKey | default "client-id" }}: {{ $secret.clientId | default "" | quote }}
   {{ $secret.clientSecretKey | default "client-secret" }}: {{ $secret.clientSecret | default "" | quote }}
+{{- end }}
+{{- if and $sciaEnabled ($todoist.enabled | default false) ($todoistSecret.create | default true) (not $todoistSecret.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentapi-proxy.sciaTodoistSecretName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+type: Opaque
+stringData:
+  {{ $todoistSecret.clientIdKey | default "client-id" }}: {{ $todoistSecret.clientId | default "" | quote }}
+  {{ $todoistSecret.clientSecretKey | default "client-secret" }}: {{ $todoistSecret.clientSecret | default "" | quote }}
 {{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -78,6 +78,7 @@ scia:
   publicBaseUrl: ""
   proxyUrl: ""
   credential: "default.google"
+  todoistCredential: "default.todoist"
   userNamespace: "default"
   noProxy: "localhost,127.0.0.1,.svc,.cluster.local"
   googleHosts:
@@ -86,6 +87,10 @@ scia:
   googlePaths:
     - /calendar/v3/*
     - /tasks/v1/*
+  todoistHosts:
+    - api.todoist.com
+  todoistPaths:
+    - /api/v1/*
   sessionSidecar:
     enabled: true
     image: ghcr.io/takutakahashi/scia:0.10.0
@@ -131,6 +136,27 @@ scia:
           enabled: false
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.
+      secret:
+        create: true
+        existingSecret: ""
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+        clientId: ""
+        clientSecret: ""
+    todoist:
+      enabled: false
+      scope: "data:read_write"
+      scopes:
+        - id: read-write
+          value: "data:read_write"
+          name: "Todoist read/write"
+          desc: "Read and write Todoist tasks and projects."
+          enabled: true
+        - id: task-add
+          value: "task:add"
+          name: "Todoist task add"
+          desc: "Add Todoist tasks without reading existing data."
+          enabled: false
       secret:
         create: true
         existingSecret: ""

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -146,6 +146,7 @@ scia:
     todoist:
       enabled: false
       scope: "data:read_write"
+      omitRedirectUrl: false
       scopes:
         - id: read-write
           value: "data:read_write"

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -91,6 +91,8 @@ scia:
     - api.todoist.com
   todoistPaths:
     - /api/v1/*
+    - /rest/v2/*
+    - /sync/v9/*
   sessionSidecar:
     enabled: true
     image: ghcr.io/takutakahashi/scia:0.10.0

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2572,8 +2572,20 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 	if len(paths) == 0 {
 		paths = []string{"/calendar/v3/*"}
 	}
+	todoistCredentialID := scia.TodoistCredential
+	if todoistCredentialID == "" {
+		todoistCredentialID = userNamespace + ".todoist"
+	}
+	todoistHosts := scia.TodoistHosts
+	if len(todoistHosts) == 0 {
+		todoistHosts = []string{"api.todoist.com"}
+	}
+	todoistPaths := scia.TodoistPaths
+	if len(todoistPaths) == 0 {
+		todoistPaths = []string{"/api/v1/*"}
+	}
 
-	configYAML := buildSciaSidecarConfigYAML(m.namespace, userNamespace, credentialID, port, hosts, paths, sandboxEnabled)
+	configYAML := buildSciaSidecarConfigYAML(m.namespace, userNamespace, credentialID, todoistCredentialID, port, hosts, paths, todoistHosts, todoistPaths, sandboxEnabled)
 	configScript := fmt.Sprintf("cat > /etc/scia-config/config.yaml <<'EOF'\n%sEOF\n", configYAML)
 
 	initContainer := corev1.Container{
@@ -2626,13 +2638,14 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 		{Name: "NODE_EXTRA_CA_CERTS", Value: sciaCAPath},
 		{Name: "AGENTAPI_SCIA_PROXY_URL", Value: proxyAddr},
 		{Name: "AGENTAPI_SCIA_GOOGLE_CREDENTIAL", Value: credentialID},
+		{Name: "AGENTAPI_SCIA_TODOIST_CREDENTIAL", Value: todoistCredentialID},
 		{Name: "AGENTAPI_SCIA_USER_NAMESPACE", Value: userNamespace},
 	}
 
 	return &initContainer, &sidecar, envVars
 }
 
-func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID string, port int, hosts, paths []string, useNFA bool) string {
+func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistCredentialID string, port int, hosts, paths, todoistHosts, todoistPaths []string, useNFA bool) string {
 	var b strings.Builder
 	b.WriteString("server:\n")
 	b.WriteString("  mode: proxy\n")
@@ -2645,6 +2658,11 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID string, p
 	b.WriteString("    google:\n")
 	b.WriteString("      hosts:\n")
 	for _, host := range hosts {
+		b.WriteString(fmt.Sprintf("        - %q\n", host))
+	}
+	b.WriteString("    todoist:\n")
+	b.WriteString("      hosts:\n")
+	for _, host := range todoistHosts {
 		b.WriteString(fmt.Sprintf("        - %q\n", host))
 	}
 	b.WriteString("  mitm:\n")
@@ -2662,6 +2680,10 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID string, p
 	b.WriteString("    type: google-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
 	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/google/token", namespace, url.PathEscape(userNamespace))))
+	b.WriteString(fmt.Sprintf("  - id: %q\n", todoistCredentialID))
+	b.WriteString("    type: todoist-oauth-refresh-token\n")
+	b.WriteString("    params:\n")
+	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/todoist/token", namespace, url.PathEscape(userNamespace))))
 	b.WriteString("rules:\n")
 	b.WriteString("  - name: inject-google-oauth-token\n")
 	b.WriteString("    hosts:\n")
@@ -2675,6 +2697,18 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID string, p
 	b.WriteString("    action: allow\n")
 	b.WriteString("    credentials:\n")
 	b.WriteString(fmt.Sprintf("      - %q\n", credentialID))
+	b.WriteString("  - name: inject-todoist-oauth-token\n")
+	b.WriteString("    hosts:\n")
+	for _, host := range todoistHosts {
+		b.WriteString(fmt.Sprintf("      - %q\n", host))
+	}
+	b.WriteString("    paths:\n")
+	for _, path := range todoistPaths {
+		b.WriteString(fmt.Sprintf("      - %q\n", path))
+	}
+	b.WriteString("    action: allow\n")
+	b.WriteString("    credentials:\n")
+	b.WriteString(fmt.Sprintf("      - %q\n", todoistCredentialID))
 	return b.String()
 }
 
@@ -4859,6 +4893,9 @@ func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req
 		if scia.Credential != "" {
 			env["AGENTAPI_SCIA_GOOGLE_CREDENTIAL"] = scia.Credential
 		}
+		if scia.TodoistCredential != "" {
+			env["AGENTAPI_SCIA_TODOIST_CREDENTIAL"] = scia.TodoistCredential
+		}
 		if scia.UserNamespace != "" {
 			env["AGENTAPI_SCIA_USER_NAMESPACE"] = scia.UserNamespace
 		}
@@ -4895,6 +4932,13 @@ func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req
 	env["NODE_EXTRA_CA_CERTS"] = sciaCAPath
 	if credential != "" {
 		env["AGENTAPI_SCIA_GOOGLE_CREDENTIAL"] = credential
+	}
+	todoistCredential := scia.TodoistCredential
+	if todoistCredential == "" && userNamespace != "" {
+		todoistCredential = userNamespace + ".todoist"
+	}
+	if todoistCredential != "" {
+		env["AGENTAPI_SCIA_TODOIST_CREDENTIAL"] = todoistCredential
 	}
 	if userNamespace != "" {
 		env["AGENTAPI_SCIA_USER_NAMESPACE"] = userNamespace

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -92,6 +92,9 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 				NoProxy:                   ".svc,.cluster.local",
 				GoogleHosts:               []string{"www.googleapis.com"},
 				GooglePaths:               []string{"/calendar/v3/*"},
+				TodoistCredential:         "takutakahashi.todoist",
+				TodoistHosts:              []string{"api.todoist.com"},
+				TodoistPaths:              []string{"/api/v1/*"},
 			},
 		},
 		k8sConfig: &config.KubernetesSessionConfig{
@@ -148,12 +151,16 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 		assert.Contains(t, script, `url: "http://127.0.0.1:3128"`)
 		assert.Contains(t, script, "  integrations:\n")
 		assert.Contains(t, script, "    google:\n")
+		assert.Contains(t, script, "    todoist:\n")
 		assert.Contains(t, script, `        - "www.googleapis.com"`)
+		assert.Contains(t, script, `        - "api.todoist.com"`)
 		assert.Contains(t, script, `secretName: "scia-oauth-takutakahashi"`)
 		assert.NotContains(t, script, `scia-google-oauth`)
 		assert.NotContains(t, script, `clientSecretRef`)
 		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/google/token"`)
+		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/todoist/token"`)
 		assert.Contains(t, script, `- "takutakahashi.google"`)
+		assert.Contains(t, script, `- "takutakahashi.todoist"`)
 	}
 
 	main := podSpec.Containers[0]
@@ -168,6 +175,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 	assert.Equal(t, "http://127.0.0.1:18081", env["HTTPS_PROXY"])
 	assert.Equal(t, sciaCABundlePath, env["SSL_CERT_FILE"])
 	assert.Equal(t, "takutakahashi.google", env["AGENTAPI_SCIA_GOOGLE_CREDENTIAL"])
+	assert.Equal(t, "takutakahashi.todoist", env["AGENTAPI_SCIA_TODOIST_CREDENTIAL"])
 	assert.NotContains(t, env["NO_PROXY"], "api.openai.com")
 	assert.NotContains(t, env["no_proxy"], "api.openai.com")
 
@@ -248,6 +256,9 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 				UserNamespace:             "takutakahashi",
 				GoogleHosts:               []string{"www.googleapis.com"},
 				GooglePaths:               []string{"/calendar/v3/*"},
+				TodoistCredential:         "takutakahashi.todoist",
+				TodoistHosts:              []string{"api.todoist.com"},
+				TodoistPaths:              []string{"/api/v1/*"},
 			},
 		},
 		k8sConfig: &config.KubernetesSessionConfig{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1338,7 +1338,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.google_paths", []string{"/calendar/v3/*"})
 	v.SetDefault("scia.todoist_credential", "")
 	v.SetDefault("scia.todoist_hosts", []string{"api.todoist.com"})
-	v.SetDefault("scia.todoist_paths", []string{"/api/v1/*"})
+	v.SetDefault("scia.todoist_paths", []string{"/api/v1/*", "/rest/v2/*", "/sync/v9/*"})
 
 	// Memory backend defaults
 	v.SetDefault("memory.backend", "kubernetes")
@@ -1434,7 +1434,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.TodoistHosts = []string{"api.todoist.com"}
 	}
 	if len(config.Scia.TodoistPaths) == 0 {
-		config.Scia.TodoistPaths = []string{"/api/v1/*"}
+		config.Scia.TodoistPaths = []string{"/api/v1/*", "/rest/v2/*", "/sync/v9/*"}
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,6 +261,12 @@ type SciaConfig struct {
 	GoogleHosts []string `json:"google_hosts" mapstructure:"google_hosts"`
 	// GooglePaths is the list of paths where the sidecar injects the Google access token.
 	GooglePaths []string `json:"google_paths" mapstructure:"google_paths"`
+	// TodoistCredential is the scia credential ID used for Todoist OAuth, e.g. "takutakahashi.todoist".
+	TodoistCredential string `json:"todoist_credential" mapstructure:"todoist_credential"`
+	// TodoistHosts is the list of hosts where the sidecar injects the Todoist access token.
+	TodoistHosts []string `json:"todoist_hosts" mapstructure:"todoist_hosts"`
+	// TodoistPaths is the list of paths where the sidecar injects the Todoist access token.
+	TodoistPaths []string `json:"todoist_paths" mapstructure:"todoist_paths"`
 }
 
 // KubernetesSessionConfig represents Kubernetes session manager configuration
@@ -965,6 +971,15 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	if paths := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_GOOGLE_PATHS")); len(paths) > 0 {
 		config.Scia.GooglePaths = paths
 	}
+	if credential := os.Getenv("AGENTAPI_SCIA_TODOIST_CREDENTIAL"); credential != "" {
+		config.Scia.TodoistCredential = credential
+	}
+	if hosts := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_TODOIST_HOSTS")); len(hosts) > 0 {
+		config.Scia.TodoistHosts = hosts
+	}
+	if paths := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_TODOIST_PATHS")); len(paths) > 0 {
+		config.Scia.TodoistPaths = paths
+	}
 
 	// Override fields if environment variables are set (even if structures already exist)
 	if config.Auth.Static != nil {
@@ -1050,6 +1065,9 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("scia.session_sidecar_port", "AGENTAPI_SCIA_SESSION_SIDECAR_PORT")
 	_ = v.BindEnv("scia.google_hosts", "AGENTAPI_SCIA_GOOGLE_HOSTS")
 	_ = v.BindEnv("scia.google_paths", "AGENTAPI_SCIA_GOOGLE_PATHS")
+	_ = v.BindEnv("scia.todoist_credential", "AGENTAPI_SCIA_TODOIST_CREDENTIAL")
+	_ = v.BindEnv("scia.todoist_hosts", "AGENTAPI_SCIA_TODOIST_HOSTS")
+	_ = v.BindEnv("scia.todoist_paths", "AGENTAPI_SCIA_TODOIST_PATHS")
 
 	// Role-based environment files configuration
 	_ = v.BindEnv("role_env_files.enabled")
@@ -1318,6 +1336,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
 	v.SetDefault("scia.google_paths", []string{"/calendar/v3/*"})
+	v.SetDefault("scia.todoist_credential", "")
+	v.SetDefault("scia.todoist_hosts", []string{"api.todoist.com"})
+	v.SetDefault("scia.todoist_paths", []string{"/api/v1/*"})
 
 	// Memory backend defaults
 	v.SetDefault("memory.backend", "kubernetes")
@@ -1408,6 +1429,12 @@ func applyConfigDefaults(config *Config) {
 	}
 	if len(config.Scia.GooglePaths) == 0 {
 		config.Scia.GooglePaths = []string{"/calendar/v3/*"}
+	}
+	if len(config.Scia.TodoistHosts) == 0 {
+		config.Scia.TodoistHosts = []string{"api.todoist.com"}
+	}
+	if len(config.Scia.TodoistPaths) == 0 {
+		config.Scia.TodoistPaths = []string{"/api/v1/*"}
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -466,6 +466,9 @@ func TestLoadConfigWithSciaEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("AGENTAPI_SCIA_SESSION_SIDECAR_PORT", "18082")
 	_ = os.Setenv("AGENTAPI_SCIA_GOOGLE_HOSTS", "www.googleapis.com,content.googleapis.com")
 	_ = os.Setenv("AGENTAPI_SCIA_GOOGLE_PATHS", "/calendar/v3/*,/drive/v3/*")
+	_ = os.Setenv("AGENTAPI_SCIA_TODOIST_CREDENTIAL", "default.todoist")
+	_ = os.Setenv("AGENTAPI_SCIA_TODOIST_HOSTS", "api.todoist.com")
+	_ = os.Setenv("AGENTAPI_SCIA_TODOIST_PATHS", "/api/v1/*")
 
 	loadedConfig, err := LoadConfig("")
 	if err != nil {
@@ -480,6 +483,9 @@ func TestLoadConfigWithSciaEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, 18082, loadedConfig.Scia.SessionSidecarPort)
 	assert.Equal(t, []string{"www.googleapis.com", "content.googleapis.com"}, loadedConfig.Scia.GoogleHosts)
 	assert.Equal(t, []string{"/calendar/v3/*", "/drive/v3/*"}, loadedConfig.Scia.GooglePaths)
+	assert.Equal(t, "default.todoist", loadedConfig.Scia.TodoistCredential)
+	assert.Equal(t, []string{"api.todoist.com"}, loadedConfig.Scia.TodoistHosts)
+	assert.Equal(t, []string{"/api/v1/*"}, loadedConfig.Scia.TodoistPaths)
 }
 
 func TestLoadConfigNetworkFilterResourceDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Todoist OAuth values and Helm rendering for scia
- inject Todoist OAuth client credentials into the scia broker
- configure session sidecars to inject Todoist bearer tokens for api.todoist.com/api/v1/*

## Testing
- git diff --check
- not run: go/gofmt/helm are not installed in this workspace