### PR TITLE
Add scia Notion OAuth chart support

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -102,6 +102,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scia.oauth.todoist.omitRedirectUrl`               | Omit Todoist redirect_uri from OAuth requests   | `false` |
 | `scia.oauth.todoist.secret.create`                 | Create a Kubernetes Secret for Todoist OAuth    | `true` |
 | `scia.oauth.todoist.secret.existingSecret`         | Existing Secret containing Todoist OAuth values | `""` |
+| `scia.oauth.notion.enabled`                        | Enable Notion OAuth in scia                     | `false` |
+| `scia.oauth.notion.omitRedirectUrl`                | Omit Notion redirect_uri from OAuth requests    | `false` |
+| `scia.oauth.notion.secret.create`                  | Create a Kubernetes Secret for Notion OAuth     | `true` |
+| `scia.oauth.notion.secret.existingSecret`          | Existing Secret containing Notion OAuth values  | `""` |
 | `scia.users`                                       | scia user-to-refresh-token Secret mapping       | `{default: {secretName: scia-oauth-default}}` |
 | `scia.sessionRefreshTokenSecretNames`              | Refresh-token Secrets readable by session pods  | `[scia-oauth-default]` |
 
@@ -244,6 +248,28 @@ scia:
 ```
 
 The `scia-todoist-oauth` Secret must contain the Todoist OAuth client ID and client secret. Register the same `redirectUrl` in the Todoist app console. The session sidecar injects the Todoist token for `api.todoist.com/api/v1/*` requests by default.
+
+### With scia Notion OAuth
+
+```yaml
+scia:
+  enabled: true
+  publicBaseUrl: https://agentapi.yourdomain.com
+  userNamespace: default
+  notionCredential: default.notion
+  oauth:
+    notion:
+      enabled: true
+      redirectUrl: https://agentapi.yourdomain.com/api/oauth/notion/callback
+      omitRedirectUrl: false
+      secret:
+        create: false
+        existingSecret: scia-notion-oauth
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+```
+
+The `scia-notion-oauth` Secret must contain the Notion OAuth client ID and client secret. Register the same `redirectUrl` in the Notion integration settings. The session sidecar injects the Notion token for `api.notion.com/v1/*` requests by default.
 
 ### With Environment Variables
 

--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -271,6 +271,8 @@ scia:
 
 The `scia-notion-oauth` Secret must contain the Notion OAuth client ID and client secret. Register the same `redirectUrl` in the Notion integration settings. The session sidecar injects the Notion token for `api.notion.com/v1/*` requests by default.
 
+Notion permissions are ultimately controlled by the connection capabilities configured in the Notion Developer portal. The chart exposes read-only/read-write scope metadata so the UI can present an access-mode choice, but the Notion public connection must be configured with matching capabilities.
+
 ### With Environment Variables
 
 ```yaml

--- a/helm/agentapi-proxy/templates/_helpers.tpl
+++ b/helm/agentapi-proxy/templates/_helpers.tpl
@@ -87,3 +87,11 @@ scia-oauth
 {{- $secret := $todoist.secret | default dict }}
 {{- default (printf "%s-todoist" (include "agentapi-proxy.sciaName" .) | trunc 63 | trimSuffix "-") $secret.existingSecret }}
 {{- end }}
+
+{{- define "agentapi-proxy.sciaNotionSecretName" -}}
+{{- $scia := .Values.scia | default dict }}
+{{- $oauth := $scia.oauth | default dict }}
+{{- $notion := $oauth.notion | default dict }}
+{{- $secret := $notion.secret | default dict }}
+{{- default (printf "%s-notion" (include "agentapi-proxy.sciaName" .) | trunc 63 | trimSuffix "-") $secret.existingSecret }}
+{{- end }}

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -293,6 +293,16 @@ spec:
               value: {{ $scia.todoistHosts | default (list "api.todoist.com") | join "," | quote }}
             - name: AGENTAPI_SCIA_TODOIST_PATHS
               value: {{ $scia.todoistPaths | default (list "/api/v1/*") | join "," | quote }}
+            {{- $sciaOAuth := $scia.oauth | default dict }}
+            {{- $sciaNotion := $sciaOAuth.notion | default dict }}
+            - name: AGENTAPI_SCIA_NOTION_ENABLED
+              value: {{ ($sciaNotion.enabled | default false) | quote }}
+            - name: AGENTAPI_SCIA_NOTION_CREDENTIAL
+              value: {{ $scia.notionCredential | default (printf "%s.notion" ($scia.userNamespace | default "default")) | quote }}
+            - name: AGENTAPI_SCIA_NOTION_HOSTS
+              value: {{ $scia.notionHosts | default (list "api.notion.com") | join "," | quote }}
+            - name: AGENTAPI_SCIA_NOTION_PATHS
+              value: {{ $scia.notionPaths | default (list "/v1/*") | join "," | quote }}
             # Kubernetes Session Management configuration
             - name: AGENTAPI_K8S_SESSION_ENABLED
               value: "true"

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -182,15 +182,6 @@ data:
               redirectUrl: {{ $todoistRedirectURL | quote }}
               {{- end }}
             {{- end }}
-            {{- if $notionEnabled }}
-            notion:
-              clientId: "env:NOTION_OAUTH_CLIENT_ID"
-              clientSecret: "env:NOTION_OAUTH_CLIENT_SECRET"
-              scope: {{ $notion.scope | default "" | quote }}
-              {{- if $notionRedirectURL }}
-              redirectUrl: {{ $notionRedirectURL | quote }}
-              {{- end }}
-            {{- end }}
           {{- end }}
     credentials: []
     rules: []

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -67,6 +67,18 @@ data:
       oauth:
         listen: {{ $oauth.listen | default "0.0.0.0:8081" | quote }}
         redirectUrl: {{ $redirectURL | quote }}
+        {{- if $notionEnabled }}
+        notion:
+          credentialId: {{ $scia.notionCredential | default (printf "%s.notion" ($scia.userNamespace | default "default")) | quote }}
+          clientId: "env:NOTION_OAUTH_CLIENT_ID"
+          clientSecret: "env:NOTION_OAUTH_CLIENT_SECRET"
+          {{- if $notionRedirectURL }}
+          redirectUrl: {{ $notionRedirectURL | quote }}
+          {{- end }}
+          {{- if $notion.notionVersion }}
+          notionVersion: {{ $notion.notionVersion | quote }}
+          {{- end }}
+        {{- end }}
         integrations:
           google:
             name: {{ $google.name | default "Google" | quote }}

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -8,6 +8,8 @@
 {{- $google := $oauth.google | default dict }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistEnabled := $todoist.enabled | default false }}
+{{- $notion := $oauth.notion | default dict }}
+{{- $notionEnabled := $notion.enabled | default false }}
 {{- $users := $scia.users | default (dict "default" (dict "secretName" "scia-oauth-default")) }}
 {{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
 {{- $sciaHost := .Values.config.hostname | default "" }}
@@ -31,8 +33,16 @@
 {{- if $todoist.omitRedirectUrl }}
   {{- $todoistRedirectURL = "" }}
 {{- end }}
+{{- $notionRedirectURL := $notion.redirectUrl | default "" }}
+{{- if and (eq $notionRedirectURL "") $sciaPublicBaseURL }}
+  {{- $notionRedirectURL = printf "%s/api/oauth/notion/callback" (trimSuffix "/" $sciaPublicBaseURL) }}
+{{- end }}
+{{- if $notion.omitRedirectUrl }}
+  {{- $notionRedirectURL = "" }}
+{{- end }}
 {{- $googleScopes := $google.scopes | default (list (dict "id" ($google.scopeId | default "calendar-read") "value" ($google.scope | default "https://www.googleapis.com/auth/calendar.readonly") "name" ($google.scopeName | default "Google Calendar read-only") "desc" ($google.scopeDesc | default "Read Google Calendar events.") "enabled" true)) }}
 {{- $todoistScopes := $todoist.scopes | default (list (dict "id" "read-write" "value" ($todoist.scope | default "data:read_write") "name" "Todoist read/write" "desc" "Read and write Todoist tasks and projects." "enabled" true)) }}
+{{- $notionScopes := $notion.scopes | default (list (dict "id" "default" "value" ($notion.scope | default "") "name" "Notion access" "desc" "Connect Notion pages and databases selected during authorization." "enabled" true)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -114,6 +124,33 @@ data:
                 enabled: {{ $scope.enabled | default false }}
               {{- end }}
           {{- end }}
+          {{- if $notionEnabled }}
+          notion:
+            name: {{ $notion.name | default "Notion" | quote }}
+            iconUrl: {{ $notion.iconUrl | default "https://www.notion.so/images/favicon.ico" | quote }}
+            description: {{ $notion.description | default "Connect Notion pages and databases." | quote }}
+            setup:
+              callback_url: {{ $notionRedirectURL | quote }}
+            scopes:
+              {{- range $scope := $notionScopes }}
+              - id: {{ $scope.id | quote }}
+                value: {{ $scope.value | quote }}
+                name: {{ $scope.name | quote }}
+                {{- if $scope.desc }}
+                desc: {{ $scope.desc | quote }}
+                {{- end }}
+                {{- if $scope.group }}
+                group: {{ $scope.group | quote }}
+                {{- end }}
+                {{- if $scope.groupName }}
+                groupName: {{ $scope.groupName | quote }}
+                {{- end }}
+                {{- if $scope.groupDesc }}
+                groupDesc: {{ $scope.groupDesc | quote }}
+                {{- end }}
+                enabled: {{ $scope.enabled | default false }}
+              {{- end }}
+          {{- end }}
         namespaces:
           {{- range $userID, $_ := $users }}
           {{ $userID | quote }}:
@@ -131,6 +168,15 @@ data:
               scope: {{ $todoist.scope | default "data:read_write" | quote }}
               {{- if $todoistRedirectURL }}
               redirectUrl: {{ $todoistRedirectURL | quote }}
+              {{- end }}
+            {{- end }}
+            {{- if $notionEnabled }}
+            notion:
+              clientId: "env:NOTION_OAUTH_CLIENT_ID"
+              clientSecret: "env:NOTION_OAUTH_CLIENT_SECRET"
+              scope: {{ $notion.scope | default "" | quote }}
+              {{- if $notionRedirectURL }}
+              redirectUrl: {{ $notionRedirectURL | quote }}
               {{- end }}
             {{- end }}
           {{- end }}

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -10,6 +10,8 @@
 {{- $secret := $google.secret | default dict }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistSecret := $todoist.secret | default dict }}
+{{- $notion := $oauth.notion | default dict }}
+{{- $notionSecret := $notion.secret | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,6 +75,18 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentapi-proxy.sciaTodoistSecretName" . }}
                   key: {{ $todoistSecret.clientSecretKey | default "client-secret" | quote }}
+                  optional: true
+            - name: NOTION_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentapi-proxy.sciaNotionSecretName" . }}
+                  key: {{ $notionSecret.clientIdKey | default "client-id" | quote }}
+                  optional: true
+            - name: NOTION_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentapi-proxy.sciaNotionSecretName" . }}
+                  key: {{ $notionSecret.clientSecretKey | default "client-secret" | quote }}
                   optional: true
           volumeMounts:
             - name: scia-config

--- a/helm/agentapi-proxy/templates/scia-secret.yaml
+++ b/helm/agentapi-proxy/templates/scia-secret.yaml
@@ -8,6 +8,8 @@
 {{- $secret := $google.secret | default dict }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistSecret := $todoist.secret | default dict }}
+{{- $notion := $oauth.notion | default dict }}
+{{- $notionSecret := $notion.secret | default dict }}
 {{- if and $sciaEnabled ($secret.create | default true) (not $secret.existingSecret) }}
 apiVersion: v1
 kind: Secret
@@ -34,4 +36,18 @@ type: Opaque
 stringData:
   {{ $todoistSecret.clientIdKey | default "client-id" }}: {{ $todoistSecret.clientId | default "" | quote }}
   {{ $todoistSecret.clientSecretKey | default "client-secret" }}: {{ $todoistSecret.clientSecret | default "" | quote }}
+{{- end }}
+{{- if and $sciaEnabled ($notion.enabled | default false) ($notionSecret.create | default true) (not $notionSecret.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentapi-proxy.sciaNotionSecretName" . }}
+  labels:
+    {{- include "agentapi-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scia-oauth
+type: Opaque
+stringData:
+  {{ $notionSecret.clientIdKey | default "client-id" }}: {{ $notionSecret.clientId | default "" | quote }}
+  {{ $notionSecret.clientSecretKey | default "client-secret" }}: {{ $notionSecret.clientSecret | default "" | quote }}
 {{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -177,11 +177,22 @@ scia:
       scope: ""
       omitRedirectUrl: false
       scopes:
-        - id: default
-          value: ""
-          name: "Notion access"
-          desc: "Connect Notion pages and databases selected during authorization."
+        - id: read-only
+          value: "read_content"
+          name: "Notion read-only"
+          desc: "Read pages and databases selected during authorization."
+          group: content
+          groupName: "Notion content access"
+          groupDesc: "Choose the access mode to request for selected Notion pages and databases."
           enabled: true
+        - id: read-write
+          value: "read_content update_content insert_content"
+          name: "Notion read/write"
+          desc: "Read, update, and create content in selected Notion pages and databases."
+          group: content
+          groupName: "Notion content access"
+          groupDesc: "Choose the access mode to request for selected Notion pages and databases."
+          enabled: false
       secret:
         create: true
         existingSecret: ""

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -79,6 +79,7 @@ scia:
   proxyUrl: ""
   credential: "default.google"
   todoistCredential: "default.todoist"
+  notionCredential: ""
   userNamespace: "default"
   noProxy: "localhost,127.0.0.1,.svc,.cluster.local"
   googleHosts:
@@ -93,6 +94,10 @@ scia:
     - /api/v1/*
     - /rest/v2/*
     - /sync/v9/*
+  notionHosts:
+    - api.notion.com
+  notionPaths:
+    - /v1/*
   sessionSidecar:
     enabled: true
     image: ghcr.io/takutakahashi/scia:0.12.1
@@ -160,6 +165,23 @@ scia:
           name: "Todoist task add"
           desc: "Add Todoist tasks without reading existing data."
           enabled: false
+      secret:
+        create: true
+        existingSecret: ""
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+        clientId: ""
+        clientSecret: ""
+    notion:
+      enabled: false
+      scope: ""
+      omitRedirectUrl: false
+      scopes:
+        - id: default
+          value: ""
+          name: "Notion access"
+          desc: "Connect Notion pages and databases selected during authorization."
+          enabled: true
       secret:
         create: true
         existingSecret: ""

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2584,8 +2584,20 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 	if len(todoistPaths) == 0 {
 		todoistPaths = []string{"/api/v1/*"}
 	}
+	notionCredentialID := scia.NotionCredential
+	if notionCredentialID == "" {
+		notionCredentialID = userNamespace + ".notion"
+	}
+	notionHosts := scia.NotionHosts
+	if len(notionHosts) == 0 {
+		notionHosts = []string{"api.notion.com"}
+	}
+	notionPaths := scia.NotionPaths
+	if len(notionPaths) == 0 {
+		notionPaths = []string{"/v1/*"}
+	}
 
-	configYAML := buildSciaSidecarConfigYAML(m.namespace, userNamespace, credentialID, todoistCredentialID, port, hosts, paths, todoistHosts, todoistPaths, sandboxEnabled)
+	configYAML := buildSciaSidecarConfigYAML(m.namespace, userNamespace, credentialID, todoistCredentialID, notionCredentialID, scia.NotionEnabled, port, hosts, paths, todoistHosts, todoistPaths, notionHosts, notionPaths, sandboxEnabled)
 	configScript := fmt.Sprintf("cat > /etc/scia-config/config.yaml <<'EOF'\n%sEOF\n", configYAML)
 
 	initContainer := corev1.Container{
@@ -2641,11 +2653,14 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 		{Name: "AGENTAPI_SCIA_TODOIST_CREDENTIAL", Value: todoistCredentialID},
 		{Name: "AGENTAPI_SCIA_USER_NAMESPACE", Value: userNamespace},
 	}
+	if scia.NotionEnabled {
+		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_SCIA_NOTION_CREDENTIAL", Value: notionCredentialID})
+	}
 
 	return &initContainer, &sidecar, envVars
 }
 
-func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistCredentialID string, port int, hosts, paths, todoistHosts, todoistPaths []string, useNFA bool) string {
+func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistCredentialID, notionCredentialID string, notionEnabled bool, port int, hosts, paths, todoistHosts, todoistPaths, notionHosts, notionPaths []string, useNFA bool) string {
 	var b strings.Builder
 	b.WriteString("server:\n")
 	b.WriteString("  mode: proxy\n")
@@ -2664,6 +2679,13 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	b.WriteString("      hosts:\n")
 	for _, host := range todoistHosts {
 		b.WriteString(fmt.Sprintf("        - %q\n", host))
+	}
+	if notionEnabled {
+		b.WriteString("    notion:\n")
+		b.WriteString("      hosts:\n")
+		for _, host := range notionHosts {
+			b.WriteString(fmt.Sprintf("        - %q\n", host))
+		}
 	}
 	b.WriteString("  mitm:\n")
 	b.WriteString(fmt.Sprintf("    caCertPath: %q\n", sciaCAPath))
@@ -2684,6 +2706,12 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	b.WriteString("    type: todoist-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
 	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/todoist/token", namespace, url.PathEscape(userNamespace))))
+	if notionEnabled {
+		b.WriteString(fmt.Sprintf("  - id: %q\n", notionCredentialID))
+		b.WriteString("    type: notion-oauth-refresh-token\n")
+		b.WriteString("    params:\n")
+		b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/notion/token", namespace, url.PathEscape(userNamespace))))
+	}
 	b.WriteString("rules:\n")
 	b.WriteString("  - name: inject-google-oauth-token\n")
 	b.WriteString("    hosts:\n")
@@ -2709,6 +2737,20 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	b.WriteString("    action: allow\n")
 	b.WriteString("    credentials:\n")
 	b.WriteString(fmt.Sprintf("      - %q\n", todoistCredentialID))
+	if notionEnabled {
+		b.WriteString("  - name: inject-notion-oauth-token\n")
+		b.WriteString("    hosts:\n")
+		for _, host := range notionHosts {
+			b.WriteString(fmt.Sprintf("      - %q\n", host))
+		}
+		b.WriteString("    paths:\n")
+		for _, path := range notionPaths {
+			b.WriteString(fmt.Sprintf("      - %q\n", path))
+		}
+		b.WriteString("    action: allow\n")
+		b.WriteString("    credentials:\n")
+		b.WriteString(fmt.Sprintf("      - %q\n", notionCredentialID))
+	}
 	return b.String()
 }
 
@@ -4896,6 +4938,9 @@ func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req
 		if scia.TodoistCredential != "" {
 			env["AGENTAPI_SCIA_TODOIST_CREDENTIAL"] = scia.TodoistCredential
 		}
+		if scia.NotionEnabled && scia.NotionCredential != "" {
+			env["AGENTAPI_SCIA_NOTION_CREDENTIAL"] = scia.NotionCredential
+		}
 		if scia.UserNamespace != "" {
 			env["AGENTAPI_SCIA_USER_NAMESPACE"] = scia.UserNamespace
 		}
@@ -4939,6 +4984,15 @@ func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req
 	}
 	if todoistCredential != "" {
 		env["AGENTAPI_SCIA_TODOIST_CREDENTIAL"] = todoistCredential
+	}
+	if scia.NotionEnabled {
+		notionCredential := scia.NotionCredential
+		if notionCredential == "" && userNamespace != "" {
+			notionCredential = userNamespace + ".notion"
+		}
+		if notionCredential != "" {
+			env["AGENTAPI_SCIA_NOTION_CREDENTIAL"] = notionCredential
+		}
 	}
 	if userNamespace != "" {
 		env["AGENTAPI_SCIA_USER_NAMESPACE"] = userNamespace

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -95,6 +95,10 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 				TodoistCredential:         "takutakahashi.todoist",
 				TodoistHosts:              []string{"api.todoist.com"},
 				TodoistPaths:              []string{"/api/v1/*"},
+				NotionEnabled:             true,
+				NotionCredential:          "takutakahashi.notion",
+				NotionHosts:               []string{"api.notion.com"},
+				NotionPaths:               []string{"/v1/*"},
 			},
 		},
 		k8sConfig: &config.KubernetesSessionConfig{
@@ -152,15 +156,19 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 		assert.Contains(t, script, "  integrations:\n")
 		assert.Contains(t, script, "    google:\n")
 		assert.Contains(t, script, "    todoist:\n")
+		assert.Contains(t, script, "    notion:\n")
 		assert.Contains(t, script, `        - "www.googleapis.com"`)
 		assert.Contains(t, script, `        - "api.todoist.com"`)
+		assert.Contains(t, script, `        - "api.notion.com"`)
 		assert.Contains(t, script, `secretName: "scia-oauth-takutakahashi"`)
 		assert.NotContains(t, script, `scia-google-oauth`)
 		assert.NotContains(t, script, `clientSecretRef`)
 		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/google/token"`)
 		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/todoist/token"`)
+		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/notion/token"`)
 		assert.Contains(t, script, `- "takutakahashi.google"`)
 		assert.Contains(t, script, `- "takutakahashi.todoist"`)
+		assert.Contains(t, script, `- "takutakahashi.notion"`)
 	}
 
 	main := podSpec.Containers[0]
@@ -176,6 +184,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 	assert.Equal(t, sciaCABundlePath, env["SSL_CERT_FILE"])
 	assert.Equal(t, "takutakahashi.google", env["AGENTAPI_SCIA_GOOGLE_CREDENTIAL"])
 	assert.Equal(t, "takutakahashi.todoist", env["AGENTAPI_SCIA_TODOIST_CREDENTIAL"])
+	assert.Equal(t, "takutakahashi.notion", env["AGENTAPI_SCIA_NOTION_CREDENTIAL"])
 	assert.NotContains(t, env["NO_PROXY"], "api.openai.com")
 	assert.NotContains(t, env["no_proxy"], "api.openai.com")
 
@@ -259,6 +268,10 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 				TodoistCredential:         "takutakahashi.todoist",
 				TodoistHosts:              []string{"api.todoist.com"},
 				TodoistPaths:              []string{"/api/v1/*"},
+				NotionEnabled:             true,
+				NotionCredential:          "takutakahashi.notion",
+				NotionHosts:               []string{"api.notion.com"},
+				NotionPaths:               []string{"/v1/*"},
 			},
 		},
 		k8sConfig: &config.KubernetesSessionConfig{

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -192,6 +192,9 @@ func (c *GoogleOAuthController) GetIntegrations(ctx echo.Context) error {
 				}
 			}
 		}
+		if integrations[i].AuthorizationURLEndpoint == "" && integrations[i].ID != "" {
+			integrations[i].AuthorizationURLEndpoint = c.publicURL(fmt.Sprintf("/integrations/%s/authorization-url", url.PathEscape(integrations[i].ID)))
+		}
 		integrations[i].Connected = c.oauthTokenSecretExists(ctx.Request().Context(), namespace, integrations[i].CredentialID, integrations[i].Provider)
 	}
 	resp.Integrations = integrations

--- a/internal/interfaces/controllers/google_oauth_controller_test.go
+++ b/internal/interfaces/controllers/google_oauth_controller_test.go
@@ -236,3 +236,74 @@ func TestGetIntegrationsMarksConnectedPerCredentialToken(t *testing.T) {
 		t.Fatalf("todoist connected = true, want false")
 	}
 }
+
+func TestGetIntegrationsSynthesizesAuthorizationEndpointForTopLevelProvider(t *testing.T) {
+	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_scia/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/api/integrations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"integrations": []map[string]any{
+					{
+						"id":            "alice.notion",
+						"provider":      "notion",
+						"credential_id": "alice.notion",
+						"name":          "Notion",
+						"released":      true,
+						"start_url":     "/oauth/notion/start?credential=alice.notion",
+						"scopes": []map[string]any{
+							{
+								"id":      "read-only",
+								"name":    "Notion read-only",
+								"group":   "content",
+								"enabled": true,
+							},
+						},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer scia.Close()
+
+	controller := NewGoogleOAuthController(config.SciaConfig{
+		Enabled:          true,
+		OAuthInternalURL: scia.URL,
+		PublicBaseURL:    "https://app.example.com",
+	}, fake.NewSimpleClientset(), "agentapi")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/integrations", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.Set("internal_user", entities.NewUser("alice", entities.UserTypeRegular, "alice"))
+
+	if err := controller.GetIntegrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body IntegrationsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Integrations) != 1 {
+		t.Fatalf("integrations = %#v", body.Integrations)
+	}
+	got := body.Integrations[0]
+	if got.Namespace != "alice" {
+		t.Fatalf("namespace = %q", got.Namespace)
+	}
+	wantEndpoint := "https://app.example.com/integrations/alice.notion/authorization-url"
+	if got.AuthorizationURLEndpoint != wantEndpoint {
+		t.Fatalf("authorization_url_endpoint = %q, want %q", got.AuthorizationURLEndpoint, wantEndpoint)
+	}
+	if len(got.Scopes) != 1 || got.Scopes[0].ID != "read-only" {
+		t.Fatalf("scopes = %#v", got.Scopes)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -267,6 +267,14 @@ type SciaConfig struct {
 	TodoistHosts []string `json:"todoist_hosts" mapstructure:"todoist_hosts"`
 	// TodoistPaths is the list of paths where the sidecar injects the Todoist access token.
 	TodoistPaths []string `json:"todoist_paths" mapstructure:"todoist_paths"`
+	// NotionEnabled controls whether Notion OAuth is injected into session sidecars.
+	NotionEnabled bool `json:"notion_enabled" mapstructure:"notion_enabled"`
+	// NotionCredential is the scia credential ID used for Notion OAuth, e.g. "takutakahashi.notion".
+	NotionCredential string `json:"notion_credential" mapstructure:"notion_credential"`
+	// NotionHosts is the list of hosts where the sidecar injects the Notion access token.
+	NotionHosts []string `json:"notion_hosts" mapstructure:"notion_hosts"`
+	// NotionPaths is the list of paths where the sidecar injects the Notion access token.
+	NotionPaths []string `json:"notion_paths" mapstructure:"notion_paths"`
 }
 
 // KubernetesSessionConfig represents Kubernetes session manager configuration
@@ -980,6 +988,18 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	if paths := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_TODOIST_PATHS")); len(paths) > 0 {
 		config.Scia.TodoistPaths = paths
 	}
+	if enabled, ok := os.LookupEnv("AGENTAPI_SCIA_NOTION_ENABLED"); ok {
+		config.Scia.NotionEnabled = strings.EqualFold(enabled, "true")
+	}
+	if credential := os.Getenv("AGENTAPI_SCIA_NOTION_CREDENTIAL"); credential != "" {
+		config.Scia.NotionCredential = credential
+	}
+	if hosts := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_NOTION_HOSTS")); len(hosts) > 0 {
+		config.Scia.NotionHosts = hosts
+	}
+	if paths := commaSeparatedList(os.Getenv("AGENTAPI_SCIA_NOTION_PATHS")); len(paths) > 0 {
+		config.Scia.NotionPaths = paths
+	}
 
 	// Override fields if environment variables are set (even if structures already exist)
 	if config.Auth.Static != nil {
@@ -1068,6 +1088,10 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("scia.todoist_credential", "AGENTAPI_SCIA_TODOIST_CREDENTIAL")
 	_ = v.BindEnv("scia.todoist_hosts", "AGENTAPI_SCIA_TODOIST_HOSTS")
 	_ = v.BindEnv("scia.todoist_paths", "AGENTAPI_SCIA_TODOIST_PATHS")
+	_ = v.BindEnv("scia.notion_enabled", "AGENTAPI_SCIA_NOTION_ENABLED")
+	_ = v.BindEnv("scia.notion_credential", "AGENTAPI_SCIA_NOTION_CREDENTIAL")
+	_ = v.BindEnv("scia.notion_hosts", "AGENTAPI_SCIA_NOTION_HOSTS")
+	_ = v.BindEnv("scia.notion_paths", "AGENTAPI_SCIA_NOTION_PATHS")
 
 	// Role-based environment files configuration
 	_ = v.BindEnv("role_env_files.enabled")
@@ -1339,6 +1363,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.todoist_credential", "")
 	v.SetDefault("scia.todoist_hosts", []string{"api.todoist.com"})
 	v.SetDefault("scia.todoist_paths", []string{"/api/v1/*", "/rest/v2/*", "/sync/v9/*"})
+	v.SetDefault("scia.notion_enabled", false)
+	v.SetDefault("scia.notion_credential", "")
+	v.SetDefault("scia.notion_hosts", []string{"api.notion.com"})
+	v.SetDefault("scia.notion_paths", []string{"/v1/*"})
 
 	// Memory backend defaults
 	v.SetDefault("memory.backend", "kubernetes")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -469,6 +469,10 @@ func TestLoadConfigWithSciaEnvironmentVariables(t *testing.T) {
 	_ = os.Setenv("AGENTAPI_SCIA_TODOIST_CREDENTIAL", "default.todoist")
 	_ = os.Setenv("AGENTAPI_SCIA_TODOIST_HOSTS", "api.todoist.com")
 	_ = os.Setenv("AGENTAPI_SCIA_TODOIST_PATHS", "/api/v1/*")
+	_ = os.Setenv("AGENTAPI_SCIA_NOTION_ENABLED", "true")
+	_ = os.Setenv("AGENTAPI_SCIA_NOTION_CREDENTIAL", "default.notion")
+	_ = os.Setenv("AGENTAPI_SCIA_NOTION_HOSTS", "api.notion.com")
+	_ = os.Setenv("AGENTAPI_SCIA_NOTION_PATHS", "/v1/*")
 
 	loadedConfig, err := LoadConfig("")
 	if err != nil {
@@ -486,6 +490,10 @@ func TestLoadConfigWithSciaEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "default.todoist", loadedConfig.Scia.TodoistCredential)
 	assert.Equal(t, []string{"api.todoist.com"}, loadedConfig.Scia.TodoistHosts)
 	assert.Equal(t, []string{"/api/v1/*"}, loadedConfig.Scia.TodoistPaths)
+	assert.True(t, loadedConfig.Scia.NotionEnabled)
+	assert.Equal(t, "default.notion", loadedConfig.Scia.NotionCredential)
+	assert.Equal(t, []string{"api.notion.com"}, loadedConfig.Scia.NotionHosts)
+	assert.Equal(t, []string{"/v1/*"}, loadedConfig.Scia.NotionPaths)
 }
 
 func TestLoadConfigNetworkFilterResourceDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Helm values/templates for scia Notion OAuth using Secret references
- expose Notion OAuth settings to the proxy/session sidecar config
- document Notion OAuth chart configuration

## Tests
- mise exec -- go test ./pkg/config ./internal/infrastructure/services
- mise exec -- helm template agentapi-proxy helm/agentapi-proxy --namespace agentapi-ui-dev --set scia.publicBaseUrl=https://cc-dev.takutakahashi.dev --set scia.userNamespace=takutakahashi --set scia.users.takutakahashi.secretName=scia-oauth-takutakahashi --set scia.notionCredential=takutakahashi.notion --set scia.oauth.notion.enabled=true --set scia.oauth.notion.secret.create=false --set scia.oauth.notion.secret.existingSecret=scia-notion-oauth | grep -E 'notion|NOTION|scia-notion-oauth|api.notion.com|api/oauth/notion/callback'