### PR TITLE
Use scia dynamic users with personal API keys

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -91,10 +91,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------------------- | ------------------------------------------------ | ----- |
 | `scia.enabled`                                     | Deploy scia OAuth broker and configure sessions | `true` |
 | `scia.publicBaseUrl`                               | Browser-facing scia base URL                    | `""` |
-| `scia.credential`                                  | Google credential ID injected into sessions     | `default.google` |
+| `scia.credential`                                  | Google credential ID injected into sessions; empty disables Google OAuth config | `""` |
 | `scia.todoistCredential`                           | Todoist credential ID injected into sessions    | `default.todoist` |
-| `scia.userNamespace`                               | scia user namespace used by default             | `default` |
-| `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `true` |
+| `scia.userNamespace`                               | Optional fixed scia user namespace; empty derives it from each agentapi user | `""` |
+| `scia.dynamicUserSecretNamePrefix`                 | Prefix for scia dynamic user token Secrets      | `scia-oauth-` |
+| `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `false` |
 | `scia.oauth.google.secret.existingSecret`          | Existing Secret containing Google OAuth values  | `""` |
 | `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |
 | `scia.oauth.google.secret.clientSecretKey`         | Secret key for the Google OAuth client secret   | `client-secret` |
@@ -102,8 +103,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scia.oauth.todoist.omitRedirectUrl`               | Omit Todoist redirect_uri from OAuth requests   | `false` |
 | `scia.oauth.todoist.secret.create`                 | Create a Kubernetes Secret for Todoist OAuth    | `true` |
 | `scia.oauth.todoist.secret.existingSecret`         | Existing Secret containing Todoist OAuth values | `""` |
-| `scia.users`                                       | scia user-to-refresh-token Secret mapping       | `{default: {secretName: scia-oauth-default}}` |
-| `scia.sessionRefreshTokenSecretNames`              | Refresh-token Secrets readable by session pods  | `[scia-oauth-default]` |
 
 ### Application Configuration
 
@@ -204,8 +203,7 @@ config:
 scia:
   enabled: true
   publicBaseUrl: https://agentapi.yourdomain.com
-  credential: default.google
-  userNamespace: default
+  credential: your-user.google
   oauth:
     google:
       secret:
@@ -213,11 +211,6 @@ scia:
         existingSecret: scia-google-oauth
         clientIdKey: client-id
         clientSecretKey: client-secret
-  users:
-    default:
-      secretName: scia-oauth-default
-  sessionRefreshTokenSecretNames:
-    - scia-oauth-default
 ```
 
 The `scia-google-oauth` Secret must contain the Google OAuth client ID and client secret. When `ingress.enabled=true`, the chart routes `/oauth` and `/_scia` to the scia OAuth broker on the same host.
@@ -228,7 +221,6 @@ The `scia-google-oauth` Secret must contain the Google OAuth client ID and clien
 scia:
   enabled: true
   publicBaseUrl: https://agentapi.yourdomain.com
-  userNamespace: default
   todoistCredential: default.todoist
   oauth:
     todoist:

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -270,15 +270,15 @@ spec:
             - name: AGENTAPI_SCIA_PROXY_URL
               value: {{ $scia.proxyUrl | default "" | quote }}
             - name: AGENTAPI_SCIA_CREDENTIAL
-              value: {{ $scia.credential | default "default.google" | quote }}
+              value: {{ $scia.credential | default "" | quote }}
             - name: AGENTAPI_SCIA_USER_NAMESPACE
-              value: {{ $scia.userNamespace | default "default" | quote }}
+              value: {{ $scia.userNamespace | default "" | quote }}
             - name: AGENTAPI_SCIA_NO_PROXY
               value: {{ $scia.noProxy | default "localhost,127.0.0.1,.svc,.cluster.local" | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.12.1" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.12.2" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT
@@ -288,7 +288,7 @@ spec:
             - name: AGENTAPI_SCIA_GOOGLE_PATHS
               value: {{ $scia.googlePaths | default (list "/calendar/v3/*") | join "," | quote }}
             - name: AGENTAPI_SCIA_TODOIST_CREDENTIAL
-              value: {{ $scia.todoistCredential | default (printf "%s.todoist" ($scia.userNamespace | default "default")) | quote }}
+              value: {{ $scia.todoistCredential | default "default.todoist" | quote }}
             - name: AGENTAPI_SCIA_TODOIST_HOSTS
               value: {{ $scia.todoistHosts | default (list "api.todoist.com") | join "," | quote }}
             - name: AGENTAPI_SCIA_TODOIST_PATHS

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -6,9 +6,11 @@
 {{- if $sciaEnabled }}
 {{- $oauth := $scia.oauth | default dict }}
 {{- $google := $oauth.google | default dict }}
+{{- $googleCredential := $scia.credential | default "" }}
+{{- $googleEnabled := ne $googleCredential "" }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistEnabled := $todoist.enabled | default false }}
-{{- $users := $scia.users | default (dict "default" (dict "secretName" "scia-oauth-default")) }}
+{{- $dynamicUserSecretNamePrefix := $scia.dynamicUserSecretNamePrefix | default "scia-oauth-" }}
 {{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
 {{- $sciaHost := .Values.config.hostname | default "" }}
 {{- if .Values.global }}
@@ -49,15 +51,33 @@ data:
         mode: kubernetes
         kubernetes:
           namespace: {{ .Release.Namespace | quote }}
-      users:
-        {{- range $userID, $user := $users }}
-        {{ $userID | quote }}:
-          secretName: {{ $user.secretName | quote }}
-        {{- end }}
+          dynamicUsers: true
+          dynamicUserSecretNamePrefix: {{ $dynamicUserSecretNamePrefix | quote }}
       oauth:
         listen: {{ $oauth.listen | default "0.0.0.0:8081" | quote }}
         redirectUrl: {{ $redirectURL | quote }}
+        {{- if $googleEnabled }}
+        google:
+          credentialId: {{ $googleCredential | quote }}
+          clientId: "env:GOOGLE_OAUTH_CLIENT_ID"
+          clientSecret: "env:GOOGLE_OAUTH_CLIENT_SECRET"
+          scope: {{ $google.scope | default "https://www.googleapis.com/auth/calendar.readonly" | quote }}
+          {{- if $redirectURL }}
+          redirectUrl: {{ $redirectURL | quote }}
+          {{- end }}
+        {{- end }}
+        {{- if $todoistEnabled }}
+        todoist:
+          credentialId: {{ $scia.todoistCredential | default "default.todoist" | quote }}
+          clientId: "env:TODOIST_OAUTH_CLIENT_ID"
+          clientSecret: "env:TODOIST_OAUTH_CLIENT_SECRET"
+          scope: {{ $todoist.scope | default "data:read_write" | quote }}
+          {{- if $todoistRedirectURL }}
+          redirectUrl: {{ $todoistRedirectURL | quote }}
+          {{- end }}
+        {{- end }}
         integrations:
+          {{- if $googleEnabled }}
           google:
             name: {{ $google.name | default "Google" | quote }}
             {{- if $google.iconUrl }}
@@ -87,6 +107,7 @@ data:
                 {{- end }}
                 enabled: {{ $scope.enabled | default false }}
               {{- end }}
+          {{- end }}
           {{- if $todoistEnabled }}
           todoist:
             name: {{ $todoist.name | default "Todoist" | quote }}
@@ -114,26 +135,16 @@ data:
                 enabled: {{ $scope.enabled | default false }}
               {{- end }}
           {{- end }}
-        namespaces:
-          {{- range $userID, $_ := $users }}
-          {{ $userID | quote }}:
-            google:
-              clientId: "env:GOOGLE_OAUTH_CLIENT_ID"
-              clientSecret: "env:GOOGLE_OAUTH_CLIENT_SECRET"
-              scope: {{ $google.scope | default "https://www.googleapis.com/auth/calendar.readonly" | quote }}
-              {{- if $redirectURL }}
-              redirectUrl: {{ $redirectURL | quote }}
-              {{- end }}
-            {{- if $todoistEnabled }}
-            todoist:
-              clientId: "env:TODOIST_OAUTH_CLIENT_ID"
-              clientSecret: "env:TODOIST_OAUTH_CLIENT_SECRET"
-              scope: {{ $todoist.scope | default "data:read_write" | quote }}
-              {{- if $todoistRedirectURL }}
-              redirectUrl: {{ $todoistRedirectURL | quote }}
-              {{- end }}
-            {{- end }}
-          {{- end }}
-    credentials: []
+    credentials:
+      {{- if $googleEnabled }}
+      - id: {{ $googleCredential | quote }}
+        type: google-oauth-refresh-token
+        params: {}
+      {{- end }}
+      {{- if $todoistEnabled }}
+      - id: {{ $scia.todoistCredential | default "default.todoist" | quote }}
+        type: todoist-oauth-refresh-token
+        params: {}
+      {{- end }}
     rules: []
 {{- end }}

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -7,6 +7,8 @@
 {{- $image := $scia.image | default dict }}
 {{- $oauth := $scia.oauth | default dict }}
 {{- $google := $oauth.google | default dict }}
+{{- $googleCredential := $scia.credential | default "" }}
+{{- $googleEnabled := ne $googleCredential "" }}
 {{- $secret := $google.secret | default dict }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistSecret := $todoist.secret | default dict }}
@@ -40,7 +42,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.12.1" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.12.2" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config
@@ -50,6 +52,7 @@ spec:
               containerPort: {{ regexFind "[0-9]+$" ($oauth.listen | default "0.0.0.0:8081") }}
               protocol: TCP
           env:
+            {{- if $googleEnabled }}
             - name: GOOGLE_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -62,6 +65,7 @@ spec:
                   name: {{ include "agentapi-proxy.sciaSecretName" . }}
                   key: {{ $secret.clientSecretKey | default "client-secret" | quote }}
                   optional: true
+            {{- end }}
             - name: TODOIST_OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/helm/agentapi-proxy/templates/scia-secret.yaml
+++ b/helm/agentapi-proxy/templates/scia-secret.yaml
@@ -5,10 +5,12 @@
 {{- end }}
 {{- $oauth := $scia.oauth | default dict }}
 {{- $google := $oauth.google | default dict }}
+{{- $googleCredential := $scia.credential | default "" }}
+{{- $googleEnabled := ne $googleCredential "" }}
 {{- $secret := $google.secret | default dict }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistSecret := $todoist.secret | default dict }}
-{{- if and $sciaEnabled ($secret.create | default true) (not $secret.existingSecret) }}
+{{- if and $sciaEnabled $googleEnabled ($secret.create | default true) (not $secret.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/agentapi-proxy/templates/session-role.yaml
+++ b/helm/agentapi-proxy/templates/session-role.yaml
@@ -4,10 +4,6 @@
 {{- if and (hasKey .Values "scia") (hasKey $scia "enabled") }}
 {{- $sciaEnabled = $scia.enabled }}
 {{- end }}
-{{- $sciaRefreshSecretNames := list }}
-{{- if $sciaEnabled }}
-{{- $sciaRefreshSecretNames = $scia.sessionRefreshTokenSecretNames | default (list "scia-oauth-default") }}
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -30,14 +26,11 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update"]
-  {{- with $sciaRefreshSecretNames }}
-  # Permissions for the scia session sidecar to read only the per-user refresh
-  # token Secrets explicitly listed by the operator. OAuth client Secrets must
-  # remain readable only by the scia OAuth broker.
+  {{- if $sciaEnabled }}
+  # Dynamic scia users create per-user refresh-token Secrets at runtime, so
+  # session pods cannot enumerate resourceNames ahead of time.
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames:
-      {{- toYaml . | nindent 6 }}
-    verbs: ["get"]
+    verbs: ["get", "list"]
   {{- end }}
 {{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,14 +72,15 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.12.1"
+    tag: "0.12.2"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
   proxyUrl: ""
-  credential: "default.google"
+  credential: ""
   todoistCredential: "default.todoist"
-  userNamespace: "default"
+  userNamespace: ""
+  dynamicUserSecretNamePrefix: scia-oauth-
   noProxy: "localhost,127.0.0.1,.svc,.cluster.local"
   googleHosts:
     - www.googleapis.com
@@ -95,7 +96,7 @@ scia:
     - /sync/v9/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.12.1
+    image: ghcr.io/takutakahashi/scia:0.12.2
     configImage: busybox:1.36
     port: 18081
   oauth:
@@ -139,7 +140,7 @@ scia:
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.
       secret:
-        create: true
+        create: false
         existingSecret: ""
         clientIdKey: client-id
         clientSecretKey: client-secret
@@ -181,13 +182,6 @@ scia:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  users:
-    default:
-      secretName: scia-oauth-default
-  # Per-user refresh-token Secret names that session Pods may read when scia
-  # runs as a session sidecar. Do not include OAuth client-secret Secrets here.
-  sessionRefreshTokenSecretNames:
-    - scia-oauth-default
 
 asset:
   enabled: true

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -63,12 +63,23 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 	}
 	settingsController := controllers.NewSettingsController(server.settingsRepo, server.notificationSvc, gitSyncKMSKeyARN, gitSyncAWSRegion)
 
+	var apiKeyRepo *repositories.KubernetesPersonalAPIKeyRepository
+	if k8sManager, ok := server.sessionManager.(*services.KubernetesSessionManager); ok {
+		apiKeyRepo = repositories.NewKubernetesPersonalAPIKeyRepository(
+			k8sManager.GetClient(),
+			k8sManager.GetNamespace(),
+		)
+	}
+
 	var googleOAuthController *controllers.GoogleOAuthController
 	if cfg := server.GetConfig(); cfg != nil {
 		if k8sManager, ok := server.sessionManager.(*services.KubernetesSessionManager); ok {
 			googleOAuthController = controllers.NewGoogleOAuthController(cfg.Scia, k8sManager.GetClient(), k8sManager.GetNamespace())
 		} else {
 			googleOAuthController = controllers.NewGoogleOAuthController(cfg.Scia, nil, "")
+		}
+		if apiKeyRepo != nil {
+			googleOAuthController.WithPersonalAPIKeyRepository(apiKeyRepo)
 		}
 	}
 
@@ -110,11 +121,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 
 	// Create personal API key controller if session manager is Kubernetes-based
 	var personalAPIKeyController *controllers.PersonalAPIKeyController
-	if k8sManager, ok := server.sessionManager.(*services.KubernetesSessionManager); ok {
-		apiKeyRepo := repositories.NewKubernetesPersonalAPIKeyRepository(
-			k8sManager.GetClient(),
-			k8sManager.GetNamespace(),
-		)
+	if apiKeyRepo != nil {
 		getOrCreatePersonalAPIKeyUC := personal_api_key.NewGetOrCreatePersonalAPIKeyUseCase(apiKeyRepo)
 
 		// Get auth service for loading API keys into memory

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1950,7 +1950,11 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	var sciaInitContainer *corev1.Container
 	var sciaSidecar *corev1.Container
 	if m.sciaSessionSidecarEnabled(req) {
-		sciaInitContainer, sciaSidecar, _ = m.buildSciaSidecarContainers(req, sandboxEnabled)
+		var sciaUserToken string
+		if apiKey := m.ensurePersonalAPIKey(ctx, req.UserID); apiKey != nil {
+			sciaUserToken = apiKey.APIKey()
+		}
+		sciaInitContainer, sciaSidecar, _ = m.buildSciaSidecarContainers(req, sandboxEnabled, sciaUserToken)
 		initContainers = append(initContainers, *sciaInitContainer)
 		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED", Value: "true"})
 		// Do not inject sidecar proxy variables into the Pod-level container env.
@@ -2547,7 +2551,7 @@ func (m *KubernetesSessionManager) sciaSessionSidecarEnabled(req *entities.RunSe
 	return m.config.Scia.SessionSidecarEnabled
 }
 
-func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunServerRequest, sandboxEnabled bool) (*corev1.Container, *corev1.Container, []corev1.EnvVar) {
+func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunServerRequest, sandboxEnabled bool, userToken string) (*corev1.Container, *corev1.Container, []corev1.EnvVar) {
 	scia := m.config.Scia
 	port := scia.SessionSidecarPort
 	if port == 0 {
@@ -2555,7 +2559,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 	}
 	userNamespace := scia.UserNamespace
 	if userNamespace == "" {
-		userNamespace = req.UserID
+		userNamespace = sanitizeSciaDynamicUserID(req.UserID)
 	}
 	if userNamespace == "" {
 		userNamespace = "default"
@@ -2585,7 +2589,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 		todoistPaths = []string{"/api/v1/*"}
 	}
 
-	configYAML := buildSciaSidecarConfigYAML(m.namespace, userNamespace, credentialID, todoistCredentialID, port, hosts, paths, todoistHosts, todoistPaths, sandboxEnabled)
+	configYAML := buildSciaSidecarConfigYAML(m.namespace, userNamespace, credentialID, todoistCredentialID, userToken, port, hosts, paths, todoistHosts, todoistPaths, sandboxEnabled)
 	configScript := fmt.Sprintf("cat > /etc/scia-config/config.yaml <<'EOF'\n%sEOF\n", configYAML)
 
 	initContainer := corev1.Container{
@@ -2600,7 +2604,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.12.1"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.12.2"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{
@@ -2645,7 +2649,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 	return &initContainer, &sidecar, envVars
 }
 
-func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistCredentialID string, port int, hosts, paths, todoistHosts, todoistPaths []string, useNFA bool) string {
+func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistCredentialID, userToken string, port int, hosts, paths, todoistHosts, todoistPaths []string, useNFA bool) string {
 	var b strings.Builder
 	b.WriteString("server:\n")
 	b.WriteString("  mode: proxy\n")
@@ -2672,18 +2676,19 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	b.WriteString("    mode: kubernetes\n")
 	b.WriteString("    kubernetes:\n")
 	b.WriteString(fmt.Sprintf("      namespace: %q\n", namespace))
-	b.WriteString("  users:\n")
-	b.WriteString(fmt.Sprintf("    %s:\n", yamlKey(userNamespace)))
-	b.WriteString(fmt.Sprintf("      secretName: %q\n", "scia-oauth-"+sanitizeSecretName(userNamespace)))
+	b.WriteString("      dynamicUsers: true\n")
+	b.WriteString("      dynamicUserSecretNamePrefix: \"scia-oauth-\"\n")
 	b.WriteString("credentials:\n")
 	b.WriteString(fmt.Sprintf("  - id: %q\n", credentialID))
 	b.WriteString("    type: google-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
-	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/google/token", namespace, url.PathEscape(userNamespace))))
+	b.WriteString(fmt.Sprintf("      user: %q\n", userNamespace))
+	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, userNamespace, "google", userToken)))
 	b.WriteString(fmt.Sprintf("  - id: %q\n", todoistCredentialID))
 	b.WriteString("    type: todoist-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
-	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/todoist/token", namespace, url.PathEscape(userNamespace))))
+	b.WriteString(fmt.Sprintf("      user: %q\n", userNamespace))
+	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, userNamespace, "todoist", userToken)))
 	b.WriteString("rules:\n")
 	b.WriteString("  - name: inject-google-oauth-token\n")
 	b.WriteString("    hosts:\n")
@@ -2712,8 +2717,30 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	return b.String()
 }
 
-func yamlKey(value string) string {
-	return strconv.Quote(value)
+func sciaTokenBrokerURL(namespace, userNamespace, provider, userToken string) string {
+	brokerURL := fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/%s/token", namespace, url.PathEscape(userNamespace), url.PathEscape(provider))
+	if userToken == "" {
+		return brokerURL
+	}
+	return brokerURL + "?user_token=" + url.QueryEscape(userToken)
+}
+
+var sciaDynamicUserInvalidChars = regexp.MustCompile(`[^a-z0-9-]+`)
+
+func sanitizeSciaDynamicUserID(value string) string {
+	value = strings.ToLower(value)
+	value = sciaDynamicUserInvalidChars.ReplaceAllString(value, "-")
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return "default"
+	}
+	if len(value) > 63 {
+		value = strings.Trim(value[:63], "-")
+	}
+	if value == "" {
+		return "default"
+	}
+	return value
 }
 
 // buildDinDContainers returns the DinD sidecar container, env vars for the main container,
@@ -4336,6 +4363,36 @@ func generatePersonalAPIKey() (string, error) {
 	return "ap_" + hex.EncodeToString(keyBytes), nil
 }
 
+func (m *KubernetesSessionManager) ensurePersonalAPIKey(ctx context.Context, userID string) *entities.PersonalAPIKey {
+	if m.personalAPIKeyRepo == nil || userID == "" {
+		return nil
+	}
+	apiKey, err := m.personalAPIKeyRepo.FindByUserID(ctx, entities.UserID(userID))
+	if err == nil && apiKey != nil {
+		return apiKey
+	}
+
+	log.Printf("[K8S_SESSION] No personal API key found for user %s, creating new one", userID)
+	generatedKey, genErr := generatePersonalAPIKey()
+	if genErr != nil {
+		log.Printf("[K8S_SESSION] Warning: failed to generate personal API key: %v", genErr)
+		return nil
+	}
+	apiKey = entities.NewPersonalAPIKey(entities.UserID(userID), generatedKey)
+	if saveErr := m.personalAPIKeyRepo.Save(ctx, apiKey); saveErr != nil {
+		log.Printf("[K8S_SESSION] Warning: failed to save personal API key for user %s: %v", userID, saveErr)
+		return nil
+	}
+	if m.personalAPIKeyLoader != nil {
+		// Register new keys immediately so in-session callbacks can authenticate
+		// without waiting for a proxy restart and Kubernetes bootstrap.
+		if loadErr := m.personalAPIKeyLoader.LoadPersonalAPIKey(ctx, apiKey); loadErr != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to register personal API key for user %s: %v", userID, loadErr)
+		}
+	}
+	return apiKey
+}
+
 // buildSessionSettings constructs SessionSettings from RunServerRequest and session state.
 // This consolidates buildEnvVars and envFrom logic into a single unified structure.
 func (m *KubernetesSessionManager) buildSessionSettings(
@@ -4464,30 +4521,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 	// Expand personal API key directly from repository for user-scoped sessions
 	// Treat empty scope as user scope (default behavior)
 	if (req.Scope == entities.ScopeUser || req.Scope == "") && m.personalAPIKeyRepo != nil {
-		apiKey, err := m.personalAPIKeyRepo.FindByUserID(ctx, entities.UserID(req.UserID))
-		if err != nil {
-			// If no API key exists, create a new one automatically
-			log.Printf("[K8S_SESSION] No personal API key found for user %s, creating new one", req.UserID)
-			generatedKey, genErr := generatePersonalAPIKey()
-			if genErr != nil {
-				log.Printf("[K8S_SESSION] Warning: failed to generate personal API key: %v", genErr)
-			} else {
-				apiKey = entities.NewPersonalAPIKey(entities.UserID(req.UserID), generatedKey)
-				if saveErr := m.personalAPIKeyRepo.Save(ctx, apiKey); saveErr != nil {
-					log.Printf("[K8S_SESSION] Warning: failed to save personal API key for user %s: %v", req.UserID, saveErr)
-					apiKey = nil
-				} else if m.personalAPIKeyLoader != nil {
-					// Register the new key in the auth service immediately so that
-					// it is valid without waiting for a proxy restart + bootstrap.
-					// This is critical for oneshot sessions: the Stop hook calls
-					// delete-session using this key, which would fail with 401 if
-					// the key is only persisted to K8s but not loaded in-memory.
-					if loadErr := m.personalAPIKeyLoader.LoadPersonalAPIKey(ctx, apiKey); loadErr != nil {
-						log.Printf("[K8S_SESSION] Warning: failed to register personal API key for user %s: %v", req.UserID, loadErr)
-					}
-				}
-			}
-		}
+		apiKey := m.ensurePersonalAPIKey(ctx, req.UserID)
 		if apiKey != nil {
 			env["AGENTAPI_KEY"] = apiKey.APIKey()
 			log.Printf("[K8S_SESSION] Added personal API key to session settings env for user %s", req.UserID)
@@ -4911,7 +4945,7 @@ func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req
 	}
 	userNamespace := scia.UserNamespace
 	if userNamespace == "" {
-		userNamespace = env["AGENTAPI_USER_ID"]
+		userNamespace = sanitizeSciaDynamicUserID(env["AGENTAPI_USER_ID"])
 	}
 	credential := scia.Credential
 	if credential == "" && userNamespace != "" {

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.1",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.2",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -154,7 +154,9 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 		assert.Contains(t, script, "    todoist:\n")
 		assert.Contains(t, script, `        - "www.googleapis.com"`)
 		assert.Contains(t, script, `        - "api.todoist.com"`)
-		assert.Contains(t, script, `secretName: "scia-oauth-takutakahashi"`)
+		assert.Contains(t, script, `dynamicUsers: true`)
+		assert.Contains(t, script, `dynamicUserSecretNamePrefix: "scia-oauth-"`)
+		assert.NotContains(t, script, `secretName: "scia-oauth-takutakahashi"`)
 		assert.NotContains(t, script, `scia-google-oauth`)
 		assert.NotContains(t, script, `clientSecretRef`)
 		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/google/token"`)
@@ -249,7 +251,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.1",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.2",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
 	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +28,7 @@ type GoogleOAuthController struct {
 	client     kubernetes.Interface
 	namespace  string
 	httpClient *http.Client
+	apiKeyRepo portrepos.PersonalAPIKeyRepository
 }
 
 // NewGoogleOAuthController creates a GoogleOAuthController.
@@ -38,6 +41,13 @@ func NewGoogleOAuthController(scia config.SciaConfig, client kubernetes.Interfac
 			Timeout: 3 * time.Second,
 		},
 	}
+}
+
+// WithPersonalAPIKeyRepository wires the user's personal API key into scia
+// dynamic user authorization.
+func (c *GoogleOAuthController) WithPersonalAPIKeyRepository(repo portrepos.PersonalAPIKeyRepository) *GoogleOAuthController {
+	c.apiKeyRepo = repo
+	return c
 }
 
 // GetName returns the controller name.
@@ -137,13 +147,14 @@ func (c *GoogleOAuthController) GetStatus(ctx echo.Context) error {
 	userID := string(user.ID())
 	userNamespace := c.userNamespace(userID)
 	credential := c.credential(userNamespace)
+	userToken := c.userToken(ctx.Request().Context(), userID)
 
 	resp := GoogleOAuthStatusResponse{
 		Enabled:          c.scia.Enabled,
 		ClientConfigured: c.scia.Enabled && credential != "",
 		Credential:       credential,
 		UserNamespace:    userNamespace,
-		OAuthStartURL:    c.oauthStartURL(userNamespace, credential),
+		OAuthStartURL:    c.oauthStartURL(userNamespace, credential, userToken),
 		AuthorizationURL: c.authorizationURLEndpoint(userNamespace),
 		ProxyConfigured:  c.scia.Enabled && c.scia.ProxyURL != "",
 	}
@@ -177,13 +188,14 @@ func (c *GoogleOAuthController) GetIntegrations(ctx echo.Context) error {
 
 	userID := string(user.ID())
 	defaultNamespace := c.userNamespace(userID)
+	userToken := c.userToken(ctx.Request().Context(), userID)
 	for i := range integrations {
 		namespace := integrations[i].Namespace
 		if namespace == "" {
 			namespace = defaultNamespace
 			integrations[i].Namespace = namespace
 		}
-		integrations[i].StartURL = c.publicURL(integrations[i].StartURL)
+		integrations[i].StartURL = c.publicURL(c.withDynamicUserQuery(integrations[i].StartURL, namespace, userToken))
 		integrations[i].AuthorizationURLEndpoint = c.publicURL(integrations[i].AuthorizationURLEndpoint)
 		if integrations[i].Setup != nil {
 			for key, value := range integrations[i].Setup {
@@ -223,7 +235,7 @@ func (c *GoogleOAuthController) CreateAuthorizationURL(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "integration not found")
 	}
 
-	resp, err := c.createSciaAuthorizationURL(ctx.Request().Context(), integration, input)
+	resp, err := c.createSciaAuthorizationURL(ctx.Request().Context(), integration, input, c.userToken(ctx.Request().Context(), string(user.ID())))
 	if err != nil {
 		var upstream sciaHTTPError
 		if errors.As(err, &upstream) {
@@ -254,7 +266,7 @@ func (c *GoogleOAuthController) RevokeIntegration(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "integration not found")
 	}
 
-	resp, err := c.revokeSciaIntegration(ctx.Request().Context(), integration)
+	resp, err := c.revokeSciaIntegration(ctx.Request().Context(), integration, c.userToken(ctx.Request().Context(), string(user.ID())))
 	if err != nil {
 		var upstream sciaHTTPError
 		if errors.As(err, &upstream) {
@@ -283,7 +295,7 @@ func (c *GoogleOAuthController) integrationForUser(ctx context.Context, userID, 
 	return FrontendIntegration{}, false, nil
 }
 
-func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, integration FrontendIntegration, input IntegrationAuthorizationURLRequest) (IntegrationAuthorizationURLResponse, error) {
+func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, integration FrontendIntegration, input IntegrationAuthorizationURLRequest, userToken string) (IntegrationAuthorizationURLResponse, error) {
 	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
 	if base == "" {
 		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
@@ -293,6 +305,9 @@ func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, 
 	}
 	if integration.Namespace == "" || integration.Provider == "" {
 		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("integration is missing namespace or provider")
+	}
+	if integration.AuthorizationURLEndpoint == "" {
+		return c.createSciaStartAuthorizationURL(ctx, integration, input, userToken)
 	}
 
 	path := fmt.Sprintf("/oauth/%s/%s/authorization-url", url.PathEscape(integration.Namespace), url.PathEscape(integration.Provider))
@@ -306,6 +321,9 @@ func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, 
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	if userToken != "" {
+		req.Header.Set("X-Scia-User-Token", userToken)
+	}
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -328,7 +346,61 @@ func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, 
 	return output, nil
 }
 
-func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integration FrontendIntegration) (IntegrationRevokeResponse, error) {
+func (c *GoogleOAuthController) createSciaStartAuthorizationURL(ctx context.Context, integration FrontendIntegration, input IntegrationAuthorizationURLRequest, userToken string) (IntegrationAuthorizationURLResponse, error) {
+	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
+	if base == "" {
+		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
+	}
+	if base == "" {
+		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("scia_oauth_url_not_configured")
+	}
+	values := url.Values{}
+	values.Set("credential", integration.CredentialID)
+	values.Set("user", integration.Namespace)
+	if input.RedirectURI != "" {
+		values.Set("redirect_uri", input.RedirectURI)
+	}
+	if input.State != "" {
+		values.Set("state", input.State)
+	}
+	if userToken != "" {
+		values.Set("user_token", userToken)
+	}
+	endpoint := fmt.Sprintf("%s/oauth/%s/start?%s", base, url.PathEscape(integration.Provider), values.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return IntegrationAuthorizationURLResponse{}, err
+	}
+	client := *c.httpClient
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return IntegrationAuthorizationURLResponse{}, err
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+	if res.StatusCode != http.StatusFound && res.StatusCode != http.StatusSeeOther {
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return IntegrationAuthorizationURLResponse{}, sciaHTTPError{
+			StatusCode: res.StatusCode,
+			Message:    strings.TrimSpace(string(body)),
+		}
+	}
+	location := res.Header.Get("Location")
+	if location == "" {
+		return IntegrationAuthorizationURLResponse{}, fmt.Errorf("scia start response did not include Location")
+	}
+	return IntegrationAuthorizationURLResponse{
+		CredentialID:     integration.CredentialID,
+		AuthorizationURL: location,
+		RedirectURI:      input.RedirectURI,
+	}, nil
+}
+
+func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integration FrontendIntegration, userToken string) (IntegrationRevokeResponse, error) {
 	base := strings.TrimRight(c.scia.OAuthInternalURL, "/")
 	if base == "" {
 		base = strings.TrimRight(c.scia.PublicBaseURL, "/")
@@ -339,6 +411,9 @@ func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integ
 	if integration.Namespace == "" || integration.Provider == "" {
 		return IntegrationRevokeResponse{}, fmt.Errorf("integration is missing namespace or provider")
 	}
+	if integration.AuthorizationURLEndpoint == "" {
+		return c.revokeLocalOAuthSecret(ctx, integration)
+	}
 
 	path := fmt.Sprintf("/oauth/%s/%s/revoke", url.PathEscape(integration.Namespace), url.PathEscape(integration.Provider))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+path, strings.NewReader(`{}`))
@@ -347,6 +422,9 @@ func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integ
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	if userToken != "" {
+		req.Header.Set("X-Scia-User-Token", userToken)
+	}
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -370,6 +448,26 @@ func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integ
 		output.CredentialID = integration.CredentialID
 	}
 	return output, nil
+}
+
+func (c *GoogleOAuthController) revokeLocalOAuthSecret(ctx context.Context, integration FrontendIntegration) (IntegrationRevokeResponse, error) {
+	if c.client == nil || c.namespace == "" {
+		return IntegrationRevokeResponse{}, fmt.Errorf("kubernetes client is not configured")
+	}
+	secretName := "scia-oauth-" + sanitizeSciaSecretSuffix(integration.Namespace)
+	secret, err := c.client.CoreV1().Secrets(c.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return IntegrationRevokeResponse{}, err
+	}
+	delete(secret.Data, integration.CredentialID+".refresh_token")
+	delete(secret.Data, integration.CredentialID+".access_token")
+	if integration.Provider == "google" {
+		delete(secret.Data, "refresh_token")
+	}
+	if _, err := c.client.CoreV1().Secrets(c.namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+		return IntegrationRevokeResponse{}, err
+	}
+	return IntegrationRevokeResponse{Revoked: true, CredentialID: integration.CredentialID}, nil
 }
 
 func (c *GoogleOAuthController) fetchSciaIntegrations(ctx context.Context) ([]FrontendIntegration, error) {
@@ -459,7 +557,7 @@ func (c *GoogleOAuthController) userNamespace(userID string) string {
 	if c.scia.UserNamespace != "" {
 		return c.scia.UserNamespace
 	}
-	return userID
+	return sanitizeSciaDynamicUserID(userID)
 }
 
 func (c *GoogleOAuthController) credential(userNamespace string) string {
@@ -472,13 +570,16 @@ func (c *GoogleOAuthController) credential(userNamespace string) string {
 	return userNamespace + ".google"
 }
 
-func (c *GoogleOAuthController) oauthStartURL(userNamespace, credential string) string {
+func (c *GoogleOAuthController) oauthStartURL(userNamespace, credential, userToken string) string {
 	if credential == "" || userNamespace == "" {
 		return ""
 	}
 	values := url.Values{}
 	values.Set("credential", credential)
 	values.Set("user", userNamespace)
+	if userToken != "" {
+		values.Set("user_token", userToken)
+	}
 	return c.withPublicBase("/oauth/google/start") + "?" + values.Encode()
 }
 
@@ -510,7 +611,27 @@ func (c *GoogleOAuthController) publicURL(path string) string {
 	return base + path
 }
 
+func (c *GoogleOAuthController) withDynamicUserQuery(rawURL, userNamespace, userToken string) string {
+	if rawURL == "" || userNamespace == "" {
+		return rawURL
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	values := parsed.Query()
+	if values.Get("user") == "" && strings.HasPrefix(parsed.Path, "/oauth/") && strings.Count(strings.Trim(parsed.Path, "/"), "/") == 2 {
+		values.Set("user", userNamespace)
+	}
+	if userToken != "" {
+		values.Set("user_token", userToken)
+	}
+	parsed.RawQuery = values.Encode()
+	return parsed.String()
+}
+
 var sciaSecretInvalidChars = regexp.MustCompile(`[^a-z0-9.-]+`)
+var sciaDynamicUserInvalidChars = regexp.MustCompile(`[^a-z0-9-]+`)
 
 func sanitizeSciaSecretSuffix(value string) string {
 	value = strings.ToLower(value)
@@ -520,4 +641,31 @@ func sanitizeSciaSecretSuffix(value string) string {
 		return "default"
 	}
 	return value
+}
+
+func sanitizeSciaDynamicUserID(value string) string {
+	value = strings.ToLower(value)
+	value = sciaDynamicUserInvalidChars.ReplaceAllString(value, "-")
+	value = strings.Trim(value, "-")
+	if value == "" {
+		return "default"
+	}
+	if len(value) > 63 {
+		value = strings.Trim(value[:63], "-")
+	}
+	if value == "" {
+		return "default"
+	}
+	return value
+}
+
+func (c *GoogleOAuthController) userToken(ctx context.Context, userID string) string {
+	if c.apiKeyRepo == nil || userID == "" {
+		return ""
+	}
+	apiKey, err := c.apiKeyRepo.FindByUserID(ctx, entities.UserID(userID))
+	if err != nil || apiKey == nil {
+		return ""
+	}
+	return apiKey.APIKey()
 }

--- a/internal/interfaces/controllers/google_oauth_controller_test.go
+++ b/internal/interfaces/controllers/google_oauth_controller_test.go
@@ -1,9 +1,11 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -17,6 +19,7 @@ import (
 
 func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	var gotScopeIDs []string
+	var gotUserToken string
 	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/integrations":
@@ -39,6 +42,7 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Fatalf("method = %s, want POST", r.Method)
 			}
+			gotUserToken = r.Header.Get("X-Scia-User-Token")
 			var req IntegrationAuthorizationURLRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Fatal(err)
@@ -60,7 +64,9 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	controller := NewGoogleOAuthController(config.SciaConfig{
 		Enabled:          true,
 		OAuthInternalURL: scia.URL,
-	}, nil, "")
+	}, nil, "").WithPersonalAPIKeyRepository(&fakeGoogleOAuthPersonalAPIKeyRepo{
+		keys: map[entities.UserID]string{"takutakahashi": "ap-user-token"},
+	})
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/integrations/takutakahashi.google/authorization-url", strings.NewReader(`{"scope_ids":["calendar-write","tasks-write"],"redirect_uri":"https://app.example.com/api/oauth/google/callback"}`))
@@ -81,6 +87,9 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	if strings.Join(gotScopeIDs, ",") != "calendar-write,tasks-write" {
 		t.Fatalf("scope_ids = %#v", gotScopeIDs)
 	}
+	if gotUserToken != "ap-user-token" {
+		t.Fatalf("X-Scia-User-Token = %q", gotUserToken)
+	}
 	var body IntegrationAuthorizationURLResponse
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatal(err)
@@ -92,6 +101,7 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 
 func TestRevokeIntegrationProxiesToSciaNamespaceRevoke(t *testing.T) {
 	var revoked bool
+	var gotUserToken string
 	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/integrations":
@@ -114,6 +124,7 @@ func TestRevokeIntegrationProxiesToSciaNamespaceRevoke(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Fatalf("method = %s, want POST", r.Method)
 			}
+			gotUserToken = r.Header.Get("X-Scia-User-Token")
 			revoked = true
 			_ = json.NewEncoder(w).Encode(IntegrationRevokeResponse{
 				Revoked:      true,
@@ -128,7 +139,9 @@ func TestRevokeIntegrationProxiesToSciaNamespaceRevoke(t *testing.T) {
 	controller := NewGoogleOAuthController(config.SciaConfig{
 		Enabled:          true,
 		OAuthInternalURL: scia.URL,
-	}, nil, "")
+	}, nil, "").WithPersonalAPIKeyRepository(&fakeGoogleOAuthPersonalAPIKeyRepo{
+		keys: map[entities.UserID]string{"takutakahashi": "ap-user-token"},
+	})
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/integrations/takutakahashi.todoist/revoke", nil)
@@ -147,6 +160,9 @@ func TestRevokeIntegrationProxiesToSciaNamespaceRevoke(t *testing.T) {
 	if !revoked {
 		t.Fatalf("scia revoke endpoint was not called")
 	}
+	if gotUserToken != "ap-user-token" {
+		t.Fatalf("X-Scia-User-Token = %q", gotUserToken)
+	}
 	var body IntegrationRevokeResponse
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatal(err)
@@ -155,6 +171,80 @@ func TestRevokeIntegrationProxiesToSciaNamespaceRevoke(t *testing.T) {
 		t.Fatalf("unexpected revoke response: %#v", body)
 	}
 }
+
+func TestGetStatusIncludesPersonalAPIKeyUserTokenInOAuthStartURL(t *testing.T) {
+	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_scia/healthz" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer scia.Close()
+
+	controller := NewGoogleOAuthController(config.SciaConfig{
+		Enabled:          true,
+		OAuthInternalURL: scia.URL,
+		PublicBaseURL:    "https://agentapi.example.com",
+	}, nil, "").WithPersonalAPIKeyRepository(&fakeGoogleOAuthPersonalAPIKeyRepo{
+		keys: map[entities.UserID]string{"Alice_Example": "ap-user-token"},
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/integrations/google-oauth/status", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.Set("internal_user", entities.NewUser("Alice_Example", entities.UserTypeRegular, "Alice_Example"))
+
+	if err := controller.GetStatus(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body GoogleOAuthStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.UserNamespace != "alice-example" {
+		t.Fatalf("user_namespace = %q", body.UserNamespace)
+	}
+	startURL, err := url.Parse(body.OAuthStartURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if startURL.Query().Get("user_token") != "ap-user-token" {
+		t.Fatalf("user_token = %q", startURL.Query().Get("user_token"))
+	}
+}
+
+type fakeGoogleOAuthPersonalAPIKeyRepo struct {
+	keys map[entities.UserID]string
+}
+
+func (r *fakeGoogleOAuthPersonalAPIKeyRepo) FindByUserID(_ context.Context, userID entities.UserID) (*entities.PersonalAPIKey, error) {
+	key := r.keys[userID]
+	if key == "" {
+		return nil, assertAnError{}
+	}
+	return entities.NewPersonalAPIKey(userID, key), nil
+}
+
+func (r *fakeGoogleOAuthPersonalAPIKeyRepo) Save(context.Context, *entities.PersonalAPIKey) error {
+	return nil
+}
+
+func (r *fakeGoogleOAuthPersonalAPIKeyRepo) Delete(context.Context, entities.UserID) error {
+	return nil
+}
+
+func (r *fakeGoogleOAuthPersonalAPIKeyRepo) List(context.Context) ([]*entities.PersonalAPIKey, error) {
+	return nil, nil
+}
+
+type assertAnError struct{}
+
+func (assertAnError) Error() string { return "not found" }
 
 func TestGetIntegrationsMarksConnectedPerCredentialToken(t *testing.T) {
 	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1331,7 +1331,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.12.1")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.12.2")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1416,7 +1416,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.12.1"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.12.2"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"


### PR DESCRIPTION
## Summary
- upgrade scia defaults to v0.12.2 and enable Kubernetes dynamic users in Helm
- use each user's personal API key as the scia dynamic user token for OAuth start, authorization-url, revoke, and session sidecar broker URLs
- derive scia dynamic user IDs from agentapi user IDs and keep static user mappings as an opt-in compatibility path

## Verification
- mise exec -- go test ./internal/interfaces/controllers ./internal/infrastructure/services ./pkg/config
- mise exec -- helm template agentapi-proxy helm/agentapi-proxy >/tmp/agentapi-proxy-rendered.yaml
- mise exec -- go test ./... (fails in cmd package due environment/Kubernetes interaction: signal interrupt; other packages completed)