### PR TITLE
Add unsynced file paths to session profiles

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -707,6 +707,11 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		sessionTTL = startReq.Params.SessionTTL
 	}
 
+	var unsyncedFilePaths []string
+	if startReq.Params != nil && len(startReq.Params.UnsyncedFilePaths) > 0 {
+		unsyncedFilePaths = append([]string(nil), startReq.Params.UnsyncedFilePaths...)
+	}
+
 	launcher := sessionuc.NewLaunchUseCase(s.sessionManager).
 		WithMemoryRepository(s.memoryRepo)
 	result, err := launcher.Launch(context.Background(), sessionID, sessionuc.LaunchRequest{
@@ -730,6 +735,7 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		Docker:                   docker,
 		AuthProxy:                authProxy,
 		SessionTTL:               sessionTTL,
+		UnsyncedFilePaths:        unsyncedFilePaths,
 	})
 	if err != nil {
 		return nil, err
@@ -755,25 +761,28 @@ func (s *Server) createRemoteSession(ctx context.Context, sessionID string, star
 	var agentType string
 	var oneshot bool
 	var authProxy *bool
+	var unsyncedFilePaths []string
 	if startReq.Params != nil {
 		initialMessage = startReq.Params.Message
 		agentType = startReq.Params.AgentType
 		oneshot = startReq.Params.Oneshot
 		authProxy = startReq.Params.AuthProxy
+		unsyncedFilePaths = append([]string(nil), startReq.Params.UnsyncedFilePaths...)
 	}
 	runReq := &entities.RunServerRequest{
-		UserID:         userID,
-		Teams:          teams,
-		Scope:          startReq.Scope,
-		TeamID:         startReq.TeamID,
-		AgentType:      agentType,
-		Oneshot:        oneshot,
-		Environment:    startReq.Environment,
-		Tags:           startReq.Tags,
-		MemoryKey:      startReq.MemoryKey,
-		InitialMessage: initialMessage,
-		RepoInfo:       s.extractRepositoryInfo(sessionID, startReq.Tags),
-		AuthProxy:      authProxy,
+		UserID:            userID,
+		Teams:             teams,
+		Scope:             startReq.Scope,
+		TeamID:            startReq.TeamID,
+		AgentType:         agentType,
+		Oneshot:           oneshot,
+		Environment:       startReq.Environment,
+		Tags:              startReq.Tags,
+		MemoryKey:         startReq.MemoryKey,
+		InitialMessage:    initialMessage,
+		RepoInfo:          s.extractRepositoryInfo(sessionID, startReq.Tags),
+		AuthProxy:         authProxy,
+		UnsyncedFilePaths: unsyncedFilePaths,
 	}
 
 	// Try to build fully-resolved settings (env vars, Bedrock, MCP servers, OAuth token, etc.)
@@ -800,8 +809,9 @@ func (s *Server) createRemoteSession(ctx context.Context, sessionID string, star
 				Teams:     teams,
 				MemoryKey: startReq.MemoryKey,
 			},
-			Env:            startReq.Environment,
-			InitialMessage: initialMessage,
+			Env:               startReq.Environment,
+			InitialMessage:    initialMessage,
+			UnsyncedFilePaths: unsyncedFilePaths,
 		}
 	}
 

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -116,6 +116,8 @@ type SessionParams struct {
 	// Empty string means the global cleanup worker TTL is used for Slackbot sessions;
 	// non-Slackbot sessions without this field are not auto-deleted.
 	SessionTTL string `json:"session_ttl,omitempty"`
+	// UnsyncedFilePaths excludes managed file paths from syncing changes back to storage.
+	UnsyncedFilePaths []string `json:"unsynced_file_paths,omitempty"`
 }
 
 // SessionAnnotations contains user-managed annotations attached to a session.
@@ -194,6 +196,8 @@ type RunServerRequest struct {
 	// SessionTTL is the duration after the last message before this session is auto-deleted.
 	// Stored as a Go duration string (e.g. "48h"). Empty means use the global cleanup TTL.
 	SessionTTL string
+	// UnsyncedFilePaths excludes managed file paths from syncing changes back to storage.
+	UnsyncedFilePaths []string
 }
 
 // Session represents a running agentapi session

--- a/internal/domain/entities/session_profile.go
+++ b/internal/domain/entities/session_profile.go
@@ -34,7 +34,8 @@ type SessionProfileConfig struct {
 	// sessionTTL overrides the global cleanup worker TTL for sessions created with this profile.
 	// Accepted format: Go duration string (e.g. "48h", "168h").
 	// Empty string means the global cleanup worker TTL is used.
-	sessionTTL string
+	sessionTTL        string
+	unsyncedFilePaths []string
 }
 
 // NewSessionProfile creates a new SessionProfile
@@ -245,6 +246,16 @@ func (c *SessionProfileConfig) SessionTTL() string { return c.sessionTTL }
 
 // SetSessionTTL sets the session TTL override for this profile
 func (c *SessionProfileConfig) SetSessionTTL(ttl string) { c.sessionTTL = ttl }
+
+// UnsyncedFilePaths returns file paths excluded from managed file sync.
+func (c *SessionProfileConfig) UnsyncedFilePaths() []string {
+	return copyStringSlice(c.unsyncedFilePaths)
+}
+
+// SetUnsyncedFilePaths sets file paths excluded from managed file sync.
+func (c *SessionProfileConfig) SetUnsyncedFilePaths(paths []string) {
+	c.unsyncedFilePaths = copyStringSlice(paths)
+}
 
 // --- Error types ---
 

--- a/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
@@ -57,6 +57,7 @@ type sessionProfileConfigJSON struct {
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
 	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
 	SessionTTL             string                  `json:"session_ttl,omitempty"`
+	UnsyncedFilePaths      []string                `json:"unsynced_file_paths,omitempty"`
 }
 
 // KubernetesSessionProfileRepository implements SessionProfileRepository using Kubernetes Secrets
@@ -321,6 +322,7 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 	cfg.SetMemoryKey(pj.Config.MemoryKey)
 	cfg.SetSandboxPolicyID(pj.Config.SandboxPolicyID)
 	cfg.SetSessionTTL(pj.Config.SessionTTL)
+	cfg.SetUnsyncedFilePaths(pj.Config.UnsyncedFilePaths)
 	profile.SetConfig(cfg)
 
 	return profile
@@ -347,6 +349,7 @@ func (r *KubernetesSessionProfileRepository) entityToJSON(profile *entities.Sess
 			MemoryKey:              cfg.MemoryKey(),
 			SandboxPolicyID:        cfg.SandboxPolicyID(),
 			SessionTTL:             cfg.SessionTTL(),
+			UnsyncedFilePaths:      cfg.UnsyncedFilePaths(),
 		},
 		CreatedAt: profile.CreatedAt(),
 		UpdatedAt: profile.UpdatedAt(),

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4611,6 +4611,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		Teams:     req.Teams,
 		MemoryKey: req.MemoryKey,
 	}
+	settings.UnsyncedFilePaths = append([]string(nil), req.UnsyncedFilePaths...)
 
 	// Build env vars (mirrors buildEnvVars logic from line 2695)
 	env := map[string]string{

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -256,6 +256,14 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 					startReq.Params.SessionTTL = cfg.SessionTTL()
 				}
 			}
+			if len(cfg.UnsyncedFilePaths()) > 0 {
+				if startReq.Params == nil {
+					startReq.Params = &entities.SessionParams{}
+				}
+				if len(startReq.Params.UnsyncedFilePaths) == 0 {
+					startReq.Params.UnsyncedFilePaths = cfg.UnsyncedFilePaths()
+				}
+			}
 		}
 	}
 
@@ -503,8 +511,8 @@ func (c *SessionController) UpdateSessionAnnotations(ctx echo.Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"session_id":   sessionID,
-		"annotations":  annotations,
+		"session_id":  sessionID,
+		"annotations": annotations,
 		"metadata": map[string]interface{}{
 			"description": annotations.Description,
 		},
@@ -969,6 +977,9 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 	}
 	if override.SessionTTL != "" {
 		merged.SessionTTL = override.SessionTTL
+	}
+	if len(override.UnsyncedFilePaths) > 0 {
+		merged.UnsyncedFilePaths = append([]string(nil), override.UnsyncedFilePaths...)
 	}
 	return &merged
 }

--- a/internal/interfaces/controllers/session_profile_controller.go
+++ b/internal/interfaces/controllers/session_profile_controller.go
@@ -40,6 +40,7 @@ type SessionProfileConfigRequest struct {
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
 	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
 	SessionTTL             string                  `json:"session_ttl,omitempty"`
+	UnsyncedFilePaths      []string                `json:"unsynced_file_paths,omitempty"`
 }
 
 // CreateSessionProfileRequest is the request body for creating a session profile
@@ -88,6 +89,7 @@ type SessionProfileConfigResponse struct {
 	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
 	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
 	SessionTTL             string                  `json:"session_ttl,omitempty"`
+	UnsyncedFilePaths      []string                `json:"unsynced_file_paths,omitempty"`
 }
 
 // --- Handlers ---
@@ -328,6 +330,7 @@ func (c *SessionProfileController) requestToConfig(req SessionProfileConfigReque
 	}
 	cfg.SetSandboxPolicyID(req.SandboxPolicyID)
 	cfg.SetSessionTTL(req.SessionTTL)
+	cfg.SetUnsyncedFilePaths(req.UnsyncedFilePaths)
 	return cfg
 }
 
@@ -352,6 +355,7 @@ func (c *SessionProfileController) toResponse(p *entities.SessionProfile) Sessio
 			MemoryKey:              cfg.MemoryKey(),
 			SandboxPolicyID:        cfg.SandboxPolicyID(),
 			SessionTTL:             cfg.SessionTTL(),
+			UnsyncedFilePaths:      cfg.UnsyncedFilePaths(),
 		},
 		CreatedAt: p.CreatedAt().Format(time.RFC3339),
 		UpdatedAt: p.UpdatedAt().Format(time.RFC3339),

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -40,6 +40,7 @@ type LaunchRequest struct {
 	CycleMessage             string
 	CycleMaxCount            int
 	SessionTTL               string
+	UnsyncedFilePaths        []string
 
 	// Webhook payload to mount in the session filesystem (optional)
 	WebhookPayload []byte
@@ -206,6 +207,7 @@ func (uc *LaunchUseCase) Launch(ctx context.Context, sessionID string, req Launc
 		Docker:                   req.Docker,
 		AuthProxy:                req.AuthProxy,
 		SessionTTL:               req.SessionTTL,
+		UnsyncedFilePaths:        req.UnsyncedFilePaths,
 	}
 
 	session, err := uc.sessionManager.CreateSession(ctx, sessionID, runReq, req.WebhookPayload)
@@ -398,8 +400,14 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 		if req.SessionTTL == "" {
 			req.SessionTTL = cfg.Params().SessionTTL
 		}
+		if len(req.UnsyncedFilePaths) == 0 && len(cfg.Params().UnsyncedFilePaths) > 0 {
+			req.UnsyncedFilePaths = append([]string(nil), cfg.Params().UnsyncedFilePaths...)
+		}
 	}
 	if cfg.SessionTTL() != "" && req.SessionTTL == "" {
 		req.SessionTTL = cfg.SessionTTL()
+	}
+	if len(cfg.UnsyncedFilePaths()) > 0 && len(req.UnsyncedFilePaths) == 0 {
+		req.UnsyncedFilePaths = cfg.UnsyncedFilePaths()
 	}
 }

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -134,6 +134,55 @@ func TestLaunchAppliesDefaultProfileDocker(t *testing.T) {
 	}
 }
 
+func TestLaunchAppliesDefaultProfileUnsyncedFilePaths(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetUnsyncedFilePaths([]string{"/home/agentapi/.codex/auth.json"})
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	want := []string{"/home/agentapi/.codex/auth.json"}
+	if !reflect.DeepEqual(sessionManager.req.UnsyncedFilePaths, want) {
+		t.Fatalf("expected unsynced file paths %#v, got %#v", want, sessionManager.req.UnsyncedFilePaths)
+	}
+}
+
+func TestLaunchExplicitUnsyncedFilePathsOverrideProfile(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetUnsyncedFilePaths([]string{"/home/agentapi/.codex/auth.json"})
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID:            "user-1",
+		Scope:             entities.ScopeUser,
+		UnsyncedFilePaths: []string{"/home/agentapi/.claude/.credentials.json"},
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	want := []string{"/home/agentapi/.claude/.credentials.json"}
+	if !reflect.DeepEqual(sessionManager.req.UnsyncedFilePaths, want) {
+		t.Fatalf("expected explicit unsynced file paths %#v, got %#v", want, sessionManager.req.UnsyncedFilePaths)
+	}
+}
+
 func TestLaunchExplicitDockerOverridesProfileDocker(t *testing.T) {
 	sessionManager := &recordingSessionManager{}
 	profile := entities.NewSessionProfile("profile-1", "default", "user-1")

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1425,6 +1425,7 @@ type sessionProfileRecord struct {
 	ReuseMessageTemplate   string                      `yaml:"reuse_message_template,omitempty"`
 	ReuseSession           bool                        `yaml:"reuse_session,omitempty"`
 	MemoryKey              map[string]string           `yaml:"memory_key,omitempty"`
+	UnsyncedFilePaths      []string                    `yaml:"unsynced_file_paths,omitempty"`
 	Params                 *sessionProfileParamsRecord `yaml:"params,omitempty"`
 	GitHubToken            string                      `yaml:"github_token,omitempty"`
 	InitialMessage         string                      `yaml:"initial_message,omitempty"`
@@ -1445,6 +1446,7 @@ type sessionProfileParamsRecord struct {
 	CycleMaxCount            int                                `yaml:"cycle_max_count,omitempty"`
 	RepoFullName             string                             `yaml:"repo_full_name,omitempty"`
 	Sandbox                  *sessionProfileSandboxParamsRecord `yaml:"sandbox,omitempty"`
+	UnsyncedFilePaths        []string                           `yaml:"unsynced_file_paths,omitempty"`
 }
 
 type sessionProfileSlackParamsRecord struct {
@@ -1489,6 +1491,7 @@ func sessionProfileToRecord(p *entities.SessionProfile, dek []byte) (sessionProf
 		ReuseMessageTemplate:   cfg.ReuseMessageTemplate(),
 		ReuseSession:           cfg.ReuseSession(),
 		MemoryKey:              cfg.MemoryKey(),
+		UnsyncedFilePaths:      cfg.UnsyncedFilePaths(),
 		CreatedAt:              p.CreatedAt().Format(time.RFC3339),
 		UpdatedAt:              p.UpdatedAt().Format(time.RFC3339),
 	}
@@ -1521,6 +1524,7 @@ func sessionParamsToRecord(p *entities.SessionParams) *sessionProfileParamsRecor
 		CycleMessage:             p.CycleMessage,
 		CycleMaxCount:            p.CycleMaxCount,
 		RepoFullName:             p.RepoFullName,
+		UnsyncedFilePaths:        p.UnsyncedFilePaths,
 	}
 	if p.Slack != nil {
 		rec.Slack = &sessionProfileSlackParamsRecord{
@@ -1555,6 +1559,7 @@ func sessionParamsFromRecord(rec *sessionProfileParamsRecord) *entities.SessionP
 		CycleMessage:             rec.CycleMessage,
 		CycleMaxCount:            rec.CycleMaxCount,
 		RepoFullName:             rec.RepoFullName,
+		UnsyncedFilePaths:        rec.UnsyncedFilePaths,
 	}
 	if rec.Slack != nil {
 		params.Slack = &entities.SlackParams{
@@ -1713,6 +1718,9 @@ func (s *Syncer) importSessionProfileFile(ctx context.Context, data []byte, scop
 	cfg.SetReuseSession(rec.ReuseSession)
 	if len(rec.MemoryKey) > 0 {
 		cfg.SetMemoryKey(rec.MemoryKey)
+	}
+	if len(rec.UnsyncedFilePaths) > 0 {
+		cfg.SetUnsyncedFilePaths(rec.UnsyncedFilePaths)
 	}
 	if params != nil {
 		cfg.SetParams(sessionParamsFromRecord(params))

--- a/pkg/import/types.go
+++ b/pkg/import/types.go
@@ -258,4 +258,5 @@ type SessionProfileConfigImport struct {
 	Params                 *SessionParamsImport            `yaml:"params,omitempty" toml:"params,omitempty" json:"params,omitempty"`
 	ReuseSession           bool                            `yaml:"reuse_session,omitempty" toml:"reuse_session,omitempty" json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string               `yaml:"memory_key,omitempty" toml:"memory_key,omitempty" json:"memory_key,omitempty"`
+	UnsyncedFilePaths      []string                        `yaml:"unsynced_file_paths,omitempty" toml:"unsynced_file_paths,omitempty" json:"unsynced_file_paths,omitempty"`
 }

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -237,7 +237,7 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	// Syncs managedFilePaths → Kubernetes Secret agentapi-agent-files-{userID}.
 	// Runs in-process instead of as a sidecar so that UserID is always set
 	// (stock pool pods have empty UserID at pod creation time).
-	go s.runFilesSync(ctx, settings.Session.UserID)
+	go s.runFilesSync(ctx, settings.Session.UserID, settings.UnsyncedFilePaths)
 
 	// Supervise: if agentapi exits, report error so K8s restarts the Pod.
 	go func() {
@@ -607,7 +607,7 @@ func writeCredentials(credentialsJSON string) error {
 // all of them to the Kubernetes Secret agentapi-agent-files-{userID} using the
 // in-cluster k8s client.
 // The goroutine is tied to ctx: when ctx is cancelled the loop exits.
-func (s *Server) runFilesSync(ctx context.Context, userID string) {
+func (s *Server) runFilesSync(ctx context.Context, userID string, unsyncedFilePaths []string) {
 	const syncInterval = 10 * time.Second
 
 	if userID == "" {
@@ -625,7 +625,13 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 	}
 	namespace := strings.TrimSpace(string(nsBytes))
 
-	log.Printf("[FILES_SYNC] Starting: watching %v -> Secret %s/%s (interval: %s)", managedFilePaths, namespace, secretName, syncInterval)
+	watchedPaths := syncedManagedFilePaths(unsyncedFilePaths)
+	if len(watchedPaths) == 0 {
+		log.Printf("[FILES_SYNC] No managed file paths left after exclusions %v, skipping files sync", unsyncedFilePaths)
+		return
+	}
+
+	log.Printf("[FILES_SYNC] Starting: watching %v -> Secret %s/%s (interval: %s)", watchedPaths, namespace, secretName, syncInterval)
 
 	k8sCfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -639,7 +645,7 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 	}
 
 	// Track last hash per file path to detect changes.
-	lastHashes := make(map[string]string, len(managedFilePaths))
+	lastHashes := make(map[string]string, len(watchedPaths))
 
 	ticker := time.NewTicker(syncInterval)
 	defer ticker.Stop()
@@ -656,8 +662,8 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 				data []byte
 				hash string
 			}
-			snapshots := make(map[string]fileSnapshot, len(managedFilePaths))
-			for _, path := range managedFilePaths {
+			snapshots := make(map[string]fileSnapshot, len(watchedPaths))
+			for _, path := range watchedPaths {
 				data, hash, err := readFileWithHash(path)
 				if err != nil {
 					// File may not exist yet; not an error.
@@ -667,7 +673,7 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 			}
 
 			changed := false
-			for _, path := range managedFilePaths {
+			for _, path := range watchedPaths {
 				snap, ok := snapshots[path]
 				if !ok {
 					continue
@@ -682,7 +688,7 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 
 			// Build the full snapshot of all managed files from the single read above.
 			files := make([]sessionsettings.ManagedFile, 0, len(snapshots))
-			for _, path := range managedFilePaths {
+			for _, path := range watchedPaths {
 				snap, ok := snapshots[path]
 				if !ok {
 					continue
@@ -701,7 +707,7 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 			} else {
 				log.Printf("[FILES_SYNC] Successfully synced to Secret %s", secretName)
 				// Update hashes only after a successful sync so failed upserts are retried.
-				for _, path := range managedFilePaths {
+				for _, path := range watchedPaths {
 					if snap, ok := snapshots[path]; ok {
 						lastHashes[path] = snap.hash
 					}
@@ -709,6 +715,26 @@ func (s *Server) runFilesSync(ctx context.Context, userID string) {
 			}
 		}
 	}
+}
+
+func syncedManagedFilePaths(unsyncedFilePaths []string) []string {
+	excluded := make(map[string]struct{}, len(unsyncedFilePaths))
+	for _, path := range unsyncedFilePaths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		excluded[path] = struct{}{}
+	}
+
+	paths := make([]string, 0, len(managedFilePaths))
+	for _, path := range managedFilePaths {
+		if _, ok := excluded[path]; ok {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
 }
 
 // readFileWithHash reads a file and returns its content and hex-encoded SHA256 hash.

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -53,6 +53,17 @@ func TestBuildAgentCommandCursor(t *testing.T) {
 	}
 }
 
+func TestSyncedManagedFilePathsExcludesUnsyncedPaths(t *testing.T) {
+	got := syncedManagedFilePaths([]string{
+		" /home/agentapi/.codex/auth.json ",
+		"",
+	})
+	want := []string{"/home/agentapi/.claude/.credentials.json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("syncedManagedFilePaths() = %#v, want %#v", got, want)
+	}
+}
+
 // TestWriteWebhookPayloadFile_SkipsWhenPresent verifies that
 // writeWebhookPayloadFile does NOT overwrite an existing file (non-stock case:
 // Secret volume mount already provides the file as read-only).

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -174,7 +174,8 @@ type SessionSettings struct {
 	// Credentials is deprecated: use Files instead.
 	// Kept for backward compatibility with sessions provisioned before the Files field
 	// was introduced.  The provisioner falls back to this field when Files is empty.
-	Credentials string `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+	Credentials       string   `yaml:"credentials,omitempty" json:"credentials,omitempty"`
+	UnsyncedFilePaths []string `yaml:"unsynced_file_paths,omitempty" json:"unsynced_file_paths,omitempty"`
 }
 
 // OtelCollectorConfig holds OpenTelemetry Collector configuration for in-process mode.

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5500,6 +5500,16 @@
             "type": "string",
             "description": "Duration after the last message before this session is automatically deleted. Accepted format: Go duration string (e.g. '48h', '168h', '7d' is not valid — use hours). Empty string means the global cleanup worker TTL is used for Slackbot sessions; non-Slackbot sessions without this field are not auto-deleted.",
             "example": "48h"
+          },
+          "unsynced_file_paths": {
+            "type": "array",
+            "description": "Managed file paths that should not be synced back to storage from this session.",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "/home/agentapi/.codex/auth.json"
+            ]
           }
         }
       },
@@ -7540,6 +7550,16 @@
           "type": "string",
           "description": "Default TTL for sessions created with this profile. Overrides the global cleanup worker TTL. Accepted format: Go duration string (e.g. '48h', '168h'). Can be overridden per-session via params.session_ttl.",
           "example": "72h"
+        },
+        "unsynced_file_paths": {
+          "type": "array",
+          "description": "Managed file paths that should not be synced back to storage for sessions created with this profile.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "/home/agentapi/.codex/auth.json"
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary
- add unsynced_file_paths to session profile config, API DTOs, Kubernetes Secret storage, Git sync import/export, and OpenAPI
- pass profile-configured exclusions into session settings
- skip excluded managed file paths in provisioner file sync

## Tests
- mise exec -- go test ./internal/domain/entities ./internal/infrastructure/repositories ./internal/interfaces/controllers ./internal/usecases/session ./internal/app ./pkg/sessionsettings ./pkg/provisioner ./pkg/github_sync ./pkg/import

Related UI PR: takutakahashi/agentapi-ui#571