### PR TITLE
feat: enable MCP for pi sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,9 +186,10 @@ RUN bun install -g @openai/codex && \
     sudo tee /opt/claude/bin/codex > /dev/null && \
     sudo chmod +x /opt/claude/bin/codex
 
-# Install Pi, pi-acp, and the Ollama Cloud provider extension for pi-ollama sessions.
+# Install Pi, pi-acp, and Pi extensions for pi-ollama sessions.
 # pi-acp starts `pi --mode rpc`, and pi-ollama-cloud connects directly to
-# https://ollama.com/v1 using OLLAMA_API_KEY/OLLAMA_API_KEYS.
+# https://ollama.com/v1 using OLLAMA_API_KEY/OLLAMA_API_KEYS. pi-mcp-adapter
+# lets Pi read MCP servers from ~/.config/mcp/mcp.json.
 RUN bun install -g @earendil-works/pi-coding-agent && \
     npm install --global pi-acp@latest && \
     mkdir -p /home/agentapi/.pi/agent/npm && \
@@ -214,6 +215,7 @@ RUN bun install -g @earendil-works/pi-coding-agent && \
       > /tmp/pi-npm-shim/npm && \
     chmod +x /tmp/pi-npm-shim/npm && \
     PATH="/tmp/pi-npm-shim:$PATH" pi install npm:pi-ollama-cloud && \
+    PATH="/tmp/pi-npm-shim:$PATH" pi install npm:pi-mcp-adapter && \
     rm -rf /tmp/pi-npm-shim
 
 # Install Cursor Agent CLI and place stable wrappers in /opt/cursor/bin.

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -16,8 +16,8 @@ import (
 
 const piOllamaInstallPreScript = `mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
-  echo "pi-ollama-cloud already installed, skipping install"
+if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ] && [ -d "$HOME/.pi/agent/npm/node_modules/pi-mcp-adapter" ]; then
+  echo "Pi extensions already installed, skipping install"
 else
   NPM_SHIM_DIR="$(mktemp -d)"
   trap 'rm -rf "$NPM_SHIM_DIR"' EXIT
@@ -40,7 +40,12 @@ test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":
 exec bun add --cwd "$prefix" $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
-  PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
+    PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  fi
+  if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-mcp-adapter" ]; then
+    PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-mcp-adapter
+  fi
   rm -rf "$NPM_SHIM_DIR"
   trap - EXIT
 fi`

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -48,6 +48,7 @@ func TestBuildStartupConfigPiOllama(t *testing.T) {
 	assert.Equal(t, []string{"acp-server", "--", "npx", "-y", "pi-acp"}, config.Args)
 	assert.NotEmpty(t, config.PreScript)
 	assert.Contains(t, config.PreScript, "node_modules/pi-ollama-cloud")
+	assert.Contains(t, config.PreScript, "node_modules/pi-mcp-adapter")
 	assert.Contains(t, config.PreScript, "skipping install")
 }
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2791,67 +2791,67 @@ func buildSciaSidecarConfigYAML(namespace, userNamespace, credentialID, todoistC
 	var b strings.Builder
 	b.WriteString("server:\n")
 	b.WriteString("  mode: proxy\n")
-	b.WriteString(fmt.Sprintf("  listen: %q\n", fmt.Sprintf("0.0.0.0:%d", port)))
+	fmt.Fprintf(&b, "  listen: %q\n", fmt.Sprintf("0.0.0.0:%d", port))
 	if useNFA {
 		b.WriteString("  backendProxy:\n")
-		b.WriteString(fmt.Sprintf("    url: %q\n", fmt.Sprintf("http://127.0.0.1:%d", nfaProxyPort)))
+		fmt.Fprintf(&b, "    url: %q\n", fmt.Sprintf("http://127.0.0.1:%d", nfaProxyPort))
 	}
 	b.WriteString("  integrations:\n")
 	b.WriteString("    google:\n")
 	b.WriteString("      hosts:\n")
 	for _, host := range hosts {
-		b.WriteString(fmt.Sprintf("        - %q\n", host))
+		fmt.Fprintf(&b, "        - %q\n", host)
 	}
 	b.WriteString("    todoist:\n")
 	b.WriteString("      hosts:\n")
 	for _, host := range todoistHosts {
-		b.WriteString(fmt.Sprintf("        - %q\n", host))
+		fmt.Fprintf(&b, "        - %q\n", host)
 	}
 	b.WriteString("  mitm:\n")
-	b.WriteString(fmt.Sprintf("    caCertPath: %q\n", sciaCAPath))
+	fmt.Fprintf(&b, "    caCertPath: %q\n", sciaCAPath)
 	b.WriteString("    caKeyPath: \"/etc/scia/mitm/ca.key\"\n")
 	b.WriteString("  secrets:\n")
 	b.WriteString("    mode: kubernetes\n")
 	b.WriteString("    kubernetes:\n")
-	b.WriteString(fmt.Sprintf("      namespace: %q\n", namespace))
+	fmt.Fprintf(&b, "      namespace: %q\n", namespace)
 	b.WriteString("      dynamicUsers: true\n")
 	b.WriteString("      dynamicUserSecretNamePrefix: \"scia-oauth-\"\n")
 	b.WriteString("credentials:\n")
-	b.WriteString(fmt.Sprintf("  - id: %q\n", credentialID))
+	fmt.Fprintf(&b, "  - id: %q\n", credentialID)
 	b.WriteString("    type: google-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
-	b.WriteString(fmt.Sprintf("      user: %q\n", userNamespace))
-	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, "google", userToken)))
-	b.WriteString(fmt.Sprintf("  - id: %q\n", todoistCredentialID))
+	fmt.Fprintf(&b, "      user: %q\n", userNamespace)
+	fmt.Fprintf(&b, "      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, "google", userToken))
+	fmt.Fprintf(&b, "  - id: %q\n", todoistCredentialID)
 	b.WriteString("    type: todoist-oauth-refresh-token\n")
 	b.WriteString("    params:\n")
-	b.WriteString(fmt.Sprintf("      user: %q\n", userNamespace))
-	b.WriteString(fmt.Sprintf("      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, "todoist", userToken)))
+	fmt.Fprintf(&b, "      user: %q\n", userNamespace)
+	fmt.Fprintf(&b, "      token_broker_url: %q\n", sciaTokenBrokerURL(namespace, "todoist", userToken))
 	b.WriteString("rules:\n")
 	b.WriteString("  - name: inject-google-oauth-token\n")
 	b.WriteString("    hosts:\n")
 	for _, host := range hosts {
-		b.WriteString(fmt.Sprintf("      - %q\n", host))
+		fmt.Fprintf(&b, "      - %q\n", host)
 	}
 	b.WriteString("    paths:\n")
 	for _, path := range paths {
-		b.WriteString(fmt.Sprintf("      - %q\n", path))
+		fmt.Fprintf(&b, "      - %q\n", path)
 	}
 	b.WriteString("    action: allow\n")
 	b.WriteString("    credentials:\n")
-	b.WriteString(fmt.Sprintf("      - %q\n", credentialID))
+	fmt.Fprintf(&b, "      - %q\n", credentialID)
 	b.WriteString("  - name: inject-todoist-oauth-token\n")
 	b.WriteString("    hosts:\n")
 	for _, host := range todoistHosts {
-		b.WriteString(fmt.Sprintf("      - %q\n", host))
+		fmt.Fprintf(&b, "      - %q\n", host)
 	}
 	b.WriteString("    paths:\n")
 	for _, path := range todoistPaths {
-		b.WriteString(fmt.Sprintf("      - %q\n", path))
+		fmt.Fprintf(&b, "      - %q\n", path)
 	}
 	b.WriteString("    action: allow\n")
 	b.WriteString("    credentials:\n")
-	b.WriteString(fmt.Sprintf("      - %q\n", todoistCredentialID))
+	fmt.Fprintf(&b, "      - %q\n", todoistCredentialID)
 	return b.String()
 }
 
@@ -3513,8 +3513,8 @@ const (
 	piOllamaCommandPath      = "/home/agentapi/.session/pi-ollama-pi"
 	piOllamaInstallPreScript = `mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
-  echo "pi-ollama-cloud already installed, skipping install"
+if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ] && [ -d "$HOME/.pi/agent/npm/node_modules/pi-mcp-adapter" ]; then
+  echo "Pi extensions already installed, skipping install"
 else
   NPM_SHIM_DIR="$(mktemp -d)"
   trap 'rm -rf "$NPM_SHIM_DIR"' EXIT
@@ -3537,7 +3537,12 @@ test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":
 exec bun add --cwd "$prefix" $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
-  PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
+    PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  fi
+  if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-mcp-adapter" ]; then
+    PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-mcp-adapter
+  fi
   rm -rf "$NPM_SHIM_DIR"
   trap - EXIT
 fi`

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -181,4 +181,7 @@ func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 	if !strings.Contains(settings.Startup.PreScript, "node_modules/pi-ollama-cloud") {
 		t.Fatalf("expected pi-ollama pre-script to skip install when package is baked into the image")
 	}
+	if !strings.Contains(settings.Startup.PreScript, "node_modules/pi-mcp-adapter") {
+		t.Fatalf("expected pi-ollama pre-script to skip pi-mcp-adapter install when package is baked into the image")
+	}
 }

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -29,8 +29,8 @@ bun install --global @earendil-works/pi-coding-agent@latest
 npm install --global pi-acp@latest
 mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
-if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
-  echo "pi-ollama-cloud already installed, skipping install"
+if [ -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ] && [ -d "$HOME/.pi/agent/npm/node_modules/pi-mcp-adapter" ]; then
+  echo "Pi extensions already installed, skipping install"
 else
   NPM_SHIM_DIR="$(mktemp -d)"
   trap 'rm -rf "$NPM_SHIM_DIR"' EXIT
@@ -53,7 +53,12 @@ test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":
 exec bun add --cwd "$prefix" $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
-  PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
+    PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-ollama-cloud
+  fi
+  if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-mcp-adapter" ]; then
+    PATH="$NPM_SHIM_DIR:$PATH" pi install npm:pi-mcp-adapter
+  fi
   rm -rf "$NPM_SHIM_DIR"
   trap - EXIT
 fi

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -79,6 +79,11 @@ func Compile(opts CompileOptions) error {
 		return fmt.Errorf("failed to generate codex MCP servers config: %w", err)
 	}
 
+	// 3f. Generate the shared MCP config read by pi-mcp-adapter (pi sessions only)
+	if err := generatePiMCPConfig(opts.OutputDir, settings.Session.AgentType, settings.Claude.MCPServers); err != nil {
+		return fmt.Errorf("failed to generate Pi MCP config: %w", err)
+	}
+
 	// 4. Generate env file
 	if err := generateEnvFile(opts.EnvFilePath, settings.Env); err != nil {
 		return fmt.Errorf("failed to generate env file: %w", err)
@@ -150,6 +155,35 @@ func generateClaudeJSON(outputDir string, claudeJSON map[string]interface{}, mcp
 // the "Welcome to Claude Code" screen.
 func patchClaudeJSON(outputDir string, extra map[string]interface{}) error {
 	return generateClaudeJSON(outputDir, extra, nil)
+}
+
+// generatePiMCPConfig creates ~/.config/mcp/mcp.json for pi-mcp-adapter.
+// pi-mcp-adapter reads this shared MCP config automatically on first use.
+func generatePiMCPConfig(outputDir string, agentType string, mcpServers map[string]interface{}) error {
+	if agentType != "pi-ollama" || len(mcpServers) == 0 {
+		return nil
+	}
+
+	configDir := filepath.Join(outputDir, ".config", "mcp")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create Pi MCP config directory: %w", err)
+	}
+
+	config := map[string]interface{}{
+		"mcpServers": mcpServers,
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Pi MCP config: %w", err)
+	}
+
+	configPath := filepath.Join(configDir, "mcp.json")
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write Pi MCP config: %w", err)
+	}
+
+	log.Printf("[COMPILE-SETTINGS] Generated %s", configPath)
+	return nil
 }
 
 // generateSettingsJSON creates ~/.claude/settings.json.

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -603,11 +603,11 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 				AgentType: "codex-acp",
 			},
 			Env: map[string]string{
-				"OPENAI_BASE_URL": "http://proxy.example.com/v1",
-				"OPENAI_MODEL":    "gpt-oss:20b",
-				"CODEX_MODEL":     "qwen3-coder-next",
-				"CODEX_MODEL_CONTEXT_WINDOW":             "65536",
-				"CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT":    "32768",
+				"OPENAI_BASE_URL":                          "http://proxy.example.com/v1",
+				"OPENAI_MODEL":                             "gpt-oss:20b",
+				"CODEX_MODEL":                              "qwen3-coder-next",
+				"CODEX_MODEL_CONTEXT_WINDOW":               "65536",
+				"CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT":     "32768",
 				"CODEX_MODEL_SUPPORTS_REASONING_SUMMARIES": "false",
 			},
 			Codex: CodexConfig{
@@ -972,6 +972,104 @@ func TestCompile_CodexMCPServers(t *testing.T) {
 
 		// No config.toml should be created when neither ConfigTOML nor MCPServers is set.
 		assert.NoFileExists(t, filepath.Join(outputDir, ".codex/config.toml"))
+	})
+}
+
+func TestCompile_PiMCPConfig(t *testing.T) {
+	t.Run("writes shared mcp config for pi-ollama", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-pi-mcp-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-pi-mcp",
+				UserID:    "user-pi-mcp",
+				Scope:     "user",
+				AgentType: "pi-ollama",
+			},
+			Claude: ClaudeConfig{
+				MCPServers: map[string]interface{}{
+					"github": map[string]interface{}{
+						"type":    "stdio",
+						"command": "github-mcp-server",
+						"args":    []interface{}{"stdio"},
+						"env": map[string]interface{}{
+							"GITHUB_TOKEN": "ghp_secret",
+						},
+					},
+				},
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".config/mcp/mcp.json")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+
+		var config map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &config))
+		mcpServers, ok := config["mcpServers"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Contains(t, mcpServers, "github")
+	})
+
+	t.Run("skips non-pi sessions", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-non-pi-mcp-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-claude-mcp",
+				UserID:    "user-claude-mcp",
+				Scope:     "user",
+				AgentType: "claude-acp",
+			},
+			Claude: ClaudeConfig{
+				MCPServers: map[string]interface{}{
+					"github": map[string]interface{}{
+						"type": "http",
+						"url":  "https://mcp.example.com",
+					},
+				},
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		assert.NoFileExists(t, filepath.Join(outputDir, ".config/mcp/mcp.json"))
 	})
 }
 


### PR DESCRIPTION
## Summary
- install pi-mcp-adapter alongside pi-ollama-cloud for Pi sessions
- generate ~/.config/mcp/mcp.json for pi-ollama sessions from resolved MCP server settings
- add tests covering Pi MCP config generation and adapter install scripts

## Verification
- mise exec -- make lint
- mise exec -- go test -race ./pkg/sessionsettings ./internal/infrastructure/services ./pkg/provisioner
- mise exec -- go test -race ./cmd -run 'TestBuildStartupConfigPiOllama'
- mise exec -- make build

Note: mise exec -- make test currently fails in ./cmd at TestRunProxyWithInvalidConfig because it connects to the live Kubernetes environment and exits with signal: interrupt after restoring existing sessions.