### PR TITLE
Fix team-scoped SlackBot channel resolution

### DIFF
--- a/internal/domain/entities/slackbot.go
+++ b/internal/domain/entities/slackbot.go
@@ -300,17 +300,29 @@ func (s *SlackBot) IsEventTypeAllowed(eventType string) bool {
 
 // IsChannelNameAllowed returns true if the given channel name matches any of the allowed patterns.
 // Matching is partial (substring): a pattern is considered matched if the channel name contains it.
-// If no patterns are configured, all channels are allowed.
+// If no patterns are configured, all channels are allowed. Channel names are normalized so
+// user-facing values like "#general" and case differences still match Slack's API result.
 func (s *SlackBot) IsChannelNameAllowed(channelName string) bool {
 	if len(s.allowedChannelNames) == 0 {
 		return true
 	}
+	normalizedChannelName := normalizeSlackChannelPattern(channelName)
 	for _, pattern := range s.allowedChannelNames {
-		if strings.Contains(channelName, pattern) {
+		normalizedPattern := normalizeSlackChannelPattern(pattern)
+		if normalizedPattern == "" {
+			continue
+		}
+		if strings.Contains(normalizedChannelName, normalizedPattern) {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeSlackChannelPattern(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimPrefix(value, "#")
+	return strings.ToLower(value)
 }
 
 // IsUserIDAllowed returns true if the given Slack user ID is allowed.

--- a/internal/domain/entities/slackbot_test.go
+++ b/internal/domain/entities/slackbot_test.go
@@ -235,6 +235,24 @@ func TestSlackBot_IsChannelNameAllowed(t *testing.T) {
 			channelName:         "backend-alerts",
 			want:                true,
 		},
+		{
+			name:                "hash-prefixed channel name matches",
+			allowedChannelNames: []string{"#dev-alerts"},
+			channelName:         "dev-alerts",
+			want:                true,
+		},
+		{
+			name:                "case-insensitive match",
+			allowedChannelNames: []string{"Dev-Alerts"},
+			channelName:         "dev-alerts",
+			want:                true,
+		},
+		{
+			name:                "slack channel ID match",
+			allowedChannelNames: []string{"C0AJABWPZMF"},
+			channelName:         "C0AJABWPZMF",
+			want:                true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/repositories/kubernetes_slackbot_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_slackbot_repository.go
@@ -125,7 +125,17 @@ func (r *KubernetesSlackBotRepository) List(ctx context.Context, filter repoport
 	}
 
 	var result []*entities.SlackBot
+	listAll := filter.UserID == "" &&
+		len(filter.TeamIDs) == 0 &&
+		filter.Status == "" &&
+		filter.Scope == "" &&
+		filter.TeamID == ""
 	for _, sb := range slackBots {
+		if listAll {
+			result = append(result, sb)
+			continue
+		}
+
 		// Determine accessibility based on scope:
 		// - Team-scoped bots: accessible if user is a team member OR the creator
 		// - User-scoped bots: accessible if user is the owner
@@ -459,6 +469,9 @@ func (r *KubernetesSlackBotRepository) sessionConfigJSONToSlackBotEntity(scj *we
 	if scj.Params != nil {
 		sc.SetParams(scj.Params)
 	}
+	if scj.SessionProfileID != "" {
+		sc.SetSessionProfileID(scj.SessionProfileID)
+	}
 	return sc
 }
 
@@ -473,6 +486,7 @@ func (r *KubernetesSlackBotRepository) sessionConfigSlackBotEntityToJSON(sc *ent
 		ReuseSession:           sc.ReuseSession(),
 		MountPayload:           sc.MountPayload(),
 		MemoryKey:              sc.MemoryKey(),
+		SessionProfileID:       sc.SessionProfileID(),
 	}
 	if params := sc.Params(); params != nil {
 		scj.Params = params

--- a/internal/infrastructure/repositories/kubernetes_slackbot_repository_test.go
+++ b/internal/infrastructure/repositories/kubernetes_slackbot_repository_test.go
@@ -1,0 +1,71 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	repoports "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubernetesSlackBotRepository_ListEmptyFilterReturnsAllBots(t *testing.T) {
+	ctx := context.Background()
+	repo := NewKubernetesSlackBotRepository(fake.NewSimpleClientset(), "test-ns")
+
+	userBot := entities.NewSlackBot("user-bot", "User Bot", "user-1")
+	require.NoError(t, repo.Create(ctx, userBot))
+
+	teamBot := entities.NewSlackBot("team-bot", "Team Bot", "user-2")
+	teamBot.SetScope(entities.ScopeTeam)
+	teamBot.SetTeamID("myorg/backend")
+	require.NoError(t, repo.Create(ctx, teamBot))
+
+	bots, err := repo.List(ctx, repoports.SlackBotFilter{})
+	require.NoError(t, err)
+	assert.Len(t, bots, 2)
+	assert.ElementsMatch(t, []string{"user-bot", "team-bot"}, slackBotIDs(bots))
+}
+
+func TestKubernetesSlackBotRepository_ListUserFilterStillRestrictsTeamBots(t *testing.T) {
+	ctx := context.Background()
+	repo := NewKubernetesSlackBotRepository(fake.NewSimpleClientset(), "test-ns")
+
+	userBot := entities.NewSlackBot("user-bot", "User Bot", "user-1")
+	require.NoError(t, repo.Create(ctx, userBot))
+
+	teamBot := entities.NewSlackBot("team-bot", "Team Bot", "user-2")
+	teamBot.SetScope(entities.ScopeTeam)
+	teamBot.SetTeamID("myorg/backend")
+	require.NoError(t, repo.Create(ctx, teamBot))
+
+	bots, err := repo.List(ctx, repoports.SlackBotFilter{UserID: "user-1"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"user-bot"}, slackBotIDs(bots))
+}
+
+func TestKubernetesSlackBotRepository_PreservesSessionProfileID(t *testing.T) {
+	ctx := context.Background()
+	repo := NewKubernetesSlackBotRepository(fake.NewSimpleClientset(), "test-ns")
+
+	bot := entities.NewSlackBot("profile-bot", "Profile Bot", "user-1")
+	sessionConfig := entities.NewWebhookSessionConfig()
+	sessionConfig.SetSessionProfileID("profile-slack")
+	bot.SetSessionConfig(sessionConfig)
+	require.NoError(t, repo.Create(ctx, bot))
+
+	loaded, err := repo.Get(ctx, "profile-bot")
+	require.NoError(t, err)
+	require.NotNil(t, loaded.SessionConfig())
+	assert.Equal(t, "profile-slack", loaded.SessionConfig().SessionProfileID())
+}
+
+func slackBotIDs(bots []*entities.SlackBot) []string {
+	ids := make([]string, 0, len(bots))
+	for _, bot := range bots {
+		ids = append(ids, bot.ID())
+	}
+	return ids
+}

--- a/internal/modules/slackbot/controller.go
+++ b/internal/modules/slackbot/controller.go
@@ -93,6 +93,7 @@ type SlackBotSessionConfig struct {
 	Environment            map[string]string      `json:"environment,omitempty"`
 	Params                 *SlackBotSessionParams `json:"params,omitempty"`
 	MemoryKey              map[string]string      `json:"memory_key,omitempty"`
+	SessionProfileID       string                 `json:"session_profile_id,omitempty"`
 }
 
 // SlackBotSessionParams contains session parameters for SlackBot sessions
@@ -454,6 +455,9 @@ func toEntitySessionConfig(cfg *SlackBotSessionConfig) *entities.WebhookSessionC
 	if cfg.MemoryKey != nil {
 		sc.SetMemoryKey(cfg.MemoryKey)
 	}
+	if cfg.SessionProfileID != "" {
+		sc.SetSessionProfileID(cfg.SessionProfileID)
+	}
 	if cfg.Params != nil {
 		params := &entities.SessionParams{
 			AgentType:    cfg.Params.AgentType,
@@ -476,6 +480,7 @@ func fromEntitySessionConfig(sc *entities.WebhookSessionConfig) *SlackBotSession
 		Tags:                   sc.Tags(),
 		Environment:            sc.Environment(),
 		MemoryKey:              sc.MemoryKey(),
+		SessionProfileID:       sc.SessionProfileID(),
 	}
 	if sc.Params() != nil {
 		cfg.Params = &SlackBotSessionParams{

--- a/internal/modules/slackbot/controller_test.go
+++ b/internal/modules/slackbot/controller_test.go
@@ -52,7 +52,17 @@ func (r *mockSlackBotRepository) List(_ context.Context, filter portrepos.SlackB
 		return nil, errors.New("storage error")
 	}
 	var result []*entities.SlackBot
+	listAll := filter.UserID == "" &&
+		len(filter.TeamIDs) == 0 &&
+		filter.Status == "" &&
+		filter.Scope == "" &&
+		filter.TeamID == ""
 	for _, bot := range r.bots {
+		if listAll {
+			result = append(result, bot)
+			continue
+		}
+
 		accessible := false
 		if bot.Scope() == entities.ScopeTeam && len(filter.TeamIDs) > 0 {
 			for _, teamID := range filter.TeamIDs {
@@ -227,6 +237,7 @@ func TestCreateSlackBot_WithAllOptionalFields(t *testing.T) {
 			ReuseMessageTemplate:   "Continue: {{.event.text}}",
 			Tags:                   map[string]string{"team": "engineering"},
 			Environment:            map[string]string{"LOG_LEVEL": "debug"},
+			SessionProfileID:       "profile-slack",
 		},
 	}, "user-1")
 
@@ -247,6 +258,7 @@ func TestCreateSlackBot_WithAllOptionalFields(t *testing.T) {
 	assert.Equal(t, "Continue: {{.event.text}}", resp.SessionConfig.ReuseMessageTemplate)
 	assert.Equal(t, "engineering", resp.SessionConfig.Tags["team"])
 	assert.Equal(t, "debug", resp.SessionConfig.Environment["LOG_LEVEL"])
+	assert.Equal(t, "profile-slack", resp.SessionConfig.SessionProfileID)
 }
 
 func TestCreateSlackBot_WithTeamScope(t *testing.T) {

--- a/internal/modules/slackbot/event_handler.go
+++ b/internal/modules/slackbot/event_handler.go
@@ -167,34 +167,24 @@ func (h *SlackBotEventHandler) ProcessEvent(ctx context.Context, botID string, p
 			log.Printf("[SLACKBOT] User ID not allowed: id=%s, user=%s", botID, event.User)
 			return nil
 		}
-		// Channel name filter: resolve channel ID → name, then apply partial-match filter
+		// Channel filter: allow either Slack channel ID or resolved channel name.
 		if len(bot.AllowedChannelNames()) > 0 && h.channelResolver != nil {
-			secretName := bot.BotTokenSecretName()
-			if secretName == "" {
-				secretName = h.defaultBotTokenSecretName
-			}
-			secretKey := bot.BotTokenSecretKey()
-			if secretKey == "" {
-				secretKey = h.defaultBotTokenSecretKey
-			}
-			botToken, tokenErr := h.channelResolver.GetBotToken(ctx, secretName, secretKey)
+			allowed, tokenErr := h.isBotAllowedInChannel(ctx, bot, event.Channel)
 			if tokenErr != nil {
-				log.Printf("[SLACKBOT] Failed to get bot token for channel filter: id=%s, err=%v", botID, tokenErr)
-				return fmt.Errorf("failed to get bot token: %w", tokenErr)
-			}
-			channelName, resolveErr := h.channelResolver.ResolveChannelName(ctx, event.Channel, botToken)
-			if resolveErr != nil {
-				log.Printf("[SLACKBOT] Failed to resolve channel name: id=%s, channel=%s, err=%v", botID, event.Channel, resolveErr)
+				log.Printf("[SLACKBOT] Failed to check channel filter: id=%s, channel=%s, err=%v", botID, event.Channel, tokenErr)
 				threadTS := event.ThreadTs
 				if threadTS == "" {
 					threadTS = event.Ts
 				}
-				h.postErrorToSlack(ctx, event.Channel, threadTS,
-					":warning: チャンネル情報を取得できませんでした。しばらく待ってから再度お試しください。",
-					botToken)
-				return fmt.Errorf("failed to resolve channel name for channel %s: %w", event.Channel, resolveErr)
-			} else if !bot.IsChannelNameAllowed(channelName) {
-				log.Printf("[SLACKBOT] Channel name not allowed: id=%s, channel=%s, name=%s", botID, event.Channel, channelName)
+				if botToken, err := h.getBotToken(ctx, bot); err == nil {
+					h.postErrorToSlack(ctx, event.Channel, threadTS,
+						":warning: チャンネル情報を取得できませんでした。しばらく待ってから再度お試しください。",
+						botToken)
+				}
+				return fmt.Errorf("failed to resolve channel name for channel %s: %w", event.Channel, tokenErr)
+			}
+			if !allowed {
+				log.Printf("[SLACKBOT] Channel not allowed: id=%s, channel=%s", botID, event.Channel)
 				return nil
 			}
 		}
@@ -503,6 +493,33 @@ func (h *SlackBotEventHandler) resolveBotByChannel(ctx context.Context, channelI
 	if h.channelResolver == nil || h.defaultBotTokenSecretName == "" {
 		return nil
 	}
+	allBots, err := h.repo.List(ctx, repositories.SlackBotFilter{})
+	if err != nil {
+		log.Printf("[SLACKBOT] resolveBotByChannel: failed to list bots: %v", err)
+		return nil
+	}
+
+	candidates := make([]*entities.SlackBot, 0, len(allBots))
+	for _, candidate := range allBots {
+		// Only match bots that rely on the default bot token
+		if candidate.BotTokenSecretName() != "" {
+			continue
+		}
+		// Must have at least one AllowedChannelName to be identifiable via the default endpoint
+		if len(candidate.AllowedChannelNames()) == 0 {
+			continue
+		}
+		candidates = append(candidates, candidate)
+		if candidate.IsChannelNameAllowed(channelID) {
+			log.Printf("[SLACKBOT] resolveBotByChannel: matched bot id=%s for channel=%s by channel ID",
+				candidate.ID(), channelID)
+			return candidate
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
 	botToken, err := h.channelResolver.GetBotToken(
 		ctx,
 		h.defaultBotTokenSecretName,
@@ -517,20 +534,7 @@ func (h *SlackBotEventHandler) resolveBotByChannel(ctx context.Context, channelI
 		log.Printf("[SLACKBOT] resolveBotByChannel: failed to resolve channel name: channelID=%s, err=%v", channelID, err)
 		return nil
 	}
-	allBots, err := h.repo.List(ctx, repositories.SlackBotFilter{})
-	if err != nil {
-		log.Printf("[SLACKBOT] resolveBotByChannel: failed to list bots: %v", err)
-		return nil
-	}
-	for _, candidate := range allBots {
-		// Only match bots that rely on the default bot token
-		if candidate.BotTokenSecretName() != "" {
-			continue
-		}
-		// Must have at least one AllowedChannelName to be identifiable via the default endpoint
-		if len(candidate.AllowedChannelNames()) == 0 {
-			continue
-		}
+	for _, candidate := range candidates {
 		if candidate.IsChannelNameAllowed(channelName) {
 			log.Printf("[SLACKBOT] resolveBotByChannel: matched bot id=%s for channel=%s (name=%s)",
 				candidate.ID(), channelID, channelName)
@@ -538,6 +542,22 @@ func (h *SlackBotEventHandler) resolveBotByChannel(ctx context.Context, channelI
 		}
 	}
 	return nil
+}
+
+func (h *SlackBotEventHandler) isBotAllowedInChannel(ctx context.Context, bot *entities.SlackBot, channelID string) (bool, error) {
+	if bot.IsChannelNameAllowed(channelID) {
+		return true, nil
+	}
+
+	botToken, err := h.getBotToken(ctx, bot)
+	if err != nil {
+		return false, err
+	}
+	channelName, err := h.channelResolver.ResolveChannelName(ctx, channelID, botToken)
+	if err != nil {
+		return false, err
+	}
+	return bot.IsChannelNameAllowed(channelName), nil
 }
 
 // buildMessage constructs the message to send to the session

--- a/internal/modules/slackbot/event_handler_test.go
+++ b/internal/modules/slackbot/event_handler_test.go
@@ -225,6 +225,39 @@ func TestResolveBotByChannel_Success(t *testing.T) {
 	assert.Equal(t, "bot-uuid-1", resolved.ID())
 }
 
+func TestResolveBotByChannel_TeamScopedBotSuccess(t *testing.T) {
+	const (
+		namespace  = "test-ns"
+		secretName = "bot-token-secret"
+		channelID  = "C0AJABWPZMF"
+	)
+
+	fakeClient := fake.NewSimpleClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+			Data:       map[string][]byte{"bot-token": []byte("xoxb-test-token")},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "agentapi-slack-channel-cache", Namespace: namespace},
+			Data:       map[string]string{channelID: "dev-alerts"},
+		},
+	)
+	resolver := NewSlackChannelResolver(fakeClient, namespace)
+
+	repo := newMockSlackBotRepository()
+	bot := entities.NewSlackBot("bot-team-uuid", "Team Dev Alerts Bot", "user-1")
+	bot.SetScope(entities.ScopeTeam)
+	bot.SetTeamID("myorg/backend")
+	bot.SetAllowedChannelNames([]string{"dev-alerts"})
+	repo.bots["bot-team-uuid"] = bot
+
+	handler := NewSlackBotEventHandler(repo, &mockSessionManager{}, secretName, "bot-token", resolver, "", false, nil, nil)
+
+	resolved := handler.resolveBotByChannel(context.Background(), channelID)
+	require.NotNil(t, resolved, "should resolve team-scoped bot by channel name")
+	assert.Equal(t, "bot-team-uuid", resolved.ID())
+}
+
 func TestResolveBotByChannel_NoMatch(t *testing.T) {
 	const (
 		namespace  = "test-ns"

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7249,6 +7249,11 @@
           },
           "description": "Environment variables to set for created sessions (Go template values supported)"
         },
+        "session_profile_id": {
+          "type": "string",
+          "description": "Optional SessionProfile ID to use as the base configuration for sessions created by this SlackBot.",
+          "example": "profile-default"
+        },
         "params": {
           "$ref": "#/components/schemas/SlackBotSessionParams"
         }


### PR DESCRIPTION
## Summary
- Return all SlackBots for internal empty-filter list calls so team-scoped bots are visible to Socket Mode/default channel resolution
- Allow SlackBot channel filters to match normalized names and channel IDs before resolving names
- Persist and expose SlackBot session_config.session_profile_id

## Tests
- mise exec -- go test ./internal/domain/entities ./internal/infrastructure/repositories ./internal/modules/slackbot
- mise exec -- make lint
- mise exec -- make test (fails: race detector requires CGO, but gcc is not installed in this environment)