### PR TITLE
Add user prompt index support to ACP GET /messages

### DIFF
--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -40,7 +40,7 @@ The HTTP interface is compatible with coder/agentapi.
 Endpoints exposed:
   GET  /health    - health check
   GET  /status    - agent status (running|stable)
-  GET  /messages  - conversation history
+  GET  /messages  - conversation history (optional ?userPromptIndex=N for turn-based retrieval)
   POST /message   - send a user message
   GET  /events    - SSE event stream (message_update, status_change, agent_error)
   GET  /action    - list pending actions (permission requests, plan approvals)

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -75,6 +75,7 @@ type Bridge struct {
 	histMu             sync.RWMutex
 	history            []json.RawMessage
 	lastUserMessageIdx int
+	userMessageIndices []int // history indices of each user_message_chunk
 
 	// Agent-initiated RPCs (e.g. session/request_permission):
 	// We assign local sequential ids, emit them via SSE, and await replies on POST /rpc.
@@ -169,19 +170,119 @@ func (b *Bridge) appendToOutputFile(text string) {
 	}
 }
 
+// UserPromptInfo describes one user prompt turn for GET /messages metadata.
+type UserPromptInfo struct {
+	Index   int    `json:"index"`
+	Preview string `json:"preview,omitempty"`
+}
+
 // Messages returns a snapshot of broadcasted JSON-RPC messages from the last
 // user message onward. This keeps GET /messages focused on the current turn,
 // including large tool output produced after the user's most recent prompt.
 func (b *Bridge) Messages() []json.RawMessage {
 	b.histMu.RLock()
 	defer b.histMu.RUnlock()
-	start := b.lastUserMessageIdx
+	return b.messagesFromIndexLocked(b.lastUserMessageIdx)
+}
+
+// UserPromptCount returns the number of user prompts recorded in history.
+func (b *Bridge) UserPromptCount() int {
+	b.histMu.RLock()
+	defer b.histMu.RUnlock()
+	return len(b.userMessageIndices)
+}
+
+// LatestUserPromptIndex returns the index of the most recent user prompt, or -1
+// when no user prompt exists yet.
+func (b *Bridge) LatestUserPromptIndex() int {
+	b.histMu.RLock()
+	defer b.histMu.RUnlock()
+	return len(b.userMessageIndices) - 1
+}
+
+// MessagesForUserPromptIndex returns messages from the given user prompt index
+// up to (but not including) the next user prompt, or the end of history when
+// index is the latest prompt.
+func (b *Bridge) MessagesForUserPromptIndex(index int) ([]json.RawMessage, bool) {
+	b.histMu.RLock()
+	defer b.histMu.RUnlock()
+	start, end, ok := b.userPromptRangeLocked(index)
+	if !ok {
+		return nil, false
+	}
+	out := make([]json.RawMessage, end-start)
+	copy(out, b.history[start:end])
+	return out, true
+}
+
+// UserPromptInfos returns metadata for every user prompt in conversation order.
+func (b *Bridge) UserPromptInfos() []UserPromptInfo {
+	b.histMu.RLock()
+	defer b.histMu.RUnlock()
+
+	infos := make([]UserPromptInfo, len(b.userMessageIndices))
+	for i, histIdx := range b.userMessageIndices {
+		infos[i] = UserPromptInfo{
+			Index:   i,
+			Preview: userPromptPreviewFromRawLocked(b.history[histIdx]),
+		}
+	}
+	return infos
+}
+
+func (b *Bridge) messagesFromIndexLocked(start int) []json.RawMessage {
 	if start < 0 {
 		start = 0
+	}
+	if start >= len(b.history) {
+		return []json.RawMessage{}
 	}
 	out := make([]json.RawMessage, len(b.history)-start)
 	copy(out, b.history[start:])
 	return out
+}
+
+func (b *Bridge) userPromptRangeLocked(index int) (start, end int, ok bool) {
+	if index < 0 || index >= len(b.userMessageIndices) {
+		return 0, 0, false
+	}
+	start = b.userMessageIndices[index]
+	if index+1 < len(b.userMessageIndices) {
+		end = b.userMessageIndices[index+1]
+	} else {
+		end = len(b.history)
+	}
+	return start, end, true
+}
+
+const userPromptPreviewMaxLen = 80
+
+func userPromptPreviewFromRawLocked(raw json.RawMessage) string {
+	var envelope struct {
+		Params struct {
+			Update struct {
+				Content json.RawMessage `json:"content"`
+			} `json:"update"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return ""
+	}
+	var content struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(envelope.Params.Update.Content, &content); err != nil {
+		return ""
+	}
+	text := strings.TrimSpace(content.Text)
+	if text == "" {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= userPromptPreviewMaxLen {
+		return text
+	}
+	return string(runes[:userPromptPreviewMaxLen]) + "…"
 }
 
 // SessionID returns the ACP session ID.
@@ -606,6 +707,7 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 	b.histMu.Lock()
 	if isUserMessageUpdate(msg) {
 		b.lastUserMessageIdx = len(b.history)
+		b.userMessageIndices = append(b.userMessageIndices, len(b.history))
 	}
 	b.history = append(b.history, raw)
 	b.histMu.Unlock()

--- a/pkg/acp/bridge/bridge_test.go
+++ b/pkg/acp/bridge/bridge_test.go
@@ -2,8 +2,12 @@ package bridge
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
 )
 
@@ -31,6 +35,119 @@ func TestMessagesReturnsMessagesSinceLastUserMessage(t *testing.T) {
 	}
 }
 
+func TestMessagesForUserPromptIndexReturnsTurnSlice(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+
+	b.broadcast(userPromptUpdate(t, "first prompt"))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindAgentMessageChunk, 1))
+	b.broadcast(userPromptUpdate(t, "second prompt"))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindToolCall, 3))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindAgentMessageChunk, 4))
+
+	if got := b.UserPromptCount(); got != 2 {
+		t.Fatalf("UserPromptCount = %d, want 2", got)
+	}
+
+	turn0, ok := b.MessagesForUserPromptIndex(0)
+	if !ok {
+		t.Fatal("expected turn 0 to exist")
+	}
+	if len(turn0) != 2 {
+		t.Fatalf("turn 0 length = %d, want 2", len(turn0))
+	}
+
+	turn1, ok := b.MessagesForUserPromptIndex(1)
+	if !ok {
+		t.Fatal("expected turn 1 to exist")
+	}
+	if len(turn1) != 3 {
+		t.Fatalf("turn 1 length = %d, want 3", len(turn1))
+	}
+
+	if _, ok := b.MessagesForUserPromptIndex(2); ok {
+		t.Fatal("expected turn 2 to be out of range")
+	}
+}
+
+func TestUserPromptInfosIncludePreview(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+	b.broadcast(userPromptUpdate(t, "hello from user"))
+
+	infos := b.UserPromptInfos()
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 user prompt info, got %d", len(infos))
+	}
+	if infos[0].Index != 0 {
+		t.Fatalf("index = %d, want 0", infos[0].Index)
+	}
+	if infos[0].Preview != "hello from user" {
+		t.Fatalf("preview = %q, want %q", infos[0].Preview, "hello from user")
+	}
+}
+
+func TestHandleGetMessagesUserPromptIndex(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+	b.broadcast(userPromptUpdate(t, "turn one"))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindAgentMessageChunk, 1))
+	b.broadcast(userPromptUpdate(t, "turn two"))
+	b.broadcast(testIndexedUpdate(t, acp.SessionUpdateKindAgentMessageChunk, 3))
+
+	srv := NewServer(b, false)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/messages?userPromptIndex=0", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/messages")
+
+	if err := srv.handleGetMessages(c); err != nil {
+		t.Fatalf("handleGetMessages returned error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Messages        []json.RawMessage `json:"messages"`
+		UserPromptCount int               `json:"userPromptCount"`
+		UserPromptIndex int               `json:"userPromptIndex"`
+		UserPrompts     []UserPromptInfo  `json:"userPrompts"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Messages) != 2 {
+		t.Fatalf("messages length = %d, want 2", len(resp.Messages))
+	}
+	if resp.UserPromptCount != 2 {
+		t.Fatalf("userPromptCount = %d, want 2", resp.UserPromptCount)
+	}
+	if resp.UserPromptIndex != 0 {
+		t.Fatalf("userPromptIndex = %d, want 0", resp.UserPromptIndex)
+	}
+	if len(resp.UserPrompts) != 2 {
+		t.Fatalf("userPrompts length = %d, want 2", len(resp.UserPrompts))
+	}
+}
+
+func TestHandleGetMessagesInvalidUserPromptIndex(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+	srv := NewServer(b, false)
+	e := echo.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/messages?userPromptIndex=abc", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/messages")
+
+	if err := srv.handleGetMessages(c); err != nil {
+		t.Fatalf("handleGetMessages returned error: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
 func TestMessagesReturnsAllMessagesWhenNoUserMessageExists(t *testing.T) {
 	b := New(nil, "session-1", false, "", false)
 
@@ -41,6 +158,28 @@ func TestMessagesReturnsAllMessagesWhenNoUserMessageExists(t *testing.T) {
 	msgs := b.Messages()
 	if len(msgs) != 3 {
 		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+}
+
+func userPromptUpdate(t *testing.T, text string) jsonRPCMsg {
+	t.Helper()
+	content, err := json.Marshal(map[string]interface{}{
+		"type": "text",
+		"text": text,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal content: %v", err)
+	}
+	return jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: "session-1",
+			Update: acp.SessionUpdate{
+				Kind:    acp.SessionUpdateKindUserMessageChunk,
+				Content: content,
+			},
+		},
 	}
 }
 
@@ -86,4 +225,24 @@ func messageIndex(t *testing.T, msg json.RawMessage) int {
 		t.Fatalf("failed to unmarshal content: %v", err)
 	}
 	return content.Index
+}
+
+func TestUserPromptPreviewTruncation(t *testing.T) {
+	longText := strings.Repeat("あ", userPromptPreviewMaxLen+10)
+	preview := userPromptPreviewFromRawLocked(mustMarshalUserPrompt(t, longText))
+	if len([]rune(preview)) != userPromptPreviewMaxLen+1 {
+		t.Fatalf("preview rune length = %d, want %d", len([]rune(preview)), userPromptPreviewMaxLen+1)
+	}
+	if !strings.HasSuffix(preview, "…") {
+		t.Fatalf("preview should be truncated with ellipsis: %q", preview)
+	}
+}
+
+func mustMarshalUserPrompt(t *testing.T, text string) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(userPromptUpdate(t, text))
+	if err != nil {
+		t.Fatalf("failed to marshal user prompt: %v", err)
+	}
+	return raw
 }

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -115,15 +115,56 @@ func (s *Server) handleStatus(c echo.Context) error {
 }
 
 // GET /messages
-// Returns the most recent JSON-RPC 2.0 messages that have been broadcast.
-// The response is a JSON object with a "messages" array so the client can distinguish
-// an empty history ({"messages":[]}) from an error.
+// Returns JSON-RPC 2.0 messages for a user prompt turn.
+//
+// Query parameters:
+//   - userPromptIndex (optional int): zero-based user prompt index. When omitted,
+//     returns messages from the latest user prompt onward (current turn).
+//
+// The response includes userPromptCount and userPrompts metadata so clients can
+// build turn navigation UI.
 func (s *Server) handleGetMessages(c echo.Context) error {
-	msgs := s.bridge.Messages()
+	indexParam := c.QueryParam("userPromptIndex")
+	userPromptCount := s.bridge.UserPromptCount()
+	userPrompts := s.bridge.UserPromptInfos()
+
+	var (
+		msgs            []json.RawMessage
+		userPromptIndex int
+	)
+	if indexParam == "" {
+		msgs = s.bridge.Messages()
+		userPromptIndex = s.bridge.LatestUserPromptIndex()
+	} else {
+		index, err := strconv.Atoi(indexParam)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"error": "userPromptIndex must be an integer",
+			})
+		}
+		var ok bool
+		msgs, ok = s.bridge.MessagesForUserPromptIndex(index)
+		if !ok {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"error": fmt.Sprintf("userPromptIndex %d is out of range (count=%d)", index, userPromptCount),
+			})
+		}
+		userPromptIndex = index
+	}
+
 	if msgs == nil {
 		msgs = []json.RawMessage{}
 	}
-	return c.JSON(http.StatusOK, map[string]interface{}{"messages": msgs})
+
+	resp := map[string]interface{}{
+		"messages":        msgs,
+		"userPromptCount": userPromptCount,
+		"userPrompts":     userPrompts,
+	}
+	if userPromptIndex >= 0 {
+		resp["userPromptIndex"] = userPromptIndex
+	}
+	return c.JSON(http.StatusOK, resp)
 }
 
 // GET /session


### PR DESCRIPTION
## Summary
- `GET /messages` に `userPromptIndex` クエリパラメータを追加し、ユーザープロンプト単位で履歴を取得できるようにした
- レスポンスに `userPromptCount` / `userPrompts` / `userPromptIndex` メタデータを追加し、UI 側でターン選択 UI を構築可能にした
- パラメータ省略時は従来どおり最新ターン（最後のユーザープロンプト以降）を返す

## Test plan
- [x] `go test ./pkg/acp/bridge/...`
- [ ] ACP セッションで複数ターン会話後、`GET /messages?userPromptIndex=0` が最初のターンのみ返すことを確認
- [ ] `GET /messages`（パラメータなし）が最新ターンを返すことを確認
- [ ] agentapi-ui PR と合わせてプルダウンから過去ターンを表示できることを確認

Made with [Cursor](https://cursor.com)