### PR TITLE
Fix scia integration connected status

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.10.3" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.12.1" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.10.3" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.12.1" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,7 +72,7 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.10.3"
+    tag: "0.12.1"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
@@ -95,7 +95,7 @@ scia:
     - /sync/v9/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.10.3
+    image: ghcr.io/takutakahashi/scia:0.12.1
     configImage: busybox:1.36
     port: 18081
   oauth:

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -416,6 +416,7 @@ func (r *Router) registerConditionalRoutes() error {
 		log.Printf("[ROUTES] Registering scia integration endpoints...")
 		r.echo.GET("/integrations", r.handlers.googleOAuthController.GetIntegrations, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.POST("/integrations/:id/authorization-url", r.handlers.googleOAuthController.CreateAuthorizationURL, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.POST("/integrations/:id/revoke", r.handlers.googleOAuthController.RevokeIntegration, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
 		r.echo.GET("/integrations/google-oauth/status", r.handlers.googleOAuthController.GetStatus, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		log.Printf("[ROUTES] scia integration endpoints registered")
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2600,7 +2600,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.10.3"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.12.1"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.3",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.1",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -249,7 +249,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.10.3",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.1",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -144,7 +144,7 @@ func (c *GoogleOAuthController) GetStatus(ctx echo.Context) error {
 
 	if c.scia.Enabled {
 		resp.HealthOK, resp.HealthStatus = c.checkHealth(ctx.Request().Context())
-		resp.Connected = c.refreshTokenSecretExists(ctx.Request().Context(), userNamespace)
+		resp.Connected = c.oauthTokenSecretExists(ctx.Request().Context(), userNamespace, c.credential(userNamespace), "google")
 	}
 
 	return ctx.JSON(http.StatusOK, resp)
@@ -186,7 +186,7 @@ func (c *GoogleOAuthController) GetIntegrations(ctx echo.Context) error {
 				}
 			}
 		}
-		integrations[i].Connected = c.refreshTokenSecretExists(ctx.Request().Context(), namespace)
+		integrations[i].Connected = c.oauthTokenSecretExists(ctx.Request().Context(), namespace, integrations[i].CredentialID, integrations[i].Provider)
 	}
 	resp.Integrations = integrations
 
@@ -353,13 +353,26 @@ func (c *GoogleOAuthController) checkHealth(ctx context.Context) (bool, string) 
 	return false, res.Status
 }
 
-func (c *GoogleOAuthController) refreshTokenSecretExists(ctx context.Context, userNamespace string) bool {
+func (c *GoogleOAuthController) oauthTokenSecretExists(ctx context.Context, userNamespace, credentialID, provider string) bool {
 	if c.client == nil || c.namespace == "" || userNamespace == "" {
 		return false
 	}
 	secretName := "scia-oauth-" + sanitizeSciaSecretSuffix(userNamespace)
-	_, err := c.client.CoreV1().Secrets(c.namespace).Get(ctx, secretName, metav1.GetOptions{})
-	return err == nil
+	secret, err := c.client.CoreV1().Secrets(c.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	if hasSecretData(secret.Data, credentialID+".refresh_token") || hasSecretData(secret.Data, credentialID+".access_token") {
+		return true
+	}
+	// Older scia deployments stored the original Google refresh token under a
+	// shared key. Treat it as Google-only so other providers do not appear connected.
+	return provider == "google" && hasSecretData(secret.Data, "refresh_token")
+}
+
+func hasSecretData(data map[string][]byte, key string) bool {
+	value, ok := data[key]
+	return ok && len(value) > 0
 }
 
 func (c *GoogleOAuthController) userNamespace(userID string) string {

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -83,6 +83,12 @@ type IntegrationAuthorizationURLResponse struct {
 	Scope            string `json:"scope,omitempty"`
 }
 
+// IntegrationRevokeResponse is returned after disconnecting a scia integration.
+type IntegrationRevokeResponse struct {
+	Revoked      bool   `json:"revoked"`
+	CredentialID string `json:"credential_id,omitempty"`
+}
+
 type sciaHTTPError struct {
 	StatusCode int
 	Message    string
@@ -229,6 +235,36 @@ func (c *GoogleOAuthController) CreateAuthorizationURL(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, resp)
 }
 
+// RevokeIntegration removes the stored OAuth token for one scia integration.
+func (c *GoogleOAuthController) RevokeIntegration(ctx echo.Context) error {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "Authentication required")
+	}
+	if !c.scia.Enabled {
+		return echo.NewHTTPError(http.StatusNotFound, "scia integration is disabled")
+	}
+
+	integrationID := ctx.Param("id")
+	integration, ok, err := c.integrationForUser(ctx.Request().Context(), string(user.ID()), integrationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+	if !ok {
+		return echo.NewHTTPError(http.StatusNotFound, "integration not found")
+	}
+
+	resp, err := c.revokeSciaIntegration(ctx.Request().Context(), integration)
+	if err != nil {
+		var upstream sciaHTTPError
+		if errors.As(err, &upstream) {
+			return echo.NewHTTPError(upstream.StatusCode, upstream.Message)
+		}
+		return echo.NewHTTPError(http.StatusBadGateway, err.Error())
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
 func (c *GoogleOAuthController) integrationForUser(ctx context.Context, userID, integrationID string) (FrontendIntegration, bool, error) {
 	integrations, err := c.fetchSciaIntegrations(ctx)
 	if err != nil {
@@ -288,6 +324,50 @@ func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, 
 	var output IntegrationAuthorizationURLResponse
 	if err := json.NewDecoder(res.Body).Decode(&output); err != nil {
 		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("failed to decode scia authorization-url: %w", err)
+	}
+	return output, nil
+}
+
+func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integration FrontendIntegration) (IntegrationRevokeResponse, error) {
+	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
+	if base == "" {
+		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
+	}
+	if base == "" {
+		return IntegrationRevokeResponse{}, fmt.Errorf("scia_oauth_url_not_configured")
+	}
+	if integration.Namespace == "" || integration.Provider == "" {
+		return IntegrationRevokeResponse{}, fmt.Errorf("integration is missing namespace or provider")
+	}
+
+	path := fmt.Sprintf("/oauth/%s/%s/revoke", url.PathEscape(integration.Namespace), url.PathEscape(integration.Provider))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+path, strings.NewReader(`{}`))
+	if err != nil {
+		return IntegrationRevokeResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return IntegrationRevokeResponse{}, err
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return IntegrationRevokeResponse{}, sciaHTTPError{
+			StatusCode: res.StatusCode,
+			Message:    strings.TrimSpace(string(body)),
+		}
+	}
+	var output IntegrationRevokeResponse
+	if err := json.NewDecoder(res.Body).Decode(&output); err != nil {
+		return IntegrationRevokeResponse{}, fmt.Errorf("failed to decode scia revoke response: %w", err)
+	}
+	if output.CredentialID == "" {
+		output.CredentialID = integration.CredentialID
 	}
 	return output, nil
 }

--- a/internal/interfaces/controllers/google_oauth_controller_test.go
+++ b/internal/interfaces/controllers/google_oauth_controller_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
@@ -84,5 +87,86 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	}
 	if body.AuthorizationURL != "https://accounts.google.com/o/oauth2/v2/auth?scope=calendar" {
 		t.Fatalf("authorization_url = %q", body.AuthorizationURL)
+	}
+}
+
+func TestGetIntegrationsMarksConnectedPerCredentialToken(t *testing.T) {
+	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_scia/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/api/integrations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"integrations": []map[string]any{
+					{
+						"id":                         "alice.google",
+						"provider":                   "google",
+						"namespace":                  "alice",
+						"credential_id":              "alice.google",
+						"name":                       "Google",
+						"released":                   true,
+						"start_url":                  "/oauth/alice/google/start",
+						"authorization_url_endpoint": "/oauth/alice/google/authorization-url",
+						"scopes":                     []map[string]any{},
+					},
+					{
+						"id":                         "alice.todoist",
+						"provider":                   "todoist",
+						"namespace":                  "alice",
+						"credential_id":              "alice.todoist",
+						"name":                       "Todoist",
+						"released":                   true,
+						"start_url":                  "/oauth/alice/todoist/start",
+						"authorization_url_endpoint": "/oauth/alice/todoist/authorization-url",
+						"scopes":                     []map[string]any{},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer scia.Close()
+
+	k8s := fake.NewSimpleClientset(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "scia-oauth-alice", Namespace: "agentapi"},
+		Data: map[string][]byte{
+			"refresh_token": []byte("legacy-google-refresh-token"),
+		},
+	})
+	controller := NewGoogleOAuthController(config.SciaConfig{
+		Enabled:          true,
+		OAuthInternalURL: scia.URL,
+	}, k8s, "agentapi")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/integrations", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.Set("internal_user", entities.NewUser("alice", entities.UserTypeRegular, "alice"))
+
+	if err := controller.GetIntegrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body IntegrationsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Integrations) != 2 {
+		t.Fatalf("integrations = %#v", body.Integrations)
+	}
+	connected := map[string]bool{}
+	for _, integration := range body.Integrations {
+		connected[integration.ID] = integration.Connected
+	}
+	if !connected["alice.google"] {
+		t.Fatalf("google connected = false, want true")
+	}
+	if connected["alice.todoist"] {
+		t.Fatalf("todoist connected = true, want false")
 	}
 }

--- a/internal/interfaces/controllers/google_oauth_controller_test.go
+++ b/internal/interfaces/controllers/google_oauth_controller_test.go
@@ -90,6 +90,72 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	}
 }
 
+func TestRevokeIntegrationProxiesToSciaNamespaceRevoke(t *testing.T) {
+	var revoked bool
+	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/integrations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"integrations": []map[string]any{
+					{
+						"id":                         "takutakahashi.todoist",
+						"provider":                   "todoist",
+						"namespace":                  "takutakahashi",
+						"credential_id":              "takutakahashi.todoist",
+						"name":                       "Todoist",
+						"released":                   true,
+						"start_url":                  "/oauth/takutakahashi/todoist/start",
+						"authorization_url_endpoint": "/oauth/takutakahashi/todoist/authorization-url",
+						"scopes":                     []map[string]any{},
+					},
+				},
+			})
+		case "/oauth/takutakahashi/todoist/revoke":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			revoked = true
+			_ = json.NewEncoder(w).Encode(IntegrationRevokeResponse{
+				Revoked:      true,
+				CredentialID: "takutakahashi.todoist",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer scia.Close()
+
+	controller := NewGoogleOAuthController(config.SciaConfig{
+		Enabled:          true,
+		OAuthInternalURL: scia.URL,
+	}, nil, "")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/integrations/takutakahashi.todoist/revoke", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("takutakahashi.todoist")
+	ctx.Set("internal_user", entities.NewUser("takutakahashi", entities.UserTypeRegular, "takutakahashi"))
+
+	if err := controller.RevokeIntegration(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !revoked {
+		t.Fatalf("scia revoke endpoint was not called")
+	}
+	var body IntegrationRevokeResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.Revoked || body.CredentialID != "takutakahashi.todoist" {
+		t.Fatalf("unexpected revoke response: %#v", body)
+	}
+}
+
 func TestGetIntegrationsMarksConnectedPerCredentialToken(t *testing.T) {
 	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1331,7 +1331,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.10.3")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.12.1")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1416,7 +1416,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.10.3"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.12.1"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"


### PR DESCRIPTION
## Summary
- mark integrations connected only when the matching credential token exists
- keep legacy shared refresh_token fallback Google-only
- add regression coverage for Google legacy token not marking Todoist connected

## Tests
- Not run: Go toolchain is unavailable in this environment (go/gofmt not found).