### PR TITLE
Fix OAuth redirect URI prefix validation

### DIFF
--- a/internal/app/auth.go
+++ b/internal/app/auth.go
@@ -225,38 +225,65 @@ func (s *Server) handleOAuthRefresh(c echo.Context) error {
 
 // isAllowedRedirectURI validates if the redirect URI is in the allowed list
 func isAllowedRedirectURI(redirectURI string) bool {
+	redirectURL, err := url.Parse(redirectURI)
+	if err != nil || redirectURL.Scheme == "" || redirectURL.Host == "" {
+		return false
+	}
+
 	// Get allowed redirect URIs from environment variable
 	allowedURIs := os.Getenv("OAUTH_ALLOWED_REDIRECT_URIS")
 	if allowedURIs == "" {
 		// Fallback to localhost for development
-		allowedDefaultURIs := []string{
-			"http://localhost",
-			"https://localhost",
-			"http://127.0.0.1",
-			"https://127.0.0.1",
-		}
-		for _, allowed := range allowedDefaultURIs {
-			if strings.HasPrefix(redirectURI, allowed) {
-				return true
-			}
-		}
-		return false
+		return isLoopbackRedirectURI(redirectURL)
 	}
 
 	// Parse comma-separated allowed URIs
 	uris := strings.Split(allowedURIs, ",")
 	for _, allowed := range uris {
 		allowed = strings.TrimSpace(allowed)
-		if allowed == redirectURI {
-			return true
+		if allowed == "" {
+			continue
 		}
-		// Also allow prefix match for same domain with different paths
-		if strings.HasPrefix(redirectURI, allowed) {
+		if isSameAllowedRedirectURI(redirectURL, allowed) {
 			return true
 		}
 	}
 
 	return false
+}
+
+func isLoopbackRedirectURI(redirectURL *url.URL) bool {
+	if redirectURL.Scheme != "http" && redirectURL.Scheme != "https" {
+		return false
+	}
+
+	host := strings.ToLower(redirectURL.Hostname())
+	return host == "localhost" || host == "127.0.0.1"
+}
+
+func isSameAllowedRedirectURI(redirectURL *url.URL, allowed string) bool {
+	allowedURL, err := url.Parse(allowed)
+	if err != nil || allowedURL.Scheme == "" || allowedURL.Host == "" {
+		return false
+	}
+
+	if !strings.EqualFold(redirectURL.Scheme, allowedURL.Scheme) {
+		return false
+	}
+	if !strings.EqualFold(redirectURL.Host, allowedURL.Host) {
+		return false
+	}
+
+	allowedPath := allowedURL.EscapedPath()
+	redirectPath := redirectURL.EscapedPath()
+	if allowedPath == "" || allowedPath == "/" {
+		return true
+	}
+	if redirectPath == allowedPath {
+		return true
+	}
+
+	return strings.HasPrefix(redirectPath, strings.TrimRight(allowedPath, "/")+"/")
 }
 
 // validateOAuthSession validates an OAuth session from the request

--- a/internal/app/auth_test.go
+++ b/internal/app/auth_test.go
@@ -118,6 +118,90 @@ func TestHandleOAuthLogin_InvalidRequest(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 }
 
+func TestIsAllowedRedirectURIRejectsPrefixBypass(t *testing.T) {
+	t.Setenv("OAUTH_ALLOWED_REDIRECT_URIS", "https://example.com/callback, https://app.example.com")
+
+	tests := []struct {
+		name        string
+		redirectURI string
+		want        bool
+	}{
+		{
+			name:        "exact configured redirect URI",
+			redirectURI: "https://example.com/callback",
+			want:        true,
+		},
+		{
+			name:        "path below configured redirect URI",
+			redirectURI: "https://example.com/callback/complete",
+			want:        true,
+		},
+		{
+			name:        "same origin allowed when configured without path",
+			redirectURI: "https://app.example.com/oauth/callback",
+			want:        true,
+		},
+		{
+			name:        "host prefix attack",
+			redirectURI: "https://example.com.evil.test/callback",
+			want:        false,
+		},
+		{
+			name:        "path prefix attack",
+			redirectURI: "https://example.com/callback.evil",
+			want:        false,
+		},
+		{
+			name:        "userinfo host confusion",
+			redirectURI: "https://example.com@evil.test/callback",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAllowedRedirectURI(tt.redirectURI))
+		})
+	}
+}
+
+func TestIsAllowedRedirectURIDefaultLoopbackOnly(t *testing.T) {
+	t.Setenv("OAUTH_ALLOWED_REDIRECT_URIS", "")
+
+	tests := []struct {
+		name        string
+		redirectURI string
+		want        bool
+	}{
+		{
+			name:        "localhost with port",
+			redirectURI: "http://localhost:3000/callback",
+			want:        true,
+		},
+		{
+			name:        "127 loopback with port",
+			redirectURI: "https://127.0.0.1:8443/callback",
+			want:        true,
+		},
+		{
+			name:        "localhost host prefix attack",
+			redirectURI: "http://localhost.evil.test/callback",
+			want:        false,
+		},
+		{
+			name:        "unsupported scheme",
+			redirectURI: "javascript:alert(1)",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAllowedRedirectURI(tt.redirectURI))
+		})
+	}
+}
+
 func TestHandleOAuthCallback(t *testing.T) {
 	proxy, mockServer := setupTestServerWithOAuth(t)
 	defer mockServer.Close()


### PR DESCRIPTION
## Summary
- Replace prefix-based OAuth redirect allowlist checks with parsed scheme/host/path validation
- Keep localhost development redirects and same-origin path allowance without permitting host/path prefix bypasses
- Add tests for host prefix, path prefix, userinfo confusion, and loopback defaults

## Testing
- git diff --check -- internal/app/auth.go internal/app/auth_test.go
- Not run: Go tests and govulncheck, because go/gofmt are not installed in this environment