### PR TITLE
Limit ACP bridge /messages response

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -37,6 +37,8 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
+const messagesHistoryLimit = 20
+
 // sessionUpdateParams is the params envelope for a session/update notification.
 type sessionUpdateParams struct {
 	SessionId string            `json:"sessionId"`
@@ -167,13 +169,17 @@ func (b *Bridge) appendToOutputFile(text string) {
 	}
 }
 
-// Messages returns a snapshot of all broadcasted JSON-RPC messages since the
-// bridge started.  Callers can use this to replay history for reconnecting clients.
+// Messages returns a snapshot of the most recent broadcasted JSON-RPC messages.
+// This keeps GET /messages bounded even when tool output makes the full history large.
 func (b *Bridge) Messages() []json.RawMessage {
 	b.histMu.RLock()
 	defer b.histMu.RUnlock()
-	out := make([]json.RawMessage, len(b.history))
-	copy(out, b.history)
+	start := len(b.history) - messagesHistoryLimit
+	if start < 0 {
+		start = 0
+	}
+	out := make([]json.RawMessage, len(b.history)-start)
+	copy(out, b.history[start:])
 	return out
 }
 

--- a/pkg/acp/bridge/bridge_test.go
+++ b/pkg/acp/bridge/bridge_test.go
@@ -1,0 +1,53 @@
+package bridge
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMessagesReturnsMostRecentTwentyMessages(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+
+	for i := 0; i < 25; i++ {
+		b.broadcast(jsonRPCMsg{
+			JSONRPC: "2.0",
+			Method:  "session/update",
+			Params:  map[string]int{"index": i},
+		})
+	}
+
+	msgs := b.Messages()
+	if len(msgs) != messagesHistoryLimit {
+		t.Fatalf("expected %d messages, got %d", messagesHistoryLimit, len(msgs))
+	}
+
+	for i, msg := range msgs {
+		var got struct {
+			Params map[string]int `json:"params"`
+		}
+		if err := json.Unmarshal(msg, &got); err != nil {
+			t.Fatalf("failed to unmarshal message %d: %v", i, err)
+		}
+		want := i + 5
+		if got.Params["index"] != want {
+			t.Fatalf("message %d index = %d, want %d", i, got.Params["index"], want)
+		}
+	}
+}
+
+func TestMessagesReturnsAllMessagesWhenHistoryIsUnderLimit(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+
+	for i := 0; i < 3; i++ {
+		b.broadcast(jsonRPCMsg{
+			JSONRPC: "2.0",
+			Method:  "session/update",
+			Params:  map[string]int{"index": i},
+		})
+	}
+
+	msgs := b.Messages()
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+}

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -59,9 +59,8 @@ func (s *Server) registerRoutes() {
 	// that existing tooling can parse it without changes.
 	s.echo.GET("/status", s.handleStatus)
 	s.echo.GET("/session", s.handleGetSession)
-	// /messages returns the full in-memory message history as a JSON array of
-	// raw JSON-RPC 2.0 objects.  Reconnecting clients use this to replay events
-	// they missed while disconnected from the SSE stream.
+	// /messages returns the most recent in-memory message history as a JSON array
+	// of raw JSON-RPC 2.0 objects.
 	s.echo.GET("/messages", s.handleGetMessages)
 	s.echo.POST("/rpc", s.handleRPC)
 	s.echo.GET("/sse", s.handleSSE)
@@ -116,7 +115,7 @@ func (s *Server) handleStatus(c echo.Context) error {
 }
 
 // GET /messages
-// Returns all JSON-RPC 2.0 messages that have been broadcast since the bridge started.
+// Returns the most recent JSON-RPC 2.0 messages that have been broadcast.
 // The response is a JSON object with a "messages" array so the client can distinguish
 // an empty history ({"messages":[]}) from an error.
 func (s *Server) handleGetMessages(c echo.Context) error {


### PR DESCRIPTION
## Summary
- limit ACP bridge GET /messages snapshots to the latest 20 JSON-RPC messages
- keep the full internal history for SSE resume behavior
- add bridge tests for capped and under-limit history

## Test
- mise exec -- go test ./pkg/acp/...