### PR TITLE
Use scia 0.17.0

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -278,7 +278,7 @@ spec:
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED
               value: {{ dig "sessionSidecar" "enabled" true $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_IMAGE
-              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.16.0" $scia | quote }}
+              value: {{ dig "sessionSidecar" "image" "ghcr.io/takutakahashi/scia:0.17.0" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_CONFIG_IMAGE
               value: {{ dig "sessionSidecar" "configImage" "busybox:1.36" $scia | quote }}
             - name: AGENTAPI_SCIA_SESSION_SIDECAR_PORT

--- a/helm/agentapi-proxy/templates/scia-deployment.yaml
+++ b/helm/agentapi-proxy/templates/scia-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: {{ include "agentapi-proxy.sciaName" . }}
       containers:
         - name: scia-oauth
-          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.16.0" }}"
+          image: "{{ $image.repository | default "ghcr.io/takutakahashi/scia" }}:{{ $image.tag | default "0.17.0" }}"
           imagePullPolicy: {{ $image.pullPolicy | default "IfNotPresent" }}
           args:
             - -config

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -72,7 +72,7 @@ scia:
   enabled: true
   image:
     repository: ghcr.io/takutakahashi/scia
-    tag: "0.16.0"
+    tag: "0.17.0"
     pullPolicy: IfNotPresent
   replicaCount: 1
   publicBaseUrl: ""
@@ -96,7 +96,7 @@ scia:
     - /sync/v9/*
   sessionSidecar:
     enabled: true
-    image: ghcr.io/takutakahashi/scia:0.16.0
+    image: ghcr.io/takutakahashi/scia:0.17.0
     configImage: busybox:1.36
     port: 18081
   oauth:
@@ -107,54 +107,54 @@ scia:
         name: Google
         setup: {}
         scopes:
-        - id: calendar-read
-          value: "https://www.googleapis.com/auth/calendar.readonly"
-          name: "Google Calendar read-only"
-          desc: "Read Google Calendar events."
-          group: calendar
-          groupName: "Google Calendar"
-          groupDesc: "Choose how much Google Calendar access to grant."
-          enabled: true
-        - id: calendar-write
-          value: "https://www.googleapis.com/auth/calendar"
-          name: "Google Calendar read/write"
-          desc: "Read and write Google Calendar events."
-          group: calendar
-          groupName: "Google Calendar"
-          groupDesc: "Choose how much Google Calendar access to grant."
-          enabled: false
-        - id: tasks-read
-          value: "https://www.googleapis.com/auth/tasks.readonly"
-          name: "Google Tasks read-only"
-          desc: "Read Google Tasks and task lists."
-          group: tasks
-          groupName: "Google Tasks"
-          groupDesc: "Choose how much Google Tasks access to grant."
-          enabled: true
-        - id: tasks-write
-          value: "https://www.googleapis.com/auth/tasks"
-          name: "Google Tasks read/write"
-          desc: "Read and write Google Tasks and task lists."
-          group: tasks
-          groupName: "Google Tasks"
-          groupDesc: "Choose how much Google Tasks access to grant."
-          enabled: false
+          - id: calendar-read
+            value: "https://www.googleapis.com/auth/calendar.readonly"
+            name: "Google Calendar read-only"
+            desc: "Read Google Calendar events."
+            group: calendar
+            groupName: "Google Calendar"
+            groupDesc: "Choose how much Google Calendar access to grant."
+            enabled: true
+          - id: calendar-write
+            value: "https://www.googleapis.com/auth/calendar"
+            name: "Google Calendar read/write"
+            desc: "Read and write Google Calendar events."
+            group: calendar
+            groupName: "Google Calendar"
+            groupDesc: "Choose how much Google Calendar access to grant."
+            enabled: false
+          - id: tasks-read
+            value: "https://www.googleapis.com/auth/tasks.readonly"
+            name: "Google Tasks read-only"
+            desc: "Read Google Tasks and task lists."
+            group: tasks
+            groupName: "Google Tasks"
+            groupDesc: "Choose how much Google Tasks access to grant."
+            enabled: true
+          - id: tasks-write
+            value: "https://www.googleapis.com/auth/tasks"
+            name: "Google Tasks read/write"
+            desc: "Read and write Google Tasks and task lists."
+            group: tasks
+            groupName: "Google Tasks"
+            groupDesc: "Choose how much Google Tasks access to grant."
+            enabled: false
       todoist:
         name: Todoist
         iconUrl: "https://todoist.com/favicon.ico"
         description: "Connect Todoist tasks and projects."
         setup: {}
         scopes:
-        - id: read-write
-          value: "data:read_write"
-          name: "Todoist read/write"
-          desc: "Read and write Todoist tasks and projects."
-          enabled: true
-        - id: task-add
-          value: "task:add"
-          name: "Todoist task add"
-          desc: "Add Todoist tasks without reading existing data."
-          enabled: false
+          - id: read-write
+            value: "data:read_write"
+            name: "Todoist read/write"
+            desc: "Read and write Todoist tasks and projects."
+            enabled: true
+          - id: task-add
+            value: "task:add"
+            name: "Todoist task add"
+            desc: "Add Todoist tasks without reading existing data."
+            enabled: false
     google:
       scope: "https://www.googleapis.com/auth/calendar.readonly"
       # Secret-backed Google OAuth client credentials. Set create=false and

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2699,7 +2699,7 @@ func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunS
 
 	sidecar := corev1.Container{
 		Name:            "scia-proxy",
-		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.16.0"),
+		Image:           defaultIfEmpty(scia.SessionSidecarImage, "ghcr.io/takutakahashi/scia:0.17.0"),
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Args:            []string{"-config", "/etc/scia-config/config.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     true,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.16.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.17.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",
@@ -254,7 +254,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			Scia: config.SciaConfig{
 				Enabled:                   true,
 				SessionSidecarEnabled:     sessionSidecarEnabled,
-				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.16.0",
+				SessionSidecarImage:       "ghcr.io/takutakahashi/scia:0.17.0",
 				SessionSidecarConfigImage: "busybox:1.36",
 				SessionSidecarPort:        18081,
 				Credential:                "takutakahashi.google",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1334,7 +1334,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scia.user_namespace", "")
 	v.SetDefault("scia.no_proxy", "localhost,127.0.0.1,.svc,.cluster.local")
 	v.SetDefault("scia.session_sidecar_enabled", false)
-	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.16.0")
+	v.SetDefault("scia.session_sidecar_image", "ghcr.io/takutakahashi/scia:0.17.0")
 	v.SetDefault("scia.session_sidecar_config_image", "busybox:1.36")
 	v.SetDefault("scia.session_sidecar_port", 18081)
 	v.SetDefault("scia.google_hosts", []string{"www.googleapis.com"})
@@ -1419,7 +1419,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.NoProxy = "localhost,127.0.0.1,.svc,.cluster.local"
 	}
 	if config.Scia.SessionSidecarImage == "" {
-		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.16.0"
+		config.Scia.SessionSidecarImage = "ghcr.io/takutakahashi/scia:0.17.0"
 	}
 	if config.Scia.SessionSidecarConfigImage == "" {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"


### PR DESCRIPTION
## Summary
- Update scia OAuth broker and session sidecar defaults to ghcr.io/takutakahashi/scia:0.17.0
- Keep Kubernetes session manager and config defaults aligned with the Helm chart

## Tests
- go test ./pkg/config ./internal/infrastructure/services

## Context
scia v0.17.0 adds /oauth/google/token and /oauth/todoist/token endpoints required by the session sidecar token_broker_url flow.

Release: https://github.com/takutakahashi/scia/releases/tag/v0.17.0