### PR TITLE
Update scia image to 0.10.3

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.10.0" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.10.3" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.10.0" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.10.3" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,7 +72,7 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.10.0"
+    tag: "0.10.3"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
@@ -95,7 +95,7 @@ scia:
     - /sync/v9/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.10.0
+    image: ghcr.io/takutakahashi/scia:0.10.3
     configImage: busybox:1.36
     port: 18081
   oauth:

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2600,7 +2600,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.10.0"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.10.3"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.3",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -249,7 +249,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.3",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1331,7 +1331,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.10.0")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.10.3")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1416,7 +1416,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.10.0"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.10.3"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"


### PR DESCRIPTION
## Summary
- update default scia OAuth broker image tag to 0.10.3
- update default scia session sidecar image to 0.10.3
- keep chart values able to explicitly override scia images
- deployed the dev chart to agentapi-ui-dev and removed dev release scia image overrides so chart defaults are used

## Dev deployment
- release: agentapi-proxy / agentapi-ui-dev
- chart: 0.3.0-dev.20260621072112.08312f2
- appVersion: dev-08312f2
- previous scia.image and scia.sessionSidecar.image release overrides removed

## Tests
- GitHub Actions dev chart build: passed (run 27897043152)
- Helm release status: deployed revision 1088
- Local go test not run: go is not installed in this environment
- Local helm template not run: helm is not installed in this environment
- kubectl rollout verification not run: kubectl is not installed in this environment or the operations MCP runtime