### PR TITLE
Return ACP messages since last user prompt

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -37,8 +37,6 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
-const messagesHistoryLimit = 20
-
 // sessionUpdateParams is the params envelope for a session/update notification.
 type sessionUpdateParams struct {
 	SessionId string            `json:"sessionId"`
@@ -74,8 +72,9 @@ type Bridge struct {
 
 	// Message history: every broadcast message is appended so that reconnecting
 	// SSE clients can replay missed events via GET /messages.
-	histMu  sync.RWMutex
-	history []json.RawMessage
+	histMu             sync.RWMutex
+	history            []json.RawMessage
+	lastUserMessageIdx int
 
 	// Agent-initiated RPCs (e.g. session/request_permission):
 	// We assign local sequential ids, emit them via SSE, and await replies on POST /rpc.
@@ -111,13 +110,14 @@ type statusSubscriber struct {
 // broadcasting them to the UI (equivalent to always selecting the first option).
 func New(client *acp.Client, sessionId string, verbose bool, outputFile string, autoApprove bool) *Bridge {
 	return &Bridge{
-		acp:            client,
-		sessionId:      sessionId,
-		verbose:        verbose,
-		autoApprove:    autoApprove,
-		outputFile:     outputFile,
-		pendingReplies: make(map[int64]chan json.RawMessage),
-		currentStatus:  "stable",
+		acp:                client,
+		sessionId:          sessionId,
+		verbose:            verbose,
+		autoApprove:        autoApprove,
+		outputFile:         outputFile,
+		pendingReplies:     make(map[int64]chan json.RawMessage),
+		currentStatus:      "stable",
+		lastUserMessageIdx: -1,
 	}
 }
 
@@ -169,12 +169,13 @@ func (b *Bridge) appendToOutputFile(text string) {
 	}
 }
 
-// Messages returns a snapshot of the most recent broadcasted JSON-RPC messages.
-// This keeps GET /messages bounded even when tool output makes the full history large.
+// Messages returns a snapshot of broadcasted JSON-RPC messages from the last
+// user message onward. This keeps GET /messages focused on the current turn,
+// including large tool output produced after the user's most recent prompt.
 func (b *Bridge) Messages() []json.RawMessage {
 	b.histMu.RLock()
 	defer b.histMu.RUnlock()
-	start := len(b.history) - messagesHistoryLimit
+	start := b.lastUserMessageIdx
 	if start < 0 {
 		start = 0
 	}
@@ -603,6 +604,9 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 
 	// Persist to history inside subsMu so SubscribeFrom sees a consistent snapshot.
 	b.histMu.Lock()
+	if isUserMessageUpdate(msg) {
+		b.lastUserMessageIdx = len(b.history)
+	}
 	b.history = append(b.history, raw)
 	b.histMu.Unlock()
 
@@ -612,5 +616,19 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 		default:
 			// Slow subscriber – drop the message rather than blocking.
 		}
+	}
+}
+
+func isUserMessageUpdate(msg jsonRPCMsg) bool {
+	if msg.Method != "session/update" {
+		return false
+	}
+	switch params := msg.Params.(type) {
+	case sessionUpdateParams:
+		return params.Update.Kind == acp.SessionUpdateKindUserMessageChunk
+	case *sessionUpdateParams:
+		return params != nil && params.Update.Kind == acp.SessionUpdateKindUserMessageChunk
+	default:
+		return false
 	}
 }

--- a/pkg/acp/bridge/bridge_test.go
+++ b/pkg/acp/bridge/bridge_test.go
@@ -3,51 +3,87 @@ package bridge
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
 )
 
-func TestMessagesReturnsMostRecentTwentyMessages(t *testing.T) {
+func TestMessagesReturnsMessagesSinceLastUserMessage(t *testing.T) {
 	b := New(nil, "session-1", false, "", false)
 
-	for i := 0; i < 25; i++ {
-		b.broadcast(jsonRPCMsg{
-			JSONRPC: "2.0",
-			Method:  "session/update",
-			Params:  map[string]int{"index": i},
-		})
-	}
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindUserMessageChunk, 0))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindAgentMessageChunk, 1))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindToolCall, 2))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindUserMessageChunk, 3))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindToolCall, 4))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindToolCallUpdate, 5))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindAgentMessageChunk, 6))
 
 	msgs := b.Messages()
-	if len(msgs) != messagesHistoryLimit {
-		t.Fatalf("expected %d messages, got %d", messagesHistoryLimit, len(msgs))
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(msgs))
 	}
 
 	for i, msg := range msgs {
-		var got struct {
-			Params map[string]int `json:"params"`
-		}
-		if err := json.Unmarshal(msg, &got); err != nil {
-			t.Fatalf("failed to unmarshal message %d: %v", i, err)
-		}
-		want := i + 5
-		if got.Params["index"] != want {
-			t.Fatalf("message %d index = %d, want %d", i, got.Params["index"], want)
+		want := i + 3
+		if got := messageIndex(t, msg); got != want {
+			t.Fatalf("message %d index = %d, want %d", i, got, want)
 		}
 	}
 }
 
-func TestMessagesReturnsAllMessagesWhenHistoryIsUnderLimit(t *testing.T) {
+func TestMessagesReturnsAllMessagesWhenNoUserMessageExists(t *testing.T) {
 	b := New(nil, "session-1", false, "", false)
 
 	for i := 0; i < 3; i++ {
-		b.broadcast(jsonRPCMsg{
-			JSONRPC: "2.0",
-			Method:  "session/update",
-			Params:  map[string]int{"index": i},
-		})
+		b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindToolCall, i))
 	}
 
 	msgs := b.Messages()
 	if len(msgs) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(msgs))
 	}
+}
+
+func testIndexedUpdate(t *testing.T, kind acp.SessionUpdateKind, index int) jsonRPCMsg {
+	t.Helper()
+	content, err := json.Marshal(map[string]interface{}{
+		"type":  "text",
+		"text":  "message",
+		"index": index,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal content: %v", err)
+	}
+	return jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: "session-1",
+			Update: acp.SessionUpdate{
+				Kind:    kind,
+				Content: content,
+			},
+		},
+	}
+}
+
+func messageIndex(t *testing.T, msg json.RawMessage) int {
+	t.Helper()
+	var got struct {
+		Params struct {
+			Update struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"update"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(msg, &got); err != nil {
+		t.Fatalf("failed to unmarshal message: %v", err)
+	}
+	var content struct {
+		Index int `json:"index"`
+	}
+	if err := json.Unmarshal(got.Params.Update.Content, &content); err != nil {
+		t.Fatalf("failed to unmarshal content: %v", err)
+	}
+	return content.Index
 }


### PR DESCRIPTION
## Summary
- change ACP bridge message history to return messages from the latest user message onward instead of the last 20 entries
- track the latest user message index when broadcasting session/update events
- update bridge tests for the new message-history boundary

## Testing
- `git diff --check`
- Not run: `go test ./pkg/acp/bridge` (`go` and `gofmt` are not installed in this container)