### PR TITLE
Install Node.js/npm and add claude-legacy agent type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,10 @@ RUN apk add --no-cache ca-certificates curl && \
 # Runtime stage
 FROM ubuntu:24.04
 
-# Install essential packages: ca-certificates, curl, bash, git, make, sudo, jq, procps, and GitHub CLI
+# Install essential packages, including the real Node.js and npm executables.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables nodejs npm && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
@@ -162,35 +162,20 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     echo 'export PATH="/home/agentapi/.cargo/bin:$PATH"' >> /home/agentapi/.bashrc && \
     rm -rf /home/agentapi/.cache/uv 2>/dev/null || true
 
-# Create npm, npx, bun, bunx, and node wrapper scripts that use claude x with BUN_BE_BUN=1
-RUN printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/npm > /dev/null && \
-    sudo chmod +x /usr/local/bin/npm && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/npx > /dev/null && \
-    sudo chmod +x /usr/local/bin/npx && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/bun > /dev/null && \
-    sudo chmod +x /usr/local/bin/bun && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude x "$@"\n' | sudo tee /usr/local/bin/bunx > /dev/null && \
-    sudo chmod +x /usr/local/bin/bunx && \
-    printf '#!/bin/bash\nexec env BUN_BE_BUN=1 /opt/claude/bin/claude "$@"\n' | sudo tee /usr/local/bin/node > /dev/null && \
-    sudo chmod +x /usr/local/bin/node
+# Keep npm global packages in the non-root user home directory.
+ENV NPM_CONFIG_PREFIX=/home/agentapi/.npm-global
 
 # Set combined PATH environment variable (including /opt/claude/bin for claude CLI and /opt/cursor/bin for Cursor CLI)
-ENV PATH="/opt/claude/bin:/opt/cursor/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:/home/agentapi/.bun/bin:/home/agentapi/.bun/bin:$PATH"
+ENV PATH="/opt/claude/bin:/opt/cursor/bin:/home/agentapi/.npm-global/bin:/home/agentapi/.cargo/bin:/home/agentapi/.local/bin:/home/agentapi/.local/share/mise/shims:$PATH"
 
-# Install codex CLI and place a wrapper in /opt/claude/bin (first in PATH).
-# The bun-installed codex script uses "#!/usr/bin/env node", but /usr/local/bin/node is a
-# claude wrapper. The wrapper here explicitly invokes bun so codex works reliably in the proxy.
-# Uses the absolute path to the codex script so it works even when HOME is overridden.
-RUN bun install -g @openai/codex && \
-    printf '#!/bin/bash\nexec bun /home/agentapi/.bun/bin/codex "$@"\n' | \
-    sudo tee /opt/claude/bin/codex > /dev/null && \
-    sudo chmod +x /opt/claude/bin/codex
+# Install codex CLI with npm. Its node shebang resolves to the real Node.js executable.
+RUN npm install --global @openai/codex
 
 # Install Pi, pi-acp, and Pi extensions for pi-ollama sessions.
 # pi-acp starts `pi --mode rpc`, and pi-ollama-cloud connects directly to
 # https://ollama.com/v1 using OLLAMA_API_KEY/OLLAMA_API_KEYS. pi-mcp-adapter
 # lets Pi read MCP servers from ~/.config/mcp/mcp.json.
-RUN bun install -g @earendil-works/pi-coding-agent && \
+RUN npm install --global @earendil-works/pi-coding-agent && \
     npm install --global pi-acp@latest && \
     mkdir -p /home/agentapi/.pi/agent/npm && \
     printf '{"private":true,"dependencies":{}}\n' > /home/agentapi/.pi/agent/npm/package.json && \
@@ -211,7 +196,7 @@ RUN bun install -g @earendil-works/pi-coding-agent && \
       'if [ -z "$prefix" ]; then prefix="$PWD"; fi' \
       'mkdir -p "$prefix"' \
       'test -f "$prefix/package.json" || printf "%s\n" "{\"private\":true,\"dependencies\":{}}" > "$prefix/package.json"' \
-      'exec bun add --cwd "$prefix" $packages' \
+      'exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages' \
       > /tmp/pi-npm-shim/npm && \
     chmod +x /tmp/pi-npm-shim/npm && \
     PATH="/tmp/pi-npm-shim:$PATH" pi install npm:pi-ollama-cloud && \
@@ -232,24 +217,12 @@ RUN curl https://cursor.com/install -fsS | bash && \
     ln -sf /opt/cursor/bin/agent /home/agentapi/.local/bin/agent && \
     ln -sf /opt/cursor/bin/cursor-agent /home/agentapi/.local/bin/cursor-agent
 
-# Install claude-agent-sdk CLI and create arch-agnostic symlink
-RUN bun install -g @anthropic-ai/claude-agent-sdk && \
-    ARCH=$(dpkg --print-architecture) && \
-    case "$ARCH" in \
-      amd64) SDK_ARCH="linux-x64" ;; \
-      arm64) SDK_ARCH="linux-arm64" ;; \
-      *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
-    esac && \
-    ln -sf "/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk-${SDK_ARCH}/claude" \
-           /home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
-
 # Set default CLAUDE_MD_PATH for Docker environment
 ENV CLAUDE_MD_PATH=/tmp/config/CLAUDE.md
 
-# Set CLAUDE_CODE_EXECUTABLE_PATH to use claude-agent-sdk native binary (via arch-agnostic symlink)
-ENV CLAUDE_CODE_EXECUTABLE_PATH=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
-# Set CLAUDE_CODE_EXECUTABLE for @agentclientprotocol/claude-agent-acp (reads this env var, not CLAUDE_CODE_EXECUTABLE_PATH)
-ENV CLAUDE_CODE_EXECUTABLE=/home/agentapi/.bun/install/global/node_modules/@anthropic-ai/claude-agent-sdk/claude
+# Use the installed Claude Code CLI directly for the SDK and ACP adapter.
+ENV CLAUDE_CODE_EXECUTABLE_PATH=/opt/claude/bin/claude
+ENV CLAUDE_CODE_EXECUTABLE=/opt/claude/bin/claude
 
 # Copy the frequently changing proxy binary after the expensive runtime toolchain
 # setup so ordinary app changes do not invalidate those cached layers.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/agentapi-proxy main.go
 
 # Download agentapi release binary instead of rebuilding it from source.
+FROM node:22.19.0-bookworm-slim AS node-runtime
+
 FROM alpine:3.22 AS agentapi-downloader
 
 ARG TARGETOS=linux
@@ -54,10 +56,13 @@ RUN apk add --no-cache ca-certificates curl && \
 # Runtime stage
 FROM ubuntu:24.04
 
-# Install essential packages, including the real Node.js and npm executables.
+# Copy the official Node.js runtime, including npm and npx.
+COPY --from=node-runtime /usr/local/ /usr/local/
+
+# Install essential OS packages and GitHub CLI.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables nodejs npm && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates curl bash git make sudo jq procps tzdata iptables && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,7 +201,7 @@ RUN npm install --global @earendil-works/pi-coding-agent && \
       'if [ -z "$prefix" ]; then prefix="$PWD"; fi' \
       'mkdir -p "$prefix"' \
       'test -f "$prefix/package.json" || printf "%s\n" "{\"private\":true,\"dependencies\":{}}" > "$prefix/package.json"' \
-      'exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages' \
+      'exec /usr/local/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages' \
       > /tmp/pi-npm-shim/npm && \
     chmod +x /tmp/pi-npm-shim/npm && \
     PATH="/tmp/pi-npm-shim:$PATH" pi install npm:pi-ollama-cloud && \

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -37,7 +37,7 @@ done
 if [ -z "$prefix" ]; then prefix="$PWD"; fi
 mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
-exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
+exec /usr/local/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
   if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then

--- a/cmd/helpers_generate_setting.go
+++ b/cmd/helpers_generate_setting.go
@@ -37,7 +37,7 @@ done
 if [ -z "$prefix" ]; then prefix="$PWD"; fi
 mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
-exec bun add --cwd "$prefix" $packages
+exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
   if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
@@ -574,10 +574,10 @@ func buildStartupConfig(agentType string) sessionsettings.StartupConfig {
 	case "claude-acp":
 		// acp-server bridges claude-agent-acp (ACP over stdio) to the agentapi HTTP interface.
 		// Port is determined at runtime via AGENTAPI_PORT env var.
-		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- bunx @agentclientprotocol/claude-agent-acp]")
+		log.Printf("[GENERATE-SETTING]   startup.command: [agentapi-proxy acp-server -- npx -y @agentclientprotocol/claude-agent-acp]")
 		return sessionsettings.StartupConfig{
 			Command: []string{"agentapi-proxy"},
-			Args:    []string{"acp-server", "--", "bunx", "@agentclientprotocol/claude-agent-acp"},
+			Args:    []string{"acp-server", "--", "npx", "-y", "@agentclientprotocol/claude-agent-acp"},
 		}
 	case "codex-acp":
 		// acp-server bridges codex-acp (ACP adapter for OpenAI Codex) to the agentapi HTTP interface.

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -34,6 +34,13 @@ func TestHelpersInit(t *testing.T) {
 	assert.Contains(t, commandNames, "compile-settings")
 }
 
+func TestBuildStartupConfigClaudeLegacy(t *testing.T) {
+	config := buildStartupConfig("claude-legacy")
+
+	assert.Equal(t, []string{"agentapi", "server"}, config.Command)
+	assert.Equal(t, []string{"--allowed-hosts", "*", "--allowed-origins", "*"}, config.Args)
+}
+
 func TestBuildStartupConfigClaudeACP(t *testing.T) {
 	config := buildStartupConfig("claude-acp")
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -34,6 +34,13 @@ func TestHelpersInit(t *testing.T) {
 	assert.Contains(t, commandNames, "compile-settings")
 }
 
+func TestBuildStartupConfigClaudeACP(t *testing.T) {
+	config := buildStartupConfig("claude-acp")
+
+	assert.Equal(t, []string{"agentapi-proxy"}, config.Command)
+	assert.Equal(t, []string{"acp-server", "--", "npx", "-y", "@agentclientprotocol/claude-agent-acp"}, config.Args)
+}
+
 func TestBuildStartupConfigCursor(t *testing.T) {
 	config := buildStartupConfig("cursor")
 

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3534,7 +3534,7 @@ done
 if [ -z "$prefix" ]; then prefix="$PWD"; fi
 mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
-exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
+exec /usr/local/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
   if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -3534,7 +3534,7 @@ done
 if [ -z "$prefix" ]; then prefix="$PWD"; fi
 mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
-exec bun add --cwd "$prefix" $packages
+exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
   if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then
@@ -4989,7 +4989,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 				"acp-server",
 				"--port", fmt.Sprintf("%d", m.k8sConfig.BasePort),
 				"--",
-				"bunx", "@agentclientprotocol/claude-agent-acp",
+				"npx", "-y", "@agentclientprotocol/claude-agent-acp",
 			},
 		}
 		// Bypass permission prompts for claude-acp sessions so tool calls

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -1820,7 +1820,7 @@ func isACPAgentType(agentType string) bool {
 
 func supportedAgentTypeOrDefault(agentType string) string {
 	switch agentType {
-	case "claude-acp", "codex-acp", "pi-ollama", "cursor":
+	case "claude-legacy", "claude-acp", "codex-acp", "pi-ollama", "cursor":
 		return agentType
 	default:
 		return ""

--- a/internal/infrastructure/services/kubernetes_session_manager_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_message_test.go
@@ -240,6 +240,7 @@ func TestSupportedAgentTypeOrDefault(t *testing.T) {
 		want      string
 	}{
 		{name: "default", agentType: "", want: ""},
+		{name: "claude legacy", agentType: "claude-legacy", want: "claude-legacy"},
 		{name: "claude acp", agentType: "claude-acp", want: "claude-acp"},
 		{name: "codex acp", agentType: "codex-acp", want: "codex-acp"},
 		{name: "pi ollama", agentType: "pi-ollama", want: "pi-ollama"},

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -197,7 +197,7 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 
 	// ── Step 5.5: run pre-script ─────────────────────────────────────────────
 	// Executes the optional shell pre-script before starting the agent.
-	// Pre-scripts are used for setup tasks such as pre-fetching npm/bun packages.
+	// Pre-scripts are used for setup tasks such as pre-fetching npm packages.
 	// Failure is non-fatal: a warning is logged and provisioning continues.
 	if settings.Startup.PreScript != "" {
 		s.setPhase("provision:pre-script")
@@ -954,7 +954,7 @@ func (s *Server) buildAgentCommand(settings *sessionsettings.SessionSettings, en
 			"--port", agentapiPort,
 			"--output-file", "/opt/acp-posts/history.jsonl",
 			"--",
-			"bunx", "@agentclientprotocol/claude-agent-acp",
+			"npx", "-y", "@agentclientprotocol/claude-agent-acp",
 		}
 
 	case "codex-acp":

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -37,6 +37,23 @@ func TestWriteWebhookPayloadFile_WritesWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestBuildAgentCommandClaudeLegacy(t *testing.T) {
+	t.Setenv("AGENTAPI_PORT", "9000")
+	t.Setenv("CLAUDE_ARGS", "--dangerously-skip-permissions")
+
+	cmd, args := (&Server{}).buildAgentCommand(&sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{AgentType: "claude-legacy"},
+	}, nil)
+
+	if cmd != "agentapi" {
+		t.Fatalf("command = %q, want agentapi", cmd)
+	}
+	want := []string{"server", "--allowed-hosts", "*", "--allowed-origins", "*", "--port", "9000", "--", "sh", "-c", "claude --dangerously-skip-permissions"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
 func TestBuildAgentCommandClaudeACP(t *testing.T) {
 	t.Setenv("AGENTAPI_PORT", "9000")
 

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -37,6 +37,22 @@ func TestWriteWebhookPayloadFile_WritesWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestBuildAgentCommandClaudeACP(t *testing.T) {
+	t.Setenv("AGENTAPI_PORT", "9000")
+
+	cmd, args := (&Server{}).buildAgentCommand(&sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{AgentType: "claude-acp"},
+	}, nil)
+
+	if cmd != "agentapi-proxy" {
+		t.Fatalf("command = %q, want agentapi-proxy", cmd)
+	}
+	want := []string{"acp-server", "--port", "9000", "--output-file", "/opt/acp-posts/history.jsonl", "--", "npx", "-y", "@agentclientprotocol/claude-agent-acp"}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
 func TestBuildAgentCommandCursor(t *testing.T) {
 	t.Setenv("AGENTAPI_PORT", "9000")
 

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -23,9 +23,9 @@ import (
 // It pre-fetches the latest ACP package binaries so that agent startup does
 // not incur a network download when a provision request arrives.
 // Override with the PROVISIONER_PRE_SCRIPT environment variable.
-const defaultStartupScript = `bun install --global @agentclientprotocol/claude-agent-acp@latest
+const defaultStartupScript = `npm install --global @agentclientprotocol/claude-agent-acp@latest
 npm install --global @agentclientprotocol/codex-acp@latest
-bun install --global @earendil-works/pi-coding-agent@latest
+npm install --global @earendil-works/pi-coding-agent@latest
 npm install --global pi-acp@latest
 mkdir -p "$HOME/.pi/agent/npm"
 test -f "$HOME/.pi/agent/npm/package.json" || printf '{"private":true,"dependencies":{}}\n' > "$HOME/.pi/agent/npm/package.json"
@@ -50,7 +50,7 @@ done
 if [ -z "$prefix" ]; then prefix="$PWD"; fi
 mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
-exec bun add --cwd "$prefix" $packages
+exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
   if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -50,7 +50,7 @@ done
 if [ -z "$prefix" ]; then prefix="$PWD"; fi
 mkdir -p "$prefix"
 test -f "$prefix/package.json" || printf '%s\n' '{"private":true,"dependencies":{}}' > "$prefix/package.json"
-exec /usr/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
+exec /usr/local/bin/npm install --prefix "$prefix" --legacy-peer-deps $packages
 EOF
   chmod +x "$NPM_SHIM_DIR/npm"
   if [ ! -d "$HOME/.pi/agent/npm/node_modules/pi-ollama-cloud" ]; then

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5462,7 +5462,7 @@
           },
           "agent_type": {
             "type": "string",
-            "description": "Agent type for the session. Supported values: 'claude-acp', 'codex-acp', and 'cursor'. If not specified, uses default agentapi.",
+            "description": "Agent type for the session. Supported values: 'claude-legacy', 'claude-acp', 'codex-acp', 'pi-ollama', and 'cursor'. If not specified, uses default agentapi.",
             "example": "claude-acp"
           },
           "slack": {
@@ -7214,7 +7214,7 @@
       "properties": {
         "agent_type": {
           "type": "string",
-          "description": "Agent type to use. Supported values: 'claude-acp', 'codex-acp', and 'cursor'. If omitted, the default agentapi is used.",
+          "description": "Agent type to use. Supported values: 'claude-legacy', 'claude-acp', 'codex-acp', 'pi-ollama', and 'cursor'. If omitted, the default agentapi is used.",
           "example": "claude-acp"
         },
         "oneshot": {


### PR DESCRIPTION
## Summary
- install real Node.js and npm executables and remove the Claude/BUN_BE_BUN compatibility wrappers
- use npm/npx for ACP, Codex, and Pi package installation
- use the installed Claude CLI directly
- add `claude-legacy` as an explicit agent type that starts the legacy `agentapi server` + Claude CLI path
- keep an omitted `agent_type` mapped to the same default agentapi path for backward compatibility
- update the OpenAPI descriptions and regression tests

## Validation
- `make lint` (passes: 0 issues)
- targeted race tests for startup configuration, provisioner commands, and agent type normalization (pass)
- `make test` reaches the pre-existing environment-dependent `TestRunProxyWithInvalidConfig`, which restores live Kubernetes sessions and terminates the test process with `signal: interrupt`