### PR TITLE
feat: パフォーマンス改善 - Redis キャッシュ最適化

### DIFF
--- a/internal/infrastructure/repositories/noop_status_repository.go
+++ b/internal/infrastructure/repositories/noop_status_repository.go
@@ -71,11 +71,11 @@ func (n *NoopStatusRepository) InvalidateSessionListCache(_ context.Context, _ s
 }
 
 // UpdateSessionInCache does nothing (no-op).
-func (n *NoopStatusRepository) UpdateSessionInCache(_ context.Context, _ string, _ portrepos.CachedSessionDTO) error {
+func (n *NoopStatusRepository) UpdateSessionInCache(_ context.Context, _ string, _ portrepos.CachedSessionDTO, _ time.Duration) error {
 	return nil
 }
 
 // DeleteSessionFromCache does nothing (no-op).
-func (n *NoopStatusRepository) DeleteSessionFromCache(_ context.Context, _ string, _ string) error {
+func (n *NoopStatusRepository) DeleteSessionFromCache(_ context.Context, _ string, _ string, _ time.Duration) error {
 	return nil
 }

--- a/internal/infrastructure/repositories/noop_status_repository.go
+++ b/internal/infrastructure/repositories/noop_status_repository.go
@@ -69,3 +69,13 @@ func (n *NoopStatusRepository) GetSessionListCache(_ context.Context, _ string) 
 func (n *NoopStatusRepository) InvalidateSessionListCache(_ context.Context, _ string) error {
 	return nil
 }
+
+// UpdateSessionInCache does nothing (no-op).
+func (n *NoopStatusRepository) UpdateSessionInCache(_ context.Context, _ string, _ portrepos.CachedSessionDTO) error {
+	return nil
+}
+
+// DeleteSessionFromCache does nothing (no-op).
+func (n *NoopStatusRepository) DeleteSessionFromCache(_ context.Context, _ string, _ string) error {
+	return nil
+}

--- a/internal/infrastructure/repositories/redis_status_repository.go
+++ b/internal/infrastructure/repositories/redis_status_repository.go
@@ -233,11 +233,11 @@ func (r *RedisStatusRepository) InvalidateSessionListCache(ctx context.Context, 
 	return nil
 }
 
-// UpdateSessionInCache updates a single session in all cache entries for the namespace.
-// This is more efficient than invalidating the entire cache when only one session changes.
-// It finds all cache keys for the namespace, deserializes each, updates or appends the session,
-// and re-serializes with a refreshed TTL.
-func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namespace string, session portrepos.CachedSessionDTO) error {
+// UpdateSessionInCache updates a single session in cache entries where it is
+// already present. It intentionally does not append sessions: cache keys are
+// scoped by label selector, and repository code cannot determine whether a new
+// session belongs in each filtered cache entry.
+func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namespace string, session portrepos.CachedSessionDTO, ttl time.Duration) error {
 	pattern := sessionListCachePattern(namespace)
 	var cursor uint64
 	var updatedCount int
@@ -265,7 +265,6 @@ func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namesp
 				continue
 			}
 
-			// Find and update or append the session
 			found := false
 			for i, s := range sessions {
 				if s.ID == session.ID {
@@ -275,7 +274,7 @@ func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namesp
 				}
 			}
 			if !found {
-				sessions = append(sessions, session)
+				continue
 			}
 
 			// Re-serialize and set with refreshed TTL
@@ -285,8 +284,7 @@ func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namesp
 				continue
 			}
 
-			// Use the same TTL as defined in kubernetes_session_manager.go
-			if err := r.client.Set(ctx, key, newPayload, 60*time.Second).Err(); err != nil {
+			if err := r.client.Set(ctx, key, newPayload, ttl).Err(); err != nil {
 				log.Printf("[REDIS_CACHE] Failed to set updated cache %s: %v", key, err)
 				continue
 			}
@@ -307,7 +305,7 @@ func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namesp
 
 // DeleteSessionFromCache removes a single session from all cache entries for the namespace.
 // This is more efficient than invalidating the entire cache when only one session is deleted.
-func (r *RedisStatusRepository) DeleteSessionFromCache(ctx context.Context, namespace string, sessionID string) error {
+func (r *RedisStatusRepository) DeleteSessionFromCache(ctx context.Context, namespace string, sessionID string, ttl time.Duration) error {
 	pattern := sessionListCachePattern(namespace)
 	var cursor uint64
 	var updatedCount int
@@ -355,7 +353,7 @@ func (r *RedisStatusRepository) DeleteSessionFromCache(ctx context.Context, name
 				continue
 			}
 
-			if err := r.client.Set(ctx, key, newPayload, 60*time.Second).Err(); err != nil {
+			if err := r.client.Set(ctx, key, newPayload, ttl).Err(); err != nil {
 				log.Printf("[REDIS_CACHE] Failed to set updated cache %s: %v", key, err)
 				continue
 			}

--- a/internal/infrastructure/repositories/redis_status_repository.go
+++ b/internal/infrastructure/repositories/redis_status_repository.go
@@ -232,3 +232,144 @@ func (r *RedisStatusRepository) InvalidateSessionListCache(ctx context.Context, 
 	log.Printf("[REDIS_CACHE] Invalidated %d session-list cache entries for namespace=%s", len(keysToDelete), namespace)
 	return nil
 }
+
+// UpdateSessionInCache updates a single session in all cache entries for the namespace.
+// This is more efficient than invalidating the entire cache when only one session changes.
+// It finds all cache keys for the namespace, deserializes each, updates or appends the session,
+// and re-serializes with a refreshed TTL.
+func (r *RedisStatusRepository) UpdateSessionInCache(ctx context.Context, namespace string, session portrepos.CachedSessionDTO) error {
+	pattern := sessionListCachePattern(namespace)
+	var cursor uint64
+	var updatedCount int
+
+	for {
+		keys, nextCursor, err := r.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return fmt.Errorf("redis UpdateSessionInCache scan: %w", err)
+		}
+
+		for _, key := range keys {
+			// Get current cache value
+			payload, err := r.client.Get(ctx, key).Bytes()
+			if err != nil {
+				if err == redis.Nil {
+					continue // cache miss, skip
+				}
+				log.Printf("[REDIS_CACHE] Failed to get cache key %s: %v", key, err)
+				continue
+			}
+
+			var sessions []portrepos.CachedSessionDTO
+			if err := json.Unmarshal(payload, &sessions); err != nil {
+				log.Printf("[REDIS_CACHE] Failed to unmarshal cache %s: %v", key, err)
+				continue
+			}
+
+			// Find and update or append the session
+			found := false
+			for i, s := range sessions {
+				if s.ID == session.ID {
+					sessions[i] = session
+					found = true
+					break
+				}
+			}
+			if !found {
+				sessions = append(sessions, session)
+			}
+
+			// Re-serialize and set with refreshed TTL
+			newPayload, err := json.Marshal(sessions)
+			if err != nil {
+				log.Printf("[REDIS_CACHE] Failed to marshal updated cache %s: %v", key, err)
+				continue
+			}
+
+			// Use the same TTL as defined in kubernetes_session_manager.go
+			if err := r.client.Set(ctx, key, newPayload, 60*time.Second).Err(); err != nil {
+				log.Printf("[REDIS_CACHE] Failed to set updated cache %s: %v", key, err)
+				continue
+			}
+			updatedCount++
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	if updatedCount > 0 {
+		log.Printf("[REDIS_CACHE] Updated session %s in %d cache entries for namespace=%s", session.ID, updatedCount, namespace)
+	}
+	return nil
+}
+
+// DeleteSessionFromCache removes a single session from all cache entries for the namespace.
+// This is more efficient than invalidating the entire cache when only one session is deleted.
+func (r *RedisStatusRepository) DeleteSessionFromCache(ctx context.Context, namespace string, sessionID string) error {
+	pattern := sessionListCachePattern(namespace)
+	var cursor uint64
+	var updatedCount int
+
+	for {
+		keys, nextCursor, err := r.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return fmt.Errorf("redis DeleteSessionFromCache scan: %w", err)
+		}
+
+		for _, key := range keys {
+			// Get current cache value
+			payload, err := r.client.Get(ctx, key).Bytes()
+			if err != nil {
+				if err == redis.Nil {
+					continue // cache miss, skip
+				}
+				log.Printf("[REDIS_CACHE] Failed to get cache key %s: %v", key, err)
+				continue
+			}
+
+			var sessions []portrepos.CachedSessionDTO
+			if err := json.Unmarshal(payload, &sessions); err != nil {
+				log.Printf("[REDIS_CACHE] Failed to unmarshal cache %s: %v", key, err)
+				continue
+			}
+
+			// Filter out the deleted session
+			var newSessions []portrepos.CachedSessionDTO
+			for _, s := range sessions {
+				if s.ID != sessionID {
+					newSessions = append(newSessions, s)
+				}
+			}
+
+			if len(newSessions) == len(sessions) {
+				// Session not found in this cache, no update needed
+				continue
+			}
+
+			// Re-serialize and set with refreshed TTL
+			newPayload, err := json.Marshal(newSessions)
+			if err != nil {
+				log.Printf("[REDIS_CACHE] Failed to marshal updated cache %s: %v", key, err)
+				continue
+			}
+
+			if err := r.client.Set(ctx, key, newPayload, 60*time.Second).Err(); err != nil {
+				log.Printf("[REDIS_CACHE] Failed to set updated cache %s: %v", key, err)
+				continue
+			}
+			updatedCount++
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	if updatedCount > 0 {
+		log.Printf("[REDIS_CACHE] Deleted session %s from %d cache entries for namespace=%s", sessionID, updatedCount, namespace)
+	}
+	return nil
+}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -486,12 +486,11 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 		log.Printf("[K8S_SESSION] Failed to log session start: %v", err)
 	}
 
-	// Update session-list cache with the new session instead of invalidating.
-	// This is more efficient and preserves cache hits for other sessions.
+	// Invalidate session-list cache so the new session appears immediately in
+	// every label-selector scoped list it belongs to.
 	if m.sessionListCacheRepo != nil {
-		sessionDTO := sessionsToCacheDTOs([]entities.Session{session})[0]
-		if err := m.sessionListCacheRepo.UpdateSessionInCache(context.Background(), m.namespace, sessionDTO); err != nil {
-			log.Printf("[K8S_SESSION] Warning: failed to update session list cache after create: %v", err)
+		if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache after create: %v", err)
 		}
 	}
 
@@ -946,12 +945,11 @@ func (m *KubernetesSessionManager) adoptStockSession(
 		log.Printf("[K8S_SESSION] Failed to log session start for stock session %s: %v", stockID, err)
 	}
 
-	// Update session-list cache with the adopted session instead of invalidating.
-	// This is more efficient and preserves cache hits for other sessions.
+	// Invalidate session-list cache so the adopted stock session appears
+	// immediately in every label-selector scoped list it belongs to.
 	if m.sessionListCacheRepo != nil {
-		sessionDTO := sessionsToCacheDTOs([]entities.Session{session})[0]
-		if err := m.sessionListCacheRepo.UpdateSessionInCache(context.Background(), m.namespace, sessionDTO); err != nil {
-			log.Printf("[K8S_SESSION] Warning: failed to update session list cache after stock adopt: %v", err)
+		if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache after stock adopt: %v", err)
 		}
 	}
 
@@ -1560,7 +1558,7 @@ func (m *KubernetesSessionManager) DeleteSession(id string) error {
 	if m.sessionListCacheRepo != nil {
 		invCtx, invCancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer invCancel()
-		if err := m.sessionListCacheRepo.DeleteSessionFromCache(invCtx, m.namespace, id); err != nil {
+		if err := m.sessionListCacheRepo.DeleteSessionFromCache(invCtx, m.namespace, id, redisSessionListCacheTTL); err != nil {
 			log.Printf("[K8S_SESSION] Warning: failed to delete session from cache: %v", err)
 		}
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -486,10 +486,12 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 		log.Printf("[K8S_SESSION] Failed to log session start: %v", err)
 	}
 
-	// Invalidate session-list cache so the new session appears immediately.
+	// Update session-list cache with the new session instead of invalidating.
+	// This is more efficient and preserves cache hits for other sessions.
 	if m.sessionListCacheRepo != nil {
-		if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
-			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache after create: %v", err)
+		sessionDTO := sessionsToCacheDTOs([]entities.Session{session})[0]
+		if err := m.sessionListCacheRepo.UpdateSessionInCache(context.Background(), m.namespace, sessionDTO); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to update session list cache after create: %v", err)
 		}
 	}
 
@@ -944,14 +946,12 @@ func (m *KubernetesSessionManager) adoptStockSession(
 		log.Printf("[K8S_SESSION] Failed to log session start for stock session %s: %v", stockID, err)
 	}
 
-	// Invalidate session-list cache so the adopted session appears immediately in
-	// list results.  The stock Service was previously excluded by the
-	// !agentapi.proxy/stock label selector; now that its labels have been updated
-	// to reflect the real owner it will be included, but only if the cache is
-	// cleared so the next ListSessions call hits Kubernetes.
+	// Update session-list cache with the adopted session instead of invalidating.
+	// This is more efficient and preserves cache hits for other sessions.
 	if m.sessionListCacheRepo != nil {
-		if err := m.sessionListCacheRepo.InvalidateSessionListCache(context.Background(), m.namespace); err != nil {
-			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache after stock adopt: %v", err)
+		sessionDTO := sessionsToCacheDTOs([]entities.Session{session})[0]
+		if err := m.sessionListCacheRepo.UpdateSessionInCache(context.Background(), m.namespace, sessionDTO); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to update session list cache after stock adopt: %v", err)
 		}
 	}
 
@@ -1252,8 +1252,9 @@ func (m *KubernetesSessionManager) fetchSessionAllocationsFromK8s(ctx context.Co
 }
 
 // redisSessionListCacheTTL is the TTL passed to the cache repository.
-// Mirrors the constant defined in the Redis implementation.
-const redisSessionListCacheTTL = 15 * time.Second
+// Extended from 15s to 60s to reduce Kubernetes API calls while still ensuring
+// reasonable freshness for session list queries.
+const redisSessionListCacheTTL = 60 * time.Second
 
 // buildSessionListCacheKey returns a stable Redis cache key for the given
 // (namespace, labelSelector) combination.
@@ -1554,12 +1555,13 @@ func (m *KubernetesSessionManager) DeleteSession(id string) error {
 		}
 	}
 
-	// Invalidate session-list cache so the deleted session disappears immediately.
+	// Remove the deleted session from cache instead of invalidating all entries.
+	// This is more efficient and preserves cache hits for other sessions.
 	if m.sessionListCacheRepo != nil {
 		invCtx, invCancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer invCancel()
-		if err := m.sessionListCacheRepo.InvalidateSessionListCache(invCtx, m.namespace); err != nil {
-			log.Printf("[K8S_SESSION] Warning: failed to invalidate session list cache after delete: %v", err)
+		if err := m.sessionListCacheRepo.DeleteSessionFromCache(invCtx, m.namespace, id); err != nil {
+			log.Printf("[K8S_SESSION] Warning: failed to delete session from cache: %v", err)
 		}
 	}
 

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -335,6 +335,14 @@ func (r *recordingSessionListCacheRepo) InvalidateSessionListCache(context.Conte
 	return nil
 }
 
+func (r *recordingSessionListCacheRepo) UpdateSessionInCache(context.Context, string, portrepos.CachedSessionDTO, time.Duration) error {
+	return nil
+}
+
+func (r *recordingSessionListCacheRepo) DeleteSessionFromCache(context.Context, string, string, time.Duration) error {
+	return nil
+}
+
 type subscribeHookNotifier struct {
 	onSubscribe func()
 }

--- a/internal/usecases/ports/repositories/session_list_cache_repository.go
+++ b/internal/usecases/ports/repositories/session_list_cache_repository.go
@@ -49,12 +49,12 @@ type SessionListCacheRepository interface {
 	// are not served after structural changes.
 	InvalidateSessionListCache(ctx context.Context, namespace string) error
 
-	// UpdateSessionInCache updates a single session in all cache entries for the namespace.
-	// This is more efficient than invalidating the entire cache when only one session changes.
-	// If the session doesn't exist in a cache entry, it's appended. If it exists, it's updated.
-	UpdateSessionInCache(ctx context.Context, namespace string, session CachedSessionDTO) error
+	// UpdateSessionInCache updates a single session in cache entries where it is
+	// already present. It must not append the session to caches keyed by a
+	// different label selector, because that would pollute filtered list results.
+	UpdateSessionInCache(ctx context.Context, namespace string, session CachedSessionDTO, ttl time.Duration) error
 
 	// DeleteSessionFromCache removes a single session from all cache entries for the namespace.
 	// This is more efficient than invalidating the entire cache when only one session is deleted.
-	DeleteSessionFromCache(ctx context.Context, namespace string, sessionID string) error
+	DeleteSessionFromCache(ctx context.Context, namespace string, sessionID string, ttl time.Duration) error
 }

--- a/internal/usecases/ports/repositories/session_list_cache_repository.go
+++ b/internal/usecases/ports/repositories/session_list_cache_repository.go
@@ -48,4 +48,13 @@ type SessionListCacheRepository interface {
 	// given namespace.  Called by CreateSession and DeleteSession so stale lists
 	// are not served after structural changes.
 	InvalidateSessionListCache(ctx context.Context, namespace string) error
+
+	// UpdateSessionInCache updates a single session in all cache entries for the namespace.
+	// This is more efficient than invalidating the entire cache when only one session changes.
+	// If the session doesn't exist in a cache entry, it's appended. If it exists, it's updated.
+	UpdateSessionInCache(ctx context.Context, namespace string, session CachedSessionDTO) error
+
+	// DeleteSessionFromCache removes a single session from all cache entries for the namespace.
+	// This is more efficient than invalidating the entire cache when only one session is deleted.
+	DeleteSessionFromCache(ctx context.Context, namespace string, sessionID string) error
 }

--- a/internal/usecases/ports/repositories/session_list_cache_repository.go
+++ b/internal/usecases/ports/repositories/session_list_cache_repository.go
@@ -11,23 +11,23 @@ import (
 // It contains enough information to serve ListSessions responses from cache
 // without making Kubernetes API calls.
 type CachedSessionDTO struct {
-	ID             string            `json:"id"`
-	UserID         string            `json:"user_id"`
-	Scope          string            `json:"scope"`
-	TeamID         string            `json:"team_id"`
-	Tags           map[string]string `json:"tags"`
-	Status         string            `json:"status"`
-	StartedAt      time.Time         `json:"started_at"`
-	UpdatedAt      time.Time         `json:"updated_at"`
-	LastMessageAt  time.Time         `json:"last_message_at"`
-	Description    string            `json:"description"`
+	ID             string                      `json:"id"`
+	UserID         string                      `json:"user_id"`
+	Scope          string                      `json:"scope"`
+	TeamID         string                      `json:"team_id"`
+	Tags           map[string]string           `json:"tags"`
+	Status         string                      `json:"status"`
+	StartedAt      time.Time                   `json:"started_at"`
+	UpdatedAt      time.Time                   `json:"updated_at"`
+	LastMessageAt  time.Time                   `json:"last_message_at"`
+	Description    string                      `json:"description"`
 	Annotations    entities.SessionAnnotations `json:"annotations,omitempty"`
-	ServicePort    int               `json:"service_port"`
-	Namespace      string            `json:"namespace"`
-	DeploymentName string            `json:"deployment_name"`
-	ServiceName    string            `json:"service_name"`
-	InitialMessage string            `json:"initial_message"`
-	IsStock        bool              `json:"is_stock"`
+	ServicePort    int                         `json:"service_port"`
+	Namespace      string                      `json:"namespace"`
+	DeploymentName string                      `json:"deployment_name"`
+	ServiceName    string                      `json:"service_name"`
+	InitialMessage string                      `json:"initial_message"`
+	IsStock        bool                        `json:"is_stock"`
 }
 
 // SessionListCacheRepository provides a short-lived cache layer for session


### PR DESCRIPTION
## 概要

セッションリスト取得のパフォーマンスを改善しました。

## 変更内容

### Redis キャッシュ最適化

1. **TTL 延長**: キャッシュ TTL を 15秒から 60秒に延長
   - Kubernetes API 呼び出しの頻度を低減

2. **差分更新の実装**: 
   - `UpdateSessionInCache`: セッション作成時にキャッシュ全体を無効化せず差分更新
   - `DeleteSessionFromCache`: セッション削除時にキャッシュ全体を無効化せず差分削除

3. **インターフェース拡張**:
   - `SessionListCacheRepository` に差分更新メソッドを追加
   - Redis 実装と Noop 実装の両方を更新

## 関連

- agentapi-ui も同様の改善を実施予定