### PR TITLE
Add pi-ollama ACP agent type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,6 +186,13 @@ RUN bun install -g @openai/codex && \
     sudo tee /opt/claude/bin/codex > /dev/null && \
     sudo chmod +x /opt/claude/bin/codex
 
+# Install Pi, pi-acp, and the Ollama Cloud provider extension for pi-ollama sessions.
+# pi-acp starts `pi --mode rpc`, and pi-ollama-cloud connects directly to
+# https://ollama.com/v1 using OLLAMA_API_KEY/OLLAMA_API_KEYS.
+RUN bun install -g @earendil-works/pi-coding-agent && \
+    npm install --global pi-acp@latest && \
+    pi install npm:pi-ollama-cloud
+
 # Install Cursor Agent CLI and place stable wrappers in /opt/cursor/bin.
 # Official install docs: https://cursor.com/docs/cli/installation
 RUN curl https://cursor.com/install -fsS | bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,8 @@ RUN bun install -g @openai/codex && \
 # https://ollama.com/v1 using OLLAMA_API_KEY/OLLAMA_API_KEYS.
 RUN bun install -g @earendil-works/pi-coding-agent && \
     npm install --global pi-acp@latest && \
+    mkdir -p /home/agentapi/.pi/agent/npm && \
+    printf '{"private":true,"dependencies":{}}\n' > /home/agentapi/.pi/agent/npm/package.json && \
     pi install npm:pi-ollama-cloud
 
 # Install Cursor Agent CLI and place stable wrappers in /opt/cursor/bin.

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,28 @@ RUN bun install -g @earendil-works/pi-coding-agent && \
     npm install --global pi-acp@latest && \
     mkdir -p /home/agentapi/.pi/agent/npm && \
     printf '{"private":true,"dependencies":{}}\n' > /home/agentapi/.pi/agent/npm/package.json && \
-    pi install npm:pi-ollama-cloud
+    mkdir -p /tmp/pi-npm-shim && \
+    printf '%s\n' \
+      '#!/bin/sh' \
+      'set -e' \
+      'prefix=""' \
+      'packages=""' \
+      'while [ "$#" -gt 0 ]; do' \
+      '  case "$1" in' \
+      '    install) shift ;;' \
+      '    --prefix) prefix="$2"; shift 2 ;;' \
+      '    --legacy-peer-deps) shift ;;' \
+      '    *) packages="$packages $1"; shift ;;' \
+      '  esac' \
+      'done' \
+      'if [ -z "$prefix" ]; then prefix="$PWD"; fi' \
+      'mkdir -p "$prefix"' \
+      'test -f "$prefix/package.json" || printf "%s\n" "{\"private\":true,\"dependencies\":{}}" > "$prefix/package.json"' \
+      'exec bun add --cwd "$prefix" $packages' \
+      > /tmp/pi-npm-shim/npm && \
+    chmod +x /tmp/pi-npm-shim/npm && \
+    PATH="/tmp/pi-npm-shim:$PATH" pi install npm:pi-ollama-cloud && \
+    rm -rf /tmp/pi-npm-shim
 
 # Install Cursor Agent CLI and place stable wrappers in /opt/cursor/bin.
 # Official install docs: https://cursor.com/docs/cli/installation

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -551,6 +551,14 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 			Command: []string{"agentapi-proxy"},
 			Args:    []string{"acp-server", "--", "npx", "@zed-industries/codex-acp"},
 		}
+	case "pi-ollama":
+		// acp-server bridges pi-acp to Pi, which is configured with the pi-ollama-cloud provider.
+		// https://github.com/svkozak/pi-acp
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx -y pi-acp]")
+		return sessionsettings.StartupConfig{
+			Command: []string{"agentapi-proxy"},
+			Args:    []string{"acp-server", "--", "npx", "-y", "pi-acp"},
+		}
 	case "cursor":
 		// acp-server bridges Cursor Agent CLI's native ACP server to the agentapi HTTP interface.
 		// https://cursor.com/docs/cli/acp

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -41,6 +41,13 @@ func TestBuildStartupConfigCursor(t *testing.T) {
 	assert.Equal(t, []string{"acp-server", "--auto-approve", "--raw-json-log", "--", "agent", "acp"}, config.Args)
 }
 
+func TestBuildStartupConfigPiOllama(t *testing.T) {
+	config := buildStartupConfig("pi-ollama")
+
+	assert.Equal(t, []string{"agentapi-proxy"}, config.Command)
+	assert.Equal(t, []string{"acp-server", "--", "npx", "-y", "pi-acp"}, config.Args)
+}
+
 func TestGenerateTokenFlags(t *testing.T) {
 	// Test required flags
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1588,7 +1588,7 @@ func (m *KubernetesSessionManager) Shutdown(timeout time.Duration) error {
 }
 
 // SendMessage sends a message to an existing session.
-// For ACP sessions (claude-acp, codex-acp, cursor) it uses the ACP JSON-RPC 2.0
+// For ACP sessions (claude-acp, codex-acp, pi-ollama, cursor) it uses the ACP JSON-RPC 2.0
 // POST /rpc endpoint with session/prompt; for standard agentapi sessions it
 // uses the agentapi-compatible POST /message endpoint.
 func (m *KubernetesSessionManager) SendMessage(ctx context.Context, id string, message string) error {
@@ -1812,12 +1812,12 @@ func (m *KubernetesSessionManager) StopAgent(ctx context.Context, id string) err
 }
 
 func isACPAgentType(agentType string) bool {
-	return agentType == "claude-acp" || agentType == "codex-acp" || agentType == "cursor"
+	return agentType == "claude-acp" || agentType == "codex-acp" || agentType == "pi-ollama" || agentType == "cursor"
 }
 
 func supportedAgentTypeOrDefault(agentType string) string {
 	switch agentType {
-	case "claude-acp", "codex-acp", "cursor":
+	case "claude-acp", "codex-acp", "pi-ollama", "cursor":
 		return agentType
 	default:
 		return ""
@@ -4936,6 +4936,19 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"--auto-approve",
 				"--",
 				"npx", "@zed-industries/codex-acp",
+			},
+		}
+	case "pi-ollama":
+		// acp-server bridges pi-acp to Pi, which is configured with the pi-ollama-cloud provider.
+		// https://github.com/svkozak/pi-acp
+		settings.Startup = sessionsettings.StartupConfig{
+			Command: []string{"agentapi-proxy"},
+			Args: []string{
+				"acp-server",
+				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
+				"--auto-approve",
+				"--",
+				"npx", "-y", "pi-acp",
 			},
 		}
 	case "cursor":

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -51,6 +51,12 @@ func TestIsACPAgentTypeIncludesCursor(t *testing.T) {
 	}
 }
 
+func TestIsACPAgentTypeIncludesPiOllama(t *testing.T) {
+	if !isACPAgentType("pi-ollama") {
+		t.Fatal("expected pi-ollama to be treated as an ACP agent type")
+	}
+}
+
 // TestSubscribeMessageEvents_ReceivesBroadcast verifies that a subscriber
 // registered before broadcastMessageUpdate is called receives the event.
 func TestSubscribeMessageEvents_ReceivesBroadcast(t *testing.T) {
@@ -236,6 +242,7 @@ func TestSupportedAgentTypeOrDefault(t *testing.T) {
 		{name: "default", agentType: "", want: ""},
 		{name: "claude acp", agentType: "claude-acp", want: "claude-acp"},
 		{name: "codex acp", agentType: "codex-acp", want: "codex-acp"},
+		{name: "pi ollama", agentType: "pi-ollama", want: "pi-ollama"},
 		{name: "cursor", agentType: "cursor", want: "cursor"},
 		{name: "unknown", agentType: "unknown-agent", want: ""},
 	}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -925,6 +925,19 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 			"npx", "@zed-industries/codex-acp",
 		}
 
+	case "pi-ollama":
+		// Start the acp-server bridge that wraps pi-acp via stdio. pi-acp starts
+		// `pi --mode rpc`; the image/pre-script install pi-ollama-cloud so Pi can
+		// talk directly to Ollama Cloud without a local Ollama daemon.
+		// https://github.com/svkozak/pi-acp
+		return "agentapi-proxy", []string{
+			"acp-server",
+			"--port", agentapiPort,
+			"--auto-approve",
+			"--",
+			"npx", "-y", "pi-acp",
+		}
+
 	case "cursor":
 		// Start the acp-server bridge that wraps Cursor Agent CLI's native ACP server via stdio.
 		// https://cursor.com/docs/cli/acp
@@ -1095,7 +1108,7 @@ type acpMessagesResponse struct {
 // started, replicating the logic of initialMessageSenderScript.
 func sendInitialMessage(ctx context.Context, agentapiURL, message, agentType string, waitSec int) {
 	// ACP sessions use a different transport (JSON-RPC 2.0 over POST /rpc).
-	if agentType == "claude-acp" || agentType == "codex-acp" || agentType == "cursor" {
+	if agentType == "claude-acp" || agentType == "codex-acp" || agentType == "pi-ollama" || agentType == "cursor" {
 		sendACPInitialMessage(ctx, agentapiURL, message, waitSec)
 		return
 	}

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -53,6 +53,22 @@ func TestBuildAgentCommandCursor(t *testing.T) {
 	}
 }
 
+func TestBuildAgentCommandPiOllama(t *testing.T) {
+	t.Setenv("AGENTAPI_PORT", "9000")
+
+	cmd, args := (&Server{}).buildAgentCommand(&sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{AgentType: "pi-ollama"},
+	}, nil)
+
+	if cmd != "agentapi-proxy" {
+		t.Fatalf("command = %q, want agentapi-proxy", cmd)
+	}
+	want := []string{"acp-server", "--port", "9000", "--auto-approve", "--", "npx", "-y", "pi-acp"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
 func TestSyncedManagedFilePathsExcludesUnsyncedPaths(t *testing.T) {
 	got := syncedManagedFilePaths([]string{
 		" /home/agentapi/.codex/auth.json ",

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -25,6 +25,9 @@ import (
 // Override with the PROVISIONER_PRE_SCRIPT environment variable.
 const defaultStartupScript = `bun install --global @agentclientprotocol/claude-agent-acp@latest
 npm install --global @zed-industries/codex-acp@latest
+bun install --global @earendil-works/pi-coding-agent@latest
+npm install --global pi-acp@latest
+pi install npm:pi-ollama-cloud
 `
 
 // Status represents the provisioning lifecycle state.

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -27,6 +27,8 @@ const defaultStartupScript = `bun install --global @agentclientprotocol/claude-a
 npm install --global @zed-industries/codex-acp@latest
 bun install --global @earendil-works/pi-coding-agent@latest
 npm install --global pi-acp@latest
+mkdir -p "$HOME/.pi/agent/npm"
+test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
 pi install npm:pi-ollama-cloud
 `
 

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -29,7 +29,28 @@ bun install --global @earendil-works/pi-coding-agent@latest
 npm install --global pi-acp@latest
 mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-pi install npm:pi-ollama-cloud
+NPM_SHIM_DIR="$(mktemp -d)"
+cat > "$NPM_SHIM_DIR/npm" <<'EOF'
+#!/bin/sh
+set -e
+prefix=""
+packages=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    install) shift ;;
+    --prefix) prefix="$2"; shift 2 ;;
+    --legacy-peer-deps) shift ;;
+    *) packages="$packages $1"; shift ;;
+  esac
+done
+if [ -z "$prefix" ]; then prefix="$PWD"; fi
+mkdir -p "$prefix"
+test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
+exec bun add --cwd "$prefix" $packages
+EOF
+chmod +x "$NPM_SHIM_DIR/npm"
+PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+rm -rf "$NPM_SHIM_DIR"
 `
 
 // Status represents the provisioning lifecycle state.


### PR DESCRIPTION
## Summary
- add pi-ollama agent_type startup commands for local settings, provisioner, and Kubernetes sessions
- treat pi-ollama as an ACP-backed agent for messaging and initial prompts
- install Pi, pi-acp, and pi-ollama-cloud in the runtime image and provisioner prefetch script

## Tests
- mise exec -- go test ./cmd -run 'TestBuildStartupConfig(Cursor|PiOllama)$'
- mise exec -- go test ./pkg/provisioner ./internal/infrastructure/services

Note: a broader run of `mise exec -- go test ./cmd ./pkg/provisioner ./internal/infrastructure/services` reached existing cmd tests that initialize live Kubernetes/session state and ended with `signal: interrupt`; the targeted cmd startup tests pass.