### PR TITLE
Fix scia selectable provider scopes

### DIFF
--- a/helm/agentapi-proxy/README.md
+++ b/helm/agentapi-proxy/README.md
@@ -95,7 +95,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scia.todoistCredential`                           | Todoist credential ID injected into sessions    | `default.todoist` |
 | `scia.userNamespace`                               | Optional fixed scia user namespace; empty derives it from each agentapi user | `""` |
 | `scia.dynamicUserSecretNamePrefix`                 | Prefix for scia dynamic user token Secrets      | `scia-oauth-` |
-| `scia.oauth.integrations`                          | Service integration display metadata and scopes rendered into scia config with `toYaml` | Google/Todoist defaults |
+| `scia.oauth.google.scopes`                         | Google OAuth scope choices exposed to the frontend and rendered into scia integration metadata | Calendar/Tasks defaults |
+| `scia.oauth.todoist.scopes`                        | Todoist OAuth scope choices exposed to the frontend and rendered into scia integration metadata | Todoist defaults |
 | `scia.oauth.google.secret.create`                  | Create a Kubernetes Secret for Google OAuth     | `false` |
 | `scia.oauth.google.secret.existingSecret`          | Existing Secret containing Google OAuth values  | `""` |
 | `scia.oauth.google.secret.clientIdKey`             | Secret key for the Google OAuth client ID       | `client-id` |
@@ -207,6 +208,15 @@ scia:
   credential: your-user.google
   oauth:
     google:
+      scopes:
+        - id: calendar-read
+          value: https://www.googleapis.com/auth/calendar.readonly
+          name: Google Calendar read-only
+          enabled: true
+        - id: tasks-read
+          value: https://www.googleapis.com/auth/tasks.readonly
+          name: Google Tasks read-only
+          enabled: true
       secret:
         create: false
         existingSecret: scia-google-oauth
@@ -214,7 +224,7 @@ scia:
         clientSecretKey: client-secret
 ```
 
-The `scia-google-oauth` Secret must contain the Google OAuth client ID and client secret. When `ingress.enabled=true`, the chart routes `/oauth` and `/_scia` to the scia OAuth broker on the same host.
+The `scia-google-oauth` Secret must contain the Google OAuth client ID and client secret. `scia.oauth.google.scopes` is rendered into scia integration metadata, and frontends can request a selected subset by posting those scope IDs to `/integrations/{id}/authorization-url`. When `ingress.enabled=true`, the chart routes `/oauth` and `/_scia` to the scia OAuth broker on the same host.
 
 ### With scia Todoist OAuth
 

--- a/helm/agentapi-proxy/templates/scia-configmap.yaml
+++ b/helm/agentapi-proxy/templates/scia-configmap.yaml
@@ -10,7 +10,6 @@
 {{- $googleEnabled := ne $googleCredential "" }}
 {{- $todoist := $oauth.todoist | default dict }}
 {{- $todoistEnabled := $todoist.enabled | default false }}
-{{- $integrationValues := $oauth.integrations | default dict }}
 {{- $dynamicUserSecretNamePrefix := $scia.dynamicUserSecretNamePrefix | default "scia-oauth-" }}
 {{- $sciaPublicBaseURL := $scia.publicBaseUrl | default "" }}
 {{- $sciaHost := .Values.config.hostname | default "" }}
@@ -35,11 +34,37 @@
   {{- $todoistRedirectURL = "" }}
 {{- end }}
 {{- $integrations := dict }}
-{{- if and $googleEnabled (hasKey $integrationValues "google") }}
-  {{- $_ := set $integrations "google" (deepCopy (get $integrationValues "google")) }}
+{{- if $googleEnabled }}
+  {{- $googleIntegration := dict "name" ($google.name | default "Google") "setup" ($google.setup | default dict) }}
+  {{- with $google.iconUrl }}
+    {{- $_ := set $googleIntegration "iconUrl" . }}
+  {{- end }}
+  {{- with $google.description }}
+    {{- $_ := set $googleIntegration "description" . }}
+  {{- end }}
+  {{- if hasKey $google "released" }}
+    {{- $_ := set $googleIntegration "released" $google.released }}
+  {{- end }}
+  {{- with $google.scopes }}
+    {{- $_ := set $googleIntegration "scopes" . }}
+  {{- end }}
+  {{- $_ := set $integrations "google" $googleIntegration }}
 {{- end }}
-{{- if and $todoistEnabled (hasKey $integrationValues "todoist") }}
-  {{- $_ := set $integrations "todoist" (deepCopy (get $integrationValues "todoist")) }}
+{{- if $todoistEnabled }}
+  {{- $todoistIntegration := dict "name" ($todoist.name | default "Todoist") "setup" ($todoist.setup | default dict) }}
+  {{- with ($todoist.iconUrl | default "https://todoist.com/favicon.ico") }}
+    {{- $_ := set $todoistIntegration "iconUrl" . }}
+  {{- end }}
+  {{- with $todoist.description }}
+    {{- $_ := set $todoistIntegration "description" . }}
+  {{- end }}
+  {{- if hasKey $todoist "released" }}
+    {{- $_ := set $todoistIntegration "released" $todoist.released }}
+  {{- end }}
+  {{- with $todoist.scopes }}
+    {{- $_ := set $todoistIntegration "scopes" . }}
+  {{- end }}
+  {{- $_ := set $integrations "todoist" $todoistIntegration }}
 {{- end }}
 apiVersion: v1
 kind: ConfigMap

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -102,61 +102,43 @@ scia:
   oauth:
     listen: "0.0.0.0:8081"
     redirectUrl: ""
-    integrations:
-      google:
-        name: Google
-        setup: {}
-        scopes:
-          - id: calendar-read
-            value: "https://www.googleapis.com/auth/calendar.readonly"
-            name: "Google Calendar read-only"
-            desc: "Read Google Calendar events."
-            group: calendar
-            groupName: "Google Calendar"
-            groupDesc: "Choose how much Google Calendar access to grant."
-            enabled: true
-          - id: calendar-write
-            value: "https://www.googleapis.com/auth/calendar"
-            name: "Google Calendar read/write"
-            desc: "Read and write Google Calendar events."
-            group: calendar
-            groupName: "Google Calendar"
-            groupDesc: "Choose how much Google Calendar access to grant."
-            enabled: false
-          - id: tasks-read
-            value: "https://www.googleapis.com/auth/tasks.readonly"
-            name: "Google Tasks read-only"
-            desc: "Read Google Tasks and task lists."
-            group: tasks
-            groupName: "Google Tasks"
-            groupDesc: "Choose how much Google Tasks access to grant."
-            enabled: true
-          - id: tasks-write
-            value: "https://www.googleapis.com/auth/tasks"
-            name: "Google Tasks read/write"
-            desc: "Read and write Google Tasks and task lists."
-            group: tasks
-            groupName: "Google Tasks"
-            groupDesc: "Choose how much Google Tasks access to grant."
-            enabled: false
-      todoist:
-        name: Todoist
-        iconUrl: "https://todoist.com/favicon.ico"
-        description: "Connect Todoist tasks and projects."
-        setup: {}
-        scopes:
-          - id: read-write
-            value: "data:read_write"
-            name: "Todoist read/write"
-            desc: "Read and write Todoist tasks and projects."
-            enabled: true
-          - id: task-add
-            value: "task:add"
-            name: "Todoist task add"
-            desc: "Add Todoist tasks without reading existing data."
-            enabled: false
     google:
       scope: "https://www.googleapis.com/auth/calendar.readonly"
+      name: Google
+      setup: {}
+      scopes:
+        - id: calendar-read
+          value: "https://www.googleapis.com/auth/calendar.readonly"
+          name: "Google Calendar read-only"
+          desc: "Read Google Calendar events."
+          group: calendar
+          groupName: "Google Calendar"
+          groupDesc: "Choose how much Google Calendar access to grant."
+          enabled: true
+        - id: calendar-write
+          value: "https://www.googleapis.com/auth/calendar"
+          name: "Google Calendar read/write"
+          desc: "Read and write Google Calendar events."
+          group: calendar
+          groupName: "Google Calendar"
+          groupDesc: "Choose how much Google Calendar access to grant."
+          enabled: false
+        - id: tasks-read
+          value: "https://www.googleapis.com/auth/tasks.readonly"
+          name: "Google Tasks read-only"
+          desc: "Read Google Tasks and task lists."
+          group: tasks
+          groupName: "Google Tasks"
+          groupDesc: "Choose how much Google Tasks access to grant."
+          enabled: true
+        - id: tasks-write
+          value: "https://www.googleapis.com/auth/tasks"
+          name: "Google Tasks read/write"
+          desc: "Read and write Google Tasks and task lists."
+          group: tasks
+          groupName: "Google Tasks"
+          groupDesc: "Choose how much Google Tasks access to grant."
+          enabled: false
       # Secret-backed Google OAuth client credentials. Set create=false and
       # existingSecret to use a Secret managed outside Helm.
       secret:
@@ -169,6 +151,21 @@ scia:
     todoist:
       enabled: false
       scope: "data:read_write"
+      name: Todoist
+      iconUrl: "https://todoist.com/favicon.ico"
+      description: "Connect Todoist tasks and projects."
+      setup: {}
+      scopes:
+        - id: read-write
+          value: "data:read_write"
+          name: "Todoist read/write"
+          desc: "Read and write Todoist tasks and projects."
+          enabled: true
+        - id: task-add
+          value: "task:add"
+          name: "Todoist task add"
+          desc: "Add Todoist tasks without reading existing data."
+          enabled: false
       omitRedirectUrl: false
       secret:
         create: true

--- a/internal/interfaces/controllers/google_oauth_controller.go
+++ b/internal/interfaces/controllers/google_oauth_controller.go
@@ -81,6 +81,7 @@ type IntegrationsResponse struct {
 type IntegrationAuthorizationURLRequest struct {
 	RedirectURI string   `json:"redirect_uri"`
 	ScopeIDs    []string `json:"scope_ids"`
+	Scope       string   `json:"scope,omitempty"`
 	State       string   `json:"state,omitempty"`
 }
 
@@ -311,7 +312,7 @@ func (c *GoogleOAuthController) createSciaAuthorizationURL(ctx context.Context, 
 	}
 
 	path := fmt.Sprintf("/oauth/%s/%s/authorization-url", url.PathEscape(integration.Namespace), url.PathEscape(integration.Provider))
-	payload, err := json.Marshal(input)
+	payload, err := json.Marshal(input.sciaRequest())
 	if err != nil {
 		return IntegrationAuthorizationURLResponse{}, err
 	}
@@ -363,6 +364,9 @@ func (c *GoogleOAuthController) createSciaStartAuthorizationURL(ctx context.Cont
 	if input.State != "" {
 		values.Set("state", input.State)
 	}
+	if scope := input.requestedScope(); scope != "" {
+		values.Set("scope", scope)
+	}
 	if userToken != "" {
 		values.Set("user_token", userToken)
 	}
@@ -398,6 +402,27 @@ func (c *GoogleOAuthController) createSciaStartAuthorizationURL(ctx context.Cont
 		AuthorizationURL: location,
 		RedirectURI:      input.RedirectURI,
 	}, nil
+}
+
+type sciaAuthorizationURLRequest struct {
+	RedirectURI string `json:"redirect_uri,omitempty"`
+	Scope       string `json:"scope,omitempty"`
+	State       string `json:"state,omitempty"`
+}
+
+func (r IntegrationAuthorizationURLRequest) sciaRequest() sciaAuthorizationURLRequest {
+	return sciaAuthorizationURLRequest{
+		RedirectURI: r.RedirectURI,
+		Scope:       r.requestedScope(),
+		State:       r.State,
+	}
+}
+
+func (r IntegrationAuthorizationURLRequest) requestedScope() string {
+	if r.Scope != "" {
+		return r.Scope
+	}
+	return strings.Join(r.ScopeIDs, " ")
 }
 
 func (c *GoogleOAuthController) revokeSciaIntegration(ctx context.Context, integration FrontendIntegration, userToken string) (IntegrationRevokeResponse, error) {

--- a/internal/interfaces/controllers/google_oauth_controller_test.go
+++ b/internal/interfaces/controllers/google_oauth_controller_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
-	var gotScopeIDs []string
+	var gotScope string
 	var gotUserToken string
 	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -43,11 +43,11 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 				t.Fatalf("method = %s, want POST", r.Method)
 			}
 			gotUserToken = r.Header.Get("X-Scia-User-Token")
-			var req IntegrationAuthorizationURLRequest
+			var req sciaAuthorizationURLRequest
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Fatal(err)
 			}
-			gotScopeIDs = req.ScopeIDs
+			gotScope = req.Scope
 			if req.RedirectURI != "https://app.example.com/api/oauth/google/callback" {
 				t.Fatalf("redirect_uri = %q", req.RedirectURI)
 			}
@@ -84,8 +84,8 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
 	}
-	if strings.Join(gotScopeIDs, ",") != "calendar-write,tasks-write" {
-		t.Fatalf("scope_ids = %#v", gotScopeIDs)
+	if gotScope != "calendar-write tasks-write" {
+		t.Fatalf("scope = %q", gotScope)
 	}
 	if gotUserToken != "ap-user-token" {
 		t.Fatalf("X-Scia-User-Token = %q", gotUserToken)
@@ -96,6 +96,70 @@ func TestCreateAuthorizationURLProxiesScopeIDsToScia(t *testing.T) {
 	}
 	if body.AuthorizationURL != "https://accounts.google.com/o/oauth2/v2/auth?scope=calendar" {
 		t.Fatalf("authorization_url = %q", body.AuthorizationURL)
+	}
+}
+
+func TestCreateAuthorizationURLAddsScopeIDsToFallbackStartURL(t *testing.T) {
+	var gotScope string
+	var gotUserToken string
+	scia := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/integrations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"integrations": []map[string]any{
+					{
+						"id":            "takutakahashi.google",
+						"provider":      "google",
+						"namespace":     "takutakahashi",
+						"credential_id": "takutakahashi.google",
+						"name":          "Google",
+						"released":      true,
+						"start_url":     "/oauth/google/start",
+						"scopes":        []map[string]any{},
+					},
+				},
+			})
+		case "/oauth/google/start":
+			if r.Method != http.MethodGet {
+				t.Fatalf("method = %s, want GET", r.Method)
+			}
+			gotScope = r.URL.Query().Get("scope")
+			gotUserToken = r.URL.Query().Get("user_token")
+			http.Redirect(w, r, "https://accounts.google.com/o/oauth2/v2/auth?scope=drive", http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer scia.Close()
+
+	controller := NewGoogleOAuthController(config.SciaConfig{
+		Enabled:          true,
+		OAuthInternalURL: scia.URL,
+	}, nil, "").WithPersonalAPIKeyRepository(&fakeGoogleOAuthPersonalAPIKeyRepo{
+		keys: map[entities.UserID]string{"takutakahashi": "ap-user-token"},
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/integrations/takutakahashi.google/authorization-url", strings.NewReader(`{"scope_ids":["drive-read","gmail-read"],"redirect_uri":"https://app.example.com/oauth/google/callback"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("id")
+	ctx.SetParamValues("takutakahashi.google")
+	ctx.Set("internal_user", entities.NewUser("takutakahashi", entities.UserTypeRegular, "takutakahashi"))
+
+	if err := controller.CreateAuthorizationURL(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotScope != "drive-read gmail-read" {
+		t.Fatalf("scope = %q", gotScope)
+	}
+	if gotUserToken != "ap-user-token" {
+		t.Fatalf("user_token = %q", gotUserToken)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Render scia frontend integration metadata from provider-level OAuth scope settings
- Move default Google and Todoist selectable scopes under scia.oauth.<provider>.scopes
- Document that frontends should post selected scope IDs to /integrations/{id}/authorization-url

## Tests
- git diff --check
- Not run: go test ./internal/interfaces/controllers ./pkg/config (go is not installed in this environment)
- Not run: helm template (helm is not installed in this environment)