### PR TITLE
Fix scia token broker URL path

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.12.2" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.16.0" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.12.2" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.16.0" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,7 +72,7 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.12.2"
+    tag: "0.16.0"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
@@ -96,7 +96,7 @@ scia:
     - /sync/v9/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.12.2
+    image: ghcr.io/takutakahashi/scia:0.16.0
     configImage: busybox:1.36
     port: 18081
   oauth:

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2778,12 +2778,12 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	b.WriteString("    type: google-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
 	b.WriteString(fmt.Sprintf("      user: %q\n", userNamespace))
-	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, userNamespace, "google", userToken)))
+	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, "google", userToken)))
 	b.WriteString(fmt.Sprintf("  - id: %q\n", todoistCredentialID))
 	b.WriteString("    type: todoist-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
 	b.WriteString(fmt.Sprintf("      user: %q\n", userNamespace))
-	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, userNamespace, "todoist", userToken)))
+	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, "todoist", userToken)))
 	b.WriteString("rules:\n")
 	b.WriteString("  - name: inject-google-oauth-token\n")
 	b.WriteString("    hosts:\n")
@@ -2812,8 +2812,8 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	return b.String()
 }
 
-func sciaTokenBrokerURL(namespace, userNamespace, provider, userToken string) string {
-	brokerURL := fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/%s/token", namespace, url.PathEscape(userNamespace), url.PathEscape(provider))
+func sciaTokenBrokerURL(namespace, provider, userToken string) string {
+	brokerURL := fmt.Sprintf("http://scia-oauth.%s.svc.cluster.local:8081/oauth/%s/token", namespace, url.PathEscape(provider))
 	if userToken == "" {
 		return brokerURL
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2699,7 +2699,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.12.2"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.16.0"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -160,8 +160,8 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 		assert.NotContains(t, script, `secretName: "scia-oauth-takutakahashi"`)
 		assert.NotContains(t, script, `scia-google-oauth`)
 		assert.NotContains(t, script, `clientSecretRef`)
-		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/google/token"`)
-		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/takutakahashi/todoist/token"`)
+		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/google/token"`)
+		assert.Contains(t, script, `token_broker_url: "http://scia-oauth.test-ns.svc.cluster.local:8081/oauth/todoist/token"`)
 		assert.Contains(t, script, `- "takutakahashi.google"`)
 		assert.Contains(t, script, `- "takutakahashi.todoist"`)
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.2",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.16.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -254,7 +254,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.12.2",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.16.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1334,7 +1334,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.12.2")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.16.0")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1419,7 +1419,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.12.2"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.16.0"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"


### PR DESCRIPTION
## Summary
- remove the user namespace segment from generated scia token broker URLs
- update scia OAuth broker and session sidecar image defaults from 0.12.2 to 0.16.0
- update scia sidecar sandbox test expectations

## Testing
- make lint: failed because go is not installed in this environment
- make test: failed because go is not installed in this environment
