### PR TITLE
Configure Pi Ollama Cloud runtime

### DIFF
--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -14,6 +14,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const piOllamaInstallPreScript = `mkdir -p "$HOME/.pi/agent/npm"
+test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
+NPM_SHIM_DIR="$(mktemp -d)"
+cat > "$NPM_SHIM_DIR/npm" <<'EOF'
+#!/bin/sh
+set -e
+prefix=""
+packages=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    install) shift ;;
+    --prefix) prefix="$2"; shift 2 ;;
+    --legacy-peer-deps) shift ;;
+    *) packages="$packages $1"; shift ;;
+  esac
+done
+if [ -z "$prefix" ]; then prefix="$PWD"; fi
+mkdir -p "$prefix"
+test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
+exec bun add --cwd "$prefix" $packages
+EOF
+chmod +x "$NPM_SHIM_DIR/npm"
+PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+rm -rf "$NPM_SHIM_DIR"`
+
 // ---------------------------------------------------------------------------
 // Input types – SlackBot mode (--input)
 // ---------------------------------------------------------------------------
@@ -556,8 +581,9 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 		// https://github.com/svkozak/pi-acp
 		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx -y pi-acp]")
 		return sessionsettings.StartupConfig{
-			Command: []string{"agentapi-proxy"},
-			Args:    []string{"acp-server", "--", "npx", "-y", "pi-acp"},
+			Command:   []string{"agentapi-proxy"},
+			Args:      []string{"acp-server", "--", "npx", "-y", "pi-acp"},
+			PreScript: piOllamaInstallPreScript,
 		}
 	case "cursor":
 		// acp-server bridges Cursor Agent CLI's native ACP server to the agentapi HTTP interface.

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -46,6 +46,7 @@ func TestBuildStartupConfigPiOllama(t *testing.T) {
 
 	assert.Equal(t, []string{"agentapi-proxy"}, config.Command)
 	assert.Equal(t, []string{"acp-server", "--", "npx", "-y", "pi-acp"}, config.Args)
+	assert.NotEmpty(t, config.PreScript)
 }
 
 func TestGenerateTokenFlags(t *testing.T) {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3481,6 +3481,10 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 		}
 	}
 
+	if req.AgentType == "pi-ollama" {
+		envVars = ensurePiOllamaPodEnv(envVars)
+	}
+
 	// Add VAPID environment variables for push notifications
 	vapidEnvVars := []string{"VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY", "VAPID_CONTACT_EMAIL"}
 	for _, envName := range vapidEnvVars {
@@ -3498,6 +3502,58 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 	// which is synced by CredentialsSecretSyncer when settings are updated via API
 
 	return envVars
+}
+
+const (
+	piOllamaCommandPath      = "/home/agentapi/.session/pi-ollama-pi"
+	piOllamaInstallPreScript = `mkdir -p "$HOME/.pi/agent/npm"
+test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
+NPM_SHIM_DIR="$(mktemp -d)"
+cat > "$NPM_SHIM_DIR/npm" <<'EOF'
+#!/bin/sh
+set -e
+prefix=""
+packages=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    install) shift ;;
+    --prefix) prefix="$2"; shift 2 ;;
+    --legacy-peer-deps) shift ;;
+    *) packages="$packages $1"; shift ;;
+  esac
+done
+if [ -z "$prefix" ]; then prefix="$PWD"; fi
+mkdir -p "$prefix"
+test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
+exec bun add --cwd "$prefix" $packages
+EOF
+chmod +x "$NPM_SHIM_DIR/npm"
+PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+rm -rf "$NPM_SHIM_DIR"`
+)
+
+func ensurePiOllamaPodEnv(envVars []corev1.EnvVar) []corev1.EnvVar {
+	values := make(map[string]string, len(envVars))
+	for _, envVar := range envVars {
+		if envVar.ValueFrom == nil {
+			values[envVar.Name] = envVar.Value
+		}
+	}
+
+	if strings.TrimSpace(values["PI_ACP_PI_COMMAND"]) == "" {
+		envVars = append(envVars, corev1.EnvVar{Name: "PI_ACP_PI_COMMAND", Value: piOllamaCommandPath})
+	}
+
+	return envVars
+}
+
+func ensurePiOllamaSettingsEnv(env map[string]string) {
+	if env == nil {
+		return
+	}
+	if strings.TrimSpace(env["PI_ACP_PI_COMMAND"]) == "" {
+		env["PI_ACP_PI_COMMAND"] = piOllamaCommandPath
+	}
 }
 
 // sanitizeLabelKey sanitizes a string to be used as a Kubernetes label key
@@ -4770,6 +4826,10 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		env[k] = v
 	}
 
+	if req.AgentType == "pi-ollama" {
+		ensurePiOllamaSettingsEnv(env)
+	}
+
 	m.injectSciaProxyEnv(env, req)
 
 	// Memory integration: generate MEMORY_KEY_FLAGS and AGENTAPI_SCOPE for startup script
@@ -4950,6 +5010,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"--",
 				"npx", "-y", "pi-acp",
 			},
+			PreScript: piOllamaInstallPreScript,
 		}
 	case "cursor":
 		// acp-server bridges Cursor Agent CLI's native ACP server to the agentapi HTTP interface.

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -125,3 +125,56 @@ func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
 		t.Fatalf("SECRET_TOKEN = %q, want decrypted-secret", got)
 	}
 }
+
+func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:     "test-ns",
+			Image:         "test-image:latest",
+			BasePort:      9000,
+			PVCEnabled:    boolPtrForTest(false),
+			CPURequest:    "100m",
+			CPULimit:      "1",
+			MemoryRequest: "128Mi",
+			MemoryLimit:   "512Mi",
+		},
+	}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.namespace = "test-ns"
+
+	session := NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "test-user"},
+		"test-deploy",
+		"agentapi-session-test-svc",
+		"test-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+	req := &entities.RunServerRequest{
+		UserID:    "test-user",
+		AgentType: "pi-ollama",
+		Environment: map[string]string{
+			"OPENAI_API_KEY": "openai-key",
+		},
+	}
+
+	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	if _, ok := settings.Env["OLLAMA_API_KEY"]; ok {
+		t.Fatalf("OLLAMA_API_KEY should not be synthesized")
+	}
+	if got := settings.Env["PI_ACP_PI_COMMAND"]; got != piOllamaCommandPath {
+		t.Fatalf("PI_ACP_PI_COMMAND = %q", got)
+	}
+	if settings.Startup.PreScript == "" {
+		t.Fatalf("expected pi-ollama startup pre-script")
+	}
+}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -31,6 +31,7 @@ const (
 	sessionEnvFile        = "/home/agentapi/.session/env"
 	claudeMDPath          = "/home/agentapi/.claude/CLAUDE.md"
 	workdirRepoPath       = "/home/agentapi/workdir/repo"
+	piOllamaDefaultModel  = "glm-5"
 	// webhookPayloadPath is the well-known path where the webhook payload JSON
 	// is exposed inside the session container.
 	// For non-stock sessions this file is provided by a read-only Kubernetes
@@ -40,6 +41,8 @@ const (
 	webhookPayloadPath    = "/opt/webhook/payload.json"
 	codexRequirementsPath = "/etc/codex/requirements.toml"
 )
+
+var piOllamaCommandPath = "/home/agentapi/.session/pi-ollama-pi"
 
 // runProvision executes the full provisioning sequence and then supervises
 // the agentapi subprocess.
@@ -930,6 +933,7 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 		// `pi --mode rpc`; the image/pre-script install pi-ollama-cloud so Pi can
 		// talk directly to Ollama Cloud without a local Ollama daemon.
 		// https://github.com/svkozak/pi-acp
+		ensurePiOllamaEnv(envMap)
 		return "agentapi-proxy", []string{
 			"acp-server",
 			"--port", agentapiPort,
@@ -966,6 +970,38 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 			"sh", "-c", claudeCmd,
 		}
 	}
+}
+
+func ensurePiOllamaEnv(envMap map[string]string) {
+	if envMap == nil {
+		return
+	}
+	if strings.TrimSpace(envMap["PI_ACP_PI_COMMAND"]) == "" {
+		envMap["PI_ACP_PI_COMMAND"] = piOllamaCommandPath
+	}
+	if envMap["PI_ACP_PI_COMMAND"] == piOllamaCommandPath {
+		if err := writePiOllamaCommandWrapper(piOllamaCommandPath); err != nil {
+			log.Printf("[PROVISIONER] Warning: failed to write pi-ollama command wrapper: %v", err)
+		}
+	}
+}
+
+func writePiOllamaCommandWrapper(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	const script = `#!/bin/sh
+set -e
+model="${PI_OLLAMA_MODEL:-${OLLAMA_MODEL:-` + piOllamaDefaultModel + `}}"
+case "$model" in
+  */*) exec pi --model "$model" "$@" ;;
+  *) exec pi --provider ollama-cloud --model "$model" "$@" ;;
+esac
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o755)
 }
 
 // waitForAgentAPI polls agentapiURL/status until it responds 200 or the

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -55,10 +55,14 @@ func TestBuildAgentCommandCursor(t *testing.T) {
 
 func TestBuildAgentCommandPiOllama(t *testing.T) {
 	t.Setenv("AGENTAPI_PORT", "9000")
+	origCommandPath := piOllamaCommandPath
+	piOllamaCommandPath = filepath.Join(t.TempDir(), "pi-ollama-pi")
+	t.Cleanup(func() { piOllamaCommandPath = origCommandPath })
+	env := map[string]string{"OPENAI_API_KEY": "openai-key"}
 
 	cmd, args := (&Server{}).buildAgentCommand(&sessionsettings.SessionSettings{
 		Session: sessionsettings.SessionMeta{AgentType: "pi-ollama"},
-	}, nil)
+	}, env)
 
 	if cmd != "agentapi-proxy" {
 		t.Fatalf("command = %q, want agentapi-proxy", cmd)
@@ -66,6 +70,35 @@ func TestBuildAgentCommandPiOllama(t *testing.T) {
 	want := []string{"acp-server", "--port", "9000", "--auto-approve", "--", "npx", "-y", "pi-acp"}
 	if !reflect.DeepEqual(args, want) {
 		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+	if _, ok := env["OLLAMA_API_KEY"]; ok {
+		t.Fatalf("OLLAMA_API_KEY should not be synthesized")
+	}
+	if got := env["PI_ACP_PI_COMMAND"]; got != piOllamaCommandPath {
+		t.Fatalf("PI_ACP_PI_COMMAND = %q", got)
+	}
+	content, err := os.ReadFile(piOllamaCommandPath)
+	if err != nil {
+		t.Fatalf("failed to read pi-ollama wrapper: %v", err)
+	}
+	if !strings.Contains(string(content), `exec pi --model "$model" "$@"`) {
+		t.Fatalf("wrapper does not pass model args to pi: %s", string(content))
+	}
+}
+
+func TestBuildAgentCommandPiOllamaPreservesExplicitModel(t *testing.T) {
+	t.Setenv("AGENTAPI_PORT", "9000")
+	env := map[string]string{
+		"PI_ACP_PI_COMMAND": "/custom/pi-wrapper",
+		"PI_OLLAMA_MODEL":   "ollama-cloud/gpt-oss:120b",
+	}
+
+	_, _ = (&Server{}).buildAgentCommand(&sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{AgentType: "pi-ollama"},
+	}, env)
+
+	if got := env["PI_ACP_PI_COMMAND"]; got != "/custom/pi-wrapper" {
+		t.Fatalf("PI_ACP_PI_COMMAND = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- configure pi-ollama sessions to start Pi through pi-acp with an executable wrapper, because PI_ACP_PI_COMMAND accepts only an executable path
- wrapper selects ollama-cloud models via PI_OLLAMA_MODEL / OLLAMA_MODEL, defaulting to glm-5
- run pi-ollama-cloud install in the synchronous startup pre-script before ACP agent startup
- do not synthesize or copy Ollama API keys; credentials remain externally supplied

## Verification
- mise exec -- go test ./pkg/provisioner
- mise exec -- go test ./internal/infrastructure/services -run 'TestBuildSessionSettings_PiOllamaConfiguresCloudProvider|TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars'
- mise exec -- go test ./cmd -run 'TestBuildStartupConfigPiOllama|TestBuildStartupConfigCursor'
- mise exec -- go test ./cmd ./pkg/provisioner ./internal/infrastructure/services (cmd package has pre-existing live-k8s test interruption; provisioner/services passed)