### PR TITLE
Add scia dynamic user Helm options

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -90,10 +90,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                               | Description                                      | Value |
 | -------------------------------------------------- | ------------------------------------------------ | ----- |
 | `scia.enabled`                                     | Deploy scia OAuth broker and configure sessions | `true` |
+| `scia.config`                                      | Raw scia `config.yaml` content for the OAuth broker | `""` |
+| `scia.dynamicUsers.enabled`                        | Derive session scia user/Secret names from authenticated users | `false` |
 | `scia.publicBaseUrl`                               | Browser-facing scia base URL                    | `""` |
-| `scia.credential`                                  | Google credential ID injected into sessions     | `default.google` |
-| `scia.todoistCredential`                           | Todoist credential ID injected into sessions    | `default.todoist` |
-| `scia.userNamespace`                               | scia user namespace used by default             | `default` |
+| `scia.credential`                                  | Google credential ID injected into sessions; empty derives `<user>.google` | `default.google` |
+| `scia.todoistCredential`                           | Todoist credential ID injected into sessions; empty derives `<user>.todoist` | `default.todoist` |
+| `scia.userNamespace`                               | scia user namespace used by default; empty uses the authenticated user | `default` |
 | `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `true` |
 | `scia.oauth.google.secret.existingSecret`          | Existing Secret containing Google OAuth values  | `""` |
 | `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |
@@ -244,6 +246,59 @@ scia:
 ```
 
 The `scia-todoist-oauth` Secret must contain the Todoist OAuth client ID and client secret. Register the same `redirectUrl` in the Todoist app console. The session sidecar injects the Todoist token for `api.todoist.com/api/v1/*` requests by default.
+
+### With dynamic scia users
+
+Leave the runtime namespace and credential values empty so agentapi-proxy derives
+them from the authenticated user. For example, user `alice` uses scia namespace
+`alice`, Google credential `alice.google`, Todoist credential `alice.todoist`,
+and refresh-token Secret `scia-oauth-alice`.
+
+```yaml
+scia:
+  enabled: true
+  dynamicUsers:
+    enabled: true
+  publicBaseUrl: https://agentapi.yourdomain.com
+  credential: ""
+  todoistCredential: ""
+  userNamespace: ""
+```
+
+`scia.dynamicUsers.enabled=true` grants session Pods `get` access to Secrets in
+the release namespace because Kubernetes RBAC cannot enumerate authenticated
+user-derived Secret names ahead of time.
+
+The chart-generated scia OAuth broker config still needs explicit scia
+`server.users` and `server.oauth.namespaces` entries unless the scia image being
+used supports dynamic users. To provide the broker config directly, set
+`scia.config` with a YAML block:
+
+```yaml
+scia:
+  enabled: true
+  config: |
+    server:
+      mode: "oauth"
+      listen: "0.0.0.0:8081"
+      secrets:
+        mode: kubernetes
+        kubernetes:
+          namespace: {{ .Release.Namespace | quote }}
+      users:
+        alice:
+          secretName: scia-oauth-alice
+      oauth:
+        listen: "0.0.0.0:8081"
+        integrations: {}
+        namespaces:
+          alice:
+            google:
+              clientId: "env:GOOGLE_OAUTH_CLIENT_ID"
+              clientSecret: "env:GOOGLE_OAUTH_CLIENT_SECRET"
+    credentials: []
+    rules: []
+```
 
 ### With Environment Variables
 

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -270,9 +270,9 @@ spec:
             - name: AGENTAPI_SCIA_PROXY_URL
               value: {{ $scia.proxyUrl | default "" | quote }}
             - name: AGENTAPI_SCIA_CREDENTIAL
-              value: {{ $scia.credential | default "default.google" | quote }}
+              value: {{ $scia.credential | default "" | quote }}
             - name: AGENTAPI_SCIA_USER_NAMESPACE
-              value: {{ $scia.userNamespace | default "default" | quote }}
+              value: {{ $scia.userNamespace | default "" | quote }}
             - name: AGENTAPI_SCIA_NO_PROXY
               value: {{ $scia.noProxy | default "localhost,127.0.0.1,.svc,.cluster.local" | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
@@ -288,7 +288,7 @@ spec:
             - name: AGENTAPI_SCIA_GOOGLE_PATHS
               value: {{ $scia.googlePaths | default (list "/calendar/v3/*") | join "," | quote }}
             - name: AGENTAPI_SCIA_TODOIST_CREDENTIAL
-              value: {{ $scia.todoistCredential | default (printf "%s.todoist" ($scia.userNamespace | default "default")) | quote }}
+              value: {{ $scia.todoistCredential | default "" | quote }}
             - name: AGENTAPI_SCIA_TODOIST_HOSTS
               value: {{ $scia.todoistHosts | default (list "api.todoist.com") | join "," | quote }}
             - name: AGENTAPI_SCIA_TODOIST_PATHS

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -33,6 +33,7 @@
 {{- end }}
 {{- $googleScopes := $google.scopes | default (list (dict "id" ($google.scopeId | default "calendar-read") "value" ($google.scope | default "https://www.googleapis.com/auth/calendar.readonly") "name" ($google.scopeName | default "Google Calendar read-only") "desc" ($google.scopeDesc | default "Read Google Calendar events.") "enabled" true)) }}
 {{- $todoistScopes := $todoist.scopes | default (list (dict "id" "read-write" "value" ($todoist.scope | default "data:read_write") "name" "Todoist read/write" "desc" "Read and write Todoist tasks and projects." "enabled" true)) }}
+{{- $rawConfig := $scia.config | default "" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,6 +43,9 @@ metadata:
     app.kubernetes.io/component: scia-oauth
 data:
   config.yaml: |
+{{ if $rawConfig }}
+{{ tpl $rawConfig . | nindent 4 }}
+{{ else }}
     server:
       mode: "oauth"
       listen: {{ $oauth.listen | default "0.0.0.0:8081" | quote }}
@@ -136,4 +140,5 @@ data:
           {{- end }}
     credentials: []
     rules: []
+{{ end }}
 {{- end }}

--- a/helm/agentapi-proxy/templates/session-role.yaml
+++ b/helm/agentapi-proxy/templates/session-role.yaml
@@ -5,8 +5,10 @@
 {{- $sciaEnabled = $scia.enabled }}
 {{- end }}
 {{- $sciaRefreshSecretNames := list }}
+{{- $sciaDynamicUsers := false }}
 {{- if $sciaEnabled }}
 {{- $sciaRefreshSecretNames = $scia.sessionRefreshTokenSecretNames | default (list "scia-oauth-default") }}
+{{- $sciaDynamicUsers = dig "dynamicUsers" "enabled" false $scia }}
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -30,6 +32,13 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update"]
+  {{- if $sciaDynamicUsers }}
+  # Dynamic scia users derive refresh-token Secret names from the authenticated
+  # user at runtime, so Kubernetes RBAC cannot enumerate resourceNames here.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  {{- else }}
   {{- with $sciaRefreshSecretNames }}
   # Permissions for the scia session sidecar to read only the per-user refresh
   # token Secrets explicitly listed by the operator. OAuth client Secrets must
@@ -39,5 +48,6 @@ rules:
     resourceNames:
       {{- toYaml . | nindent 6 }}
     verbs: ["get"]
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -70,6 +70,14 @@ service:
 scia:
   # Deploy and configure scia Google OAuth broker/proxy integration.
   enabled: true
+  # Raw scia config.yaml. When set, this replaces the chart-generated scia
+  # OAuth broker config and is rendered with Helm tpl.
+  config: ""
+  dynamicUsers:
+    # Use runtime authenticated user IDs for session-sidecar Secret access.
+    # This grants session Pods get access to Secrets in the release namespace
+    # because Kubernetes RBAC cannot enumerate user-derived Secret names.
+    enabled: false
   image:
     repository: ghcr.io/takutakahashi/scia
     tag: "0.12.1"
@@ -77,6 +85,8 @@ scia:
   replicaCount: 1
   publicBaseUrl: ""
   proxyUrl: ""
+  # Leave credential and userNamespace empty to derive them from the
+  # authenticated user at runtime: <user>.google and <user>.
   credential: "default.google"
   todoistCredential: "default.todoist"
   userNamespace: "default"


### PR DESCRIPTION
## Summary
- add scia.config raw config support for the scia-oauth ConfigMap, rendered through Helm tpl
- allow empty scia credential/userNamespace values to reach agentapi-proxy so it can derive them from the authenticated user
- add scia.dynamicUsers.enabled to grant session Pods Secret get access when refresh-token Secret names are user-derived at runtime
- document dynamic-user values and raw config block usage

## Notes
- agentapi-proxy already derives the namespace/credential from the authenticated user when scia.userNamespace/scia.credential are empty.
- The current scia OAuth broker still requires its own users/namespaces config unless the deployed scia image supports dynamic users; scia.config provides an escape hatch for that broker config.

## Tests
- Not run: helm is not installed in this environment.
- Not run: go is not installed in this environment.