### PR TITLE
Expose Codex skills to Pi sessions

### DIFF
--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -43,6 +43,8 @@ const (
 )
 
 var piOllamaCommandPath = "/home/agentapi/.session/pi-ollama-pi"
+var codexSkillsPath = "/home/agentapi/.codex/skills"
+var piSkillsPath = "/home/agentapi/.pi/agent/skills"
 
 // runProvision executes the full provisioning sequence and then supervises
 // the agentapi subprocess.
@@ -133,6 +135,14 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 		} else {
 			log.Printf("[PROVISIONER] Restored credentials to ~/.codex/auth.json (legacy)")
 		}
+	}
+
+	// ── Step 2.6: expose Codex skills to Pi ─────────────────────────────────
+	// sessionsettings.Setup syncs marketplace skills into ~/.codex/skills. Pi
+	// discovers global skills from ~/.pi/agent/skills, so link that path to the
+	// Codex skills directory before the ACP bridge starts Pi.
+	if err := symlinkCodexSkillsForPi(codexSkillsPath, piSkillsPath); err != nil {
+		log.Printf("[PROVISIONER] Warning: failed to link Codex skills for Pi: %v", err)
 	}
 
 	// ── Step 2.7: write managed Codex requirements ─────────────────────────
@@ -1002,6 +1012,56 @@ esac
 		return err
 	}
 	return os.Chmod(path, 0o755)
+}
+
+func symlinkCodexSkillsForPi(codexPath, piPath string) error {
+	if strings.TrimSpace(codexPath) == "" || strings.TrimSpace(piPath) == "" {
+		return fmt.Errorf("codex and pi skills paths must be set")
+	}
+	if err := os.MkdirAll(codexPath, 0o755); err != nil {
+		return fmt.Errorf("create codex skills dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(piPath), 0o755); err != nil {
+		return fmt.Errorf("create pi skills parent: %w", err)
+	}
+
+	info, err := os.Lstat(piPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.Symlink(codexPath, piPath)
+		}
+		return fmt.Errorf("stat pi skills path: %w", err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(piPath)
+		if err != nil {
+			return fmt.Errorf("read pi skills symlink: %w", err)
+		}
+		if target == codexPath {
+			return nil
+		}
+		if err := os.Remove(piPath); err != nil {
+			return fmt.Errorf("remove stale pi skills symlink: %w", err)
+		}
+		return os.Symlink(codexPath, piPath)
+	}
+
+	if info.IsDir() {
+		entries, err := os.ReadDir(piPath)
+		if err != nil {
+			return fmt.Errorf("read existing pi skills dir: %w", err)
+		}
+		if len(entries) == 0 {
+			if err := os.Remove(piPath); err != nil {
+				return fmt.Errorf("remove empty pi skills dir: %w", err)
+			}
+			return os.Symlink(codexPath, piPath)
+		}
+		return fmt.Errorf("pi skills path already exists and is not empty: %s", piPath)
+	}
+
+	return fmt.Errorf("pi skills path already exists and is not a directory or symlink: %s", piPath)
 }
 
 // waitForAgentAPI polls agentapiURL/status until it responds 200 or the

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -102,6 +102,79 @@ func TestBuildAgentCommandPiOllamaPreservesExplicitModel(t *testing.T) {
 	}
 }
 
+func TestSymlinkCodexSkillsForPiCreatesLink(t *testing.T) {
+	dir := t.TempDir()
+	codexPath := filepath.Join(dir, ".codex", "skills")
+	piPath := filepath.Join(dir, ".pi", "agent", "skills")
+
+	if err := symlinkCodexSkillsForPi(codexPath, piPath); err != nil {
+		t.Fatalf("symlinkCodexSkillsForPi: %v", err)
+	}
+	target, err := os.Readlink(piPath)
+	if err != nil {
+		t.Fatalf("read pi skills symlink: %v", err)
+	}
+	if target != codexPath {
+		t.Fatalf("pi skills symlink target = %q, want %q", target, codexPath)
+	}
+	if _, err := os.Stat(codexPath); err != nil {
+		t.Fatalf("codex skills dir should exist: %v", err)
+	}
+}
+
+func TestSymlinkCodexSkillsForPiIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	codexPath := filepath.Join(dir, ".codex", "skills")
+	piPath := filepath.Join(dir, ".pi", "agent", "skills")
+
+	if err := symlinkCodexSkillsForPi(codexPath, piPath); err != nil {
+		t.Fatalf("first symlinkCodexSkillsForPi: %v", err)
+	}
+	if err := symlinkCodexSkillsForPi(codexPath, piPath); err != nil {
+		t.Fatalf("second symlinkCodexSkillsForPi: %v", err)
+	}
+}
+
+func TestSymlinkCodexSkillsForPiReplacesEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	codexPath := filepath.Join(dir, ".codex", "skills")
+	piPath := filepath.Join(dir, ".pi", "agent", "skills")
+	if err := os.MkdirAll(piPath, 0o755); err != nil {
+		t.Fatalf("mkdir pi skills: %v", err)
+	}
+
+	if err := symlinkCodexSkillsForPi(codexPath, piPath); err != nil {
+		t.Fatalf("symlinkCodexSkillsForPi: %v", err)
+	}
+	target, err := os.Readlink(piPath)
+	if err != nil {
+		t.Fatalf("read pi skills symlink: %v", err)
+	}
+	if target != codexPath {
+		t.Fatalf("pi skills symlink target = %q, want %q", target, codexPath)
+	}
+}
+
+func TestSymlinkCodexSkillsForPiPreservesNonEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	codexPath := filepath.Join(dir, ".codex", "skills")
+	piPath := filepath.Join(dir, ".pi", "agent", "skills")
+	if err := os.MkdirAll(piPath, 0o755); err != nil {
+		t.Fatalf("mkdir pi skills: %v", err)
+	}
+	existingPath := filepath.Join(piPath, "existing.md")
+	if err := os.WriteFile(existingPath, []byte("existing"), 0o644); err != nil {
+		t.Fatalf("write existing skill: %v", err)
+	}
+
+	if err := symlinkCodexSkillsForPi(codexPath, piPath); err == nil {
+		t.Fatal("expected error for non-empty pi skills dir")
+	}
+	if got, err := os.ReadFile(existingPath); err != nil || string(got) != "existing" {
+		t.Fatalf("existing skill was not preserved, got %q err=%v", string(got), err)
+	}
+}
+
 func TestSyncedManagedFilePathsExcludesUnsyncedPaths(t *testing.T) {
 	got := syncedManagedFilePaths([]string{
 		" /home/agentapi/.codex/auth.json ",


### PR DESCRIPTION
## Summary
- Link /home/agentapi/.pi/agent/skills to /home/agentapi/.codex/skills during provisioner startup
- Keep the link idempotent and avoid overwriting non-empty Pi skill directories
- Add unit tests for link creation, idempotency, empty-dir replacement, and non-empty-dir preservation

## Tests
- mise exec -- go test ./pkg/provisioner