### PR TITLE
Use internal SlackBot repository for worker-wide listing

### DIFF
--- a/internal/infrastructure/repositories/kubernetes_slackbot_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_slackbot_repository.go
@@ -125,17 +125,7 @@ func (r *KubernetesSlackBotRepository) List(ctx context.Context, filter repoport
 	}
 
 	var result []*entities.SlackBot
-	listAll := filter.UserID == "" &&
-		len(filter.TeamIDs) == 0 &&
-		filter.Status == "" &&
-		filter.Scope == "" &&
-		filter.TeamID == ""
 	for _, sb := range slackBots {
-		if listAll {
-			result = append(result, sb)
-			continue
-		}
-
 		// Determine accessibility based on scope:
 		// - Team-scoped bots: accessible if user is a team member OR the creator
 		// - User-scoped bots: accessible if user is the owner
@@ -176,6 +166,18 @@ func (r *KubernetesSlackBotRepository) List(ctx context.Context, filter repoport
 	}
 
 	return result, nil
+}
+
+// ListAll retrieves all SlackBots without applying access filters.
+func (r *KubernetesSlackBotRepository) ListAll(ctx context.Context) ([]*entities.SlackBot, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	slackBots, err := r.loadAllSlackBots(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load slackbots: %w", err)
+	}
+	return slackBots, nil
 }
 
 // Update updates an existing SlackBot

--- a/internal/infrastructure/repositories/kubernetes_slackbot_repository_test.go
+++ b/internal/infrastructure/repositories/kubernetes_slackbot_repository_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestKubernetesSlackBotRepository_ListEmptyFilterReturnsAllBots(t *testing.T) {
+func TestKubernetesSlackBotRepository_ListAllReturnsAllBots(t *testing.T) {
 	ctx := context.Background()
 	repo := NewKubernetesSlackBotRepository(fake.NewSimpleClientset(), "test-ns")
 
@@ -23,7 +23,7 @@ func TestKubernetesSlackBotRepository_ListEmptyFilterReturnsAllBots(t *testing.T
 	teamBot.SetTeamID("myorg/backend")
 	require.NoError(t, repo.Create(ctx, teamBot))
 
-	bots, err := repo.List(ctx, repoports.SlackBotFilter{})
+	bots, err := repo.ListAll(ctx)
 	require.NoError(t, err)
 	assert.Len(t, bots, 2)
 	assert.ElementsMatch(t, []string{"user-bot", "team-bot"}, slackBotIDs(bots))

--- a/internal/modules/slackbot/controller_test.go
+++ b/internal/modules/slackbot/controller_test.go
@@ -97,6 +97,17 @@ func (r *mockSlackBotRepository) List(_ context.Context, filter portrepos.SlackB
 	return result, nil
 }
 
+func (r *mockSlackBotRepository) ListAll(_ context.Context) ([]*entities.SlackBot, error) {
+	if r.errOn == "ListAll" {
+		return nil, errors.New("storage error")
+	}
+	result := make([]*entities.SlackBot, 0, len(r.bots))
+	for _, bot := range r.bots {
+		result = append(result, bot)
+	}
+	return result, nil
+}
+
 func (r *mockSlackBotRepository) Update(_ context.Context, bot *entities.SlackBot) error {
 	if r.errOn == "Update" {
 		return errors.New("storage error")

--- a/internal/modules/slackbot/event_handler.go
+++ b/internal/modules/slackbot/event_handler.go
@@ -493,7 +493,12 @@ func (h *SlackBotEventHandler) resolveBotByChannel(ctx context.Context, channelI
 	if h.channelResolver == nil || h.defaultBotTokenSecretName == "" {
 		return nil
 	}
-	allBots, err := h.repo.List(ctx, repositories.SlackBotFilter{})
+	internalRepo, ok := h.repo.(repositories.SlackBotInternalRepository)
+	if !ok {
+		log.Printf("[SLACKBOT] resolveBotByChannel: internal slackbot repository is not configured")
+		return nil
+	}
+	allBots, err := internalRepo.ListAll(ctx)
 	if err != nil {
 		log.Printf("[SLACKBOT] resolveBotByChannel: failed to list bots: %v", err)
 		return nil

--- a/internal/modules/slackbot/socket_manager.go
+++ b/internal/modules/slackbot/socket_manager.go
@@ -30,6 +30,7 @@ type SlackSocketManager struct {
 	kubeClient      kubernetes.Interface
 	namespace       string
 	repo            repoports.SlackBotRepository
+	internalRepo    repoports.SlackBotInternalRepository
 	eventHandler    *SlackBotEventHandler
 	channelResolver *SlackChannelResolver
 
@@ -82,10 +83,13 @@ func NewSlackSocketManager(
 		cfg.DefaultBotTokenSecretKey = "bot-token"
 	}
 
+	internalRepo, _ := repo.(repoports.SlackBotInternalRepository)
+
 	return &SlackSocketManager{
 		kubeClient:                kubeClient,
 		namespace:                 namespace,
 		repo:                      repo,
+		internalRepo:              internalRepo,
 		eventHandler:              eventHandler,
 		channelResolver:           channelResolver,
 		defaultAppTokenSecretName: cfg.DefaultAppTokenSecretName,
@@ -126,7 +130,11 @@ func (m *SlackSocketManager) Stop() {
 
 // reconcile lists all SlackBots and starts/stops leader elections as needed
 func (m *SlackSocketManager) reconcile(ctx context.Context) {
-	bots, err := m.repo.List(ctx, repoports.SlackBotFilter{})
+	if m.internalRepo == nil {
+		log.Printf("[SOCKET_MANAGER] Internal SlackBot repository is not configured")
+		return
+	}
+	bots, err := m.internalRepo.ListAll(ctx)
 	if err != nil {
 		log.Printf("[SOCKET_MANAGER] Failed to list SlackBots: %v", err)
 		return

--- a/internal/usecases/ports/repositories/slackbot_repository.go
+++ b/internal/usecases/ports/repositories/slackbot_repository.go
@@ -37,3 +37,11 @@ type SlackBotRepository interface {
 	// Delete removes a SlackBot by ID
 	Delete(ctx context.Context, id string) error
 }
+
+// SlackBotInternalRepository exposes internal-only SlackBot queries.
+// These methods are for infrastructure workers that must inspect all bots,
+// independent of user/team access filtering.
+type SlackBotInternalRepository interface {
+	// ListAll retrieves all SlackBots without applying access filters.
+	ListAll(ctx context.Context) ([]*entities.SlackBot, error)
+}


### PR DESCRIPTION
## Summary
- Add SlackBotInternalRepository.ListAll for worker/default-channel internal listing
- Remove empty-filter special handling from the user-facing SlackBotRepository.List path
- Switch Socket Mode reconciliation and default channel resolution to ListAll

## Tests
- mise exec -- go test ./internal/domain/entities ./internal/infrastructure/repositories ./internal/modules/slackbot
- mise exec -- make lint
- mise exec -- make test (fails: race detector requires CGO, but gcc is not installed in this environment)