### PR TITLE
Support session branch and PR checkout tags

### DIFF
--- a/internal/core/repository/repository.go
+++ b/internal/core/repository/repository.go
@@ -31,7 +31,18 @@ func ExtractInfo(tags map[string]string, cloneDir string) (*entities.RepositoryI
 	return &entities.RepositoryInfo{
 		FullName: repoFullName,
 		CloneDir: cloneDir,
+		Branch:   strings.TrimSpace(tags["branch"]),
+		PR:       pullRequestTag(tags),
 	}, nil
+}
+
+func pullRequestTag(tags map[string]string) string {
+	for _, key := range []string{"pr", "pr_number", "pull_request_number"} {
+		if value := strings.TrimSpace(tags[key]); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // IsValidURL checks for supported GitHub URL or owner/repo formats.

--- a/internal/core/repository/repository_test.go
+++ b/internal/core/repository/repository_test.go
@@ -1,0 +1,42 @@
+package repository
+
+import "testing"
+
+func TestExtractInfoIncludesCheckoutTags(t *testing.T) {
+	info, err := ExtractInfo(map[string]string{
+		"repository": "https://github.com/owner/repo.git",
+		"branch":     " feature/test ",
+		"pr":         " 123 ",
+	}, "session-id")
+	if err != nil {
+		t.Fatalf("ExtractInfo returned error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected repository info")
+	}
+	if info.FullName != "owner/repo" {
+		t.Fatalf("FullName = %q, want owner/repo", info.FullName)
+	}
+	if info.CloneDir != "session-id" {
+		t.Fatalf("CloneDir = %q, want session-id", info.CloneDir)
+	}
+	if info.Branch != "feature/test" {
+		t.Fatalf("Branch = %q, want feature/test", info.Branch)
+	}
+	if info.PR != "123" {
+		t.Fatalf("PR = %q, want 123", info.PR)
+	}
+}
+
+func TestExtractInfoSupportsPRNumberAliases(t *testing.T) {
+	info, err := ExtractInfo(map[string]string{
+		"repository": "owner/repo",
+		"pr_number":  "456",
+	}, "session-id")
+	if err != nil {
+		t.Fatalf("ExtractInfo returned error: %v", err)
+	}
+	if info.PR != "456" {
+		t.Fatalf("PR = %q, want 456", info.PR)
+	}
+}

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -141,6 +141,8 @@ type StartRequest struct {
 type RepositoryInfo struct {
 	FullName string
 	CloneDir string
+	Branch   string
+	PR       string
 }
 
 // RunServerRequest contains parameters needed to run an agentapi server

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4659,6 +4659,8 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		settings.Repository = &sessionsettings.RepositoryConfig{
 			FullName: req.RepoInfo.FullName,
 			CloneDir: "/home/agentapi/workdir/repo",
+			Branch:   req.RepoInfo.Branch,
+			PR:       req.RepoInfo.PR,
 		}
 	}
 

--- a/internal/modules/sessionmanager/allocator_worker.go
+++ b/internal/modules/sessionmanager/allocator_worker.go
@@ -112,6 +112,8 @@ func runRequestFromSettings(settings *sessionsettings.SessionSettings) *entities
 		req.RepoInfo = &entities.RepositoryInfo{
 			FullName: settings.Repository.FullName,
 			CloneDir: settings.Repository.CloneDir,
+			Branch:   settings.Repository.Branch,
+			PR:       settings.Repository.PR,
 		}
 	}
 	return req

--- a/internal/modules/sessionmanager/handlers.go
+++ b/internal/modules/sessionmanager/handlers.go
@@ -174,6 +174,8 @@ func (h *Handlers) CreateSession(c echo.Context) error {
 		req.RepoInfo = &entities.RepositoryInfo{
 			FullName: settings.Repository.FullName,
 			CloneDir: settings.Repository.CloneDir,
+			Branch:   settings.Repository.Branch,
+			PR:       settings.Repository.PR,
 		}
 	}
 

--- a/internal/modules/webhook/launcher.go
+++ b/internal/modules/webhook/launcher.go
@@ -119,6 +119,8 @@ func (s *WebhookSessionService) CreateSessionFromWebhook(ctx context.Context, pa
 		repoInfo = &entities.RepositoryInfo{
 			FullName: repoFullName,
 			CloneDir: sessionID,
+			Branch:   strings.TrimSpace(tags["branch"]),
+			PR:       firstNonEmptyTag(tags, "pr", "pr_number", "pull_request_number"),
 		}
 	}
 
@@ -302,4 +304,13 @@ func (s *WebhookSessionService) determineInitialMessage(
 	}
 
 	return defaultMessage, nil
+}
+
+func firstNonEmptyTag(tags map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(tags[key]); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/pkg/sessionsettings/setup.go
+++ b/pkg/sessionsettings/setup.go
@@ -157,44 +157,107 @@ func cloneRepo(settings *SessionSettings) error {
 	// Skip clone if already present
 	if _, err := os.Stat(filepath.Join(cloneDir, ".git")); err == nil {
 		log.Printf("[SETUP] Repository already cloned at %s, skipping", cloneDir)
-		return nil
+	} else {
+		if err := os.MkdirAll(filepath.Dir(cloneDir), 0755); err != nil {
+			return fmt.Errorf("failed to create parent dir for clone: %w", err)
+		}
+
+		log.Printf("[SETUP] Cloning %s into %s via gh repo clone", repo.FullName, cloneDir)
+		cmd := exec.Command("gh", "repo", "clone", repo.FullName, cloneDir, "--", "--depth", "1")
+		cmd.Env = githubCommandEnv()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			// Fallback: try GITHUB_URL-based git clone for non-GitHub hosts
+			githubURL := github_pkg.GetGitHubURL()
+			cloneURL := fmt.Sprintf("%s/%s.git", githubURL, repo.FullName)
+			log.Printf("[SETUP] gh repo clone failed, falling back to git clone: %s", cloneURL)
+			cmd2 := exec.Command("git", "clone", "--depth", "1", cloneURL, cloneDir)
+			cmd2.Env = githubCommandEnv()
+			cmd2.Stdout = os.Stdout
+			cmd2.Stderr = os.Stderr
+			if err2 := cmd2.Run(); err2 != nil {
+				return fmt.Errorf("git clone failed: %w", err2)
+			}
+		}
+
+		log.Printf("[SETUP] Cloned %s to %s", repo.FullName, cloneDir)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(cloneDir), 0755); err != nil {
-		return fmt.Errorf("failed to create parent dir for clone: %w", err)
+	if err := checkoutRepositoryTarget(repo, cloneDir); err != nil {
+		return err
 	}
 
-	// Build env with GH_HOST for GitHub Enterprise Server.
+	return nil
+}
+
+func githubCommandEnv() []string {
 	env := os.Environ()
 	if githubAPI := os.Getenv("GITHUB_API"); githubAPI != "" && githubAPI != "https://api.github.com" {
 		githubHost := strings.TrimPrefix(githubAPI, "https://")
 		githubHost = strings.TrimPrefix(githubHost, "http://")
 		githubHost = strings.TrimSuffix(githubHost, "/api/v3")
 		env = append(env, fmt.Sprintf("GH_HOST=%s", githubHost))
-		log.Printf("[SETUP] GHE detected, setting GH_HOST=%s for clone", githubHost)
+		log.Printf("[SETUP] GHE detected, setting GH_HOST=%s for gh/git", githubHost)
+	}
+	return env
+}
+
+func checkoutRepositoryTarget(repo *RepositoryConfig, cloneDir string) error {
+	if repo == nil {
+		return nil
 	}
 
-	log.Printf("[SETUP] Cloning %s into %s via gh repo clone", repo.FullName, cloneDir)
-	cmd := exec.Command("gh", "repo", "clone", repo.FullName, cloneDir, "--", "--depth", "1")
-	cmd.Env = env
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		// Fallback: try GITHUB_URL-based git clone for non-GitHub hosts
-		githubURL := github_pkg.GetGitHubURL()
-		cloneURL := fmt.Sprintf("%s/%s.git", githubURL, repo.FullName)
-		log.Printf("[SETUP] gh repo clone failed, falling back to git clone: %s", cloneURL)
-		cmd2 := exec.Command("git", "clone", "--depth", "1", cloneURL, cloneDir)
-		cmd2.Env = env
-		cmd2.Stdout = os.Stdout
-		cmd2.Stderr = os.Stderr
-		if err2 := cmd2.Run(); err2 != nil {
-			return fmt.Errorf("git clone failed: %w", err2)
+	targetType, targetValue := repositoryCheckoutTarget(repo)
+	switch targetType {
+	case "pr":
+		pr := targetValue
+		log.Printf("[SETUP] Checking out PR %s for %s", pr, repo.FullName)
+		cmd := exec.Command("gh", "pr", "checkout", pr, "--detach")
+		cmd.Dir = cloneDir
+		cmd.Env = githubCommandEnv()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to checkout PR %s: %w", pr, err)
+		}
+		return nil
+	case "branch":
+		branch := targetValue
+		log.Printf("[SETUP] Checking out branch %s for %s", branch, repo.FullName)
+		fetch := exec.Command("git", "fetch", "origin", branch, "--depth", "1")
+		fetch.Dir = cloneDir
+		fetch.Env = githubCommandEnv()
+		fetch.Stdout = os.Stdout
+		fetch.Stderr = os.Stderr
+		if err := fetch.Run(); err != nil {
+			return fmt.Errorf("failed to fetch branch %s: %w", branch, err)
+		}
+
+		checkout := exec.Command("git", "checkout", "-B", branch, "FETCH_HEAD")
+		checkout.Dir = cloneDir
+		checkout.Env = githubCommandEnv()
+		checkout.Stdout = os.Stdout
+		checkout.Stderr = os.Stderr
+		if err := checkout.Run(); err != nil {
+			return fmt.Errorf("failed to checkout branch %s: %w", branch, err)
 		}
 	}
 
-	log.Printf("[SETUP] Cloned %s to %s", repo.FullName, cloneDir)
 	return nil
+}
+
+func repositoryCheckoutTarget(repo *RepositoryConfig) (string, string) {
+	if repo == nil {
+		return "", ""
+	}
+	if pr := strings.TrimSpace(repo.PR); pr != "" {
+		return "pr", pr
+	}
+	if branch := strings.TrimSpace(repo.Branch); branch != "" {
+		return "branch", branch
+	}
+	return "", ""
 }
 
 // syncExtra handles credentials, notification subscriptions,

--- a/pkg/sessionsettings/setup_test.go
+++ b/pkg/sessionsettings/setup_test.go
@@ -1,0 +1,53 @@
+package sessionsettings
+
+import "testing"
+
+func TestRepositoryCheckoutTarget(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      *RepositoryConfig
+		wantType  string
+		wantValue string
+	}{
+		{
+			name:      "none",
+			repo:      &RepositoryConfig{},
+			wantType:  "",
+			wantValue: "",
+		},
+		{
+			name: "branch",
+			repo: &RepositoryConfig{
+				Branch: " feature/test ",
+			},
+			wantType:  "branch",
+			wantValue: "feature/test",
+		},
+		{
+			name: "pr",
+			repo: &RepositoryConfig{
+				PR: " 123 ",
+			},
+			wantType:  "pr",
+			wantValue: "123",
+		},
+		{
+			name: "pr takes precedence over branch",
+			repo: &RepositoryConfig{
+				Branch: "feature/test",
+				PR:     "123",
+			},
+			wantType:  "pr",
+			wantValue: "123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotValue := repositoryCheckoutTarget(tt.repo)
+			if gotType != tt.wantType || gotValue != tt.wantValue {
+				t.Fatalf("repositoryCheckoutTarget() = (%q, %q), want (%q, %q)", gotType, gotValue, tt.wantType, tt.wantValue)
+			}
+		})
+	}
+}

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -246,6 +246,8 @@ type CodexConfig struct {
 type RepositoryConfig struct {
 	FullName string `yaml:"fullname"   json:"fullname"`
 	CloneDir string `yaml:"clone_dir"  json:"clone_dir"`
+	Branch   string `yaml:"branch,omitempty" json:"branch,omitempty"`
+	PR       string `yaml:"pr,omitempty"     json:"pr,omitempty"`
 }
 
 // StartupConfig holds the startup command configuration.


### PR DESCRIPTION
## Summary
- add branch/pr fields to repository session settings
- extract checkout targets from session tags, with pr taking precedence over branch
- checkout PRs via gh pr checkout --detach and branches via git fetch/checkout during setup

## Tests
- mise exec -- go test ./internal/core/repository ./pkg/sessionsettings ./internal/modules/webhook ./internal/modules/sessionmanager
- git diff --check
- mise exec -- go test ./... (fails in existing cmd package with signal: interrupt after server startup test; touched packages pass)

## Dev verification
- Deployed chart 0.3.0-dev.20260623034914.e8c5bd5 to agentapi-ui-dev revision 1110
- branch tag: session 52aac8e5-8263-4574-9e42-f55884cca797 checked out remove-scia-image-tag-defaults at 2764a81
- pr priority: session d5a9223d-354a-4585-9951-f3ace4cd15b2 was started with branch=main and pr=877, and checked out detached HEAD 2764a81 from PR #877