### PR TITLE
Skip pi-ollama cloud install when baked in

### DIFF
--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -16,8 +16,12 @@ import (
 
 const piOllamaInstallPreScript = `mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-NPM_SHIM_DIR="$(mktemp -d)"
-cat > "$NPM_SHIM_DIR/npm" <<'EOF'
+if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
+  echo "pi-ollama-cloud already installed, skipping install"
+else
+  NPM_SHIM_DIR="$(mktemp -d)"
+  trap 'rm -rf "$NPM_SHIM_DIR"' EXIT
+  cat > "$NPM_SHIM_DIR/npm" <<'EOF'
 #!/bin/sh
 set -e
 prefix=""
@@ -35,9 +39,11 @@ mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
 exec bun add --cwd "$prefix" $packages
 EOF
-chmod +x "$NPM_SHIM_DIR/npm"
-PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
-rm -rf "$NPM_SHIM_DIR"`
+  chmod +x "$NPM_SHIM_DIR/npm"
+  PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  rm -rf "$NPM_SHIM_DIR"
+  trap - EXIT
+fi`
 
 // ---------------------------------------------------------------------------
 // Input types – SlackBot mode (--input)

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -47,6 +47,8 @@ func TestBuildStartupConfigPiOllama(t *testing.T) {
 	assert.Equal(t, []string{"agentapi-proxy"}, config.Command)
 	assert.Equal(t, []string{"acp-server", "--", "npx", "-y", "pi-acp"}, config.Args)
 	assert.NotEmpty(t, config.PreScript)
+	assert.Contains(t, config.PreScript, "node_modules/pi-ollama-cloud")
+	assert.Contains(t, config.PreScript, "skipping install")
 }
 
 func TestGenerateTokenFlags(t *testing.T) {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3508,8 +3508,12 @@ const (
 	piOllamaCommandPath      = "/home/agentapi/.session/pi-ollama-pi"
 	piOllamaInstallPreScript = `mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-NPM_SHIM_DIR="$(mktemp -d)"
-cat > "$NPM_SHIM_DIR/npm" <<'EOF'
+if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
+  echo "pi-ollama-cloud already installed, skipping install"
+else
+  NPM_SHIM_DIR="$(mktemp -d)"
+  trap 'rm -rf "$NPM_SHIM_DIR"' EXIT
+  cat > "$NPM_SHIM_DIR/npm" <<'EOF'
 #!/bin/sh
 set -e
 prefix=""
@@ -3527,9 +3531,11 @@ mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
 exec bun add --cwd "$prefix" $packages
 EOF
-chmod +x "$NPM_SHIM_DIR/npm"
-PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
-rm -rf "$NPM_SHIM_DIR"`
+  chmod +x "$NPM_SHIM_DIR/npm"
+  PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  rm -rf "$NPM_SHIM_DIR"
+  trap - EXIT
+fi`
 )
 
 func ensurePiOllamaPodEnv(envVars []corev1.EnvVar) []corev1.EnvVar {

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -176,5 +177,8 @@ func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 	}
 	if settings.Startup.PreScript == "" {
 		t.Fatalf("expected pi-ollama startup pre-script")
+	}
+	if !strings.Contains(settings.Startup.PreScript, "node_modules/pi-ollama-cloud") {
+		t.Fatalf("expected pi-ollama pre-script to skip install when package is baked into the image")
 	}
 }

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -29,8 +29,12 @@ bun install --global @earendil-works/pi-coding-agent@latest
 npm install --global pi-acp@latest
 mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-NPM_SHIM_DIR="$(mktemp -d)"
-cat > "$NPM_SHIM_DIR/npm" <<'EOF'
+if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
+  echo "pi-ollama-cloud already installed, skipping install"
+else
+  NPM_SHIM_DIR="$(mktemp -d)"
+  trap 'rm -rf "$NPM_SHIM_DIR"' EXIT
+  cat > "$NPM_SHIM_DIR/npm" <<'EOF'
 #!/bin/sh
 set -e
 prefix=""
@@ -48,9 +52,11 @@ mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
 exec bun add --cwd "$prefix" $packages
 EOF
-chmod +x "$NPM_SHIM_DIR/npm"
-PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
-rm -rf "$NPM_SHIM_DIR"
+  chmod +x "$NPM_SHIM_DIR/npm"
+  PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  rm -rf "$NPM_SHIM_DIR"
+  trap - EXIT
+fi
 `
 
 // Status represents the provisioning lifecycle state.


### PR DESCRIPTION
## Summary
- skip runtime `pi install npm:pi-ollama-cloud` when the baked image already has `node_modules/pi-ollama-cloud`
- apply the same guard to generated pi-ollama session settings and the provisioner startup prefetch script
- add focused assertions for the generated pi-ollama pre-script

## Verification
- `go test ./cmd -run TestBuildStartupConfigPiOllama`
- `go test ./internal/infrastructure/services -run TestBuildSessionSettings_PiOllamaConfiguresCloudProvider`
- `go test ./pkg/provisioner`

## Context
Production session `a5574520-12f4-4e3b-89b2-88bff0f4df44` stayed in provisioning while the pi-ollama pre-script spent about 300s reinstalling `pi-ollama-cloud`. The image already bakes the package, so new sessions should skip that runtime install unless the package is missing.