### PR TITLE
Expose Pi instructions and MCP settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -45,6 +45,8 @@ const (
 var piOllamaCommandPath = "/home/agentapi/.session/pi-ollama-pi"
 var codexSkillsPath = "/home/agentapi/.codex/skills"
 var piSkillsPath = "/home/agentapi/.pi/agent/skills"
+var piAgentInstructionsPath = "/home/agentapi/.pi/agent/AGENTS.md"
+var piSettingsPath = "/home/agentapi/.pi/agent/settings.json"
 
 // runProvision executes the full provisioning sequence and then supervises
 // the agentapi subprocess.
@@ -160,6 +162,14 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 
 	// ── Step 4: fetch memory from proxy → inject into CLAUDE.md ──────────────
 	s.fetchAndInjectMemory(envMap)
+
+	// ── Step 4.5: expose managed instructions and MCP servers to Pi ──────────
+	if err := writePiAgentInstructions(claudeMDPath, piAgentInstructionsPath); err != nil {
+		log.Printf("[PROVISIONER] Warning: failed to write Pi AGENTS.md: %v", err)
+	}
+	if err := writePiMCPServers(piSettingsPath, piMCPServers(settings)); err != nil {
+		log.Printf("[PROVISIONER] Warning: failed to write Pi MCP settings: %v", err)
+	}
 
 	// ── Step 5: cd into cloned repo ───────────────────────────────────────────
 	if _, err := os.Stat(workdirRepoPath); err == nil {
@@ -1062,6 +1072,75 @@ func symlinkCodexSkillsForPi(codexPath, piPath string) error {
 	}
 
 	return fmt.Errorf("pi skills path already exists and is not a directory or symlink: %s", piPath)
+}
+
+func writePiAgentInstructions(sourcePath, destPath string) error {
+	if strings.TrimSpace(sourcePath) == "" || strings.TrimSpace(destPath) == "" {
+		return fmt.Errorf("source and destination paths must be set")
+	}
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read source instructions: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create Pi agent dir: %w", err)
+	}
+	if err := os.WriteFile(destPath, content, 0o644); err != nil {
+		return fmt.Errorf("write Pi instructions: %w", err)
+	}
+	log.Printf("[PROVISIONER] Wrote Pi instructions to %s", destPath)
+	return nil
+}
+
+func piMCPServers(settings *sessionsettings.SessionSettings) map[string]interface{} {
+	if settings == nil {
+		return nil
+	}
+	if len(settings.Codex.MCPServers) > 0 {
+		return settings.Codex.MCPServers
+	}
+	if len(settings.Claude.MCPServers) > 0 {
+		return settings.Claude.MCPServers
+	}
+	return nil
+}
+
+func writePiMCPServers(settingsPath string, mcpServers map[string]interface{}) error {
+	if len(mcpServers) == 0 {
+		return nil
+	}
+	if strings.TrimSpace(settingsPath) == "" {
+		return fmt.Errorf("settings path must be set")
+	}
+
+	settingsJSON := make(map[string]interface{})
+	if data, err := os.ReadFile(settingsPath); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		if err := json.Unmarshal(data, &settingsJSON); err != nil {
+			return fmt.Errorf("parse existing Pi settings: %w", err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read existing Pi settings: %w", err)
+	}
+
+	settingsJSON["mcpServers"] = mcpServers
+
+	data, err := json.MarshalIndent(settingsJSON, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Pi settings: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		return fmt.Errorf("create Pi settings dir: %w", err)
+	}
+	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+		return fmt.Errorf("write Pi settings: %w", err)
+	}
+	log.Printf("[PROVISIONER] Wrote Pi MCP settings to %s", settingsPath)
+	return nil
 }
 
 // waitForAgentAPI polls agentapiURL/status until it responds 200 or the

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -175,6 +175,110 @@ func TestSymlinkCodexSkillsForPiPreservesNonEmptyDir(t *testing.T) {
 	}
 }
 
+func TestWritePiAgentInstructionsCopiesClaudeMD(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, ".claude", "CLAUDE.md")
+	destPath := filepath.Join(dir, ".pi", "agent", "AGENTS.md")
+	content := "# Instructions\n\nUse the repo conventions.\n"
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatalf("mkdir source dir: %v", err)
+	}
+	if err := os.WriteFile(sourcePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	if err := writePiAgentInstructions(sourcePath, destPath); err != nil {
+		t.Fatalf("writePiAgentInstructions: %v", err)
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("read Pi AGENTS.md: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("Pi AGENTS.md = %q, want %q", string(got), content)
+	}
+}
+
+func TestWritePiAgentInstructionsSkipsMissingSource(t *testing.T) {
+	destPath := filepath.Join(t.TempDir(), ".pi", "agent", "AGENTS.md")
+
+	if err := writePiAgentInstructions("/does/not/exist/CLAUDE.md", destPath); err != nil {
+		t.Fatalf("writePiAgentInstructions should skip missing source: %v", err)
+	}
+	if _, err := os.Stat(destPath); !os.IsNotExist(err) {
+		t.Fatalf("Pi AGENTS.md should not be created, stat err=%v", err)
+	}
+}
+
+func TestWritePiMCPServersMergesSettings(t *testing.T) {
+	settingsPath := filepath.Join(t.TempDir(), ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	existing := map[string]interface{}{
+		"defaultProvider": "ollama-cloud",
+		"theme":           "dark",
+	}
+	existingData, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(settingsPath, existingData, 0o644); err != nil {
+		t.Fatalf("write existing settings: %v", err)
+	}
+
+	servers := map[string]interface{}{
+		"github": map[string]interface{}{
+			"type":    "stdio",
+			"command": "github-mcp-server",
+			"args":    []interface{}{"stdio"},
+			"env": map[string]interface{}{
+				"GITHUB_TOKEN": "token",
+			},
+		},
+	}
+	if err := writePiMCPServers(settingsPath, servers); err != nil {
+		t.Fatalf("writePiMCPServers: %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	if got["defaultProvider"] != "ollama-cloud" || got["theme"] != "dark" {
+		t.Fatalf("existing settings not preserved: %#v", got)
+	}
+	gotServers, ok := got["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers = %T, want map", got["mcpServers"])
+	}
+	if _, ok := gotServers["github"]; !ok {
+		t.Fatalf("github MCP server missing: %#v", gotServers)
+	}
+}
+
+func TestPiMCPServersPrefersCodexThenClaude(t *testing.T) {
+	claudeServers := map[string]interface{}{"claude": map[string]interface{}{"type": "http", "url": "https://claude.example"}}
+	codexServers := map[string]interface{}{"codex": map[string]interface{}{"type": "http", "url": "https://codex.example"}}
+
+	got := piMCPServers(&sessionsettings.SessionSettings{
+		Claude: sessionsettings.ClaudeConfig{MCPServers: claudeServers},
+		Codex:  sessionsettings.CodexConfig{MCPServers: codexServers},
+	})
+	if !reflect.DeepEqual(got, codexServers) {
+		t.Fatalf("piMCPServers should prefer Codex MCP servers, got %#v", got)
+	}
+
+	got = piMCPServers(&sessionsettings.SessionSettings{
+		Claude: sessionsettings.ClaudeConfig{MCPServers: claudeServers},
+	})
+	if !reflect.DeepEqual(got, claudeServers) {
+		t.Fatalf("piMCPServers should fall back to Claude MCP servers, got %#v", got)
+	}
+}
+
 func TestSyncedManagedFilePathsExcludesUnsyncedPaths(t *testing.T) {
 	got := syncedManagedFilePaths([]string{
 		" /home/agentapi/.codex/auth.json ",


### PR DESCRIPTION
## Summary
- Add root AGENTS.md as a symlink to existing CLAUDE.md
- Have the provisioner copy managed CLAUDE.md content into Pi's global ~/.pi/agent/AGENTS.md after memory injection
- Have the provisioner merge session MCP servers into ~/.pi/agent/settings.json as mcpServers

## Tests
- mise exec -- go test ./pkg/provisioner