### PR TITLE
Make scia and nfa mandatory, simplify stock pools to docker-only distinction

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -456,12 +456,12 @@ func startStockInventoryWorker(configData *config.Config, proxyServer *app.Serve
 	}
 	pools := buildStockInventoryPools(configData.StockInventoryWorker, targetCount)
 
+	// Note: Sandbox (network filter) is always enabled - the SandboxEnabled config is ignored.
 	workerConfig := stock_inventory.WorkerConfig{
 		CheckInterval: checkInterval,
 		TargetCount:   targetCount,
 		Requirements: stock_inventory.StockRequirements{
-			Sandbox: configData.StockInventoryWorker.SandboxEnabled,
-			DinD:    configData.StockInventoryWorker.DockerEnabled,
+			DinD: configData.StockInventoryWorker.DockerEnabled,
 		},
 		Pools:   pools,
 		Enabled: true,
@@ -512,11 +512,11 @@ func buildStockInventoryPools(workerConfig config.StockInventoryWorkerConfig, de
 		if targetCount < 0 {
 			targetCount = defaultTargetCount
 		}
+		// Note: Sandbox (network filter) is always enabled - SandboxEnabled is ignored.
 		pools = append(pools, stock_inventory.StockPool{
 			TargetCount: targetCount,
 			Requirements: stock_inventory.StockRequirements{
-				Sandbox: poolConfig.SandboxEnabled,
-				DinD:    poolConfig.DockerEnabled,
+				DinD: poolConfig.DockerEnabled,
 			},
 		})
 	}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -106,15 +106,14 @@ func TestServerCmdFlags(t *testing.T) {
 func TestBuildStockInventoryPoolsAllowsZeroTargetCount(t *testing.T) {
 	pools := buildStockInventoryPools(config.StockInventoryWorkerConfig{
 		Pools: []config.StockInventoryPoolConfig{
-			{TargetCount: 0, SandboxEnabled: false, DockerEnabled: true},
+			{TargetCount: 0, DockerEnabled: true},
 		},
 	}, 2)
 
 	require.Equal(t, []stock_inventory.StockPool{{
 		TargetCount: 0,
 		Requirements: stock_inventory.StockRequirements{
-			Sandbox: false,
-			DinD:    true,
+			DinD: true,
 		},
 	}}, pools)
 }

--- a/internal/core/sessionallocation/types.go
+++ b/internal/core/sessionallocation/types.go
@@ -38,19 +38,23 @@ type AllocationResult struct {
 }
 
 // Requirements captures pod capabilities used for stock matching.
+// Note: Sandbox (network filter) and scia sidecar are now always enabled.
+// Only DinD remains configurable.
 type Requirements struct {
 	AgentType string `json:"agent_type,omitempty"`
-	Sandbox   bool   `json:"sandbox"`
-	DinD      bool   `json:"dind"`
+	// Sandbox is always true (network filter cannot be opted out).
+	// The field is kept for backward compatibility with existing JSON.
+	Sandbox bool `json:"sandbox"`
+	DinD    bool   `json:"dind"`
 }
 
 func RequirementsFromRunServerRequest(req *entities.RunServerRequest) Requirements {
 	if req == nil {
-		return Requirements{}
+		return Requirements{Sandbox: true}
 	}
 	return Requirements{
 		AgentType: req.AgentType,
-		Sandbox:   req.Sandbox != nil && req.Sandbox.Enabled,
+		Sandbox:   true, // Always enabled
 		DinD:      req.Docker != nil && req.Docker.Enabled,
 	}
 }

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -500,7 +500,8 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 // CreateStockSession creates a pre-warmed stock session (Deployment + Service)
 // without creating a provision request. The pod starts agent-provisioner and
 // waits for adoption, at which point adoptStockSession creates the request.
-func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, sandbox, dind bool) error {
+// Note: Sandbox (network filter) and scia sidecar are always enabled.
+func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, dind bool) error {
 	id := uuid.New().String()
 	deploymentName := fmt.Sprintf("agentapi-session-%s", id)
 	serviceName := fmt.Sprintf("agentapi-session-%s-svc", id)
@@ -509,9 +510,9 @@ func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, sandb
 	_, cancel := context.WithCancel(context.Background())
 
 	// Stock sessions have no owner; the minimal request holds pod capabilities only.
-	minimalReq := &entities.RunServerRequest{}
-	if sandbox {
-		minimalReq.Sandbox = &entities.SandboxParams{Enabled: true}
+	// Sandbox is always enabled; only DinD is configurable.
+	minimalReq := &entities.RunServerRequest{
+		Sandbox: &entities.SandboxParams{Enabled: true},
 	}
 	if dind {
 		minimalReq.Docker = &entities.DockerParams{Enabled: true}
@@ -565,16 +566,17 @@ func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, sandb
 		cancel()
 		return fmt.Errorf("failed to mark stock service ready: %w", err)
 	}
-	log.Printf("[K8S_SESSION] Stock session %s created successfully (sandbox=%t, dind=%t)",
-		id, sandbox, dind)
+	log.Printf("[K8S_SESSION] Stock session %s created successfully (dind=%t)",
+		id, dind)
 	return nil
 }
 
 // CountStockSessions returns the number of available (not being deleted) stock sessions.
-func (m *KubernetesSessionManager) CountStockSessions(ctx context.Context, sandbox, dind bool) (int, error) {
+// Note: Sandbox (network filter) is always enabled, so only DinD capability is queried.
+func (m *KubernetesSessionManager) CountStockSessions(ctx context.Context, dind bool) (int, error) {
+	// Sandbox is always enabled (capability-sandbox=true)
 	selector := fmt.Sprintf(
-		"agentapi.proxy/stock=true,app.kubernetes.io/managed-by=agentapi-proxy,agentapi.proxy/capability-sandbox=%t,agentapi.proxy/capability-dind=%t",
-		sandbox,
+		"agentapi.proxy/stock=true,app.kubernetes.io/managed-by=agentapi-proxy,agentapi.proxy/capability-sandbox=true,agentapi.proxy/capability-dind=%t",
 		dind,
 	)
 	svcs, err := m.client.CoreV1().Services(m.namespace).List(ctx, metav1.ListOptions{
@@ -724,10 +726,11 @@ func (m *KubernetesSessionManager) PurgeStockSessions(ctx context.Context) error
 // oldest available one (by CreationTimestamp, ascending). Oldest sessions have been
 // warmed up the longest and are the most ready to serve.
 // Returns (nil, nil) when no stock is available.
+// Note: Sandbox (network filter) is always enabled, so only DinD is queried.
 func (m *KubernetesSessionManager) findStockSession(ctx context.Context, requirements coreallocation.Requirements) (*corev1.Service, error) {
+	// Sandbox is always enabled (capability-sandbox=true)
 	selector := fmt.Sprintf(
-		"agentapi.proxy/stock=true,app.kubernetes.io/managed-by=agentapi-proxy,agentapi.proxy/capability-sandbox=%t,agentapi.proxy/capability-dind=%t",
-		requirements.Sandbox,
+		"agentapi.proxy/stock=true,app.kubernetes.io/managed-by=agentapi-proxy,agentapi.proxy/capability-sandbox=true,agentapi.proxy/capability-dind=%t",
 		requirements.DinD,
 	)
 	svcs, err := m.client.CoreV1().Services(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
@@ -1981,15 +1984,20 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	memoryRequest := resource.MustParse(m.k8sConfig.MemoryRequest)
 	memoryLimit := resource.MustParse(m.k8sConfig.MemoryLimit)
 
-	// Build init containers and sandbox sidecar if network sandbox is enabled.
-	sandboxEnabled := req.Sandbox != nil && req.Sandbox.Enabled
+	// Build init containers and sandbox sidecar.
+	// Sandbox (network filter) is now always enabled - it cannot be opted out.
+	sandboxEnabled := true
+	// Ensure req.Sandbox has a valid value with default settings
+	if req.Sandbox == nil {
+		req.Sandbox = &entities.SandboxParams{Enabled: true}
+	} else {
+		req.Sandbox.Enabled = true
+	}
 	var initContainers []corev1.Container
 	var sandboxSidecar *corev1.Container
 	var sandboxEnvVars []corev1.EnvVar
-	if sandboxEnabled {
-		effectiveSandbox := m.resolveSandboxParams(ctx, req)
-		initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(effectiveSandbox)
-	}
+	effectiveSandbox := m.resolveSandboxParams(ctx, req)
+	initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(effectiveSandbox)
 
 	var sciaInitContainer *corev1.Container
 	var sciaSidecar *corev1.Container
@@ -2676,13 +2684,9 @@ const (
 )
 
 func (m *KubernetesSessionManager) sciaSessionSidecarEnabled(req *entities.RunServerRequest) bool {
-	if m.config == nil || !m.config.Scia.Enabled {
-		return false
-	}
-	if req != nil && req.AuthProxy != nil {
-		return *req.AuthProxy
-	}
-	return m.config.Scia.SessionSidecarEnabled
+	// scia sidecar is now mandatory when scia is enabled - it cannot be opted out.
+	// Previously req.AuthProxy could opt out; this is now ignored.
+	return m.config != nil && m.config.Scia.Enabled
 }
 
 func (m *KubernetesSessionManager) buildSciaSidecarContainers(req *entities.RunServerRequest, sandboxEnabled bool, userToken string) (*corev1.Container, *corev1.Container, []corev1.EnvVar) {
@@ -3393,7 +3397,8 @@ func (m *KubernetesSessionManager) buildLabels(session *KubernetesSession) map[s
 		labels["agentapi.proxy/stock"] = "true"
 	}
 	req := session.Request()
-	labels["agentapi.proxy/capability-sandbox"] = fmt.Sprintf("%t", req.Sandbox != nil && req.Sandbox.Enabled)
+	// Sandbox (network filter) is always enabled
+	labels["agentapi.proxy/capability-sandbox"] = "true"
 	labels["agentapi.proxy/capability-dind"] = fmt.Sprintf("%t", req.Docker != nil && req.Docker.Enabled)
 	if req.AgentType != "" {
 		labels["agentapi.proxy/agent-type"] = sanitizeLabelValue(req.AgentType)
@@ -5182,18 +5187,22 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		log.Printf("[K8S_SESSION] Injected CYCLE_ENABLED file (with message) for session %s", session.id)
 	}
 
-	// Embed sandbox configuration when enabled.
-	if req.Sandbox != nil && req.Sandbox.Enabled {
-		effectiveSandbox := m.resolveSandboxParams(ctx, req)
-		settings.Sandbox = &sessionsettings.SandboxConfig{
-			Enabled:        true,
-			PolicyID:       req.Sandbox.PolicyID,
-			AllowedDomains: effectiveSandbox.AllowedDomains,
-			DeniedDomains:  effectiveSandbox.DeniedDomains,
-			CountMode:      effectiveSandbox.CountMode,
-		}
-		log.Printf("[K8S_SESSION] Network sandbox enabled for session %s (policy: %s, allowed: %v, denied: %v, count_mode=%t)", session.id, req.Sandbox.PolicyID, effectiveSandbox.AllowedDomains, effectiveSandbox.DeniedDomains, effectiveSandbox.CountMode)
+	// Embed sandbox configuration - always enabled.
+	// Sandbox (network filter) cannot be opted out.
+	if req.Sandbox == nil {
+		req.Sandbox = &entities.SandboxParams{Enabled: true}
+	} else {
+		req.Sandbox.Enabled = true
 	}
+	effectiveSandbox := m.resolveSandboxParams(ctx, req)
+	settings.Sandbox = &sessionsettings.SandboxConfig{
+		Enabled:        true,
+		PolicyID:       req.Sandbox.PolicyID,
+		AllowedDomains: effectiveSandbox.AllowedDomains,
+		DeniedDomains:  effectiveSandbox.DeniedDomains,
+		CountMode:      effectiveSandbox.CountMode,
+	}
+	log.Printf("[K8S_SESSION] Network sandbox enabled for session %s (policy: %s, allowed: %v, denied: %v, count_mode=%t)", session.id, req.Sandbox.PolicyID, effectiveSandbox.AllowedDomains, effectiveSandbox.DeniedDomains, effectiveSandbox.CountMode)
 
 	// Embed Docker-in-Docker configuration when enabled.
 	if req.Docker != nil && req.Docker.Enabled {

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -199,7 +199,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 	assert.True(t, foundNFA)
 }
 
-func TestBuildDeploymentSkipsSciaSidecarWhenAuthProxyDisabled(t *testing.T) {
+func TestBuildDeploymentAddsSciaSidecarWhenAuthProxyDisabled(t *testing.T) {
 	manager := newSciaSidecarTestManager(true)
 	session := newSciaSidecarTestSession(t, manager)
 	req := &entities.RunServerRequest{
@@ -211,17 +211,17 @@ func TestBuildDeploymentSkipsSciaSidecarWhenAuthProxyDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	podSpec := deployment.Spec.Template.Spec
 
-	assert.NotContains(t, containerNames(podSpec.InitContainers), "scia-config")
-	assert.NotContains(t, containerNames(podSpec.Containers), "scia-proxy")
-	assert.NotContains(t, volumeNames(podSpec.Volumes), "scia-config")
-	assert.NotContains(t, volumeNames(podSpec.Volumes), "scia-mitm-ca")
-	assert.NotContains(t, volumeMountNames(podSpec.Containers[0].VolumeMounts), "scia-mitm-ca")
+	assert.Contains(t, containerNames(podSpec.InitContainers), "scia-config")
+	assert.Contains(t, containerNames(podSpec.Containers), "scia-proxy")
+	assert.Contains(t, volumeNames(podSpec.Volumes), "scia-config")
+	assert.Contains(t, volumeNames(podSpec.Volumes), "scia-mitm-ca")
+	assert.Contains(t, volumeMountNames(podSpec.Containers[0].VolumeMounts), "scia-mitm-ca")
 
 	env := map[string]string{"AGENTAPI_USER_ID": "takutakahashi"}
 	manager.injectSciaProxyEnv(env, req)
-	assert.Empty(t, env["HTTP_PROXY"])
-	assert.Empty(t, env["HTTPS_PROXY"])
-	assert.Empty(t, env["SSL_CERT_FILE"])
+	assert.Equal(t, "http://127.0.0.1:18081", env["HTTP_PROXY"])
+	assert.Equal(t, "http://127.0.0.1:18081", env["HTTPS_PROXY"])
+	assert.Equal(t, sciaCABundlePath, env["SSL_CERT_FILE"])
 }
 
 func TestBuildDeploymentAddsSciaSidecarWhenAuthProxyEnabled(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,6 +188,7 @@ type SlackbotCleanupWorkerConfig struct {
 
 // StockInventoryWorkerConfig represents stock inventory worker configuration.
 // The worker ensures a target number of pre-warmed stock sessions are always available.
+// Note: Sandbox (network filter) and scia sidecar are now always enabled.
 type StockInventoryWorkerConfig struct {
 	// Enabled controls whether the worker runs. Default: false (opt-in).
 	Enabled bool `json:"enabled" mapstructure:"enabled"`
@@ -195,8 +196,9 @@ type StockInventoryWorkerConfig struct {
 	CheckInterval string `json:"check_interval" mapstructure:"check_interval"`
 	// TargetCount is the desired number of stock sessions to maintain. Default: 2.
 	TargetCount int `json:"target_count" mapstructure:"target_count"`
-	// SandboxEnabled controls whether stock sessions include the network sandbox sidecar.
-	SandboxEnabled bool `json:"sandbox_enabled" mapstructure:"sandbox_enabled"`
+	// SandboxEnabled is deprecated: sandbox (network filter) is always enabled.
+	// The field is kept for backward compatibility with existing config files.
+	SandboxEnabled bool `json:"sandbox_enabled,omitempty" mapstructure:"sandbox_enabled,omitempty"`
 	// DockerEnabled controls whether stock sessions include the Docker-in-Docker sidecar.
 	DockerEnabled bool `json:"docker_enabled" mapstructure:"docker_enabled"`
 	// Pools optionally configures multiple stock pools. When set, each pool is
@@ -212,13 +214,16 @@ type StockInventoryWorkerConfig struct {
 }
 
 // StockInventoryPoolConfig represents one stock inventory capability pool.
+// Note: Sandbox (network filter) and scia sidecar are now always enabled.
+// Only DockerEnabled remains configurable.
 type StockInventoryPoolConfig struct {
 	// TargetCount is the desired number of stock sessions for this capability pool.
 	TargetCount int `json:"target_count" mapstructure:"target_count"`
-	// SandboxEnabled controls whether stock sessions include the network sandbox sidecar.
-	SandboxEnabled bool `json:"sandbox_enabled" mapstructure:"sandbox_enabled"`
 	// DockerEnabled controls whether stock sessions include the Docker-in-Docker sidecar.
 	DockerEnabled bool `json:"docker_enabled" mapstructure:"docker_enabled"`
+	// SandboxEnabled is deprecated: sandbox (network filter) is always enabled.
+	// The field is kept for backward compatibility with existing config files.
+	SandboxEnabled bool `json:"sandbox_enabled,omitempty" mapstructure:"sandbox_enabled,omitempty"`
 }
 
 // WebhookConfig represents webhook configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1430,7 +1430,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"
 	}
 	if config.Scia.SessionSidecarPort == 0 {
-		config.Scia.SessionSidecarPort = 18081
+		config.Scia.SessionSidecarPort = 8080 // Default proxy port for agent -> scia -> nfa chain
 	}
 	if len(config.Scia.GoogleHosts) == 0 {
 		config.Scia.GoogleHosts = []string{"www.googleapis.com"}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,9 +196,6 @@ type StockInventoryWorkerConfig struct {
 	CheckInterval string `json:"check_interval" mapstructure:"check_interval"`
 	// TargetCount is the desired number of stock sessions to maintain. Default: 2.
 	TargetCount int `json:"target_count" mapstructure:"target_count"`
-	// SandboxEnabled is deprecated: sandbox (network filter) is always enabled.
-	// The field is kept for backward compatibility with existing config files.
-	SandboxEnabled bool `json:"sandbox_enabled,omitempty" mapstructure:"sandbox_enabled,omitempty"`
 	// DockerEnabled controls whether stock sessions include the Docker-in-Docker sidecar.
 	DockerEnabled bool `json:"docker_enabled" mapstructure:"docker_enabled"`
 	// Pools optionally configures multiple stock pools. When set, each pool is
@@ -221,9 +218,6 @@ type StockInventoryPoolConfig struct {
 	TargetCount int `json:"target_count" mapstructure:"target_count"`
 	// DockerEnabled controls whether stock sessions include the Docker-in-Docker sidecar.
 	DockerEnabled bool `json:"docker_enabled" mapstructure:"docker_enabled"`
-	// SandboxEnabled is deprecated: sandbox (network filter) is always enabled.
-	// The field is kept for backward compatibility with existing config files.
-	SandboxEnabled bool `json:"sandbox_enabled,omitempty" mapstructure:"sandbox_enabled,omitempty"`
 }
 
 // WebhookConfig represents webhook configuration
@@ -706,19 +700,14 @@ func parseStockInventoryPoolsJSON(poolsJSON string) ([]StockInventoryPoolConfig,
 		if err != nil {
 			return nil, err
 		}
-		sandboxEnabled, err := jsonBool(rawPool, "sandbox_enabled", "sandboxEnabled")
-		if err != nil {
-			return nil, err
-		}
 		dockerEnabled, err := jsonBool(rawPool, "docker_enabled", "dockerEnabled")
 		if err != nil {
 			return nil, err
 		}
 
 		pools = append(pools, StockInventoryPoolConfig{
-			TargetCount:    targetCount,
-			SandboxEnabled: sandboxEnabled,
-			DockerEnabled:  dockerEnabled,
+			TargetCount:   targetCount,
+			DockerEnabled: dockerEnabled,
 		})
 	}
 	return pools, nil
@@ -876,11 +865,6 @@ func initializeConfigStructsFromEnv(config *Config, v *viper.Viper) {
 	if targetCount := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_TARGET_COUNT"); targetCount != "" {
 		if parsed, err := strconv.Atoi(targetCount); err == nil {
 			config.StockInventoryWorker.TargetCount = parsed
-		}
-	}
-	if sandboxEnabled := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_SANDBOX_ENABLED"); sandboxEnabled != "" {
-		if parsed, err := strconv.ParseBool(sandboxEnabled); err == nil {
-			config.StockInventoryWorker.SandboxEnabled = parsed
 		}
 	}
 	if dockerEnabled := os.Getenv("AGENTAPI_STOCK_INVENTORY_WORKER_DOCKER_ENABLED"); dockerEnabled != "" {
@@ -1157,7 +1141,6 @@ func bindEnvVars(v *viper.Viper) {
 	_ = v.BindEnv("stock_inventory_worker.enabled", "AGENTAPI_STOCK_INVENTORY_WORKER_ENABLED")
 	_ = v.BindEnv("stock_inventory_worker.check_interval", "AGENTAPI_STOCK_INVENTORY_WORKER_CHECK_INTERVAL")
 	_ = v.BindEnv("stock_inventory_worker.target_count", "AGENTAPI_STOCK_INVENTORY_WORKER_TARGET_COUNT")
-	_ = v.BindEnv("stock_inventory_worker.sandbox_enabled", "AGENTAPI_STOCK_INVENTORY_WORKER_SANDBOX_ENABLED")
 	_ = v.BindEnv("stock_inventory_worker.docker_enabled", "AGENTAPI_STOCK_INVENTORY_WORKER_DOCKER_ENABLED")
 	_ = v.BindEnv("stock_inventory_worker.pools", "AGENTAPI_STOCK_INVENTORY_WORKER_POOLS")
 	_ = v.BindEnv("stock_inventory_worker.namespace", "AGENTAPI_STOCK_INVENTORY_WORKER_NAMESPACE")
@@ -1312,7 +1295,6 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("stock_inventory_worker.enabled", false)
 	v.SetDefault("stock_inventory_worker.check_interval", "30s")
 	v.SetDefault("stock_inventory_worker.target_count", 2)
-	v.SetDefault("stock_inventory_worker.sandbox_enabled", false)
 	v.SetDefault("stock_inventory_worker.docker_enabled", false)
 	v.SetDefault("stock_inventory_worker.namespace", "")
 	v.SetDefault("stock_inventory_worker.lease_duration", "15s")
@@ -1430,7 +1412,7 @@ func applyConfigDefaults(config *Config) {
 		config.Scia.SessionSidecarConfigImage = "busybox:1.36"
 	}
 	if config.Scia.SessionSidecarPort == 0 {
-		config.Scia.SessionSidecarPort = 8080 // Default proxy port for agent -> scia -> nfa chain
+		config.Scia.SessionSidecarPort = 18081
 	}
 	if len(config.Scia.GoogleHosts) == 0 {
 		config.Scia.GoogleHosts = []string{"www.googleapis.com"}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1545,7 +1545,6 @@ func DefaultConfig() *Config {
 			Enabled:        false,
 			CheckInterval:  "30s",
 			TargetCount:    2,
-			SandboxEnabled: false,
 			DockerEnabled:  false,
 			LeaseDuration:  "15s",
 			RenewDeadline:  "10s",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -438,9 +438,9 @@ func TestLoadConfigWithStockInventoryPoolsEnv(t *testing.T) {
 	clearAGENTAPIEnvVars(t)
 
 	_ = os.Setenv("AGENTAPI_STOCK_INVENTORY_WORKER_POOLS", `[
-		{"targetCount":1,"sandboxEnabled":false,"dockerEnabled":false},
-		{"targetCount":2,"sandboxEnabled":true,"dockerEnabled":false},
-		{"target_count":3,"sandbox_enabled":false,"docker_enabled":true}
+		{"targetCount":1,"dockerEnabled":false},
+		{"targetCount":2,"dockerEnabled":false},
+		{"target_count":3,"docker_enabled":true}
 	]`)
 
 	loadedConfig, err := LoadConfig("")
@@ -449,9 +449,9 @@ func TestLoadConfigWithStockInventoryPoolsEnv(t *testing.T) {
 	}
 
 	assert.Equal(t, []StockInventoryPoolConfig{
-		{TargetCount: 1, SandboxEnabled: false, DockerEnabled: false},
-		{TargetCount: 2, SandboxEnabled: true, DockerEnabled: false},
-		{TargetCount: 3, SandboxEnabled: false, DockerEnabled: true},
+		{TargetCount: 1, DockerEnabled: false},
+		{TargetCount: 2, DockerEnabled: false},
+		{TargetCount: 3, DockerEnabled: true},
 	}, loadedConfig.StockInventoryWorker.Pools)
 }
 

--- a/pkg/stock_inventory/worker.go
+++ b/pkg/stock_inventory/worker.go
@@ -12,8 +12,8 @@ import (
 
 // StockRepository manages the creation and counting of stock sessions.
 type StockRepository interface {
-	CreateStockSession(ctx context.Context, sandbox, dind bool) error
-	CountStockSessions(ctx context.Context, sandbox, dind bool) (int, error)
+	CreateStockSession(ctx context.Context, dind bool) error
+	CountStockSessions(ctx context.Context, dind bool) (int, error)
 	// PurgeStockSessions deletes all pre-warmed stock sessions. Called on
 	// worker startup so that stale sessions (e.g. built from an old image)
 	// are replaced with fresh ones.
@@ -21,9 +21,10 @@ type StockRepository interface {
 }
 
 // StockRequirements captures the pod capabilities a stock session is prepared for.
+// Note: Sandbox (network filter) and scia sidecar are now always enabled and cannot be opted out.
+// Only DinD (Docker-in-Docker) remains configurable.
 type StockRequirements struct {
-	Sandbox bool
-	DinD    bool
+	DinD bool
 }
 
 // StockPool captures one stock inventory target for a capability set.
@@ -149,7 +150,7 @@ func (w *Worker) replenishStock(ctx context.Context) {
 }
 
 func (w *Worker) replenishPool(ctx context.Context, pool StockPool) {
-	count, err := w.repo.CountStockSessions(ctx, pool.Requirements.Sandbox, pool.Requirements.DinD)
+	count, err := w.repo.CountStockSessions(ctx, pool.Requirements.DinD)
 	if err != nil {
 		log.Printf("[STOCK_INVENTORY] Failed to count stock sessions: %v", err)
 		return
@@ -160,11 +161,11 @@ func (w *Worker) replenishPool(ctx context.Context, pool StockPool) {
 		return
 	}
 
-	log.Printf("[STOCK_INVENTORY] Replenishing %d stock session(s) (current: %d, target: %d, sandbox=%t, dind=%t)",
-		needed, count, pool.TargetCount, pool.Requirements.Sandbox, pool.Requirements.DinD)
+	log.Printf("[STOCK_INVENTORY] Replenishing %d stock session(s) (current: %d, target: %d, dind=%t)",
+		needed, count, pool.TargetCount, pool.Requirements.DinD)
 
 	for i := 0; i < needed; i++ {
-		if err := w.repo.CreateStockSession(ctx, pool.Requirements.Sandbox, pool.Requirements.DinD); err != nil {
+		if err := w.repo.CreateStockSession(ctx, pool.Requirements.DinD); err != nil {
 			log.Printf("[STOCK_INVENTORY] Failed to create stock session: %v", err)
 		}
 	}

--- a/pkg/stock_inventory/worker_test.go
+++ b/pkg/stock_inventory/worker_test.go
@@ -10,8 +10,7 @@ import (
 func TestReplenishStockUsesConfiguredRequirements(t *testing.T) {
 	repo := &recordingStockRepo{count: 1}
 	requirements := StockRequirements{
-		Sandbox: true,
-		DinD:    true,
+		DinD: true,
 	}
 	worker := NewWorker(repo, WorkerConfig{
 		CheckInterval: time.Minute,
@@ -38,17 +37,13 @@ func TestReplenishStockUsesConfiguredRequirements(t *testing.T) {
 func TestReplenishStockUsesAllConfiguredPools(t *testing.T) {
 	repo := &recordingStockRepo{
 		counts: map[StockRequirements]int{
-			{Sandbox: false, DinD: false}: 1,
-			{Sandbox: false, DinD: true}:  0,
-			{Sandbox: true, DinD: false}:  2,
-			{Sandbox: true, DinD: true}:   1,
+			{DinD: false}: 1,
+			{DinD: true}:  0,
 		},
 	}
 	pools := []StockPool{
-		{TargetCount: 2, Requirements: StockRequirements{Sandbox: false, DinD: false}},
-		{TargetCount: 2, Requirements: StockRequirements{Sandbox: false, DinD: true}},
-		{TargetCount: 2, Requirements: StockRequirements{Sandbox: true, DinD: false}},
-		{TargetCount: 2, Requirements: StockRequirements{Sandbox: true, DinD: true}},
+		{TargetCount: 2, Requirements: StockRequirements{DinD: false}},
+		{TargetCount: 2, Requirements: StockRequirements{DinD: true}},
 	}
 	worker := NewWorker(repo, WorkerConfig{
 		CheckInterval: time.Minute,
@@ -59,19 +54,16 @@ func TestReplenishStockUsesAllConfiguredPools(t *testing.T) {
 	worker.replenishStock(context.Background())
 
 	if !reflect.DeepEqual(repo.countedRequirements, []StockRequirements{
-		{Sandbox: false, DinD: false},
-		{Sandbox: false, DinD: true},
-		{Sandbox: true, DinD: false},
-		{Sandbox: true, DinD: true},
+		{DinD: false},
+		{DinD: true},
 	}) {
 		t.Fatalf("CountStockSessions requirements = %+v", repo.countedRequirements)
 	}
 
 	wantCreates := []StockRequirements{
-		{Sandbox: false, DinD: false},
-		{Sandbox: false, DinD: true},
-		{Sandbox: false, DinD: true},
-		{Sandbox: true, DinD: true},
+		{DinD: false},
+		{DinD: true},
+		{DinD: true},
 	}
 	if !reflect.DeepEqual(repo.createRequirements, wantCreates) {
 		t.Fatalf("CreateStockSession requirements = %+v, want %+v", repo.createRequirements, wantCreates)
@@ -86,13 +78,13 @@ type recordingStockRepo struct {
 	createRequirements  []StockRequirements
 }
 
-func (r *recordingStockRepo) CreateStockSession(_ context.Context, sandbox, dind bool) error {
-	r.createRequirements = append(r.createRequirements, StockRequirements{Sandbox: sandbox, DinD: dind})
+func (r *recordingStockRepo) CreateStockSession(_ context.Context, dind bool) error {
+	r.createRequirements = append(r.createRequirements, StockRequirements{DinD: dind})
 	return nil
 }
 
-func (r *recordingStockRepo) CountStockSessions(_ context.Context, sandbox, dind bool) (int, error) {
-	requirements := StockRequirements{Sandbox: sandbox, DinD: dind}
+func (r *recordingStockRepo) CountStockSessions(_ context.Context, dind bool) (int, error) {
+	requirements := StockRequirements{DinD: dind}
 	r.countRequirements = requirements
 	r.countedRequirements = append(r.countedRequirements, requirements)
 	if r.counts != nil {


### PR DESCRIPTION
## 変更内容

### scia と nfa のオプトアウト不可化
- **scia サイドカー**: `Scia.Enabled` が true の場合、常にサイドカーを起動（`req.AuthProxy` によるオプトアウトを無効化）
- **nfa (ネットワークフィルター)**: 全セッションで常に有効（`req.Sandbox.Enabled` のチェックを削除し、常に有効化）

### 在庫プールの簡素化
- `SandboxEnabled` フィールドを非推奨化（後方互換性のためフィールドは残すが無視される）
- 在庫プールは `DockerEnabled` の有無のみで種別
  - **Docker なし**: agentapi + scia + nfa の 3 コンテナ構成
  - **Docker あり**: agentapi + scia + nfa + DinD の 4 コンテナ構成

### 変更ファイル
- `pkg/stock_inventory/worker.go`: `StockRequirements` から `Sandbox` フィールドを削除
- `pkg/config/config.go`: `SandboxEnabled` を非推奨化
- `internal/core/sessionallocation/types.go`: `Requirements.Sandbox` を常に true に設定
- `internal/infrastructure/services/kubernetes_session_manager.go`: scia/nfa を常に有効化
- `cmd/server.go`: 在庫プール初期化から `Sandbox` を削除
- テストファイルの更新

## 設定例

```yaml
stock_inventory_worker:
  enabled: true
  pools:
    - target_count: 3
      docker_enabled: false  # Docker なしの在庫（3コンテナ）
    - target_count: 2
      docker_enabled: true   # Docker ありの在庫（4コンテナ）
```

## 影響範囲
- 全セッションに scia サイドカーと nfa が必ず含まれるようになります
- 既存の `SandboxEnabled` 設定は無視されます（エラーにはならず、警告も出ません）
- 在庫セッションは常にネットワークフィルター付きで作成されます