### PR TITLE
Add session pod template values support

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -358,6 +358,10 @@ spec:
             - name: AGENTAPI_K8S_SESSION_CONFIG_FILE
               value: "/etc/k8s-session-config/k8s-session-config.yaml"
             {{- end }}
+            {{- if .Values.kubernetesSession.podTemplate }}
+            - name: AGENTAPI_K8S_SESSION_POD_TEMPLATE_FILE
+              value: "/etc/k8s-session-config/session-pod-template.yaml"
+            {{- end }}
             # Slack Integration configuration
             # claude-posts runs as a subprocess inside the agentapi container (not as a sidecar)
             {{- $slackIntegration := (.Values.kubernetesSession).slackIntegration }}
@@ -580,7 +584,7 @@ spec:
               mountPath: /etc/github-app
               readOnly: true
             {{- end }}
-            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations }}
+            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
             - name: k8s-session-config
               mountPath: /etc/k8s-session-config
               readOnly: true
@@ -628,7 +632,7 @@ spec:
             secretName: {{ .Values.github.app.privateKey.secretName }}
             defaultMode: 0440
         {{- end }}
-        {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations }}
+        {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
         - name: k8s-session-config
           configMap:
             name: {{ include "agentapi-proxy.fullname" . }}-k8s-session-config

--- a/helm/agentapi-proxy/templates/k8s-session-configmap.yaml
+++ b/helm/agentapi-proxy/templates/k8s-session-configmap.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.kubernetesSession.enabled }}
-{{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations }}
+{{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,5 +32,8 @@ data:
           {{- end }}
         {{- end }}
       {{- end }}
-{{- end }}
+  {{- if .Values.kubernetesSession.podTemplate }}
+  session-pod-template.yaml: |
+    {{- toYaml .Values.kubernetesSession.podTemplate | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -567,6 +567,32 @@ kubernetesSession:
   #     effect: "PreferNoSchedule"
   tolerations: []
 
+  # Additional PodTemplateSpec fields to merge into every session pod.
+  # This is rendered as a YAML file, mounted into the proxy pod, and applied
+  # with Kubernetes strategic merge patch when each session workload is created.
+  # The proxy preserves required session fields such as serviceAccountName,
+  # restartPolicy, session labels, and the main agentapi container command/args.
+  podTemplate: {}
+  # metadata:
+  #   annotations:
+  #     example.com/template: "enabled"
+  #   labels:
+  #     workload-type: agent-session
+  # spec:
+  #   priorityClassName: agent-session
+  #   imagePullSecrets:
+  #     - name: ghcr-pull-secret
+  #   volumes:
+  #     - name: extra-config
+  #       configMap:
+  #         name: extra-config
+  #   containers:
+  #     - name: agentapi
+  #       volumeMounts:
+  #         - name: extra-config
+  #           mountPath: /etc/extra-config
+  #           readOnly: true
+
   # GitHub authentication for repository cloning in session pods
   # A Secret is automatically created when github.app.id and github.app.privateKey.secretName are set
   # The Secret will be used by the clone-repo init container

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -28,8 +28,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/yaml"
 
 	coreallocation "github.com/takutakahashi/agentapi-proxy/internal/core/sessionallocation"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
@@ -1900,14 +1902,20 @@ func (m *KubernetesSessionManager) createSessionWorkload(ctx context.Context, se
 
 // createDeployment creates a Deployment for the session
 func (m *KubernetesSessionManager) createDeployment(ctx context.Context, session *KubernetesSession, req *entities.RunServerRequest) error {
-	deployment := m.buildDeployment(ctx, session, req)
-	_, err := m.client.AppsV1().Deployments(m.namespace).Create(ctx, deployment, metav1.CreateOptions{})
+	deployment, err := m.buildDeployment(ctx, session, req)
+	if err != nil {
+		return err
+	}
+	_, err = m.client.AppsV1().Deployments(m.namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	return err
 }
 
 // createPod creates a standalone Pod for an ephemeral session.
 func (m *KubernetesSessionManager) createPod(ctx context.Context, session *KubernetesSession, req *entities.RunServerRequest) error {
-	deployment := m.buildDeployment(ctx, session, req)
+	deployment, err := m.buildDeployment(ctx, session, req)
+	if err != nil {
+		return err
+	}
 	podTemplate := deployment.Spec.Template
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1920,13 +1928,13 @@ func (m *KubernetesSessionManager) createPod(ctx context.Context, session *Kuber
 	}
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 
-	_, err := m.client.CoreV1().Pods(m.namespace).Create(ctx, pod, metav1.CreateOptions{})
+	_, err = m.client.CoreV1().Pods(m.namespace).Create(ctx, pod, metav1.CreateOptions{})
 	return err
 }
 
 // buildDeployment builds the Deployment object used directly for PVC-backed
 // sessions and as a Pod template source for ephemeral sessions.
-func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session *KubernetesSession, req *entities.RunServerRequest) *appsv1.Deployment {
+func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session *KubernetesSession, req *entities.RunServerRequest) (*appsv1.Deployment, error) {
 	labels := m.buildLabels(session)
 	envVars := m.buildEnvVars(session, req)
 	replicas := int32(1)
@@ -2228,7 +2236,94 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 			},
 		},
 	}
-	return deployment
+	if err := m.applySessionPodTemplateFile(&deployment.Spec.Template); err != nil {
+		return nil, err
+	}
+	return deployment, nil
+}
+
+func (m *KubernetesSessionManager) applySessionPodTemplateFile(template *corev1.PodTemplateSpec) error {
+	if m.k8sConfig == nil || strings.TrimSpace(m.k8sConfig.SessionPodTemplateFile) == "" {
+		return nil
+	}
+
+	filename := strings.TrimSpace(m.k8sConfig.SessionPodTemplateFile)
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read session pod template file %s: %w", filename, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+
+	originalJSON, err := json.Marshal(template)
+	if err != nil {
+		return fmt.Errorf("failed to marshal generated session pod template: %w", err)
+	}
+	patchJSON, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse session pod template file %s: %w", filename, err)
+	}
+	mergedJSON, err := strategicpatch.StrategicMergePatch(originalJSON, patchJSON, corev1.PodTemplateSpec{})
+	if err != nil {
+		return fmt.Errorf("failed to merge session pod template file %s: %w", filename, err)
+	}
+
+	generated := template.DeepCopy()
+	var merged corev1.PodTemplateSpec
+	if err := json.Unmarshal(mergedJSON, &merged); err != nil {
+		return fmt.Errorf("failed to decode merged session pod template: %w", err)
+	}
+	restoreSessionPodTemplateInvariants(&merged, generated)
+	*template = merged
+	log.Printf("[K8S_SESSION] Applied session pod template file: %s", filename)
+	return nil
+}
+
+func restoreSessionPodTemplateInvariants(template *corev1.PodTemplateSpec, generated *corev1.PodTemplateSpec) {
+	if template.Labels == nil {
+		template.Labels = map[string]string{}
+	}
+	for key, value := range generated.Labels {
+		if strings.HasPrefix(key, "agentapi.proxy/") || key == "app.kubernetes.io/managed-by" {
+			template.Labels[key] = value
+		}
+	}
+
+	template.Spec.ServiceAccountName = generated.Spec.ServiceAccountName
+	template.Spec.RestartPolicy = generated.Spec.RestartPolicy
+
+	generatedMain := findContainerByName(generated.Spec.Containers, "agentapi")
+	if generatedMain == nil {
+		return
+	}
+	for i := range template.Spec.Containers {
+		if template.Spec.Containers[i].Name != "agentapi" {
+			continue
+		}
+		template.Spec.Containers[i].Image = generatedMain.Image
+		template.Spec.Containers[i].ImagePullPolicy = generatedMain.ImagePullPolicy
+		template.Spec.Containers[i].WorkingDir = generatedMain.WorkingDir
+		template.Spec.Containers[i].Command = generatedMain.Command
+		template.Spec.Containers[i].Args = generatedMain.Args
+		template.Spec.Containers[i].Ports = generatedMain.Ports
+		template.Spec.Containers[i].LivenessProbe = generatedMain.LivenessProbe
+		template.Spec.Containers[i].ReadinessProbe = generatedMain.ReadinessProbe
+		return
+	}
+	template.Spec.Containers = append([]corev1.Container{*generatedMain}, template.Spec.Containers...)
+}
+
+func findContainerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
 }
 
 // NOTE: The credentialsSyncScript / credentialsSyncSidecarImage / buildCredentialsSyncSidecar

--- a/internal/infrastructure/services/kubernetes_session_manager_pod_template_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_pod_template_test.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+func TestBuildDeploymentMergesSessionPodTemplateFile(t *testing.T) {
+	templateFile := filepath.Join(t.TempDir(), "session-pod-template.yaml")
+	if err := os.WriteFile(templateFile, []byte(`
+metadata:
+  annotations:
+    example.com/template: "enabled"
+  labels:
+    workload-type: agent-session
+spec:
+  serviceAccountName: overridden-service-account
+  restartPolicy: Never
+  priorityClassName: agent-session
+  volumes:
+    - name: extra-config
+      configMap:
+        name: extra-config
+  containers:
+    - name: agentapi
+      command: ["bad-command"]
+      args: ["bad-arg"]
+      env:
+        - name: EXTRA_ENV
+          value: enabled
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "256Mi"
+        limits:
+          cpu: "1500m"
+          memory: "2Gi"
+      volumeMounts:
+        - name: extra-config
+          mountPath: /etc/extra-config
+          readOnly: true
+    - name: observer
+      image: busybox:1.36
+      command: ["sleep", "3600"]
+`), 0o600); err != nil {
+		t.Fatalf("failed to write pod template: %v", err)
+	}
+
+	manager := newPodTemplateTestManager(templateFile)
+	session := newPodTemplateTestSession()
+
+	deployment, err := manager.buildDeployment(context.Background(), session, session.Request())
+	assert.NoError(t, err)
+
+	template := deployment.Spec.Template
+	assert.Equal(t, "enabled", template.Annotations["example.com/template"])
+	assert.Equal(t, "agent-session", template.Labels["workload-type"])
+	assert.Equal(t, "test-session", template.Labels["agentapi.proxy/session-id"])
+	assert.Equal(t, "agentapi-proxy", template.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "agentapi-proxy-session", template.Spec.ServiceAccountName)
+	assert.Equal(t, corev1.RestartPolicyAlways, template.Spec.RestartPolicy)
+	assert.Equal(t, "agent-session", template.Spec.PriorityClassName)
+	assert.Contains(t, volumeNames(template.Spec.Volumes), "extra-config")
+
+	main := template.Spec.Containers[0]
+	assert.Equal(t, "agentapi", main.Name)
+	assert.Equal(t, []string{"agentapi-proxy"}, main.Command)
+	assert.Equal(t, []string{"agent-provisioner"}, main.Args)
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "EXTRA_ENV", Value: "enabled"})
+	assert.Contains(t, main.VolumeMounts, corev1.VolumeMount{Name: "extra-config", MountPath: "/etc/extra-config", ReadOnly: true})
+	assert.Equal(t, resource.MustParse("250m"), main.Resources.Requests[corev1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("1500m"), main.Resources.Limits[corev1.ResourceCPU])
+	assert.Contains(t, containerNames(template.Spec.Containers), "observer")
+}
+
+func TestBuildDeploymentFailsOnInvalidSessionPodTemplateFile(t *testing.T) {
+	templateFile := filepath.Join(t.TempDir(), "session-pod-template.yaml")
+	if err := os.WriteFile(templateFile, []byte("metadata:\n  annotations: ["), 0o600); err != nil {
+		t.Fatalf("failed to write pod template: %v", err)
+	}
+
+	manager := newPodTemplateTestManager(templateFile)
+	session := newPodTemplateTestSession()
+
+	_, err := manager.buildDeployment(context.Background(), session, session.Request())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse session pod template file")
+}
+
+func TestBuildDeploymentIgnoresMissingSessionPodTemplateFile(t *testing.T) {
+	manager := newPodTemplateTestManager(filepath.Join(t.TempDir(), "missing.yaml"))
+	session := newPodTemplateTestSession()
+
+	deployment, err := manager.buildDeployment(context.Background(), session, session.Request())
+	assert.NoError(t, err)
+	assert.Equal(t, "agentapi-proxy-session", deployment.Spec.Template.Spec.ServiceAccountName)
+}
+
+func newPodTemplateTestManager(templateFile string) *KubernetesSessionManager {
+	return &KubernetesSessionManager{
+		config: &config.Config{},
+		k8sConfig: &config.KubernetesSessionConfig{
+			Namespace:              "test-ns",
+			Image:                  "session-image:latest",
+			ImagePullPolicy:        "IfNotPresent",
+			BasePort:               9000,
+			CPURequest:             "100m",
+			CPULimit:               "1",
+			MemoryRequest:          "128Mi",
+			MemoryLimit:            "512Mi",
+			SessionPodTemplateFile: templateFile,
+		},
+		namespace: "test-ns",
+	}
+}
+
+func newPodTemplateTestSession() *KubernetesSession {
+	return NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "test-user"},
+		"agentapi-session-test-session",
+		"agentapi-session-test-session-svc",
+		"agentapi-session-test-session-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+}

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -132,7 +132,8 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 		},
 	}
 
-	deployment := manager.buildDeployment(context.Background(), session, req)
+	deployment, err := manager.buildDeployment(context.Background(), session, req)
+	assert.NoError(t, err)
 	podSpec := deployment.Spec.Template.Spec
 
 	var configInit *corev1.Container
@@ -206,7 +207,8 @@ func TestBuildDeploymentSkipsSciaSidecarWhenAuthProxyDisabled(t *testing.T) {
 		AuthProxy: boolPtr(false),
 	}
 
-	deployment := manager.buildDeployment(context.Background(), session, req)
+	deployment, err := manager.buildDeployment(context.Background(), session, req)
+	assert.NoError(t, err)
 	podSpec := deployment.Spec.Template.Spec
 
 	assert.NotContains(t, containerNames(podSpec.InitContainers), "scia-config")
@@ -230,7 +232,8 @@ func TestBuildDeploymentAddsSciaSidecarWhenAuthProxyEnabled(t *testing.T) {
 		AuthProxy: boolPtr(true),
 	}
 
-	deployment := manager.buildDeployment(context.Background(), session, req)
+	deployment, err := manager.buildDeployment(context.Background(), session, req)
+	assert.NoError(t, err)
 	podSpec := deployment.Spec.Template.Spec
 
 	assert.Contains(t, containerNames(podSpec.InitContainers), "scia-config")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -323,6 +323,8 @@ type KubernetesSessionConfig struct {
 	// ConfigFile is the path to an external configuration file for kubernetes session settings
 	// This file can contain node_selector and tolerations settings
 	ConfigFile string `json:"config_file,omitempty" mapstructure:"config_file"`
+	// SessionPodTemplateFile is the path to a PodTemplateSpec YAML file merged into every session Pod.
+	SessionPodTemplateFile string `json:"session_pod_template_file,omitempty" mapstructure:"session_pod_template_file"`
 	// NodeSelector is a selector which must be true for the pod to fit on a node
 	// Example: {"disktype": "ssd", "kubernetes.io/arch": "amd64"}
 	NodeSelector map[string]string `json:"node_selector,omitempty" mapstructure:"node_selector" yaml:"node_selector"`
@@ -1106,6 +1108,7 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("kubernetes_session.github_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.github_config_secret_name", "AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME")
 	_ = v.BindEnv("kubernetes_session.config_file", "AGENTAPI_K8S_SESSION_CONFIG_FILE")
+	_ = v.BindEnv("kubernetes_session.session_pod_template_file", "AGENTAPI_K8S_SESSION_POD_TEMPLATE_FILE")
 	// MCP servers configuration
 
 	// Settings base secret configuration


### PR DESCRIPTION
## Summary
- Add Helm values support for kubernetesSession.podTemplate and mount it into the proxy as a file
- Add AGENTAPI_K8S_SESSION_POD_TEMPLATE_FILE config and merge the file into generated session PodTemplateSpec with strategic merge patch
- Preserve required session invariants after merge and add tests for merge, missing file, and invalid YAML

## Verification
- mise exec -- go test ./internal/infrastructure/services ./pkg/config
- mise exec -- go test ./internal/... ./pkg/...
- mise exec -- helm lint ./helm/agentapi-proxy
- mise exec -- helm template agentapi-proxy ./helm/agentapi-proxy --set-json 'kubernetesSession.podTemplate={"metadata":{"annotations":{"example.com/template":"enabled"}},"spec":{"priorityClassName":"agent-session"}}'

Note: mise exec -- go test ./... currently fails in existing cmd package tests with signal: interrupt; ./cmd -run TestNonExistent passes and the failure reproduces without touching this change path.