### PR TITLE
Add Codex custom provider for OPENAI_BASE_URL

### DIFF
--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	mcputil "github.com/takutakahashi/agentapi-proxy/pkg/mcp"
@@ -64,7 +65,7 @@ func Compile(opts CompileOptions) error {
 	}
 
 	// 3c. Generate ~/.codex/config.toml (codex-acp sessions only)
-	if err := generateCodexConfigTOML(opts.OutputDir, settings.Codex.ConfigTOML); err != nil {
+	if err := generateCodexConfigTOML(opts.OutputDir, settings.Codex.ConfigTOML, settings.Env); err != nil {
 		return fmt.Errorf("failed to generate codex config.toml: %w", err)
 	}
 
@@ -343,9 +344,10 @@ func generateCodexInstructionsMD(outputDir string, instructionsMD string) error 
 }
 
 // generateCodexConfigTOML creates ~/.codex/config.toml for Codex CLI configuration.
-// Only written when configTOML is non-empty (i.e., for codex-acp sessions).
-func generateCodexConfigTOML(outputDir string, configTOML string) error {
-	if configTOML == "" {
+// Only written when configTOML is non-empty or OPENAI_BASE_URL is configured.
+func generateCodexConfigTOML(outputDir string, configTOML string, env map[string]string) error {
+	customProviderTOML := codexCustomOpenAIProviderTOML(env)
+	if configTOML == "" && customProviderTOML == "" {
 		return nil
 	}
 
@@ -355,12 +357,102 @@ func generateCodexConfigTOML(outputDir string, configTOML string) error {
 	}
 
 	configPath := filepath.Join(codexDir, "config.toml")
-	if err := os.WriteFile(configPath, []byte(configTOML), 0644); err != nil {
+	content := appendCodexConfigSection(configTOML, customProviderTOML)
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		return fmt.Errorf("failed to write codex config.toml: %w", err)
 	}
 
 	log.Printf("[COMPILE-SETTINGS] Generated %s", configPath)
 	return nil
+}
+
+const codexCustomOpenAIProviderID = "agentapi_openai_compatible"
+
+func codexCustomOpenAIProviderTOML(env map[string]string) string {
+	baseURL := strings.TrimSpace(env["OPENAI_BASE_URL"])
+	if baseURL == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("model_provider = ")
+	sb.WriteString(tomlString(codexCustomOpenAIProviderID))
+	sb.WriteString("\n\n")
+	sb.WriteString("[model_providers.")
+	sb.WriteString(codexCustomOpenAIProviderID)
+	sb.WriteString("]\n")
+	sb.WriteString("name = \"OpenAI compatible\"\n")
+	sb.WriteString("base_url = ")
+	sb.WriteString(tomlString(baseURL))
+	sb.WriteString("\n")
+	sb.WriteString("wire_api = \"responses\"\n")
+	if strings.TrimSpace(env["OPENAI_API_KEY"]) != "" {
+		sb.WriteString("env_key = \"OPENAI_API_KEY\"\n")
+	}
+	return sb.String()
+}
+
+func appendCodexConfigSection(base string, section string) string {
+	if section == "" {
+		return base
+	}
+	base = removeTopLevelTOMLKey(base, "model_provider")
+	selector, provider := splitCodexCustomProviderTOML(section)
+	if base == "" {
+		return section
+	}
+
+	var sb strings.Builder
+	sb.WriteString(selector)
+	if !strings.HasSuffix(selector, "\n") {
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(base)
+	if !strings.HasSuffix(base, "\n") {
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(provider)
+	return sb.String()
+}
+
+func splitCodexCustomProviderTOML(section string) (string, string) {
+	parts := strings.SplitN(section, "\n\n", 2)
+	if len(parts) != 2 {
+		return section, ""
+	}
+	return parts[0] + "\n", parts[1]
+}
+
+func removeTopLevelTOMLKey(content string, key string) string {
+	if content == "" {
+		return ""
+	}
+
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	inTopLevel := true
+	prefix := key + " "
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inTopLevel = false
+		}
+		if inTopLevel && (strings.HasPrefix(trimmed, prefix) || strings.HasPrefix(trimmed, key+"=")) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+func tomlString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return strconv.Quote(s)
+	}
+	return string(b)
 }
 
 // generateCodexMCPServers appends MCP server entries to ~/.codex/config.toml using

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -373,8 +373,14 @@ func codexCustomOpenAIProviderTOML(env map[string]string) string {
 	if baseURL == "" {
 		return ""
 	}
+	model := codexModelFromEnv(env)
 
 	var sb strings.Builder
+	if model != "" {
+		sb.WriteString("model = ")
+		sb.WriteString(tomlString(model))
+		sb.WriteString("\n")
+	}
 	sb.WriteString("model_provider = ")
 	sb.WriteString(tomlString(codexCustomOpenAIProviderID))
 	sb.WriteString("\n\n")
@@ -392,12 +398,22 @@ func codexCustomOpenAIProviderTOML(env map[string]string) string {
 	return sb.String()
 }
 
+func codexModelFromEnv(env map[string]string) string {
+	if model := strings.TrimSpace(env["CODEX_MODEL"]); model != "" {
+		return model
+	}
+	return strings.TrimSpace(env["OPENAI_MODEL"])
+}
+
 func appendCodexConfigSection(base string, section string) string {
 	if section == "" {
 		return base
 	}
 	base = removeTopLevelTOMLKey(base, "model_provider")
 	selector, provider := splitCodexCustomProviderTOML(section)
+	if topLevelTOMLKeyIsSet(selector, "model") {
+		base = removeTopLevelTOMLKey(base, "model")
+	}
 	if base == "" {
 		return section
 	}
@@ -423,6 +439,25 @@ func splitCodexCustomProviderTOML(section string) (string, string) {
 		return section, ""
 	}
 	return parts[0] + "\n", parts[1]
+}
+
+func topLevelTOMLKeyIsSet(content string, key string) bool {
+	if content == "" {
+		return false
+	}
+
+	inTopLevel := true
+	prefix := key + " "
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inTopLevel = false
+		}
+		if inTopLevel && (strings.HasPrefix(trimmed, prefix) || strings.HasPrefix(trimmed, key+"=")) {
+			return true
+		}
+	}
+	return false
 }
 
 func removeTopLevelTOMLKey(content string, key string) string {

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -381,6 +381,11 @@ func codexCustomOpenAIProviderTOML(env map[string]string) string {
 		sb.WriteString(tomlString(model))
 		sb.WriteString("\n")
 	}
+	metadata := codexModelMetadataFromEnv(env, model != "")
+	for _, line := range metadata {
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
 	sb.WriteString("model_provider = ")
 	sb.WriteString(tomlString(codexCustomOpenAIProviderID))
 	sb.WriteString("\n\n")
@@ -405,6 +410,38 @@ func codexModelFromEnv(env map[string]string) string {
 	return strings.TrimSpace(env["OPENAI_MODEL"])
 }
 
+func codexModelMetadataFromEnv(env map[string]string, modelConfigured bool) []string {
+	metadata := []string{}
+
+	contextWindow := strings.TrimSpace(env["CODEX_MODEL_CONTEXT_WINDOW"])
+	if contextWindow == "" {
+		contextWindow = strings.TrimSpace(env["OPENAI_MODEL_CONTEXT_WINDOW"])
+	}
+	if contextWindow == "" && modelConfigured {
+		contextWindow = "128000"
+	}
+	if contextWindow != "" {
+		metadata = append(metadata, fmt.Sprintf("model_context_window = %s", contextWindow))
+	}
+
+	autoCompactTokenLimit := strings.TrimSpace(env["CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT"])
+	if autoCompactTokenLimit == "" {
+		autoCompactTokenLimit = strings.TrimSpace(env["OPENAI_MODEL_AUTO_COMPACT_TOKEN_LIMIT"])
+	}
+	if autoCompactTokenLimit == "" && modelConfigured {
+		autoCompactTokenLimit = "64000"
+	}
+	if autoCompactTokenLimit != "" {
+		metadata = append(metadata, fmt.Sprintf("model_auto_compact_token_limit = %s", autoCompactTokenLimit))
+	}
+
+	if supportsReasoningSummaries := strings.TrimSpace(env["CODEX_MODEL_SUPPORTS_REASONING_SUMMARIES"]); supportsReasoningSummaries != "" {
+		metadata = append(metadata, fmt.Sprintf("model_supports_reasoning_summaries = %s", supportsReasoningSummaries))
+	}
+
+	return metadata
+}
+
 func appendCodexConfigSection(base string, section string) string {
 	if section == "" {
 		return base
@@ -413,6 +450,11 @@ func appendCodexConfigSection(base string, section string) string {
 	selector, provider := splitCodexCustomProviderTOML(section)
 	if topLevelTOMLKeyIsSet(selector, "model") {
 		base = removeTopLevelTOMLKey(base, "model")
+	}
+	for _, key := range []string{"model_context_window", "model_auto_compact_token_limit", "model_supports_reasoning_summaries"} {
+		if topLevelTOMLKeyIsSet(selector, key) {
+			base = removeTopLevelTOMLKey(base, key)
+		}
 	}
 	if base == "" {
 		return section

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -553,6 +553,7 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 			Env: map[string]string{
 				"OPENAI_BASE_URL": "http://ollama:11434/v1",
 				"OPENAI_API_KEY":  "test-api-key",
+				"OPENAI_MODEL":    "qwen3-coder-next",
 			},
 		}
 
@@ -579,6 +580,7 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 		content := string(data)
 
 		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
+		assert.Contains(t, content, `model = "qwen3-coder-next"`)
 		assert.Contains(t, content, `[model_providers.agentapi_openai_compatible]`)
 		assert.Contains(t, content, `base_url = "http://ollama:11434/v1"`)
 		assert.Contains(t, content, `wire_api = "responses"`)
@@ -600,9 +602,11 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 			},
 			Env: map[string]string{
 				"OPENAI_BASE_URL": "http://proxy.example.com/v1",
+				"OPENAI_MODEL":    "gpt-oss:20b",
+				"CODEX_MODEL":     "qwen3-coder-next",
 			},
 			Codex: CodexConfig{
-				ConfigTOML: "approval-mode = \"full-auto\"\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
+				ConfigTOML: "approval-mode = \"full-auto\"\nmodel = \"gpt-5.5\"\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
 			},
 		}
 
@@ -630,10 +634,61 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 
 		assert.Contains(t, content, "approval-mode")
 		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
+		assert.Contains(t, content, `model = "qwen3-coder-next"`)
 		assert.NotContains(t, content, `model_provider = "openai"`)
+		assert.NotContains(t, content, `model = "gpt-5.5"`)
+		assert.NotContains(t, content, `model = "gpt-oss:20b"`)
+		assert.Less(t, strings.Index(content, `model = "qwen3-coder-next"`), strings.Index(content, "[sandbox_workspace_write]"))
 		assert.Less(t, strings.Index(content, `model_provider = "agentapi_openai_compatible"`), strings.Index(content, "[sandbox_workspace_write]"))
 		assert.Less(t, strings.Index(content, "[sandbox_workspace_write]"), strings.Index(content, "[model_providers.agentapi_openai_compatible]"))
 		assert.NotContains(t, content, "env_key")
+	})
+
+	t.Run("preserves existing model when model env is not set", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-codex-openai-base-url-preserve-model-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-codex-custom-provider-preserve-model",
+				UserID:    "user-codex-custom-provider-preserve-model",
+				Scope:     "user",
+				AgentType: "codex-acp",
+			},
+			Env: map[string]string{
+				"OPENAI_BASE_URL": "http://proxy.example.com/v1",
+			},
+			Codex: CodexConfig{
+				ConfigTOML: "model = \"gpt-oss:20b\"\nmodel_provider = \"openai\"\n",
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".codex/config.toml")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		content := string(data)
+
+		assert.Contains(t, content, `model = "gpt-oss:20b"`)
+		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
+		assert.NotContains(t, content, `model_provider = "openai"`)
 	})
 }
 

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -537,6 +537,104 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 
 		assert.NoFileExists(t, filepath.Join(outputDir, ".codex/config.toml"))
 	})
+
+	t.Run("writes custom provider when OPENAI_BASE_URL is set", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-codex-openai-base-url-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-codex-custom-provider",
+				UserID:    "user-codex-custom-provider",
+				Scope:     "user",
+				AgentType: "codex-acp",
+			},
+			Env: map[string]string{
+				"OPENAI_BASE_URL": "http://ollama:11434/v1",
+				"OPENAI_API_KEY":  "test-api-key",
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".codex/config.toml")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		content := string(data)
+
+		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
+		assert.Contains(t, content, `[model_providers.agentapi_openai_compatible]`)
+		assert.Contains(t, content, `base_url = "http://ollama:11434/v1"`)
+		assert.Contains(t, content, `wire_api = "responses"`)
+		assert.Contains(t, content, `env_key = "OPENAI_API_KEY"`)
+		assert.NotContains(t, content, "test-api-key")
+	})
+
+	t.Run("appends custom provider after existing ConfigTOML", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-codex-openai-base-url-append-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-codex-custom-provider-append",
+				UserID:    "user-codex-custom-provider-append",
+				Scope:     "user",
+				AgentType: "codex-acp",
+			},
+			Env: map[string]string{
+				"OPENAI_BASE_URL": "http://proxy.example.com/v1",
+			},
+			Codex: CodexConfig{
+				ConfigTOML: "approval-mode = \"full-auto\"\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".codex/config.toml")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		content := string(data)
+
+		assert.Contains(t, content, "approval-mode")
+		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
+		assert.NotContains(t, content, `model_provider = "openai"`)
+		assert.Less(t, strings.Index(content, `model_provider = "agentapi_openai_compatible"`), strings.Index(content, "[sandbox_workspace_write]"))
+		assert.Less(t, strings.Index(content, "[sandbox_workspace_write]"), strings.Index(content, "[model_providers.agentapi_openai_compatible]"))
+		assert.NotContains(t, content, "env_key")
+	})
 }
 
 func TestCompile_CodexMCPServers(t *testing.T) {

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -581,6 +581,8 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 
 		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
 		assert.Contains(t, content, `model = "qwen3-coder-next"`)
+		assert.Contains(t, content, `model_context_window = 128000`)
+		assert.Contains(t, content, `model_auto_compact_token_limit = 64000`)
 		assert.Contains(t, content, `[model_providers.agentapi_openai_compatible]`)
 		assert.Contains(t, content, `base_url = "http://ollama:11434/v1"`)
 		assert.Contains(t, content, `wire_api = "responses"`)
@@ -604,9 +606,12 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 				"OPENAI_BASE_URL": "http://proxy.example.com/v1",
 				"OPENAI_MODEL":    "gpt-oss:20b",
 				"CODEX_MODEL":     "qwen3-coder-next",
+				"CODEX_MODEL_CONTEXT_WINDOW":             "65536",
+				"CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT":    "32768",
+				"CODEX_MODEL_SUPPORTS_REASONING_SUMMARIES": "false",
 			},
 			Codex: CodexConfig{
-				ConfigTOML: "approval-mode = \"full-auto\"\nmodel = \"gpt-5.5\"\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
+				ConfigTOML: "approval-mode = \"full-auto\"\nmodel = \"gpt-5.5\"\nmodel_context_window = 128000\nmodel_auto_compact_token_limit = 64000\nmodel_supports_reasoning_summaries = true\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
 			},
 		}
 
@@ -635,9 +640,15 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 		assert.Contains(t, content, "approval-mode")
 		assert.Contains(t, content, `model_provider = "agentapi_openai_compatible"`)
 		assert.Contains(t, content, `model = "qwen3-coder-next"`)
+		assert.Contains(t, content, `model_context_window = 65536`)
+		assert.Contains(t, content, `model_auto_compact_token_limit = 32768`)
+		assert.Contains(t, content, `model_supports_reasoning_summaries = false`)
 		assert.NotContains(t, content, `model_provider = "openai"`)
 		assert.NotContains(t, content, `model = "gpt-5.5"`)
 		assert.NotContains(t, content, `model = "gpt-oss:20b"`)
+		assert.NotContains(t, content, `model_context_window = 128000`)
+		assert.NotContains(t, content, `model_auto_compact_token_limit = 64000`)
+		assert.NotContains(t, content, `model_supports_reasoning_summaries = true`)
 		assert.Less(t, strings.Index(content, `model = "qwen3-coder-next"`), strings.Index(content, "[sandbox_workspace_write]"))
 		assert.Less(t, strings.Index(content, `model_provider = "agentapi_openai_compatible"`), strings.Index(content, "[sandbox_workspace_write]"))
 		assert.Less(t, strings.Index(content, "[sandbox_workspace_write]"), strings.Index(content, "[model_providers.agentapi_openai_compatible]"))


### PR DESCRIPTION
## Summary
- generate a Codex custom OpenAI-compatible provider when session env includes OPENAI_BASE_URL
- select that provider via top-level model_provider and reference OPENAI_API_KEY through env_key when present
- avoid leaking the API key value into config.toml and keep provider tables ordered safely around existing TOML tables

## Tests
- Not run: go/gofmt are not installed in this container
- Ran: git diff --check