### PR TITLE
feat: add session annotations

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -20,6 +20,14 @@ var (
 	confirmDelete bool
 )
 
+// annotate-session command flags
+var (
+	annotationPRURL       string
+	annotationIssueURL    string
+	annotationDescription string
+	annotationRunningTask string
+)
+
 // task subcommand flags
 var (
 	taskTitle         string
@@ -227,6 +235,23 @@ Examples:
   # Delete current session without confirmation
   agentapi-proxy client delete-session --confirm`,
 	Run: runDeleteSession,
+}
+
+var annotateSessionCmd = &cobra.Command{
+	Use:   "annotate-session",
+	Short: "Annotate the current session",
+	Long: `Annotate the current session with user-managed metadata.
+
+At least one annotation flag must be specified. Use an explicit empty string
+to clear an annotation.
+
+Examples:
+  agentapi-proxy client annotate-session \
+    --endpoint http://proxy:8080 \
+    --session-id my-session \
+    --pr-url https://github.com/owner/repo/pull/123 \
+    --running-task "Implement session annotations"`,
+	Run: runAnnotateSession,
 }
 
 var memoryCmd = &cobra.Command{
@@ -481,6 +506,12 @@ func init() {
 	// delete-session command flags
 	deleteSessionCmd.Flags().BoolVar(&confirmDelete, "confirm", false, "Skip confirmation prompt")
 
+	// annotate-session command flags
+	annotateSessionCmd.Flags().StringVar(&annotationPRURL, "pr-url", "", "Pull request URL annotation")
+	annotateSessionCmd.Flags().StringVar(&annotationIssueURL, "issue-url", "", "Issue URL annotation")
+	annotateSessionCmd.Flags().StringVar(&annotationDescription, "description", "", "Description annotation")
+	annotateSessionCmd.Flags().StringVar(&annotationRunningTask, "running-task", "", "Running task annotation")
+
 	// task create flags
 	taskCreateCmd.Flags().StringVar(&taskTitle, "title", "", "Task title (required)")
 	taskCreateCmd.Flags().StringVar(&taskDescription, "description", "", "Task description")
@@ -583,6 +614,7 @@ func init() {
 	ClientCmd.AddCommand(statusCmd)
 	ClientCmd.AddCommand(eventsCmd)
 	ClientCmd.AddCommand(deleteSessionCmd)
+	ClientCmd.AddCommand(annotateSessionCmd)
 	ClientCmd.AddCommand(summarizeDraftsCmd)
 	ClientCmd.AddCommand(sendNotificationClientCmd)
 	ClientCmd.AddCommand(taskCmd)
@@ -929,6 +961,50 @@ func runTaskList(cmd *cobra.Command, args []string) {
 	for _, t := range listResp.Tasks {
 		fmt.Printf("  [%s] %s (%s/%s) session=%s\n", t.Status, t.Title, t.TaskType, t.Scope, t.SessionID)
 	}
+}
+
+func runAnnotateSession(cmd *cobra.Command, args []string) {
+	c, resolvedSessionID, err := resolveClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	req := &client.UpdateSessionAnnotationsRequest{}
+	changed := false
+	if cmd.Flags().Changed("pr-url") {
+		req.PRURL = &annotationPRURL
+		changed = true
+	}
+	if cmd.Flags().Changed("issue-url") {
+		req.IssueURL = &annotationIssueURL
+		changed = true
+	}
+	if cmd.Flags().Changed("description") {
+		req.Description = &annotationDescription
+		changed = true
+	}
+	if cmd.Flags().Changed("running-task") {
+		req.RunningTask = &annotationRunningTask
+		changed = true
+	}
+	if !changed {
+		fmt.Fprintln(os.Stderr, "Error: at least one annotation flag is required")
+		os.Exit(1)
+	}
+
+	resp, err := c.UpdateSessionAnnotations(context.Background(), resolvedSessionID, req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error updating session annotations: %v\n", err)
+		os.Exit(1)
+	}
+
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error formatting response: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
 }
 
 func runTaskGet(cmd *cobra.Command, args []string) {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -239,18 +239,23 @@ Examples:
 
 var annotateSessionCmd = &cobra.Command{
 	Use:   "annotate-session",
-	Short: "Annotate the current session",
-	Long: `Annotate the current session with user-managed metadata.
+	Short: "Update current session info",
+	Long: `Update the current session's user-managed info.
 
-At least one annotation flag must be specified. Use an explicit empty string
-to clear an annotation.
+The supported fields are PR URL, issue URL, description, and running task.
+At least one flag must be specified. Use an explicit empty string to clear a field.
 
 Examples:
   agentapi-proxy client annotate-session \
     --endpoint http://proxy:8080 \
     --session-id my-session \
     --pr-url https://github.com/owner/repo/pull/123 \
-    --running-task "Implement session annotations"`,
+    --issue-url https://github.com/owner/repo/issues/456 \
+    --description "Session annotation support" \
+    --running-task "Implement session annotations"
+
+  # Clear the running task
+  agentapi-proxy client annotate-session --running-task ""`,
 	Run: runAnnotateSession,
 }
 

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -50,3 +50,31 @@ agentapi-proxy client send-notification \
 ```
 
 **重要**: 全ての作業が完了した時点で、**必ず**上記コマンドを実行してユーザーに通知を送信してください。
+
+### セッション情報の更新
+
+作業中は、セッションに紐づく情報を `agentapi-proxy client annotate-session` で更新してください。
+更新できる情報は `pr_url`, `issue_url`, `description`, `running_task` です。
+
+特に以下のタイミングでは、該当する情報を更新してください：
+
+- PR を作成・更新したとき: `--pr-url`
+- 対応する issue があるとき: `--issue-url`
+- セッションの目的や要約が明確になったとき: `--description`
+- 現在取り組んでいる作業が変わったとき: `--running-task`
+
+例：
+
+```bash
+agentapi-proxy client annotate-session \
+  --pr-url "https://github.com/owner/repo/pull/123" \
+  --issue-url "https://github.com/owner/repo/issues/456" \
+  --description "セッションアノテーション機能の実装" \
+  --running-task "レビュー指摘の反映"
+```
+
+値を空文字で指定すると、その情報をクリアできます。
+
+```bash
+agentapi-proxy client annotate-session --running-task ""
+```

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -50,3 +50,31 @@ agentapi-proxy client send-notification \
 ```
 
 **重要**: 全ての作業が完了した時点で、**必ず**上記コマンドを実行してユーザーに通知を送信してください。
+
+### セッション情報の更新
+
+作業中は、セッションに紐づく情報を `agentapi-proxy client annotate-session` で更新してください。
+更新できる情報は `pr_url`, `issue_url`, `description`, `running_task` です。
+
+特に以下のタイミングでは、該当する情報を更新してください：
+
+- PR を作成・更新したとき: `--pr-url`
+- 対応する issue があるとき: `--issue-url`
+- セッションの目的や要約が明確になったとき: `--description`
+- 現在取り組んでいる作業が変わったとき: `--running-task`
+
+例：
+
+```bash
+agentapi-proxy client annotate-session \
+  --pr-url "https://github.com/owner/repo/pull/123" \
+  --issue-url "https://github.com/owner/repo/issues/456" \
+  --description "セッションアノテーション機能の実装" \
+  --running-task "レビュー指摘の反映"
+```
+
+値を空文字で指定すると、その情報をクリアできます。
+
+```bash
+agentapi-proxy client annotate-session --running-task ""
+```

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -292,6 +292,7 @@ func (r *Router) registerCoreRoutes() error {
 	log.Printf("[ROUTES] Registering session management endpoints...")
 	r.echo.POST("/start", r.handlers.sessionController.StartSession)
 	r.echo.GET("/search", r.handlers.sessionController.SearchSessions)
+	r.echo.PATCH("/sessions/:sessionId/annotations", r.handlers.sessionController.UpdateSessionAnnotations)
 	r.echo.DELETE("/sessions/:sessionId", r.handlers.sessionController.DeleteSession)
 
 	// Proxy-wide session status push endpoints (registered before /:sessionId/* catch-all)

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -118,6 +118,23 @@ type SessionParams struct {
 	SessionTTL string `json:"session_ttl,omitempty"`
 }
 
+// SessionAnnotations contains user-managed annotations attached to a session.
+type SessionAnnotations struct {
+	PRURL       string `json:"pr_url,omitempty"`
+	IssueURL    string `json:"issue_url,omitempty"`
+	Description string `json:"description,omitempty"`
+	RunningTask string `json:"running_task,omitempty"`
+}
+
+// UpdateSessionAnnotationsRequest partially updates user-managed session annotations.
+// Nil fields are left unchanged; an explicit empty string clears that annotation.
+type UpdateSessionAnnotationsRequest struct {
+	PRURL       *string `json:"pr_url,omitempty"`
+	IssueURL    *string `json:"issue_url,omitempty"`
+	Description *string `json:"description,omitempty"`
+	RunningTask *string `json:"running_task,omitempty"`
+}
+
 // StartRequest represents the request body for starting a new agentapi server
 type StartRequest struct {
 	Environment map[string]string `json:"environment,omitempty"`

--- a/internal/infrastructure/services/cached_session.go
+++ b/internal/infrastructure/services/cached_session.go
@@ -72,5 +72,9 @@ func (s *cachedSession) Description() string {
 	return s.dto.Description
 }
 
+func (s *cachedSession) Annotations() entities.SessionAnnotations {
+	return s.dto.Annotations
+}
+
 // Cancel is a no-op for cached sessions (they are read-only snapshots).
 func (s *cachedSession) Cancel() {}

--- a/internal/infrastructure/services/kubernetes_session.go
+++ b/internal/infrastructure/services/kubernetes_session.go
@@ -26,6 +26,7 @@ type KubernetesSession struct {
 	cancelFunc        context.CancelFunc
 	mutex             sync.RWMutex
 	description       string                           // Preserved description from Secret (not truncated by label limits)
+	annotations       entities.SessionAnnotations
 	webhookPayload    []byte                           // Webhook payload JSON
 	resolvedAPIKey    string                           // API key resolved during session creation, used by memory-sync sidecar
 	provisionSettings *sessionsettings.SessionSettings // Settings used for provisioning (stored after successful provisioning)
@@ -128,9 +129,16 @@ func (s *KubernetesSession) StartedAt() time.Time {
 
 // Description returns the session description (cached initial message)
 func (s *KubernetesSession) Description() string {
+	s.mutex.RLock()
+	annotationDescription := s.annotations.Description
+	cachedDescription := s.description
+	s.mutex.RUnlock()
+	if annotationDescription != "" {
+		return annotationDescription
+	}
 	// Return cached description if available
-	if s.description != "" {
-		return s.description
+	if cachedDescription != "" {
+		return cachedDescription
 	}
 	// Fall back to InitialMessage
 	if s.request != nil && s.request.InitialMessage != "" {
@@ -190,7 +198,23 @@ func (s *KubernetesSession) SetStartedAt(t time.Time) {
 
 // SetDescription sets the session description (used for restored sessions from Secret)
 func (s *KubernetesSession) SetDescription(desc string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.description = desc
+}
+
+// Annotations returns user-managed session annotations.
+func (s *KubernetesSession) Annotations() entities.SessionAnnotations {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.annotations
+}
+
+// SetAnnotations replaces user-managed session annotations.
+func (s *KubernetesSession) SetAnnotations(annotations entities.SessionAnnotations) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.annotations = annotations
 }
 
 // SetUpdatedAt sets the last updated time (used for restored sessions)

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1378,6 +1378,7 @@ func (m *KubernetesSessionManager) filterSessionsFromCache(dtos []portrepos.Cach
 		}
 		var s entities.Session
 		if ls, ok := live[dto.ID]; ok {
+			ls.SetAnnotations(dto.Annotations)
 			s = ls // use live in-memory session for current status
 		} else {
 			s = newCachedSession(dto)
@@ -1451,6 +1452,7 @@ func (m *KubernetesSessionManager) getOrRestoreSessionWithWorkload(svc *corev1.S
 	m.mutex.RUnlock()
 
 	if exists {
+		session.SetAnnotations(sessionAnnotationsFromMap(svc.Annotations))
 		// If the in-memory session was cached when this Service was still a stock
 		// session (user-id was empty at restore time), and the Service now has a
 		// real owner, repair the user-id in-place so authorization checks pass.

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1406,6 +1406,7 @@ func sessionsToCacheDTOs(sessions []entities.Session) []portrepos.CachedSessionD
 			UpdatedAt:     s.UpdatedAt(),
 			LastMessageAt: s.LastMessageAt(),
 			Description:   s.Description(),
+			Annotations:   sessionAnnotations(s),
 		}
 		// Capture Kubernetes-specific fields when available.
 		if ks, ok := s.(*KubernetesSession); ok {
@@ -1421,6 +1422,17 @@ func sessionsToCacheDTOs(sessions []entities.Session) []portrepos.CachedSessionD
 		dtos = append(dtos, dto)
 	}
 	return dtos
+}
+
+type sessionAnnotationsProvider interface {
+	Annotations() entities.SessionAnnotations
+}
+
+func sessionAnnotations(s entities.Session) entities.SessionAnnotations {
+	if annotated, ok := s.(sessionAnnotationsProvider); ok {
+		return annotated.Annotations()
+	}
+	return entities.SessionAnnotations{}
 }
 
 // getOrRestoreSessionWithWorkload gets a session from memory or restores it from Service
@@ -4087,6 +4099,7 @@ func (m *KubernetesSessionManager) restoreSessionFromService(svc *corev1.Service
 	session.SetLastMessageAt(lastMessageAt)
 	session.SetStatus(m.getSessionStatusFromDeployment(sessionID))
 	session.SetDescription(initialMessage) // Cache initial message as description
+	session.SetAnnotations(sessionAnnotationsFromMap(svc.Annotations))
 
 	// Register proxy-wide status change broadcaster
 	session.statusChangeCallback = m.broadcastStatusChange
@@ -4217,6 +4230,7 @@ func (m *KubernetesSessionManager) restoreSessionFromServiceWithWorkload(svc *co
 	session.SetLastMessageAt(lastMessageAt)
 	session.SetStatus(m.getStatusFromWorkloadObject(deployment, pod))
 	session.SetDescription(initialMessage) // Cache initial message as description
+	session.SetAnnotations(sessionAnnotationsFromMap(svc.Annotations))
 
 	// Register proxy-wide status change broadcaster
 	session.statusChangeCallback = m.broadcastStatusChange
@@ -4406,6 +4420,88 @@ func (m *KubernetesSessionManager) buildServicePorts(session *KubernetesSession)
 	}
 
 	return ports
+}
+
+const (
+	sessionAnnotationPRURL       = "agentapi.proxy/session-annotation-pr-url"
+	sessionAnnotationIssueURL    = "agentapi.proxy/session-annotation-issue-url"
+	sessionAnnotationDescription = "agentapi.proxy/session-annotation-description"
+	sessionAnnotationRunningTask = "agentapi.proxy/session-annotation-running-task"
+)
+
+func sessionAnnotationsFromMap(annotations map[string]string) entities.SessionAnnotations {
+	if annotations == nil {
+		return entities.SessionAnnotations{}
+	}
+	return entities.SessionAnnotations{
+		PRURL:       annotations[sessionAnnotationPRURL],
+		IssueURL:    annotations[sessionAnnotationIssueURL],
+		Description: annotations[sessionAnnotationDescription],
+		RunningTask: annotations[sessionAnnotationRunningTask],
+	}
+}
+
+func applySessionAnnotationPatch(current entities.SessionAnnotations, patch entities.UpdateSessionAnnotationsRequest) entities.SessionAnnotations {
+	if patch.PRURL != nil {
+		current.PRURL = *patch.PRURL
+	}
+	if patch.IssueURL != nil {
+		current.IssueURL = *patch.IssueURL
+	}
+	if patch.Description != nil {
+		current.Description = *patch.Description
+	}
+	if patch.RunningTask != nil {
+		current.RunningTask = *patch.RunningTask
+	}
+	return current
+}
+
+func setSessionAnnotationValue(annotations map[string]string, key, value string) {
+	if value == "" {
+		delete(annotations, key)
+		return
+	}
+	annotations[key] = value
+}
+
+// UpdateSessionAnnotations updates user-managed annotations on a session's Service.
+func (m *KubernetesSessionManager) UpdateSessionAnnotations(ctx context.Context, sessionID string, patch entities.UpdateSessionAnnotationsRequest) (entities.SessionAnnotations, error) {
+	session := m.GetSession(sessionID)
+	if session == nil {
+		return entities.SessionAnnotations{}, fmt.Errorf("session not found: %s", sessionID)
+	}
+
+	ks, ok := session.(*KubernetesSession)
+	if !ok {
+		return entities.SessionAnnotations{}, fmt.Errorf("session is not a KubernetesSession")
+	}
+
+	svc, err := m.client.CoreV1().Services(m.namespace).Get(ctx, ks.ServiceName(), metav1.GetOptions{})
+	if err != nil {
+		return entities.SessionAnnotations{}, fmt.Errorf("failed to get service: %w", err)
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+
+	updated := applySessionAnnotationPatch(sessionAnnotationsFromMap(svc.Annotations), patch)
+	setSessionAnnotationValue(svc.Annotations, sessionAnnotationPRURL, updated.PRURL)
+	setSessionAnnotationValue(svc.Annotations, sessionAnnotationIssueURL, updated.IssueURL)
+	setSessionAnnotationValue(svc.Annotations, sessionAnnotationDescription, updated.Description)
+	setSessionAnnotationValue(svc.Annotations, sessionAnnotationRunningTask, updated.RunningTask)
+
+	if _, err := m.client.CoreV1().Services(m.namespace).Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
+		return entities.SessionAnnotations{}, fmt.Errorf("failed to update service annotations: %w", err)
+	}
+
+	ks.SetAnnotations(updated)
+	if m.sessionListCacheRepo != nil {
+		if err := m.sessionListCacheRepo.InvalidateSessionListCache(ctx, m.namespace); err != nil {
+			log.Printf("[SESSION] Failed to invalidate session list cache after annotation update for %s: %v", sessionID, err)
+		}
+	}
+	return updated, nil
 }
 
 // UpdateServiceAnnotation updates a specific annotation on a session's Service

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -384,11 +384,7 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 			"tags":            session.Tags(),
 			"annotations":     annotations,
 			"metadata": map[string]interface{}{
-				"description":  description,
-				"annotations":  annotations,
-				"pr_url":       annotations.PRURL,
-				"issue_url":    annotations.IssueURL,
-				"running_task": annotations.RunningTask,
+				"description": description,
 			},
 		}
 		if ks, ok := session.(*services.KubernetesSession); ok {
@@ -453,7 +449,6 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 					"annotations":     entities.SessionAnnotations{},
 					"metadata": map[string]interface{}{
 						"description": route.InitialMessage,
-						"annotations": entities.SessionAnnotations{},
 					},
 				})
 			}
@@ -511,11 +506,7 @@ func (c *SessionController) UpdateSessionAnnotations(ctx echo.Context) error {
 		"session_id":   sessionID,
 		"annotations":  annotations,
 		"metadata": map[string]interface{}{
-			"description":  annotations.Description,
-			"annotations":  annotations,
-			"pr_url":       annotations.PRURL,
-			"issue_url":    annotations.IssueURL,
-			"running_task": annotations.RunningTask,
+			"description": annotations.Description,
 		},
 	})
 }

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -36,6 +36,14 @@ type SessionManagerProvider interface {
 	GetSessionManager() repositories.SessionManager
 }
 
+type sessionAnnotationUpdater interface {
+	UpdateSessionAnnotations(ctx context.Context, sessionID string, patch entities.UpdateSessionAnnotationsRequest) (entities.SessionAnnotations, error)
+}
+
+type sessionAnnotationsProvider interface {
+	Annotations() entities.SessionAnnotations
+}
+
 // SessionController handles session management endpoints
 type SessionController struct {
 	sessionManagerProvider SessionManagerProvider
@@ -102,6 +110,7 @@ func (c *SessionController) RegisterRoutes(e *echo.Echo) error {
 	// Session management routes
 	e.POST("/start", c.StartSession)
 	e.GET("/search", c.SearchSessions)
+	e.PATCH("/sessions/:sessionId/annotations", c.UpdateSessionAnnotations)
 	e.DELETE("/sessions/:sessionId", c.DeleteSession)
 
 	// Session proxy route
@@ -357,6 +366,11 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 		// restoration in restoreSessionFromService.
 		initialMessage := session.Description()
 
+		annotations := getSessionAnnotations(session)
+		description := initialMessage
+		if annotations.Description != "" {
+			description = annotations.Description
+		}
 		sessionData := map[string]interface{}{
 			"session_id":      session.ID(),
 			"user_id":         session.UserID(),
@@ -368,8 +382,13 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 			"last_message_at": session.LastMessageAt(),
 			"addr":            session.Addr(),
 			"tags":            session.Tags(),
+			"annotations":     annotations,
 			"metadata": map[string]interface{}{
-				"description": initialMessage,
+				"description":  description,
+				"annotations":  annotations,
+				"pr_url":       annotations.PRURL,
+				"issue_url":    annotations.IssueURL,
+				"running_task": annotations.RunningTask,
 			},
 		}
 		if ks, ok := session.(*services.KubernetesSession); ok {
@@ -431,8 +450,10 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 					"last_message_at": route.StartedAt,
 					"addr":            "",
 					"tags":            tags,
+					"annotations":     entities.SessionAnnotations{},
 					"metadata": map[string]interface{}{
 						"description": route.InitialMessage,
+						"annotations": entities.SessionAnnotations{},
 					},
 				})
 			}
@@ -441,6 +462,61 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 
 	return ctx.JSON(http.StatusOK, map[string]interface{}{
 		"sessions": filteredSessions,
+	})
+}
+
+func getSessionAnnotations(session entities.Session) entities.SessionAnnotations {
+	if annotated, ok := session.(sessionAnnotationsProvider); ok {
+		return annotated.Annotations()
+	}
+	return entities.SessionAnnotations{}
+}
+
+// UpdateSessionAnnotations handles PATCH /sessions/:sessionId/annotations.
+func (c *SessionController) UpdateSessionAnnotations(ctx echo.Context) error {
+	c.setCORSHeaders(ctx)
+
+	sessionID := ctx.Param("sessionId")
+	if sessionID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Session ID is required")
+	}
+
+	session := c.getSessionManager().GetSession(sessionID)
+	if session == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+	}
+
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	if !authzCtx.CanModifyResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return echo.NewHTTPError(http.StatusForbidden, "You don't have permission to update this session")
+	}
+
+	var req entities.UpdateSessionAnnotationsRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+	}
+
+	updater, ok := c.getSessionManager().(sessionAnnotationUpdater)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Session annotations are not supported")
+	}
+
+	annotations, err := updater.UpdateSessionAnnotations(ctx.Request().Context(), sessionID, req)
+	if err != nil {
+		log.Printf("Failed to update session annotations for %s: %v", sessionID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to update session annotations")
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]interface{}{
+		"session_id":   sessionID,
+		"annotations":  annotations,
+		"metadata": map[string]interface{}{
+			"description":  annotations.Description,
+			"annotations":  annotations,
+			"pr_url":       annotations.PRURL,
+			"issue_url":    annotations.IssueURL,
+			"running_task": annotations.RunningTask,
+		},
 	})
 }
 

--- a/internal/usecases/ports/repositories/session_list_cache_repository.go
+++ b/internal/usecases/ports/repositories/session_list_cache_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"context"
 	"time"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 )
 
 // CachedSessionDTO is a serialisable snapshot of a Kubernetes session.
@@ -19,6 +21,7 @@ type CachedSessionDTO struct {
 	UpdatedAt      time.Time         `json:"updated_at"`
 	LastMessageAt  time.Time         `json:"last_message_at"`
 	Description    string            `json:"description"`
+	Annotations    entities.SessionAnnotations `json:"annotations,omitempty"`
 	ServicePort    int               `json:"service_port"`
 	Namespace      string            `json:"namespace"`
 	DeploymentName string            `json:"deployment_name"`

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -134,11 +134,7 @@ type SessionAnnotations struct {
 
 // SessionMetadata contains additional session metadata returned by /search.
 type SessionMetadata struct {
-	Description string             `json:"description,omitempty"`
-	Annotations SessionAnnotations `json:"annotations,omitempty"`
-	PRURL       string             `json:"pr_url,omitempty"`
-	IssueURL    string             `json:"issue_url,omitempty"`
-	RunningTask string             `json:"running_task,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // UpdateSessionAnnotationsRequest partially updates user-managed session annotations.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -109,17 +109,52 @@ type StartResponse struct {
 
 // SessionInfo represents information about a session
 type SessionInfo struct {
-	SessionID string            `json:"session_id"`
-	UserID    string            `json:"user_id"`
-	Status    string            `json:"status"`
-	StartedAt time.Time         `json:"started_at"`
-	Port      int               `json:"port"`
-	Tags      map[string]string `json:"tags,omitempty"`
+	SessionID   string             `json:"session_id"`
+	UserID      string             `json:"user_id"`
+	Status      string             `json:"status"`
+	StartedAt   time.Time          `json:"started_at"`
+	Port        int                `json:"port"`
+	Tags        map[string]string  `json:"tags,omitempty"`
+	Annotations SessionAnnotations `json:"annotations,omitempty"`
+	Metadata    SessionMetadata    `json:"metadata,omitempty"`
 }
 
 // SearchResponse represents the response from searching sessions
 type SearchResponse struct {
 	Sessions []SessionInfo `json:"sessions"`
+}
+
+// SessionAnnotations contains user-managed annotations attached to a session.
+type SessionAnnotations struct {
+	PRURL       string `json:"pr_url,omitempty"`
+	IssueURL    string `json:"issue_url,omitempty"`
+	Description string `json:"description,omitempty"`
+	RunningTask string `json:"running_task,omitempty"`
+}
+
+// SessionMetadata contains additional session metadata returned by /search.
+type SessionMetadata struct {
+	Description string             `json:"description,omitempty"`
+	Annotations SessionAnnotations `json:"annotations,omitempty"`
+	PRURL       string             `json:"pr_url,omitempty"`
+	IssueURL    string             `json:"issue_url,omitempty"`
+	RunningTask string             `json:"running_task,omitempty"`
+}
+
+// UpdateSessionAnnotationsRequest partially updates user-managed session annotations.
+// Nil fields are left unchanged; an explicit empty string clears that annotation.
+type UpdateSessionAnnotationsRequest struct {
+	PRURL       *string `json:"pr_url,omitempty"`
+	IssueURL    *string `json:"issue_url,omitempty"`
+	Description *string `json:"description,omitempty"`
+	RunningTask *string `json:"running_task,omitempty"`
+}
+
+// UpdateSessionAnnotationsResponse is returned after updating session annotations.
+type UpdateSessionAnnotationsResponse struct {
+	SessionID   string             `json:"session_id"`
+	Annotations SessionAnnotations `json:"annotations"`
+	Metadata    SessionMetadata    `json:"metadata,omitempty"`
 }
 
 // Message represents an agentapi message
@@ -361,6 +396,51 @@ func (c *Client) DeleteSession(ctx context.Context, sessionID string) (*DeleteRe
 	}
 
 	return &deleteResp, nil
+}
+
+// UpdateSessionAnnotations updates user-managed annotations for a session.
+func (c *Client) UpdateSessionAnnotations(ctx context.Context, sessionID string, req *UpdateSessionAnnotationsRequest) (*UpdateSessionAnnotationsResponse, error) {
+	if sessionID == "" {
+		return nil, fmt.Errorf("session ID is required")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+
+	jsonData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s/sessions/%s/annotations", c.baseURL, sessionID)
+	httpReq, err := http.NewRequestWithContext(ctx, "PATCH", reqURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	if err := c.applyMiddlewares(httpReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var updateResp UpdateSessionAnnotationsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&updateResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &updateResp, nil
 }
 
 // SendMessage sends a message to an agentapi session


### PR DESCRIPTION
## Summary
- add session annotation API and client command for pr_url, issue_url, description, and running_task
- persist annotations on Kubernetes Service annotations and include them in /search responses
- expose annotation fields in the Go client models

## Verification
- git diff --check
- Go tests not run: go/gofmt are not installed in this environment