### PR TITLE
Use agentclientprotocol codex-acp package

### DIFF
--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -581,11 +581,11 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 		}
 	case "codex-acp":
 		// acp-server bridges codex-acp (ACP adapter for OpenAI Codex) to the agentapi HTTP interface.
-		// https://github.com/zed-industries/codex-acp
-		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx @zed-industries/codex-acp]")
+		// https://github.com/agentclientprotocol/codex-acp
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx @agentclientprotocol/codex-acp]")
 		return sessionsettings.StartupConfig{
 			Command: []string{"agentapi-proxy"},
-			Args:    []string{"acp-server", "--", "npx", "@zed-industries/codex-acp"},
+			Args:    []string{"acp-server", "--", "npx", "@agentclientprotocol/codex-acp"},
 		}
 	case "pi-ollama":
 		// acp-server bridges pi-acp to Pi, which is configured with the pi-ollama-cloud provider.

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -582,10 +582,10 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 	case "codex-acp":
 		// acp-server bridges codex-acp (ACP adapter for OpenAI Codex) to the agentapi HTTP interface.
 		// https://github.com/agentclientprotocol/codex-acp
-		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx @agentclientprotocol/codex-acp]")
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx -y @agentclientprotocol/codex-acp]")
 		return sessionsettings.StartupConfig{
 			Command: []string{"agentapi-proxy"},
-			Args:    []string{"acp-server", "--", "npx", "@agentclientprotocol/codex-acp"},
+			Args:    []string{"acp-server", "--", "npx", "-y", "@agentclientprotocol/codex-acp"},
 		}
 	case "pi-ollama":
 		// acp-server bridges pi-acp to Pi, which is configured with the pi-ollama-cloud provider.

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -5002,7 +5002,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		}
 	case "codex-acp":
 		// acp-server bridges codex-acp (ACP adapter for OpenAI Codex) to the agentapi HTTP interface.
-		// https://github.com/zed-industries/codex-acp
+		// https://github.com/agentclientprotocol/codex-acp
 		// --auto-approve bypasses the UI permission modal at the ACP bridge layer.
 		settings.Startup = sessionsettings.StartupConfig{
 			Command: []string{"agentapi-proxy"},
@@ -5011,7 +5011,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
 				"--auto-approve",
 				"--",
-				"npx", "@zed-industries/codex-acp",
+				"npx", "@agentclientprotocol/codex-acp",
 			},
 		}
 	case "pi-ollama":

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -5011,7 +5011,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
 				"--auto-approve",
 				"--",
-				"npx", "@agentclientprotocol/codex-acp",
+				"npx", "-y", "@agentclientprotocol/codex-acp",
 			},
 		}
 	case "pi-ollama":

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -945,7 +945,7 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 			"--port", agentapiPort,
 			"--auto-approve",
 			"--",
-			"npx", "@agentclientprotocol/codex-acp",
+			"npx", "-y", "@agentclientprotocol/codex-acp",
 		}
 
 	case "pi-ollama":

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -938,14 +938,14 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 
 	case "codex-acp":
 		// Start the acp-server bridge that wraps codex-acp (ACP adapter for OpenAI Codex) via stdio.
-		// https://github.com/zed-industries/codex-acp
+		// https://github.com/agentclientprotocol/codex-acp
 		// --auto-approve bypasses the UI permission modal at the ACP bridge layer.
 		return "agentapi-proxy", []string{
 			"acp-server",
 			"--port", agentapiPort,
 			"--auto-approve",
 			"--",
-			"npx", "@zed-industries/codex-acp",
+			"npx", "@agentclientprotocol/codex-acp",
 		}
 
 	case "pi-ollama":

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -24,7 +24,7 @@ import (
 // not incur a network download when a provision request arrives.
 // Override with the PROVISIONER_PRE_SCRIPT environment variable.
 const defaultStartupScript = `bun install --global @agentclientprotocol/claude-agent-acp@latest
-npm install --global @zed-industries/codex-acp@latest
+npm install --global @agentclientprotocol/codex-acp@latest
 bun install --global @earendil-works/pi-coding-agent@latest
 npm install --global pi-acp@latest
 mkdir -p "$HOME/.pi/agent/npm"


### PR DESCRIPTION
## Summary
- Replace codex-acp startup commands from @zed-industries/codex-acp to @agentclientprotocol/codex-acp
- Update codex-acp repository comments to agentclientprotocol/codex-acp
- Preinstall @agentclientprotocol/codex-acp in the provisioner startup script

## Testing
- git diff --check
- make lint (fails: go: No such file or directory)
- make test (fails: go: No such file or directory)