### PR TITLE
Fix orphan pruning for terminal session pods

### DIFF
--- a/cmd/prune_deployment_deleted.go
+++ b/cmd/prune_deployment_deleted.go
@@ -67,7 +67,14 @@ Detection uses two complementary passes so that every stale pattern is covered:
     This catches the case where the Service was already cleaned up but the
     settings Secret was left behind.
 
-Results from both passes are merged and deduplicated before deletion.
+  Pass 3 – Provision Request Secret scan:
+    Sessions whose provision request Secret (agentapi-provision-request-{id})
+    still exists, but whose Service and settings Secret are gone and whose
+    workload is gone or terminal, are considered orphaned. This catches
+    interrupted creates and partial cleanups that happened before settings
+    Secret creation.
+
+Results from all passes are merged and deduplicated before deletion.
 
 The following resources are deleted for each orphaned session:
   - Deployment  agentapi-session-{id}                     (may already be gone)
@@ -108,7 +115,18 @@ func init() {
 // resources for a single session.
 type orphanedSession struct {
 	id     string
-	source string // "service" or "settings-secret" – for logging only
+	source string // for logging only
+}
+
+func resourceExists(get func() error) (bool, error) {
+	err := get()
+	if err == nil {
+		return true, nil
+	}
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
@@ -229,6 +247,90 @@ func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
 		orphanedSessions = append(orphanedSessions, orphanedSession{
 			id:     sessionID,
 			source: "settings-secret",
+		})
+	}
+
+	// ------------------------------------------------------------------ //
+	// Pass 3: Provision Request Secret-based detection
+	//   Sessions whose provision request Secret remains after Service and
+	//   settings Secret cleanup. To avoid racing active creates, only treat the
+	//   session as orphaned when no active workload exists.
+	// ------------------------------------------------------------------ //
+	provisionRequestList, err := client.CoreV1().Secrets(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: "agentapi.proxy/provision-request=true",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list provision request secrets: %w", err)
+	}
+
+	fmt.Printf("Pass 3 (Provision Request Secret scan): found %d provision request secret(s)\n", len(provisionRequestList.Items))
+
+	for _, secret := range provisionRequestList.Items {
+		sessionID := secret.Labels["agentapi.proxy/session-id"]
+		if sessionID == "" {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] Secret %s: missing agentapi.proxy/session-id label\n", secret.Name)
+			}
+			continue
+		}
+
+		if _, alreadySeen := seen[sessionID]; alreadySeen {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] session %s: already detected in earlier pass\n", sessionID)
+			}
+			continue
+		}
+
+		svcName := fmt.Sprintf("agentapi-session-%s-svc", sessionID)
+		serviceExists, getErr := resourceExists(func() error {
+			_, err := client.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
+			return err
+		})
+		if getErr != nil {
+			fmt.Printf("  [WARN] session %s: error checking Service %s: %v\n", sessionID, svcName, getErr)
+			continue
+		}
+		if serviceExists {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: Service %s found\n", sessionID, svcName)
+			}
+			continue
+		}
+
+		settingsSecretName := fmt.Sprintf("agentapi-session-%s-settings", sessionID)
+		settingsExists, getErr := resourceExists(func() error {
+			_, err := client.CoreV1().Secrets(ns).Get(ctx, settingsSecretName, metav1.GetOptions{})
+			return err
+		})
+		if getErr != nil {
+			fmt.Printf("  [WARN] session %s: error checking settings Secret %s: %v\n", sessionID, settingsSecretName, getErr)
+			continue
+		}
+		if settingsExists {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: settings Secret %s found\n", sessionID, settingsSecretName)
+			}
+			continue
+		}
+
+		workloadName := fmt.Sprintf("agentapi-session-%s", sessionID)
+		exists, getErr := sessionWorkloadExists(ctx, client, ns, workloadName)
+		if getErr == nil && exists {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: workload %s found\n", sessionID, workloadName)
+			}
+			continue
+		}
+		if getErr != nil {
+			fmt.Printf("  [WARN] session %s: error checking workload %s: %v\n", sessionID, workloadName, getErr)
+			continue
+		}
+
+		fmt.Printf("  [ORPHANED] session %s: provision request remains but Service/settings/workload are gone (detected via Provision Request Secret)\n", sessionID)
+		seen[sessionID] = struct{}{}
+		orphanedSessions = append(orphanedSessions, orphanedSession{
+			id:     sessionID,
+			source: "provision-request-secret",
 		})
 	}
 

--- a/cmd/prune_deployment_deleted.go
+++ b/cmd/prune_deployment_deleted.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +19,7 @@ var (
 	orphanedNamespace string
 	orphanedDryRun    bool
 	orphanedVerbose   bool
+	orphanedMinAge    time.Duration
 )
 
 func sessionWorkloadExists(ctx context.Context, client kubernetes.Interface, namespace, name string) (bool, error) {
@@ -55,7 +58,7 @@ no longer exists but other associated resources are still present.
 This can happen when a workload is deleted manually or an incomplete cleanup
 leaves residual objects.
 
-Detection uses two complementary passes so that every stale pattern is covered:
+Detection uses complementary passes so that every stale pattern is covered:
 
   Pass 1 – Service scan:
     Sessions whose Service (agentapi-session-{id}-svc) still exists but
@@ -74,6 +77,11 @@ Detection uses two complementary passes so that every stale pattern is covered:
     interrupted creates and partial cleanups that happened before settings
     Secret creation.
 
+  Pass 4 – Workload scan:
+    Sessions whose Deployment or standalone Pod still exists but whose Service
+    is gone are considered orphaned. Active workloads are only pruned after
+    --min-age to avoid racing a normal in-progress create.
+
 Results from all passes are merged and deduplicated before deletion.
 
 The following resources are deleted for each orphaned session:
@@ -87,6 +95,8 @@ The following resources are deleted for each orphaned session:
   - Secret      agentapi-provision-request-{id}            (if present)
 
 Use --dry-run to preview what would be deleted without making any changes.
+Use --min-age to control how old an active workload without a Service must be
+before it is considered orphaned. Terminal or deleting workloads do not wait.
 
 Examples:
   # Preview orphaned sessions (no changes)
@@ -107,6 +117,8 @@ func init() {
 		"Show what would be deleted without actually deleting")
 	pruneOrphanedResourcesCmd.Flags().BoolVarP(&orphanedVerbose, "verbose", "v", false,
 		"Verbose output")
+	pruneOrphanedResourcesCmd.Flags().DurationVar(&orphanedMinAge, "min-age", 10*time.Minute,
+		"Minimum age before pruning active workloads that have no Service")
 
 	HelpersCmd.AddCommand(pruneOrphanedResourcesCmd)
 }
@@ -127,6 +139,36 @@ func resourceExists(get func() error) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+func oldEnoughToPrune(obj metav1.Object) bool {
+	if orphanedMinAge <= 0 {
+		return true
+	}
+	createdAt := obj.GetCreationTimestamp()
+	if createdAt.IsZero() {
+		return true
+	}
+	return time.Since(createdAt.Time) >= orphanedMinAge
+}
+
+func serviceExistsForSession(ctx context.Context, client kubernetes.Interface, namespace, sessionID string) (bool, error) {
+	svcName := fmt.Sprintf("agentapi-session-%s-svc", sessionID)
+	return resourceExists(func() error {
+		_, err := client.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+		return err
+	})
+}
+
+func deploymentWorkloadActive(deployment appsv1.Deployment) bool {
+	return deployment.DeletionTimestamp == nil
+}
+
+func podWorkloadActive(pod corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	return pod.Status.Phase != corev1.PodFailed && pod.Status.Phase != corev1.PodSucceeded
 }
 
 func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
@@ -282,10 +324,7 @@ func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
 		}
 
 		svcName := fmt.Sprintf("agentapi-session-%s-svc", sessionID)
-		serviceExists, getErr := resourceExists(func() error {
-			_, err := client.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
-			return err
-		})
+		serviceExists, getErr := serviceExistsForSession(ctx, client, ns, sessionID)
 		if getErr != nil {
 			fmt.Printf("  [WARN] session %s: error checking Service %s: %v\n", sessionID, svcName, getErr)
 			continue
@@ -316,8 +355,17 @@ func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
 		workloadName := fmt.Sprintf("agentapi-session-%s", sessionID)
 		exists, getErr := sessionWorkloadExists(ctx, client, ns, workloadName)
 		if getErr == nil && exists {
+			if oldEnoughToPrune(&secret) {
+				fmt.Printf("  [ORPHANED] session %s: provision request has no Service/settings and is older than %s (detected via Provision Request Secret)\n", sessionID, orphanedMinAge)
+				seen[sessionID] = struct{}{}
+				orphanedSessions = append(orphanedSessions, orphanedSession{
+					id:     sessionID,
+					source: "provision-request-secret",
+				})
+				continue
+			}
 			if orphanedVerbose {
-				fmt.Printf("  [ACTIVE] session %s: workload %s found\n", sessionID, workloadName)
+				fmt.Printf("  [ACTIVE] session %s: workload %s found and provision request is newer than %s\n", sessionID, workloadName, orphanedMinAge)
 			}
 			continue
 		}
@@ -331,6 +379,118 @@ func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
 		orphanedSessions = append(orphanedSessions, orphanedSession{
 			id:     sessionID,
 			source: "provision-request-secret",
+		})
+	}
+
+	// ------------------------------------------------------------------ //
+	// Pass 4: Workload-based detection
+	//   Sessions whose workload exists but Service is gone. Service is the
+	//   canonical session resource, so a workload without Service is unreachable
+	//   through the proxy. Active workloads wait for --min-age to avoid racing
+	//   normal create flow.
+	// ------------------------------------------------------------------ //
+	deployments, err := client.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=agentapi-session,app.kubernetes.io/managed-by=agentapi-proxy",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list session deployments: %w", err)
+	}
+	pods, err := client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=agentapi-session,app.kubernetes.io/managed-by=agentapi-proxy",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list session pods: %w", err)
+	}
+
+	fmt.Printf("Pass 4 (Workload scan): found %d deployment(s), %d pod(s)\n", len(deployments.Items), len(pods.Items))
+
+	for _, deployment := range deployments.Items {
+		sessionID := deployment.Labels["agentapi.proxy/session-id"]
+		if sessionID == "" {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] Deployment %s: missing agentapi.proxy/session-id label\n", deployment.Name)
+			}
+			continue
+		}
+		if _, alreadySeen := seen[sessionID]; alreadySeen {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] session %s: already detected in earlier pass\n", sessionID)
+			}
+			continue
+		}
+
+		serviceExists, getErr := serviceExistsForSession(ctx, client, ns, sessionID)
+		if getErr != nil {
+			fmt.Printf("  [WARN] session %s: error checking Service: %v\n", sessionID, getErr)
+			continue
+		}
+		if serviceExists {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: Service found for Deployment %s\n", sessionID, deployment.Name)
+			}
+			continue
+		}
+
+		if deploymentWorkloadActive(deployment) && !oldEnoughToPrune(&deployment) {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: Deployment %s has no Service but is newer than %s\n", sessionID, deployment.Name, orphanedMinAge)
+			}
+			continue
+		}
+
+		fmt.Printf("  [ORPHANED] session %s: Deployment %s has no Service (detected via workload)\n", sessionID, deployment.Name)
+		seen[sessionID] = struct{}{}
+		orphanedSessions = append(orphanedSessions, orphanedSession{
+			id:     sessionID,
+			source: "workload",
+		})
+	}
+
+	for _, pod := range pods.Items {
+		sessionID := pod.Labels["agentapi.proxy/session-id"]
+		if sessionID == "" {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] Pod %s: missing agentapi.proxy/session-id label\n", pod.Name)
+			}
+			continue
+		}
+		if pod.Name != fmt.Sprintf("agentapi-session-%s", sessionID) {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] Pod %s: not a standalone session Pod\n", pod.Name)
+			}
+			continue
+		}
+		if _, alreadySeen := seen[sessionID]; alreadySeen {
+			if orphanedVerbose {
+				fmt.Printf("  [SKIP] session %s: already detected in earlier pass\n", sessionID)
+			}
+			continue
+		}
+
+		serviceExists, getErr := serviceExistsForSession(ctx, client, ns, sessionID)
+		if getErr != nil {
+			fmt.Printf("  [WARN] session %s: error checking Service: %v\n", sessionID, getErr)
+			continue
+		}
+		if serviceExists {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: Service found for Pod %s\n", sessionID, pod.Name)
+			}
+			continue
+		}
+
+		if podWorkloadActive(pod) && !oldEnoughToPrune(&pod) {
+			if orphanedVerbose {
+				fmt.Printf("  [ACTIVE] session %s: Pod %s has no Service but is newer than %s\n", sessionID, pod.Name, orphanedMinAge)
+			}
+			continue
+		}
+
+		fmt.Printf("  [ORPHANED] session %s: Pod %s has no Service (detected via workload)\n", sessionID, pod.Name)
+		seen[sessionID] = struct{}{}
+		orphanedSessions = append(orphanedSessions, orphanedSession{
+			id:     sessionID,
+			source: "workload",
 		})
 	}
 

--- a/cmd/prune_deployment_deleted.go
+++ b/cmd/prune_deployment_deleted.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -19,16 +20,22 @@ var (
 )
 
 func sessionWorkloadExists(ctx context.Context, client kubernetes.Interface, namespace, name string) (bool, error) {
-	_, depErr := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	deployment, depErr := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
 	if depErr == nil {
-		return true, nil
+		return deployment.DeletionTimestamp == nil, nil
 	}
 	if !errors.IsNotFound(depErr) {
 		return false, depErr
 	}
 
-	_, podErr := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	pod, podErr := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 	if podErr == nil {
+		if pod.DeletionTimestamp != nil {
+			return false, nil
+		}
+		if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+			return false, nil
+		}
 		return true, nil
 	}
 	if !errors.IsNotFound(podErr) {
@@ -70,6 +77,7 @@ The following resources are deleted for each orphaned session:
   - Secret      agentapi-session-{id}-settings             (if present)
   - Secret      agentapi-session-{id}-svc-webhook-payload  (if present)
   - Secret      agentapi-session-{id}-svc-oneshot-settings (if present)
+  - Secret      agentapi-provision-request-{id}            (if present)
 
 Use --dry-run to preview what would be deleted without making any changes.
 
@@ -255,6 +263,7 @@ func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
 		settingsSecretName := fmt.Sprintf("agentapi-session-%s-settings", id)
 		webhookSecretName := fmt.Sprintf("%s-webhook-payload", svcName)
 		oneshotSecretName := fmt.Sprintf("%s-oneshot-settings", svcName)
+		provisionRequestSecretName := fmt.Sprintf("agentapi-provision-request-%s", id)
 
 		resources := []resource{
 			{
@@ -304,6 +313,13 @@ func runPruneOrphanedResources(cmd *cobra.Command, args []string) error {
 				name: oneshotSecretName,
 				del: func() error {
 					return client.CoreV1().Secrets(ns).Delete(ctx, oneshotSecretName, metav1.DeleteOptions{})
+				},
+			},
+			{
+				kind: "Secret (provision-request)",
+				name: provisionRequestSecretName,
+				del: func() error {
+					return client.CoreV1().Secrets(ns).Delete(ctx, provisionRequestSecretName, metav1.DeleteOptions{})
 				},
 			},
 		}

--- a/cmd/prune_deployment_deleted_test.go
+++ b/cmd/prune_deployment_deleted_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestSessionWorkloadExistsTreatsLivePodAsExisting(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "agentapi-session-live", Namespace: "test-ns"},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	})
+
+	exists, err := sessionWorkloadExists(context.Background(), client, "test-ns", "agentapi-session-live")
+	if err != nil {
+		t.Fatalf("sessionWorkloadExists returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected running pod to count as existing workload")
+	}
+}
+
+func TestSessionWorkloadExistsTreatsTerminalPodsAsMissing(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase corev1.PodPhase
+	}{
+		{name: "succeeded", phase: corev1.PodSucceeded},
+		{name: "failed", phase: corev1.PodFailed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "agentapi-session-done", Namespace: "test-ns"},
+				Status:     corev1.PodStatus{Phase: tt.phase},
+			})
+
+			exists, err := sessionWorkloadExists(context.Background(), client, "test-ns", "agentapi-session-done")
+			if err != nil {
+				t.Fatalf("sessionWorkloadExists returned error: %v", err)
+			}
+			if exists {
+				t.Fatalf("expected %s pod to count as missing workload", tt.phase)
+			}
+		})
+	}
+}
+
+func TestSessionWorkloadExistsTreatsDeploymentAsExisting(t *testing.T) {
+	client := fake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "agentapi-session-deploy", Namespace: "test-ns"},
+	})
+
+	exists, err := sessionWorkloadExists(context.Background(), client, "test-ns", "agentapi-session-deploy")
+	if err != nil {
+		t.Fatalf("sessionWorkloadExists returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected deployment to count as existing workload")
+	}
+}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3318,31 +3318,6 @@ func (m *KubernetesSessionManager) deleteSessionResources(ctx context.Context, s
 	return nil
 }
 
-// deleteDeployment deletes the deployment for a session
-func (m *KubernetesSessionManager) deleteDeployment(ctx context.Context, session *KubernetesSession) error {
-	return m.client.AppsV1().Deployments(m.namespace).Delete(ctx, session.DeploymentName(), metav1.DeleteOptions{})
-}
-
-// deleteSessionWorkload deletes the backing Deployment or Pod for a session.
-func (m *KubernetesSessionManager) deleteSessionWorkload(ctx context.Context, session *KubernetesSession) error {
-	var errs []string
-	if err := m.deleteDeployment(ctx, session); err != nil && !errors.IsNotFound(err) {
-		errs = append(errs, fmt.Sprintf("deployment: %v", err))
-	}
-	if err := m.client.CoreV1().Pods(m.namespace).Delete(ctx, session.DeploymentName(), metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		errs = append(errs, fmt.Sprintf("pod: %v", err))
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to delete workload: %s", strings.Join(errs, ", "))
-	}
-	return nil
-}
-
-// deletePVC deletes the PVC for a session
-func (m *KubernetesSessionManager) deletePVC(ctx context.Context, session *KubernetesSession) error {
-	return m.client.CoreV1().PersistentVolumeClaims(m.namespace).Delete(ctx, session.PVCName(), metav1.DeleteOptions{})
-}
-
 // cleanupSession removes a session from the internal map and releases its message subscribers.
 func (m *KubernetesSessionManager) cleanupSession(id string) {
 	m.mutex.Lock()

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -393,9 +393,20 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 
 	log.Printf("[K8S_SESSION] Creating session %s in namespace %s", id, m.namespace)
 
+	// Create Service first. It is the canonical session resource and owns every
+	// other per-session Kubernetes resource through ownerReferences.
+	if err := m.createService(ctx, session); err != nil {
+		m.cleanupSession(id)
+		return nil, fmt.Errorf("failed to create Service: %w", err)
+	}
+	log.Printf("[K8S_SESSION] Created Service %s for session %s", serviceName, id)
+
 	// Create PVC if enabled
 	if m.isPVCEnabled() {
 		if err := m.createPVC(ctx, session); err != nil {
+			if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+				log.Printf("[K8S_SESSION] Failed to cleanup resources after PVC creation failure: %v", delErr)
+			}
 			m.cleanupSession(id)
 			return nil, fmt.Errorf("failed to create PVC: %w", err)
 		}
@@ -445,6 +456,9 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 
 	session.SetProvisionSettings(sessionSettings)
 	if err := m.CreateProvisionRequest(ctx, session); err != nil {
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after provision request creation failure: %v", delErr)
+		}
 		m.cleanupSession(id)
 		return nil, fmt.Errorf("failed to create provision request: %w", err)
 	}
@@ -452,30 +466,13 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 	// Create workload. PVC-backed sessions use a Deployment for restart recovery;
 	// ephemeral EmptyDir sessions use a Pod with restartPolicy=Never.
 	if err := m.createSessionWorkload(ctx, session, req); err != nil {
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after workload creation failure: %v", delErr)
-			}
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after workload creation failure: %v", delErr)
 		}
 		m.cleanupSession(id)
 		return nil, fmt.Errorf("failed to create session workload: %w", err)
 	}
 	log.Printf("[K8S_SESSION] Created workload %s for session %s", deploymentName, id)
-
-	// Create Service
-	if err := m.createService(ctx, session); err != nil {
-		if delErr := m.deleteSessionWorkload(ctx, session); delErr != nil {
-			log.Printf("[K8S_SESSION] Failed to cleanup workload after service creation failure: %v", delErr)
-		}
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after service creation failure: %v", delErr)
-			}
-		}
-		m.cleanupSession(id)
-		return nil, fmt.Errorf("failed to create Service: %w", err)
-	}
-	log.Printf("[K8S_SESSION] Created Service %s for session %s", serviceName, id)
 
 	// Start watching session in background
 	go m.watchSession(sessionCtx, session)
@@ -524,34 +521,49 @@ func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, sandb
 		m.namespace, m.k8sConfig.BasePort, cancel, nil)
 	session.SetIsStock(true)
 
+	// Create the Service first so stock resources can reference it as owner.
+	// Keep it out of the available stock pool until the workload is created.
+	stockLabels := m.buildLabels(session)
+	stockLabels["agentapi.proxy/stock"] = "creating"
+	if err := m.createServiceWithLabels(ctx, session, stockLabels); err != nil {
+		cancel()
+		return fmt.Errorf("failed to create stock service: %w", err)
+	}
+
 	// Create PVC if enabled (required for Deployment volume mounts).
 	if m.isPVCEnabled() {
 		if err := m.createPVC(ctx, session); err != nil {
+			if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+				log.Printf("[K8S_SESSION] Failed to cleanup resources after stock PVC creation failure: %v", delErr)
+			}
 			cancel()
 			return fmt.Errorf("failed to create stock PVC: %w", err)
 		}
 	}
 
 	if err := m.createSessionWorkload(ctx, session, minimalReq); err != nil {
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after stock workload creation failure: %v", delErr)
-			}
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after stock workload creation failure: %v", delErr)
 		}
 		cancel()
 		return fmt.Errorf("failed to create stock workload: %w", err)
 	}
-	if err := m.createService(ctx, session); err != nil {
-		if delErr := m.deleteSessionWorkload(ctx, session); delErr != nil {
-			log.Printf("[K8S_SESSION] Failed to cleanup workload after stock service creation failure: %v", delErr)
-		}
-		if m.isPVCEnabled() {
-			if delErr := m.deletePVC(ctx, session); delErr != nil {
-				log.Printf("[K8S_SESSION] Failed to cleanup PVC after stock service creation failure: %v", delErr)
-			}
+
+	stockSvc, err := m.client.CoreV1().Services(m.namespace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after stock service lookup failure: %v", delErr)
 		}
 		cancel()
-		return fmt.Errorf("failed to create stock service: %w", err)
+		return fmt.Errorf("failed to get stock service: %w", err)
+	}
+	stockSvc.Labels["agentapi.proxy/stock"] = "true"
+	if _, err := m.client.CoreV1().Services(m.namespace).Update(ctx, stockSvc, metav1.UpdateOptions{}); err != nil {
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup resources after stock service update failure: %v", delErr)
+		}
+		cancel()
+		return fmt.Errorf("failed to mark stock service ready: %w", err)
 	}
 	log.Printf("[K8S_SESSION] Stock session %s created successfully (sandbox=%t, dind=%t)",
 		id, sandbox, dind)
@@ -590,7 +602,7 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 	// stock=claiming (abandoned mid-adoption). Collect session IDs from every
 	// resource kind so a previous partial purge cannot leave orphaned stock
 	// Deployments/PVCs behind.
-	selector := "agentapi.proxy/stock in (true, claiming),app.kubernetes.io/managed-by=agentapi-proxy"
+	selector := "agentapi.proxy/stock in (true, claiming, creating),app.kubernetes.io/managed-by=agentapi-proxy"
 	svcs, err := m.client.CoreV1().Services(m.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})
@@ -814,6 +826,12 @@ func (m *KubernetesSessionManager) adoptStockSession(
 	switch {
 	case pvcErr == nil:
 		log.Printf("[K8S_SESSION] Stock session %s has existing PVC %s, reusing it", stockID, pvcName)
+		if currentPVC, err := m.client.CoreV1().PersistentVolumeClaims(m.namespace).Get(ctx, pvcName, metav1.GetOptions{}); err == nil {
+			currentPVC.OwnerReferences = m.sessionServiceOwnerReferences(ctx, stockID)
+			if _, err := m.client.CoreV1().PersistentVolumeClaims(m.namespace).Update(ctx, currentPVC, metav1.UpdateOptions{}); err != nil {
+				log.Printf("[K8S_SESSION] Warning: failed to update stock PVC owner reference for session %s: %v", stockID, err)
+			}
+		}
 	case errors.IsNotFound(pvcErr):
 		log.Printf("[K8S_SESSION] Stock session %s has no PVC, using EmptyDir", stockID)
 	default:
@@ -896,6 +914,7 @@ func (m *KubernetesSessionManager) adoptStockSession(
 			log.Printf("[K8S_SESSION] Warning: failed to get stock deployment for label update: %v", err)
 		} else {
 			currentDep.Labels = newLabels
+			currentDep.OwnerReferences = m.sessionServiceOwnerReferences(ctx, stockID)
 			if _, err := m.client.AppsV1().Deployments(m.namespace).Update(ctx, currentDep, metav1.UpdateOptions{}); err != nil {
 				log.Printf("[K8S_SESSION] Warning: failed to update stock deployment labels for session %s: %v", stockID, err)
 			}
@@ -906,6 +925,7 @@ func (m *KubernetesSessionManager) adoptStockSession(
 			log.Printf("[K8S_SESSION] Warning: failed to get stock pod for label update: %v", err)
 		} else {
 			currentPod.Labels = newLabels
+			currentPod.OwnerReferences = m.sessionServiceOwnerReferences(ctx, stockID)
 			if _, err := m.client.CoreV1().Pods(m.namespace).Update(ctx, currentPod, metav1.UpdateOptions{}); err != nil {
 				log.Printf("[K8S_SESSION] Warning: failed to update stock pod labels for session %s: %v", stockID, err)
 			}
@@ -1878,9 +1898,10 @@ func (m *KubernetesSessionManager) createPVC(ctx context.Context, session *Kuber
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      session.PVCName(),
-			Namespace: m.namespace,
-			Labels:    m.buildLabels(session),
+			Name:            session.PVCName(),
+			Namespace:       m.namespace,
+			Labels:          m.buildLabels(session),
+			OwnerReferences: m.sessionServiceOwnerReferences(ctx, session.id),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
@@ -1933,10 +1954,11 @@ func (m *KubernetesSessionManager) createPod(ctx context.Context, session *Kuber
 	podTemplate := deployment.Spec.Template
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        session.DeploymentName(),
-			Namespace:   m.namespace,
-			Labels:      podTemplate.Labels,
-			Annotations: podTemplate.Annotations,
+			Name:            session.DeploymentName(),
+			Namespace:       m.namespace,
+			Labels:          podTemplate.Labels,
+			Annotations:     podTemplate.Annotations,
+			OwnerReferences: m.sessionServiceOwnerReferences(ctx, session.id),
 		},
 		Spec: podTemplate.Spec,
 	}
@@ -2217,9 +2239,10 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      session.DeploymentName(),
-			Namespace: m.namespace,
-			Labels:    labels,
+			Name:            session.DeploymentName(),
+			Namespace:       m.namespace,
+			Labels:          labels,
+			OwnerReferences: m.sessionServiceOwnerReferences(ctx, session.id),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -2367,8 +2390,9 @@ func (m *KubernetesSessionManager) createWebhookPayloadSecret(
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: m.namespace,
+			Name:            secretName,
+			Namespace:       m.namespace,
+			OwnerReferences: m.sessionServiceOwnerReferences(ctx, session.id),
 			Labels: map[string]string{
 				"agentapi.proxy/session-id": session.id,
 				"agentapi.proxy/user-id":    sanitizeLabelValue(session.Request().UserID),
@@ -2485,8 +2509,9 @@ func (m *KubernetesSessionManager) createOneshotSettingsSecret(
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: m.namespace,
+			Name:            secretName,
+			Namespace:       m.namespace,
+			OwnerReferences: m.sessionServiceOwnerReferences(ctx, session.id),
 			Labels: map[string]string{
 				"agentapi.proxy/session-id": session.id,
 				"agentapi.proxy/user-id":    sanitizeLabelValue(session.Request().UserID),
@@ -3068,6 +3093,10 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 
 // createService creates a Service for the session
 func (m *KubernetesSessionManager) createService(ctx context.Context, session *KubernetesSession) error {
+	return m.createServiceWithLabels(ctx, session, m.buildLabels(session))
+}
+
+func (m *KubernetesSessionManager) createServiceWithLabels(ctx context.Context, session *KubernetesSession, labels map[string]string) error {
 	annotations := map[string]string{
 		"agentapi.proxy/created-at": session.startedAt.Format(time.RFC3339),
 		"agentapi.proxy/updated-at": session.startedAt.Format(time.RFC3339),
@@ -3092,7 +3121,7 @@ func (m *KubernetesSessionManager) createService(ctx context.Context, session *K
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        session.ServiceName(),
 			Namespace:   m.namespace,
-			Labels:      m.buildLabels(session),
+			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
@@ -3106,6 +3135,26 @@ func (m *KubernetesSessionManager) createService(ctx context.Context, session *K
 
 	_, err := m.client.CoreV1().Services(m.namespace).Create(ctx, service, metav1.CreateOptions{})
 	return err
+}
+
+func (m *KubernetesSessionManager) sessionServiceOwnerReferences(ctx context.Context, sessionID string) []metav1.OwnerReference {
+	if m == nil || m.client == nil {
+		return nil
+	}
+	svcName := fmt.Sprintf("agentapi-session-%s-svc", sessionID)
+	svc, err := m.client.CoreV1().Services(m.namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[K8S_SESSION] Warning: failed to get Service %s for owner reference: %v", svcName, err)
+		return nil
+	}
+	return []metav1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "Service",
+			Name:       svc.Name,
+			UID:        svc.UID,
+		},
+	}
 }
 
 // watchSession monitors the session deployment status
@@ -5231,8 +5280,9 @@ func (m *KubernetesSessionManager) createSessionSettingsSecretFromSettings(
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: m.namespace,
+			Name:            secretName,
+			Namespace:       m.namespace,
+			OwnerReferences: m.sessionServiceOwnerReferences(ctx, session.id),
 			Labels: map[string]string{
 				"agentapi.proxy/session-id": session.id,
 				"agentapi.proxy/user-id":    sanitizeLabelValue(req.UserID),

--- a/internal/infrastructure/services/kubernetes_session_manager_workload_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_workload_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
 func newWorkloadTestManager(t *testing.T, pvcEnabled bool) *KubernetesSessionManager {
@@ -22,14 +23,15 @@ func newWorkloadTestManager(t *testing.T, pvcEnabled bool) *KubernetesSessionMan
 	k8sClient := fake.NewSimpleClientset(ns)
 	cfg := &config.Config{
 		KubernetesSession: config.KubernetesSessionConfig{
-			Namespace:     "test-ns",
-			Image:         "test-image:latest",
-			BasePort:      9000,
-			PVCEnabled:    boolPtrForTest(pvcEnabled),
-			CPURequest:    "100m",
-			CPULimit:      "1",
-			MemoryRequest: "128Mi",
-			MemoryLimit:   "512Mi",
+			Namespace:      "test-ns",
+			Image:          "test-image:latest",
+			BasePort:       9000,
+			PVCEnabled:     boolPtrForTest(pvcEnabled),
+			CPURequest:     "100m",
+			CPULimit:       "1",
+			MemoryRequest:  "128Mi",
+			MemoryLimit:    "512Mi",
+			PVCStorageSize: "1Gi",
 		},
 	}
 	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
@@ -51,6 +53,17 @@ func newWorkloadTestSession() *KubernetesSession {
 		nil,
 		nil,
 	)
+}
+
+func assertOwnedByService(t *testing.T, obj metav1.Object, serviceName string) {
+	t.Helper()
+	owners := obj.GetOwnerReferences()
+	if len(owners) != 1 {
+		t.Fatalf("Expected one owner reference on %s, got %d: %+v", obj.GetName(), len(owners), owners)
+	}
+	if owners[0].APIVersion != "v1" || owners[0].Kind != "Service" || owners[0].Name != serviceName {
+		t.Fatalf("Expected %s to be owned by Service %s, got %+v", obj.GetName(), serviceName, owners[0])
+	}
 }
 
 func TestCreateSessionWorkloadWithoutPVCUsesPodRestartPolicyNever(t *testing.T) {
@@ -110,6 +123,80 @@ func TestCreateSessionWorkloadWithPVCUsesDeploymentRestartPolicyAlways(t *testin
 	if len(pods.Items) != 0 {
 		t.Fatalf("Expected no standalone pods, got %d", len(pods.Items))
 	}
+}
+
+func TestSessionResourcesUseServiceOwnerReferenceWithoutPVC(t *testing.T) {
+	manager := newWorkloadTestManager(t, false)
+	session := newWorkloadTestSession()
+	ctx := context.Background()
+
+	if err := manager.createService(ctx, session); err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := manager.createSessionWorkload(ctx, session, session.Request()); err != nil {
+		t.Fatalf("Failed to create workload: %v", err)
+	}
+	if err := manager.createWebhookPayloadSecret(ctx, session, []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("Failed to create webhook payload secret: %v", err)
+	}
+	if err := manager.createOneshotSettingsSecret(ctx, session); err != nil {
+		t.Fatalf("Failed to create oneshot settings secret: %v", err)
+	}
+	settings := &sessionsettings.SessionSettings{}
+	session.SetProvisionSettings(settings)
+	if err := manager.CreateProvisionRequest(ctx, session); err != nil {
+		t.Fatalf("Failed to create provision request: %v", err)
+	}
+	if err := manager.createSessionSettingsSecretFromSettings(ctx, session, session.Request(), settings); err != nil {
+		t.Fatalf("Failed to create session settings secret: %v", err)
+	}
+
+	pod, err := manager.client.CoreV1().Pods("test-ns").Get(ctx, session.DeploymentName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected pod to be created: %v", err)
+	}
+	assertOwnedByService(t, pod, session.ServiceName())
+
+	for _, secretName := range []string{
+		session.ServiceName() + "-webhook-payload",
+		session.ServiceName() + "-oneshot-settings",
+		"agentapi-provision-request-" + session.ID(),
+		"agentapi-session-" + session.ID() + "-settings",
+	} {
+		secret, err := manager.client.CoreV1().Secrets("test-ns").Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Expected secret %s to be created: %v", secretName, err)
+		}
+		assertOwnedByService(t, secret, session.ServiceName())
+	}
+}
+
+func TestSessionResourcesUseServiceOwnerReferenceWithPVC(t *testing.T) {
+	manager := newWorkloadTestManager(t, true)
+	session := newWorkloadTestSession()
+	ctx := context.Background()
+
+	if err := manager.createService(ctx, session); err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	if err := manager.createPVC(ctx, session); err != nil {
+		t.Fatalf("Failed to create PVC: %v", err)
+	}
+	if err := manager.createSessionWorkload(ctx, session, session.Request()); err != nil {
+		t.Fatalf("Failed to create workload: %v", err)
+	}
+
+	pvc, err := manager.client.CoreV1().PersistentVolumeClaims("test-ns").Get(ctx, session.PVCName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected PVC to be created: %v", err)
+	}
+	assertOwnedByService(t, pvc, session.ServiceName())
+
+	deployment, err := manager.client.AppsV1().Deployments("test-ns").Get(ctx, session.DeploymentName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected deployment to be created: %v", err)
+	}
+	assertOwnedByService(t, deployment, session.ServiceName())
 }
 
 func TestPurgeStockSessionsDeletesMixedWorkloadKindsAndPVC(t *testing.T) {

--- a/internal/infrastructure/services/provisioner_requests.go
+++ b/internal/infrastructure/services/provisioner_requests.go
@@ -259,13 +259,15 @@ func (m *KubernetesSessionManager) saveProvisionRequest(ctx context.Context, req
 		"agentapi.proxy/session-id":        req.SessionID,
 		"agentapi.proxy/provision-request": "true",
 	}
+	ownerReferences := m.sessionServiceOwnerReferences(ctx, req.SessionID)
 	sec, err := m.client.CoreV1().Secrets(m.namespace).Get(ctx, name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		sec = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: m.namespace,
-				Labels:    labels,
+				Name:            name,
+				Namespace:       m.namespace,
+				Labels:          labels,
+				OwnerReferences: ownerReferences,
 			},
 			Type: corev1.SecretTypeOpaque,
 			Data: map[string][]byte{"request.json": data},
@@ -277,6 +279,7 @@ func (m *KubernetesSessionManager) saveProvisionRequest(ctx context.Context, req
 		return err
 	}
 	sec.Labels = labels
+	sec.OwnerReferences = ownerReferences
 	if sec.Data == nil {
 		sec.Data = make(map[string][]byte)
 	}


### PR DESCRIPTION
## Summary
- Make the session Service the canonical owner for per-session Kubernetes resources
- Create Service before PVC/workload/provision request for new sessions, and create stock Services in `stock=creating` until their workload is ready
- Attach Service ownerReferences to session workload, PVC, webhook payload Secret, oneshot settings Secret, session settings Secret, and provision request Secret
- Repair ownerReferences during stock adoption for existing stock workload/PVC
- Extend `prune-orphaned-resources` with workload scanning for Service-missing Deployment/standalone Pod leftovers, guarded by `--min-age` for active workloads
- Keep terminal/deleting Pod handling and provision-request-only cleanup from the earlier fix

## Investigation
Service is the canonical session resource: sessions are restored/listed/routed through the Kubernetes Service. A Pod or Deployment without its Service is unreachable through the proxy, so it should be treated as orphaned.

Standalone Pod sessions use `restartPolicy=Never`, so after the agent process exits Kubernetes can leave the Pod object in a terminal phase. The orphan pruning command only checked whether the Pod object existed, so terminal Pods were treated as active workloads and their session resources were skipped.

There is also a creation/cleanup ordering gap: the provision request existed before Service/settings in the old flow, and settings are only created after provisioning succeeds. If creation or cleanup was interrupted, it was possible to have only a provision request Secret and/or workload with no Service. The updated flow creates Service first and makes dependent resources owned by it, while the prune command can clean legacy leftovers.

Active Service-missing workloads are only pruned after `--min-age` (default `10m`) to avoid racing an in-progress create. Terminal/deleting workloads do not wait.

## Tests
- `mise exec -- go test ./internal/infrastructure/services`
- `mise exec -- go test ./cmd -run TestSessionWorkloadExists`

Note: `mise exec -- go test ./cmd` still fails in existing tests because they hit an invalid configured endpoint and are interrupted (`invalid-endpoint-that-does-not-exist`).