### PR TITLE
Render scia integrations from values

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scia.todoistCredential`                           | Todoist credential ID injected into sessions    | `default.todoist` |
 | `scia.userNamespace`                               | Optional fixed scia user namespace; empty derives it from each agentapi user | `""` |
 | `scia.dynamicUserSecretNamePrefix`                 | Prefix for scia dynamic user token Secrets      | `scia-oauth-` |
+| `scia.oauth.integrations`                          | Service integration display metadata and scopes rendered into scia config with `toYaml` | Google/Todoist defaults |
 | `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `false` |
 | `scia.oauth.google.secret.existingSecret`          | Existing Secret containing Google OAuth values  | `""` |
 | `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -10,6 +10,7 @@
 {{- $googleEnabled := ne $googleCredential "" }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistEnabled := $todoist.enabled | default false }}
+{{- $integrationValues := $oauth.integrations | default dict }}
 {{- $dynamicUserSecretNamePrefix := $scia.dynamicUserSecretNamePrefix | default "scia-oauth-" }}
 {{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
 {{- $sciaHost := .Values.config.hostname | default "" }}
@@ -33,8 +34,13 @@
 {{- if $todoist.omitRedirectUrl }}
   {{- $todoistRedirectURL = "" }}
 {{- end }}
-{{- $googleScopes := $google.scopes | default (list (dict "id" ($google.scopeId | default "calendar-read") "value" ($google.scope | default "https://www.googleapis.com/auth/calendar.readonly") "name" ($google.scopeName | default "Google Calendar read-only") "desc" ($google.scopeDesc | default "Read Google Calendar events.") "enabled" true)) }}
-{{- $todoistScopes := $todoist.scopes | default (list (dict "id" "read-write" "value" ($todoist.scope | default "data:read_write") "name" "Todoist read/write" "desc" "Read and write Todoist tasks and projects." "enabled" true)) }}
+{{- $integrations := dict }}
+{{- if and $googleEnabled (hasKey $integrationValues "google") }}
+  {{- $_ := set $integrations "google" (deepCopy (get $integrationValues "google")) }}
+{{- end }}
+{{- if and $todoistEnabled (hasKey $integrationValues "todoist") }}
+  {{- $_ := set $integrations "todoist" (deepCopy (get $integrationValues "todoist")) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -77,64 +83,7 @@ data:
           {{- end }}
         {{- end }}
         integrations:
-          {{- if $googleEnabled }}
-          google:
-            name: {{ $google.name | default "Google" | quote }}
-            {{- if $google.iconUrl }}
-            iconUrl: {{ $google.iconUrl | quote }}
-            {{- end }}
-            {{- if $google.description }}
-            description: {{ $google.description | quote }}
-            {{- end }}
-            setup:
-              callback_url: {{ $redirectURL | quote }}
-            scopes:
-              {{- range $scope := $googleScopes }}
-              - id: {{ $scope.id | quote }}
-                value: {{ $scope.value | quote }}
-                name: {{ $scope.name | quote }}
-                {{- if $scope.desc }}
-                desc: {{ $scope.desc | quote }}
-                {{- end }}
-                {{- if $scope.group }}
-                group: {{ $scope.group | quote }}
-                {{- end }}
-                {{- if $scope.groupName }}
-                groupName: {{ $scope.groupName | quote }}
-                {{- end }}
-                {{- if $scope.groupDesc }}
-                groupDesc: {{ $scope.groupDesc | quote }}
-                {{- end }}
-                enabled: {{ $scope.enabled | default false }}
-              {{- end }}
-          {{- end }}
-          {{- if $todoistEnabled }}
-          todoist:
-            name: {{ $todoist.name | default "Todoist" | quote }}
-            iconUrl: {{ $todoist.iconUrl | default "https://todoist.com/favicon.ico" | quote }}
-            description: {{ $todoist.description | default "Connect Todoist tasks and projects." | quote }}
-            setup:
-              callback_url: {{ $todoistRedirectURL | quote }}
-            scopes:
-              {{- range $scope := $todoistScopes }}
-              - id: {{ $scope.id | quote }}
-                value: {{ $scope.value | quote }}
-                name: {{ $scope.name | quote }}
-                {{- if $scope.desc }}
-                desc: {{ $scope.desc | quote }}
-                {{- end }}
-                {{- if $scope.group }}
-                group: {{ $scope.group | quote }}
-                {{- end }}
-                {{- if $scope.groupName }}
-                groupName: {{ $scope.groupName | quote }}
-                {{- end }}
-                {{- if $scope.groupDesc }}
-                groupDesc: {{ $scope.groupDesc | quote }}
-                {{- end }}
-                enabled: {{ $scope.enabled | default false }}
-              {{- end }}
-          {{- end }}
+{{- toYaml $integrations | nindent 10 }}
     credentials:
       {{- if $googleEnabled }}
       - id: {{ $googleCredential | quote }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -102,9 +102,11 @@ scia:
   oauth:
     listen: "0.0.0.0:8081"
     redirectUrl: ""
-    google:
-      scope: "https://www.googleapis.com/auth/calendar.readonly"
-      scopes:
+    integrations:
+      google:
+        name: Google
+        setup: {}
+        scopes:
         - id: calendar-read
           value: "https://www.googleapis.com/auth/calendar.readonly"
           name: "Google Calendar read-only"
@@ -137,6 +139,24 @@ scia:
           groupName: "Google Tasks"
           groupDesc: "Choose how much Google Tasks access to grant."
           enabled: false
+      todoist:
+        name: Todoist
+        iconUrl: "https://todoist.com/favicon.ico"
+        description: "Connect Todoist tasks and projects."
+        setup: {}
+        scopes:
+        - id: read-write
+          value: "data:read_write"
+          name: "Todoist read/write"
+          desc: "Read and write Todoist tasks and projects."
+          enabled: true
+        - id: task-add
+          value: "task:add"
+          name: "Todoist task add"
+          desc: "Add Todoist tasks without reading existing data."
+          enabled: false
+    google:
+      scope: "https://www.googleapis.com/auth/calendar.readonly"
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.
       secret:
@@ -150,17 +170,6 @@ scia:
       enabled: false
       scope: "data:read_write"
       omitRedirectUrl: false
-      scopes:
-        - id: read-write
-          value: "data:read_write"
-          name: "Todoist read/write"
-          desc: "Read and write Todoist tasks and projects."
-          enabled: true
-        - id: task-add
-          value: "task:add"
-          name: "Todoist task add"
-          desc: "Add Todoist tasks without reading existing data."
-          enabled: false
       secret:
         create: true
         existingSecret: ""


### PR DESCRIPTION
## Summary
- Move scia service integration metadata and scopes under scia.oauth.integrations in values.
- Render the scia oauth.integrations ConfigMap section with toYaml.
- Remove legacy integration metadata fallbacks from scia.oauth.google.* and scia.oauth.todoist.*; service integration display metadata now comes from scia.oauth.integrations only.

## Breaking change
- scia.oauth.google.scopes, scia.oauth.google.name, scia.oauth.google.description, scia.oauth.google.iconUrl, scia.oauth.todoist.scopes, scia.oauth.todoist.name, scia.oauth.todoist.description, and scia.oauth.todoist.iconUrl are no longer read for service integration metadata.

## Tests
- mise exec -- helm template agentapi-proxy helm/agentapi-proxy
- mise exec -- helm template agentapi-proxy helm/agentapi-proxy --set scia.credential=takutakahashi.google --set scia.oauth.todoist.enabled=true
- mise exec -- helm template agentapi-proxy helm/agentapi-proxy with a custom scia.oauth.integrations.google override
- mise exec -- helm lint helm/agentapi-proxy
- mise exec -- go test ./internal/interfaces/controllers ./internal/infrastructure/services ./pkg/config