### PR TITLE
Fix session profile sandbox defaults

### DIFF
--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -1041,7 +1041,8 @@ func (c *SessionController) GetSessionSandboxDomains(ctx echo.Context) error {
 
 // resolveSessionProfile returns the session profile to apply for a session creation request.
 // If profileID is set, it fetches that profile directly.
-// Otherwise it searches for a selector_tags match before falling back to the default profile.
+// Otherwise it searches for a selector_tags match before falling back to the settings default,
+// then the legacy profile-level default flag.
 func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID, userID string, scope entities.ResourceScope, teamID string, tags map[string]string) *entities.SessionProfile {
 	if profileID != "" {
 		profile, err := c.sessionProfileRepo.Get(ctx, profileID)
@@ -1068,6 +1069,10 @@ func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID
 		log.Printf("[SESSION] Applying tag-selected session profile %q (%s) for user %s", profile.ID(), profile.Name(), userID)
 		return profile
 	}
+	if profile := c.resolveSettingsDefaultSessionProfile(ctx, userID, scope, teamID, profiles); profile != nil {
+		log.Printf("[SESSION] Applying settings default session profile %q (%s) for user %s", profile.ID(), profile.Name(), userID)
+		return profile
+	}
 	for _, p := range profiles {
 		if p.IsDefault() {
 			log.Printf("[SESSION] Applying default session profile %q (%s) for user %s", p.ID(), p.Name(), userID)
@@ -1075,6 +1080,32 @@ func (c *SessionController) resolveSessionProfile(ctx context.Context, profileID
 		}
 	}
 	return nil
+}
+
+func (c *SessionController) resolveSettingsDefaultSessionProfile(ctx context.Context, userID string, scope entities.ResourceScope, teamID string, profiles []*entities.SessionProfile) *entities.SessionProfile {
+	if c.settingsRepo == nil {
+		return nil
+	}
+	settingsName := userID
+	if scope == entities.ScopeTeam && teamID != "" {
+		settingsName = teamID
+	}
+	settings, err := c.settingsRepo.FindByName(ctx, settingsName)
+	if err != nil || settings == nil || settings.DefaultSessionProfileID() == "" {
+		return nil
+	}
+	defaultID := settings.DefaultSessionProfileID()
+	for _, p := range profiles {
+		if p.ID() == defaultID {
+			return p
+		}
+	}
+	profile, err := c.sessionProfileRepo.Get(ctx, defaultID)
+	if err != nil {
+		log.Printf("[SESSION] Warning: could not resolve default_session_profile_id %q from settings %q: %v", defaultID, settingsName, err)
+		return nil
+	}
+	return profile
 }
 
 func selectSessionProfileByTags(profiles []*entities.SessionProfile, tags map[string]string) *entities.SessionProfile {

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -235,17 +235,10 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 			}
 
 			// SandboxPolicyID: apply profile's policy when request does not already specify one.
-			if cfg.SandboxPolicyID() != "" {
-				if startReq.Params == nil {
-					startReq.Params = &entities.SessionParams{}
-				}
-				if startReq.Params.Sandbox == nil {
-					startReq.Params.Sandbox = &entities.SandboxParams{Enabled: true, PolicyID: cfg.SandboxPolicyID()}
-				} else if startReq.Params.Sandbox.PolicyID == "" {
-					startReq.Params.Sandbox.Enabled = true
-					startReq.Params.Sandbox.PolicyID = cfg.SandboxPolicyID()
-				}
+			if startReq.Params == nil {
+				startReq.Params = &entities.SessionParams{}
 			}
+			applyProfileSandboxDefaults(cfg, startReq.Params)
 
 			// SessionTTL: apply profile's TTL when request does not already specify one.
 			if cfg.SessionTTL() != "" {
@@ -982,6 +975,27 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 		merged.UnsyncedFilePaths = append([]string(nil), override.UnsyncedFilePaths...)
 	}
 	return &merged
+}
+
+func applyProfileSandboxDefaults(cfg entities.SessionProfileConfig, params *entities.SessionParams) {
+	if params == nil {
+		return
+	}
+	if cfg.SandboxPolicyID() != "" {
+		if params.Sandbox == nil {
+			params.Sandbox = &entities.SandboxParams{Enabled: true, PolicyID: cfg.SandboxPolicyID()}
+		} else if params.Sandbox.PolicyID == "" {
+			params.Sandbox.Enabled = true
+			params.Sandbox.PolicyID = cfg.SandboxPolicyID()
+		}
+		return
+	}
+	if params.Sandbox == nil {
+		params.Sandbox = &entities.SandboxParams{Enabled: true, CountMode: true}
+	} else if params.Sandbox.PolicyID == "" {
+		params.Sandbox.Enabled = true
+		params.Sandbox.CountMode = true
+	}
 }
 
 // SandboxDomainsResponse is the JSON body returned by GET /sessions/:sessionId/sandbox-domains.

--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -109,6 +109,7 @@ type UpdateSettingsRequest struct {
 	NotificationChannels    *[]string                        `json:"notification_channels,omitempty"`     // Active notification channels (e.g. ["web", "slack"])
 	ExternalSessionManagers *[]ExternalSessionManagerRequest `json:"external_session_managers,omitempty"` // External session managers (External Session Manager registrations)
 	GitSync                 *GitSyncConfigRequest            `json:"git_sync,omitempty"`                  // GitHub sync configuration
+	DefaultSessionProfileID *string                          `json:"default_session_profile_id,omitempty"` // Default session profile ID for this settings scope
 }
 
 // ExternalSessionManagerRequest represents a single external session manager registration
@@ -159,6 +160,7 @@ type SettingsResponse struct {
 	NotificationChannels    []string                         `json:"notification_channels,omitempty"`     // Active notification channels
 	ExternalSessionManagers []ExternalSessionManagerResponse `json:"external_session_managers,omitempty"` // Registered external session managers
 	GitSync                 *GitSyncConfigResponse           `json:"git_sync,omitempty"`                  // GitHub sync configuration (token redacted)
+	DefaultSessionProfileID string                           `json:"default_session_profile_id,omitempty"` // Default session profile ID for this settings scope
 	CreatedAt               string                           `json:"created_at"`
 	UpdatedAt               string                           `json:"updated_at"`
 }
@@ -538,6 +540,10 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 		})
 	}
 
+	if req.DefaultSessionProfileID != nil {
+		settings.SetDefaultSessionProfileID(*req.DefaultSessionProfileID)
+	}
+
 	// Determine and set auth_mode
 	authMode := c.determineAuthMode(settings, req.AuthMode)
 	settings.SetAuthMode(authMode)
@@ -827,6 +833,7 @@ func (c *SettingsController) toResponseWithESMTokens(settings *entities.Settings
 	resp.PreferredTeamID = settings.PreferredTeamID()
 	resp.SlackUserID = settings.SlackUserID()
 	resp.NotificationChannels = settings.NotificationChannels()
+	resp.DefaultSessionProfileID = settings.DefaultSessionProfileID()
 
 	if gs := settings.GitSync(); gs != nil {
 		resp.GitSync = &GitSyncConfigResponse{

--- a/internal/interfaces/controllers/settings_controller_test.go
+++ b/internal/interfaces/controllers/settings_controller_test.go
@@ -252,6 +252,38 @@ func TestUpdateSettings_PreserveExistingCredentials(t *testing.T) {
 	}
 }
 
+func TestUpdateSettings_DefaultSessionProfileID(t *testing.T) {
+	repo := newMockSettingsRepository()
+	h := NewSettingsController(repo, nil, "", "")
+
+	defaultProfileID := "profile-1"
+	body, err := json.Marshal(UpdateSettingsRequest{
+		DefaultSessionProfileID: &defaultProfileID,
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/settings/test-user", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("name")
+	c.SetParamValues("test-user")
+	c.Set("internal_user", createTestUser("test-user", true))
+
+	err = h.UpdateSettings(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	savedSettings, err := repo.FindByName(context.Background(), "test-user")
+	require.NoError(t, err)
+	assert.Equal(t, "profile-1", savedSettings.DefaultSessionProfileID())
+
+	var resp SettingsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "profile-1", resp.DefaultSessionProfileID)
+}
+
 func TestMergeSecrets(t *testing.T) {
 	ctrl := &SettingsController{}
 

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -382,6 +382,10 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 		if req.Sandbox == nil && cfg.Params().Sandbox != nil {
 			req.Sandbox = cfg.Params().Sandbox
 		}
+		if req.Sandbox != nil && req.Sandbox.PolicyID == "" && cfg.SandboxPolicyID() != "" {
+			req.Sandbox.Enabled = true
+			req.Sandbox.PolicyID = cfg.SandboxPolicyID()
+		}
 		if req.Docker == nil && cfg.Params().Docker != nil {
 			req.Docker = cfg.Params().Docker
 		}
@@ -409,5 +413,13 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 	}
 	if len(cfg.UnsyncedFilePaths()) > 0 && len(req.UnsyncedFilePaths) == 0 {
 		req.UnsyncedFilePaths = cfg.UnsyncedFilePaths()
+	}
+	if cfg.SandboxPolicyID() != "" {
+		if req.Sandbox == nil {
+			req.Sandbox = &entities.SandboxParams{Enabled: true, PolicyID: cfg.SandboxPolicyID()}
+		} else if req.Sandbox.PolicyID == "" {
+			req.Sandbox.Enabled = true
+			req.Sandbox.PolicyID = cfg.SandboxPolicyID()
+		}
 	}
 }

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -414,6 +414,10 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 	if len(cfg.UnsyncedFilePaths()) > 0 && len(req.UnsyncedFilePaths) == 0 {
 		req.UnsyncedFilePaths = cfg.UnsyncedFilePaths()
 	}
+	applyProfileSandboxDefaults(cfg, req)
+}
+
+func applyProfileSandboxDefaults(cfg entities.SessionProfileConfig, req *LaunchRequest) {
 	if cfg.SandboxPolicyID() != "" {
 		if req.Sandbox == nil {
 			req.Sandbox = &entities.SandboxParams{Enabled: true, PolicyID: cfg.SandboxPolicyID()}
@@ -421,5 +425,12 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 			req.Sandbox.Enabled = true
 			req.Sandbox.PolicyID = cfg.SandboxPolicyID()
 		}
+		return
+	}
+	if req.Sandbox == nil {
+		req.Sandbox = &entities.SandboxParams{Enabled: true, CountMode: true}
+	} else if req.Sandbox.PolicyID == "" {
+		req.Sandbox.Enabled = true
+		req.Sandbox.CountMode = true
 	}
 }

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -134,6 +134,57 @@ func TestLaunchAppliesDefaultProfileDocker(t *testing.T) {
 	}
 }
 
+func TestLaunchAppliesDefaultProfileSandbox(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetParams(&entities.SessionParams{
+		Sandbox: &entities.SandboxParams{Enabled: true, CountMode: true},
+	})
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req == nil || sessionManager.req.Sandbox == nil || !sessionManager.req.Sandbox.Enabled || !sessionManager.req.Sandbox.CountMode {
+		t.Fatalf("expected profile sandbox params to be applied, got %#v", sessionManager.req)
+	}
+}
+
+func TestLaunchAppliesDefaultProfileSandboxPolicyID(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetSandboxPolicyID("policy-1")
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req == nil || sessionManager.req.Sandbox == nil {
+		t.Fatalf("expected profile sandbox policy params, got %#v", sessionManager.req)
+	}
+	if !sessionManager.req.Sandbox.Enabled || sessionManager.req.Sandbox.PolicyID != "policy-1" {
+		t.Fatalf("expected sandbox policy to enable sandbox, got %#v", sessionManager.req.Sandbox)
+	}
+}
+
 func TestLaunchAppliesDefaultProfileUnsyncedFilePaths(t *testing.T) {
 	sessionManager := &recordingSessionManager{}
 	profile := entities.NewSessionProfile("profile-1", "default", "user-1")

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -159,6 +159,30 @@ func TestLaunchAppliesDefaultProfileSandbox(t *testing.T) {
 	}
 }
 
+func TestLaunchAppliesCountModeSandboxWhenProfileHasNoPolicy(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	profile.SetIsDefault(true)
+	profile.SetConfig(entities.NewSessionProfileConfig())
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeUser,
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req == nil || sessionManager.req.Sandbox == nil {
+		t.Fatalf("expected count mode sandbox params, got %#v", sessionManager.req)
+	}
+	if !sessionManager.req.Sandbox.Enabled || !sessionManager.req.Sandbox.CountMode || sessionManager.req.Sandbox.PolicyID != "" {
+		t.Fatalf("expected count mode sandbox without policy, got %#v", sessionManager.req.Sandbox)
+	}
+}
+
 func TestLaunchAppliesDefaultProfileSandboxPolicyID(t *testing.T) {
 	sessionManager := &recordingSessionManager{}
 	profile := entities.NewSessionProfile("profile-1", "default", "user-1")

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -6560,6 +6560,10 @@
           "git_sync": {
             "$ref": "#/components/schemas/GitSyncConfigRequest",
             "description": "GitHub sync configuration. If omitted, the existing sync configuration is preserved."
+          },
+          "default_session_profile_id": {
+            "type": "string",
+            "description": "Default session profile ID for this settings scope. Set to empty string to clear."
           }
         }
       },
@@ -6735,6 +6739,10 @@
           "git_sync": {
             "$ref": "#/components/schemas/GitSyncConfigResponse",
             "description": "GitHub sync configuration (token redacted). Null if not configured."
+          },
+          "default_session_profile_id": {
+            "type": "string",
+            "description": "Default session profile ID for this settings scope."
           },
           "created_at": {
             "type": "string",
@@ -7544,7 +7552,7 @@
         },
         "sandbox_policy_id": {
           "type": "string",
-          "description": "Reference to a SandboxPolicy resource. When set, the sandbox sidecar is enabled automatically with this policy applied."
+          "description": "Reference to a SandboxPolicy resource. When set, the sandbox sidecar is enabled automatically with this policy applied. params.sandbox may also be used to enable sandbox without a policy."
         },
         "session_ttl": {
           "type": "string",


### PR DESCRIPTION
## Summary
- expose default_session_profile_id on settings GET/PUT and use it before legacy is_default profile fallback
- apply session profile sandbox_policy_id in LaunchUseCase so triggered sessions inherit sandbox policy defaults
- add coverage for settings default profile persistence and sandbox profile application
- update OpenAPI schema

## Verification
- UI checks are covered in the companion agentapi-ui PR
- make lint: failed in this environment because the Go toolchain is not installed (go: No such file or directory)
- make test: failed in this environment because the Go toolchain is not installed (go: No such file or directory)