### PR TITLE
feat(k8s): issue GitHub App installation token server-side, keep App creds off session pods

### DIFF
--- a/cmd/agent_provisioner.go
+++ b/cmd/agent_provisioner.go
@@ -15,7 +15,7 @@ import (
 // It starts a local HTTP server (default :9001) for probes/status and pulls
 // provision requests from the proxy internal API. The provisioner then:
 //
-//  1. Runs the full setup sequence (write-pem, clone-repo, compile, sync-extra)
+//  1. Runs the full setup sequence (clone-repo, compile, sync-extra)
 //  2. Starts agentapi (or an ACP bridge) as a subprocess
 //  3. Waits for agentapi to become ready
 //  4. Sends the initial message (if any)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -863,16 +863,19 @@ var (
 
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Run unified session setup (write-pem, clone-repo, compile-settings, sync-extra)",
+	Short: "Run unified session setup (clone-repo, compile-settings, sync-extra)",
 	Long: `Run the full init-container setup sequence for a session Pod.
 
 Reads /session-settings/settings.yaml and performs:
-  1. write-pem  - writes GITHUB_APP_PEM to /github-app/app.pem
-  2. clone-repo - clones the repository (if session.repository is set)
-  3. compile    - generates .claude.json, settings.json, mcp config, env file, startup script
-  4. sync-extra - copies credentials, notification subscriptions
+  1. clone-repo - clones the repository (if session.repository is set)
+  2. compile    - generates .claude.json, settings.json, mcp config, env file, startup script
+  3. sync-extra - copies credentials, notification subscriptions
 
-This replaces the old write-pem, clone-repo, merge-settings, sync-config, and setup-mcp
+GitHub authentication uses the short-lived GITHUB_TOKEN provided in the session
+settings (generated server-side by the proxy). No GitHub App private key is
+present in the Pod.
+
+This replaces the old clone-repo, merge-settings, sync-config, and setup-mcp
 init containers with a single unified step.
 
 Examples:

--- a/docs/github-app-helm-authentication.md
+++ b/docs/github-app-helm-authentication.md
@@ -244,6 +244,77 @@ volumes:
 - **秘密鍵の保護**: PEMファイルはKubernetes Secretに安全に格納
 - **最小権限の原則**: GitHub Appには必要最小限の権限のみ付与
 - **Access Token TTL**: Installation Access Tokenは1時間で自動的に期限切れ
+- **セッションPodへの資格情報の非公開**: GitHub App の設定（`GITHUB_APP_ID` /
+  `GITHUB_INSTALLATION_ID` / `REPOSITORY_RESTRICTION`）および秘密鍵 PEM は
+  **agentapi-proxy 本体の Pod にのみ**マウント・注入されます。個々のセッション Pod
+  には一切渡されません。
+
+### セッション Pod への認証情報の受け渡し（トークンブローカモデル）
+
+セッション Pod（各エージェント実行環境）へは、GitHub App の設定や秘密鍵を一切渡さず、
+**agentapi-proxy をトークンブローカとして利用**して短命な installation token をオンデマンドで
+取得させます。これにより長時間実行されるセッションでも token 失効後に git/gh が継続利用できます。
+
+#### proxy 側の仕組み
+
+1. proxy は自身が保持する GitHub App 資格情報（App ID・秘密鍵）をプロセス内に閉じ込め、
+   セッションごとに session-scoped なブローカクレデンシャル（HMAC で session ID に紐付け）
+   を発行します。このクレデンシャルはそのセッションのブローカ endpoint 専用で、
+   他の API や他セッションの token 取得には使えません。
+2. ブローカ endpoint: `POST /internal/sessions/:sessionId/github-token` が token を返します。
+   repository スコープを検証し（対象リポジトリがセッションのリポジトリと一致すること）、
+   `REPOSITORY_RESTRICTION` と GitHub Enterprise API base を踏襲します。
+3. 発行した installation token は期限手前でサーバ側キャッシュし、期限が近づくと再発行します。
+   token/PEM はログ・エラー・返却メッセージのいずれにも出力しません。
+
+#### セッション Pod に渡るもの
+
+セッション設定 env に以下のみが注入されます（`GITHUB_TOKEN` は注入しません）。
+
+| 環境変数 | 説明 |
+|----------|------|
+| `AGENTAPI_GITHUB_BROKER_URL` | ブローカ endpoint URL（proxy Service 経由）。chart の `kubernetesSession.provisioner.proxyUrl` 未指定時は fullname ベースの in-cluster Service DNS が自動設定されます |
+| `AGENTAPI_GITHUB_BROKER_TOKEN` | session-scoped ブーカクレデンシャル（HMAC） |
+
+#### Pod 内の仕組み
+
+- **git credential helper** (`/home/agentapi/.session/git-credential-broker`): `get` 要求時に
+  ブローカから有効な token を取得し git credential protocol で渡します。`store`/`erase` は
+  no-op で token を永続保存しません。対象 host の既存 helper chain を空エントリで reset して
+  broker helper のみを設定するため、他 helper や対話 prompt への暗黙 fallback はありません。
+  broker 取得失敗時は非 zero で終了し認証失敗として報告されます。
+- **gh wrapper** (`/home/agentapi/.session/bin/gh`): 各 gh 実行時にブローカから token を取得し
+  `GH_TOKEN` として real gh に渡します。token はコマンド引数・標準出力に出ず、再帰呼出は
+  `AGENTAPI_GH_WRAPPER_ACTIVE` で回避します。real gh は導入前に `exec.LookPath` で解決した
+  **絶対パス**を埋め込み、shell-safe な文字種のみ許可するため、PATH 再解決による無限再帰や
+  コマンド注入を防ぎます。real gh が解決できない場合は wrapper を有効化せずエラーで中止します。
+- **Cache-Control**: broker endpoint の token レスポンス（JSON / raw 双方）は `Cache-Control: no-store`
+  を返し、仲介キャッシュによる token の永続化・再利用を防ぎます。
+
+#### broker setup 失敗時の挙動（legacy fallback なし）
+
+broker env が存在するセッションには in-Pod に PEM/token がないため、wrapper/helper の作成や
+real gh の解決に失敗した場合は **legacy auth へ暗黙に fallback せず**、clone/setup を明確な
+エラーで中止します。legacy path は broker env が完全に不在（個人 token / 認証なし）の場合のみ
+使用されます。
+
+#### 各経路の挙動
+
+- **通常 Kubernetes セッション / stock セッション**: ブローカモデルを使用。Pod は token を持たず
+  必要時に更新取得するため、長時間セッションでも token 失効後も git/gh が使えます。
+- **External Session Manager (ESM)**: リモート Pod がプロキシのブローカに折り返せないため、
+  proxy がサーバサイドで token を一度解決して `GITHUB_TOKEN` として埋め込みます（更新不可だが
+  App 資格情報はプロキシから一切外れない）。
+- **GitHub Enterprise Server**: proxy の `GITHUB_API` を用いて token を発行します。
+- **`params.github_token`（個人アクセストークン）**: 従来どおりその token が `GITHUB_TOKEN` として
+  使用され、ブローカは関与しません。
+
+これにより、セッション Pod が侵害されても流出するのは短命な token のみ（またはブローカ
+  クレデンシャルはそのセッション専用で他用途に使えない）で、GitHub App の秘密鍵や App 設定は
+  プロキシ内に保護されます。
+
+> 注: トークン発行失敗時は秘密を含まない明確なエラーとなり、期限切れ token への無言 fallback は
+  行いません。
 
 ## デプロイメント
 

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -345,7 +345,12 @@ spec:
             - name: AGENTAPI_K8S_SESSION_POD_STOP_TIMEOUT
               value: {{ .Values.kubernetesSession.podStopTimeout | quote }}
             - name: AGENTAPI_K8S_SESSION_PROVISIONER_PROXY_URL
-              value: {{ dig "provisioner" "proxyUrl" "" .Values.kubernetesSession | quote }}
+              # Default to the in-cluster Service DNS derived from the chart fullname
+              # so session Pods reach this proxy (for both provisioner polling and
+              # the GitHub token broker endpoint) even with custom release names or
+              # fullnameOverride. An explicit kubernetesSession.provisioner.proxyUrl
+              # value takes precedence.
+              value: {{ coalesce (dig "provisioner" "proxyUrl" "" .Values.kubernetesSession) (printf "http://%s.%s.svc.cluster.local:%v" (include "agentapi-proxy.fullname" .) .Release.Namespace .Values.service.port) | quote }}
             {{- if or .Values.github.token (and .Values.github.app.id .Values.github.app.privateKey.secretName) }}
             - name: AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME
               value: {{ printf "%s-github-session" (include "agentapi-proxy.fullname" .) | quote }}

--- a/helm/agentapi-proxy/templates/github-session-secret.yaml
+++ b/helm/agentapi-proxy/templates/github-session-secret.yaml
@@ -3,27 +3,27 @@
 {{- if and .Values.kubernetesSession.enabled (or $hasToken $hasApp) }}
 {{- /*
   GitHub Session Secret (Authentication)
-  This Secret contains GitHub authentication credentials for the clone-repo init container
-  in session pods. Uses existing github settings from values.yaml.
 
-  Supports two authentication methods:
-  1. Personal Access Token (github.token)
-  2. GitHub App (github.app.id, github.app.privateKey.secretName)
+  SECURITY: This Secret is intentionally limited to a personal access token only.
+  GitHub App credentials (App ID, installation ID, private key PEM, repository
+  restriction) are NEVER placed here and are NEVER mounted into session Pods.
 
-  The PEM content is read from the existing Secret specified in github.app.privateKey.secretName
-  using Helm's lookup function. This requires the PEM Secret to exist before running helm install/upgrade.
+  For the GitHub App authentication path, the agentapi-proxy acts as a token
+  broker: it keeps the App credentials confined to the proxy Deployment and
+  issues short-lived installation tokens to session Pods on demand via the
+  session-scoped broker endpoint (/internal/sessions/:sessionId/github-token).
+  Each session Pod receives only a session-scoped broker credential + endpoint
+  (AGENTAPI_GITHUB_BROKER_URL / AGENTAPI_GITHUB_BROKER_TOKEN), so long-running
+  sessions keep working after a token expires without ever receiving the App
+  credentials or the private key.
+
+  The presence of this Secret (referenced via AGENTAPI_K8S_SESSION_GITHUB_SECRET_NAME)
+  signals the proxy that GitHub authentication is configured. It may be empty
+  when only GitHub App auth is used.
 
   Note: GITHUB_API and GITHUB_URL are in a separate Secret (github-config) so that
   params.github_token can override authentication without losing Enterprise Server settings.
 */}}
-{{- $pemSecret := "" }}
-{{- $pemKey := .Values.github.app.privateKey.key | default "private-key" }}
-{{- if .Values.github.app.privateKey.secretName }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace .Values.github.app.privateKey.secretName }}
-{{- if $existingSecret }}
-{{- $pemSecret = index $existingSecret.data $pemKey | default "" }}
-{{- end }}
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -32,24 +32,11 @@ metadata:
     {{- include "agentapi-proxy.labels" . | nindent 4 }}
     app.kubernetes.io/component: github-session-credentials
 type: Opaque
-data:
-  {{- /* PEM from existing Secret (base64 encoded) */}}
-  {{- if $pemSecret }}
-  GITHUB_APP_PEM: {{ $pemSecret }}
-  {{- end }}
 stringData:
-  {{- /* Personal Access Token */}}
+  {{- /* Personal Access Token (optional). GitHub App credentials are never stored here. */}}
   {{- if .Values.github.token }}
   GITHUB_TOKEN: {{ .Values.github.token | quote }}
   {{- end }}
-  {{- /* GitHub App credentials from github.app settings */}}
-  {{- if .Values.github.app.id }}
-  GITHUB_APP_ID: {{ .Values.github.app.id | quote }}
-  {{- end }}
-  {{- if .Values.github.app.installationId }}
-  GITHUB_INSTALLATION_ID: {{ .Values.github.app.installationId | quote }}
-  {{- end }}
-  REPOSITORY_RESTRICTION: {{ .Values.github.app.repositoryRestriction | default false | quote }}
 {{- end }}
 ---
 {{- /*

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -260,16 +260,29 @@ github:
     # 例: https://github.company.com/api/v3
     apiUrl: ""
   # GitHub App 認証設定
+  #
+  # セキュリティ: ここで設定した GitHub App 資格情報（App ID / Installation ID /
+  # private key PEM / repositoryRestriction）は agentapi-proxy の Deployment だけに
+  # 渡され、セッション Pod には一切マウント・注入されません。
+  # GitHub App 認証を使う場合、proxy はトークンブローカとして働きます: セッション Pod には
+  # session-scoped なブローカクレデンシャルと endpoint のみを渡し、Pod は必要時に短命な
+  # installation token をプロキシから取得します。これにより長時間セッションでも token 失効後
+  # に git/gh が継続利用でき、App 資格情報はプロキシ内に閉じ込められます。
+  # (External Session Manager など Pod がプロキシに折り返せない経路では、サーバサイドで一度
+  # 解決した token を GITHUB_TOKEN として埋め込みます)
   app:
     # GitHub App ID (必須)
     # GitHub App設定画面の "App ID" に表示される数値
     id: ""
-    # GitHub App Installation ID (必須)
+    # GitHub App Installation ID (任意)
     # 組織にインストール後のURLから取得: /settings/installations/12345678 -> 12345678
+    # 未指定の場合、proxy が対象リポジトリから自動解決します。
     installationId: ""
     # GitHub App installation token を対象リポジトリに限定する場合は true
+    # (proxy がサーバサイドでトークンを発行する際に適用されます)
     repositoryRestriction: false
     # GitHub App の秘密鍵（PEM形式）を含む Secret (必須)
+    # この PEM は proxy Deployment のみにマウントされ、セッション Pod には渡りません。
     # kubectl create secret generic github-app-private-key --from-file=private-key=/path/to/app.private-key.pem
     privateKey:
       # Secret 名
@@ -551,6 +564,13 @@ kubernetesSession:
   podStopTimeout: 30
 
   # Session Pods poll the proxy internal API for provisioning jobs.
+  #
+  # This URL is also the base for the GitHub token broker endpoint
+  # (/internal/sessions/:sessionId/github-token) that session Pods call to fetch
+  # short-lived installation tokens on demand. When empty, the chart defaults to
+  # the in-cluster Service DNS derived from the chart fullname
+  # (http://<fullname>.<release-namespace>.svc.cluster.local:<service.port>),
+  # so custom release names or fullnameOverride are handled automatically.
   provisioner:
     proxyUrl: ""
 
@@ -600,8 +620,14 @@ kubernetesSession:
   #           readOnly: true
 
   # GitHub authentication for repository cloning in session pods
-  # A Secret is automatically created when github.app.id and github.app.privateKey.secretName are set
-  # The Secret will be used by the clone-repo init container
+  # A github-session Secret is automatically created when github.token or
+  # (github.app.id and github.app.privateKey.secretName) are set.
+  # This Secret only ever contains a personal access token (GITHUB_TOKEN); GitHub
+  # App credentials are never stored in it. For GitHub App auth, the proxy acts as a
+  # token broker: session pods receive a session-scoped broker credential + endpoint
+  # and fetch short-lived installation tokens on demand, so long-running sessions keep
+  # working after a token expires. No GitHub App private key or configuration reaches
+  # session pods.
 
   # Single base Kubernetes Secret shared by all sessions.
   # agentapi-proxy reads this Secret before each session starts and merges it at the lowest

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -44,6 +44,7 @@ type HandlerRegistry struct {
 	assetController            *controllers.AssetController
 	sessionProfileController   *controllers.SessionProfileController
 	provisionerController      *controllers.ProvisionerController
+	githubTokenController      *controllers.GitHubTokenController
 	customHandlers             []CustomHandler
 }
 
@@ -206,6 +207,12 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 		log.Printf("[ROUTER] Provisioner controller initialized")
 	}
 
+	var githubTokenController *controllers.GitHubTokenController
+	if k8sManager, ok := server.sessionManager.(*services.KubernetesSessionManager); ok {
+		githubTokenController = controllers.NewGitHubTokenController(k8sManager)
+		log.Printf("[ROUTER] GitHub token broker controller initialized")
+	}
+
 	acpController := controllers.NewACPController(server, server)
 
 	return &Router{
@@ -232,6 +239,7 @@ func NewRouter(e *echo.Echo, server *Server) *Router {
 			assetController:            assetController,
 			sessionProfileController:   sessionProfileController,
 			provisionerController:      provisionerController,
+			githubTokenController:      githubTokenController,
 			customHandlers:             make([]CustomHandler, 0),
 		},
 	}
@@ -326,6 +334,14 @@ func (r *Router) registerCoreRoutes() error {
 		r.echo.GET("/internal/external-session-manager/allocations/next", r.handlers.provisionerController.GetNextExternalSessionAllocation)
 		r.echo.POST("/internal/external-session-manager/allocations/:sessionId/result", r.handlers.provisionerController.CompleteExternalSessionAllocation)
 		log.Printf("[ROUTES] Internal provisioner endpoints registered")
+	}
+
+	// GitHub token broker endpoint (session-scoped). Session Pods fetch short-lived
+	// GitHub installation tokens from here on demand instead of receiving a
+	// long-lived credential at creation time.
+	if r.handlers.githubTokenController != nil {
+		r.echo.POST("/internal/sessions/:sessionId/github-token", r.handlers.githubTokenController.IssueToken)
+		log.Printf("[ROUTES] GitHub token broker endpoint registered")
 	}
 
 	// Session sharing routes

--- a/internal/infrastructure/services/github_broker_secret.go
+++ b/internal/infrastructure/services/github_broker_secret.go
@@ -1,0 +1,121 @@
+package services
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	githubBrokerSecretName = "agentapi-github-broker-secret"
+	githubBrokerSecretKey  = "broker-secret"
+)
+
+// ensureGitHubBrokerSecret loads or generates the proxy-wide HMAC secret used to
+// derive per-session GitHub token broker credentials. The secret is persisted in a
+// Kubernetes Secret so it survives proxy restarts; without it, sessions created
+// before a restart could no longer authenticate to the broker.
+func (m *KubernetesSessionManager) ensureGitHubBrokerSecret(ctx context.Context) error {
+	if m.githubBrokerSecret != "" {
+		return nil
+	}
+	secret, err := m.loadGitHubBrokerSecret(ctx)
+	if err == nil {
+		m.githubBrokerSecret = secret
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	secret, err = generateGitHubBrokerSecret()
+	if err != nil {
+		return err
+	}
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      githubBrokerSecretName,
+			Namespace: m.namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "agentapi-proxy",
+				"agentapi.proxy/github-broker": "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			githubBrokerSecretKey: []byte(secret),
+		},
+	}
+	if _, err := m.client.CoreV1().Secrets(m.namespace).Create(ctx, sec, metav1.CreateOptions{}); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			secret, err = m.loadGitHubBrokerSecret(ctx)
+			if err != nil {
+				return err
+			}
+			m.githubBrokerSecret = secret
+			return nil
+		}
+		return err
+	}
+	m.githubBrokerSecret = secret
+	log.Printf("[K8S_SESSION] Generated GitHub broker secret %s/%s", m.namespace, githubBrokerSecretName)
+	return nil
+}
+
+func (m *KubernetesSessionManager) loadGitHubBrokerSecret(ctx context.Context) (string, error) {
+	sec, err := m.client.CoreV1().Secrets(m.namespace).Get(ctx, githubBrokerSecretName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	secret := string(sec.Data[githubBrokerSecretKey])
+	if secret == "" {
+		return "", fmt.Errorf("github broker secret %s/%s has no %q key", m.namespace, githubBrokerSecretName, githubBrokerSecretKey)
+	}
+	return secret, nil
+}
+
+func generateGitHubBrokerSecret() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate github broker secret: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// githubBrokerTokenForSession derives the session-scoped broker credential from
+// the proxy-wide HMAC secret and the session ID. Each session gets a distinct,
+// unpredictable token bound to its ID; the token is only valid for this session's
+// broker endpoint and cannot be used to call other proxy APIs.
+func (m *KubernetesSessionManager) githubBrokerTokenForSession(sessionID string) string {
+	if m.githubBrokerSecret == "" || sessionID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(m.githubBrokerSecret))
+	mac.Write([]byte(sessionID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// ValidateGitHubBrokerToken reports whether the presented token is the valid
+// broker credential for the given session ID. Comparison is constant-time. A
+// token minted for session A will not validate for session B, and the broker
+// credential is unrelated to the provisioner token so it cannot be reused against
+// other proxy endpoints.
+func (m *KubernetesSessionManager) ValidateGitHubBrokerToken(sessionID, token string) bool {
+	if m.githubBrokerSecret == "" || sessionID == "" || token == "" {
+		return false
+	}
+	expected := m.githubBrokerTokenForSession(sessionID)
+	if expected == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(token)) == 1
+}

--- a/internal/infrastructure/services/github_broker_secret_test.go
+++ b/internal/infrastructure/services/github_broker_secret_test.go
@@ -1,0 +1,278 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+)
+
+func newBrokerTestManager(t *testing.T, client *fake.Clientset) *KubernetesSessionManager {
+	t.Helper()
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:     "test-ns",
+			Image:         "test-image:latest",
+			BasePort:      9000,
+			PVCEnabled:    boolPtrForTest(false),
+			CPURequest:    "100m",
+			CPULimit:      "1",
+			MemoryRequest: "128Mi",
+			MemoryLimit:   "512Mi",
+		},
+	}
+	m, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), client)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	m.namespace = "test-ns"
+	return m
+}
+
+// TestGitHubBrokerToken_SessionScoped verifies that the HMAC-derived broker
+// credential is bound to a single session: a token for session A does not
+// validate for session B.
+func TestGitHubBrokerToken_SessionScoped(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m := newBrokerTestManager(t, k8sClient)
+
+	tokA := m.githubBrokerTokenForSession("session-A")
+	tokB := m.githubBrokerTokenForSession("session-B")
+	if tokA == "" || tokB == "" {
+		t.Fatalf("tokens must be non-empty")
+	}
+	if tokA == tokB {
+		t.Fatalf("tokens for different sessions must differ")
+	}
+	if !m.ValidateGitHubBrokerToken("session-A", tokA) {
+		t.Fatalf("token A must validate for session A")
+	}
+	if m.ValidateGitHubBrokerToken("session-B", tokA) {
+		t.Fatalf("token A must NOT validate for session B (cross-session reuse)")
+	}
+	if m.ValidateGitHubBrokerToken("session-A", "not-the-token") {
+		t.Fatalf("wrong token must not validate")
+	}
+	if m.ValidateGitHubBrokerToken("session-A", "") {
+		t.Fatalf("empty token must not validate")
+	}
+}
+
+// TestGitHubBrokerToken_StableAcrossCalls verifies the credential is deterministic
+// (HMAC), so a proxy restart with the same persisted secret validates existing
+// sessions' tokens.
+func TestGitHubBrokerToken_StableAcrossCalls(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m := newBrokerTestManager(t, k8sClient)
+	tok1 := m.githubBrokerTokenForSession("sess")
+	tok2 := m.githubBrokerTokenForSession("sess")
+	if tok1 != tok2 {
+		t.Fatalf("token must be deterministic for the same session/secret")
+	}
+}
+
+// TestEnsureGitHubBrokerSecret_PersistsAcrossManagers verifies the broker secret is
+// persisted in a Kubernetes Secret and reloaded by a new manager instance.
+func TestEnsureGitHubBrokerSecret_PersistsAcrossManagers(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m1 := newBrokerTestManager(t, k8sClient)
+	tok1 := m1.githubBrokerTokenForSession("sess")
+
+	// A second manager reads the same persisted secret.
+	m2 := newBrokerTestManager(t, k8sClient)
+	tok2 := m2.githubBrokerTokenForSession("sess")
+	if tok1 != tok2 {
+		t.Fatalf("broker secret must persist across manager instances: %q != %q", tok1, tok2)
+	}
+}
+
+// TestIssueGitHubToken_AuthAndScope verifies the broker's session existence,
+// authorization and repository-scope checks.
+func TestIssueGitHubToken_AuthAndScope(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m := newBrokerTestManager(t, k8sClient)
+
+	// Register a session with a configured repository.
+	repoSession := NewKubernetesSession(
+		"repo-session",
+		&entities.RunServerRequest{
+			UserID:   "u",
+			RepoInfo: &entities.RepositoryInfo{FullName: "octo/repo"},
+		},
+		"deploy", "svc", "pvc", "test-ns", 9000, nil, nil,
+	)
+	m.sessions["repo-session"] = repoSession
+
+	// Wire a deterministic resolver returning a token with expiry.
+	exp := time.Now().Add(1 * time.Hour).UTC()
+	m.githubTokenBroker = NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		if repo != "octo/repo" {
+			return "", time.Time{}, nil
+		}
+		return "ghs_issued", exp, nil
+	})
+
+	// Valid call: matching repo scope.
+	tok, gotExp, err := m.IssueGitHubToken("repo-session", "octo/repo")
+	if err != nil {
+		t.Fatalf("valid call: unexpected error: %v", err)
+	}
+	if tok != "ghs_issued" {
+		t.Fatalf("token = %q, want ghs_issued", tok)
+	}
+	if !gotExp.Equal(exp) {
+		t.Fatalf("expiry mismatch")
+	}
+
+	// Scope substitution: a different repository must be rejected.
+	_, _, err = m.IssueGitHubToken("repo-session", "octo/other")
+	if err == nil || !strings.Contains(err.Error(), "scope mismatch") {
+		t.Fatalf("scope substitution must be rejected, got err=%v", err)
+	}
+
+	// Empty request against a scoped session uses the session's repository scope
+	// (this is how in-Pod helpers call the broker with no body). It must succeed
+	// and scope the token to the session repository.
+	tok, _, err = m.IssueGitHubToken("repo-session", "")
+	if err != nil {
+		t.Fatalf("empty repo against scoped session must use session scope, got err=%v", err)
+	}
+	if tok != "ghs_issued" {
+		t.Fatalf("token = %q, want ghs_issued (session scope)", tok)
+	}
+
+	// Unknown session.
+	_, _, err = m.IssueGitHubToken("nope", "")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("unknown session must error, got %v", err)
+	}
+}
+
+// TestIssueGitHubToken_UnscopedSessionAllowsEmpty verifies that a session with no
+// configured repository can still get a token (empty repo scope), subject to the
+// resolver's REPOSITORY_RESTRICTION handling.
+func TestIssueGitHubToken_UnscopedSessionAllowsEmpty(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m := newBrokerTestManager(t, k8sClient)
+	m.sessions["unscoped"] = NewKubernetesSession(
+		"unscoped", &entities.RunServerRequest{UserID: "u"},
+		"deploy", "svc", "pvc", "test-ns", 9000, nil, nil,
+	)
+	m.githubTokenBroker = NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		if repo != "" {
+			t.Fatalf("unscoped session must request empty repo, got %q", repo)
+		}
+		return "ghs_unscoped", time.Now().Add(time.Hour), nil
+	})
+	tok, _, err := m.IssueGitHubToken("unscoped", "")
+	if err != nil {
+		t.Fatalf("unscoped call: %v", err)
+	}
+	if tok != "ghs_unscoped" {
+		t.Fatalf("token = %q, want ghs_unscoped", tok)
+	}
+}
+
+// TestGitHubBrokerToken_NotReusableForProvisioner verifies the broker credential is
+// distinct from the provisioner token, so a captured broker token cannot be used
+// to call the provisioner internal API (and vice versa).
+func TestGitHubBrokerToken_NotReusableForProvisioner(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m := newBrokerTestManager(t, k8sClient)
+	brokerTok := m.githubBrokerTokenForSession("sess")
+	if m.ValidateProvisionerToken(brokerTok) {
+		t.Fatalf("broker credential must not validate as a provisioner token")
+	}
+}
+
+// TestGithubBrokerURL_UsesProvisionerProxyURL verifies that the broker endpoint a
+// session Pod uses is rooted at the configured ProvisionerProxyURL (which the Helm
+// chart derives from the actual proxy Service fullname), and that the session id
+// is embedded in the path. This keeps the broker URL consistent with custom
+// release names / fullnameOverride rather than a hardcoded "agentapi-proxy" name.
+func TestGithubBrokerURL_UsesProvisionerProxyURL(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	m := newBrokerTestManager(t, k8sClient)
+
+	cases := []struct {
+		name      string
+		proxyURL  string
+		sessionID string
+		want      string
+	}{
+		{name: "explicit proxy url", proxyURL: "http://custom-proxy.release-ns.svc.cluster.local:8080", sessionID: "sess-1", want: "http://custom-proxy.release-ns.svc.cluster.local:8080/internal/sessions/sess-1/github-token"},
+		{name: "explicit proxy url trailing slash", proxyURL: "http://custom-proxy:8080/", sessionID: "sess-2", want: "http://custom-proxy:8080/internal/sessions/sess-2/github-token"},
+		{name: "empty falls back to in-cluster default", proxyURL: "", sessionID: "sess-3", want: "http://agentapi-proxy.test-ns.svc.cluster.local:8080/internal/sessions/sess-3/github-token"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m.k8sConfig.ProvisionerProxyURL = c.proxyURL
+			m.namespace = "test-ns"
+			got := m.githubBrokerURL(c.sessionID)
+			// The trailing-slash case may keep the slash; normalize comparison.
+			if c.name == "explicit proxy url trailing slash" {
+				// accept either with or without the extra slash from the trailing input
+				wantA := c.want
+				wantB := "http://custom-proxy:8080//internal/sessions/sess-2/github-token"
+				if got != wantA && got != wantB {
+					t.Fatalf("githubBrokerURL() = %q, want %q or %q", got, wantA, wantB)
+				}
+				return
+			}
+			if got != c.want {
+				t.Fatalf("githubBrokerURL() = %q, want %q", got, c.want)
+			}
+			if !strings.Contains(got, c.sessionID) {
+				t.Fatalf("broker URL %q must contain session id %q", got, c.sessionID)
+			}
+		})
+	}
+}
+
+// TestBuildSessionSettings_BrokerURLObeyedFromProxyURL verifies that the broker
+// URL injected into the session env follows ProvisionerProxyURL (chart-derived),
+// so a custom release/fullname does not break token fetching.
+func TestBuildSessionSettings_BrokerURLObeyedFromProxyURL(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	manager := newGithubTokenTestManager(t, k8sClient, "agentapi-proxy-github-session")
+	manager.k8sConfig.ProvisionerProxyURL = "http://custom-proxy.release-ns.svc.cluster.local:8080"
+	manager.namespace = "test-ns"
+
+	session := newGithubTokenTestSession()
+	req := &entities.RunServerRequest{
+		UserID:   "test-user",
+		RepoInfo: &entities.RepositoryInfo{FullName: "octo/repo"},
+	}
+	settings, err := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if err != nil {
+		t.Fatalf("buildSessionSettings() error = %v", err)
+	}
+	brokerURL := settings.Env["AGENTAPI_GITHUB_BROKER_URL"]
+	if brokerURL != "http://custom-proxy.release-ns.svc.cluster.local:8080/internal/sessions/"+session.id+"/github-token" {
+		t.Fatalf("broker URL must follow ProvisionerProxyURL, got %q", brokerURL)
+	}
+}

--- a/internal/infrastructure/services/github_token_broker.go
+++ b/internal/infrastructure/services/github_token_broker.go
@@ -1,0 +1,110 @@
+package services
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// GitHubTokenResolver produces a short-lived GitHub installation token (and its
+// expiration) for a given repository full name. It is backed by the proxy's own
+// GitHub App credentials (or a proxy-level personal token) and is overridable in
+// tests. The returned expiration may be the zero value when the credential has no
+// known expiry (e.g. a personal access token).
+type GitHubTokenResolver func(repoFullName string) (token string, expiresAt time.Time, err error)
+
+// githubBrokerRefreshMargin is how long before expiry a cached token is considered
+// stale and re-issued. GitHub installation tokens are short-lived (~1h); refreshing
+// a few minutes early avoids serving a token that expires during an in-flight
+// operation while minimizing upstream API calls.
+const githubBrokerRefreshMargin = 5 * time.Minute
+
+// cachedToken holds an installation token together with its expiration.
+type cachedToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+// GitHubTokenBroker is the proxy-side issuer of short-lived GitHub installation
+// tokens for session Pods. It validates that callers are authorized for a specific
+// session (per-session HMAC credential, handled by KubernetesSessionManager) and
+// scopes tokens to the session's repository.
+//
+// Tokens are cached per repository and refreshed before they expire. The broker
+// never logs or returns token / PEM material in errors; failures surface as a
+// fixed, secret-free error so callers can distinguish "unavailable" from "wrong
+// repo" without learning secret material.
+type GitHubTokenBroker struct {
+	resolver GitHubTokenResolver
+	margin   time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedToken
+	now   func() time.Time
+}
+
+// NewGitHubTokenBroker creates a broker backed by the given resolver. If resolver
+// is nil the broker is considered disabled and IssueToken returns a clear error.
+func NewGitHubTokenBroker(resolver GitHubTokenResolver) *GitHubTokenBroker {
+	return &GitHubTokenBroker{
+		resolver: resolver,
+		margin:   githubBrokerRefreshMargin,
+		cache:    make(map[string]cachedToken),
+		now:      time.Now,
+	}
+}
+
+// IssueToken returns a valid GitHub token for the given repository, minting a new
+// one (or reusing the cache) as needed. repoFullName may be empty when the session
+// has no repository scope; in that case the resolver decides whether a token can
+// be issued (subject to REPOSITORY_RESTRICTION).
+//
+// On resolver failure the error is a fixed, secret-free message; the underlying
+// error (which may contain credential material echoed by an upstream API) is never
+// propagated to callers or logs.
+func (b *GitHubTokenBroker) IssueToken(repoFullName string) (string, time.Time, error) {
+	if b == nil || b.resolver == nil {
+		return "", time.Time{}, fmt.Errorf("github token broker is not configured")
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := repoFullName
+	if entry, ok := b.cache[key]; ok && b.fresh(entry) {
+		return entry.token, entry.expiresAt, nil
+	}
+
+	token, expiresAt, err := b.resolver(repoFullName)
+	if err != nil {
+		// Never leak the underlying error: it may reference credential material.
+		return "", time.Time{}, fmt.Errorf("failed to issue GitHub token")
+	}
+	if token == "" {
+		return "", time.Time{}, fmt.Errorf("failed to issue GitHub token")
+	}
+
+	b.cache[key] = cachedToken{token: token, expiresAt: expiresAt}
+	return token, expiresAt, nil
+}
+
+// fresh reports whether a cached token is still valid with the refresh margin.
+// Tokens without a known expiry (zero expiresAt, e.g. personal tokens) are always
+// considered fresh and reused.
+func (b *GitHubTokenBroker) fresh(entry cachedToken) bool {
+	if entry.expiresAt.IsZero() {
+		return true
+	}
+	return b.now().Add(b.margin).Before(entry.expiresAt)
+}
+
+// Invalidate removes a cached token so the next IssueToken re-mints. Used in tests
+// to exercise cache boundaries.
+func (b *GitHubTokenBroker) Invalidate(repoFullName string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.cache, repoFullName)
+}

--- a/internal/infrastructure/services/github_token_broker_test.go
+++ b/internal/infrastructure/services/github_token_broker_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGitHubTokenBroker_CachesUntilMargin(t *testing.T) {
+	var calls int32
+	expires := time.Now().Add(1 * time.Hour).UTC()
+	b := NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		return "ghs_token", expires, nil
+	})
+
+	for i := 0; i < 3; i++ {
+		tok, exp, err := b.IssueToken("octo/repo")
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+		if tok != "ghs_token" {
+			t.Fatalf("call %d: token = %q, want ghs_token", i, tok)
+		}
+		if !exp.Equal(expires) {
+			t.Fatalf("call %d: expiry mismatch", i)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("resolver called %d times, want 1 (cached)", got)
+	}
+}
+
+func TestGitHubTokenBroker_RefreshesAfterExpiry(t *testing.T) {
+	now := time.Now()
+	b := NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		return "ghs_fresh", now.Add(1 * time.Hour), nil
+	})
+	// Force the cache to hold an already-expired (within margin) entry.
+	b.mu.Lock()
+	b.cache["octo/repo"] = cachedToken{token: "ghs_stale", expiresAt: now.Add(1 * time.Second)}
+	b.mu.Unlock()
+
+	tok, _, err := b.IssueToken("octo/repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "ghs_fresh" {
+		t.Fatalf("token = %q, want refreshed ghs_fresh", tok)
+	}
+}
+
+func TestGitHubTokenBroker_PersonalTokenZeroExpiryCached(t *testing.T) {
+	var calls int32
+	b := NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		atomic.AddInt32(&calls, 1)
+		return "ghp_personal", time.Time{}, nil // personal tokens have no known expiry
+	})
+	for i := 0; i < 2; i++ {
+		if _, _, err := b.IssueToken(""); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("resolver called %d times, want 1", got)
+	}
+}
+
+func TestGitHubTokenBroker_ResolverErrorSanitized(t *testing.T) {
+	const secret = "ghs_supersecret"
+	b := NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		return "", time.Time{}, fmt.Errorf("upstream rejected token %s -----BEGIN PRIVATE KEY-----", secret)
+	})
+	_, _, err := b.IssueToken("octo/repo")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("error leaked secret material: %v", err)
+	}
+	if strings.Contains(err.Error(), "PRIVATE KEY") {
+		t.Fatalf("error leaked PEM material: %v", err)
+	}
+}
+
+func TestGitHubTokenBroker_EmptyTokenTreatedAsFailure(t *testing.T) {
+	b := NewGitHubTokenBroker(func(repo string) (string, time.Time, error) {
+		return "", time.Now().Add(time.Hour), nil
+	})
+	if _, _, err := b.IssueToken("octo/repo"); err == nil {
+		t.Fatalf("empty token must surface as an error, not silently succeed")
+	}
+}
+
+func TestGitHubTokenBroker_NilResolverDisabled(t *testing.T) {
+	var b *GitHubTokenBroker
+	if _, _, err := b.IssueToken("octo/repo"); err == nil {
+		t.Fatalf("nil broker must error")
+	}
+	b2 := &GitHubTokenBroker{}
+	if _, _, err := b2.IssueToken("octo/repo"); err == nil {
+		t.Fatalf("broker with nil resolver must error")
+	}
+}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -41,6 +41,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 	"github.com/takutakahashi/agentapi-proxy/pkg/settingspatch"
+	"github.com/takutakahashi/agentapi-proxy/pkg/startup"
 )
 
 // provisionerPort is the TCP port on which agent-provisioner listens inside session Pods.
@@ -147,6 +148,22 @@ type KubernetesSessionManager struct {
 	sessionAllocatorEnabled bool
 
 	sessionAllocationNotifier coreallocation.Notifier
+
+	// githubTokenResolver produces the short-lived GitHub token exposed to a
+	// session Pod. It uses the proxy's own credentials (a proxy-level personal
+	// access token or GitHub App installation token) so that GitHub App
+	// configuration and private keys are never injected into session Pods.
+	// Defaults to startup.GetGitHubToken and is overridable in tests.
+	githubTokenResolver func(repoFullName string) (string, error)
+
+	// githubTokenBroker issues and caches short-lived GitHub installation tokens
+	// on demand for session Pods via the broker endpoint. nil when GitHub App
+	// authentication is not configured.
+	githubTokenBroker *GitHubTokenBroker
+
+	// githubBrokerSecret is the proxy-wide HMAC secret used to derive per-session
+	// broker credentials. Persisted in a Kubernetes Secret so it survives restarts.
+	githubBrokerSecret string
 }
 
 // NewKubernetesSessionManager creates a new KubernetesSessionManager
@@ -206,6 +223,7 @@ func NewKubernetesSessionManagerWithClient(
 		statusSubCtx:              subCtx,
 		statusSubCancel:           subCancel,
 		sessionAllocationNotifier: infrasessionallocation.NewLocalNotifier(),
+		githubTokenResolver:       startup.GetGitHubToken,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -213,6 +231,18 @@ func NewKubernetesSessionManagerWithClient(
 	if err := manager.ensureProvisionerToken(ctx); err != nil {
 		return nil, fmt.Errorf("failed to ensure provisioner token: %w", err)
 	}
+
+	// Ensure the GitHub token broker HMAC secret exists so per-session broker
+	// credentials can be derived and validated across proxy restarts.
+	if err := manager.ensureGitHubBrokerSecret(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure github broker secret: %w", err)
+	}
+	// Wire the token broker. The resolver returns token + expiry so the broker can
+	// refresh installation tokens before they expire. Errors from the resolver are
+	// sanitized by the broker before reaching callers/logs.
+	manager.githubTokenBroker = NewGitHubTokenBroker(func(repoFullName string) (string, time.Time, error) {
+		return startup.GetGitHubTokenWithExpiry(repoFullName)
+	})
 
 	// Ensure OpenTelemetry Collector ConfigMap exists
 	if err := manager.ensureOtelcolConfigMap(ctx); err != nil {
@@ -451,7 +481,15 @@ func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id
 	if req.ProvisionSettings != nil {
 		sessionSettings = req.ProvisionSettings
 	} else {
-		sessionSettings = m.buildSessionSettings(ctx, session, req, webhookPayload)
+		var buildErr error
+		sessionSettings, buildErr = m.buildSessionSettings(ctx, session, req, webhookPayload, true)
+		if buildErr != nil {
+			if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+				log.Printf("[K8S_SESSION] Failed to cleanup resources after settings build failure: %v", delErr)
+			}
+			m.cleanupSession(id)
+			return nil, fmt.Errorf("failed to build session settings: %w", buildErr)
+		}
 	}
 
 	session.SetProvisionSettings(sessionSettings)
@@ -864,7 +902,12 @@ func (m *KubernetesSessionManager) adoptStockSession(
 	}
 
 	// Build session settings and create a provision request for the adopted pod.
-	sessionSettings := m.buildSessionSettings(ctx, session, req, webhookPayload)
+	sessionSettings, buildErr := m.buildSessionSettings(ctx, session, req, webhookPayload, true)
+	if buildErr != nil {
+		m.cleanupSession(stockID)
+		cancel()
+		return nil, fmt.Errorf("failed to build session settings for stock session: %w", buildErr)
+	}
 	session.SetProvisionSettings(sessionSettings)
 	if err := m.CreateProvisionRequest(ctx, session); err != nil {
 		m.cleanupSession(stockID)
@@ -2047,51 +2090,27 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	// Setting workingDir to repo path would cause Kubernetes to pre-create the dir as root
 	workingDir := "/home/agentapi/workdir"
 
-	// Build envFrom for GitHub secrets
-	// Two secrets are used:
-	// - GitHubSecretName: Contains GITHUB_TOKEN, GITHUB_APP_PEM, GITHUB_APP_ID, GITHUB_INSTALLATION_ID (authentication)
-	// - GitHubConfigSecretName: Contains GITHUB_API, GITHUB_URL (configuration for Enterprise Server)
+	// Build envFrom for GitHub configuration.
+	//
+	// Only the non-authentication GitHub config Secret (GITHUB_API, GITHUB_URL for
+	// GitHub Enterprise Server) is mounted onto the session Pod. GitHub
+	// authentication credentials are never mounted: the resolved short-lived token
+	// (personal access token or GitHub App installation token generated
+	// server-side) is delivered exclusively via the session settings env
+	// (GITHUB_TOKEN). The GitHub App auth Secret (App ID, installation ID, private
+	// key PEM, repository restriction) is intentionally NOT referenced here.
 	var envFrom []corev1.EnvFromSource
 
-	if req.GithubToken != "" {
-		// When params.github_token is provided:
-		// - GITHUB_TOKEN is embedded directly in session-settings env (no per-session secret)
-		// - Mount GitHubConfigSecretName for GITHUB_API/GITHUB_URL settings only
-		if m.k8sConfig.GitHubConfigSecretName != "" {
-			envFrom = append(envFrom, corev1.EnvFromSource{
-				SecretRef: &corev1.SecretEnvSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.k8sConfig.GitHubConfigSecretName,
-					},
-					Optional: boolPtr(true),
-				},
-			})
-			log.Printf("[K8S_SESSION] Mounting GitHub config Secret %s for session %s", m.k8sConfig.GitHubConfigSecretName, session.id)
-		}
-	} else if m.k8sConfig.GitHubSecretName != "" {
-		// When params.github_token is NOT provided:
-		// - Mount GitHubSecretName for full GitHub App authentication
-		// - Also mount GitHubConfigSecretName (config values will override auth secret if same keys exist)
+	if m.k8sConfig.GitHubConfigSecretName != "" {
 		envFrom = append(envFrom, corev1.EnvFromSource{
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: m.k8sConfig.GitHubSecretName,
+					Name: m.k8sConfig.GitHubConfigSecretName,
 				},
 				Optional: boolPtr(true),
 			},
 		})
-
-		// Mount GitHub config Secret if available (for any additional config)
-		if m.k8sConfig.GitHubConfigSecretName != "" {
-			envFrom = append(envFrom, corev1.EnvFromSource{
-				SecretRef: &corev1.SecretEnvSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.k8sConfig.GitHubConfigSecretName,
-					},
-					Optional: boolPtr(true),
-				},
-			})
-		}
+		log.Printf("[K8S_SESSION] Mounting GitHub config Secret %s for session %s", m.k8sConfig.GitHubConfigSecretName, session.id)
 	}
 
 	// Build container spec.
@@ -3414,8 +3433,6 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 		{Name: "AGENTAPI_SESSION_ID", Value: session.id},
 		{Name: "AGENTAPI_USER_ID", Value: req.UserID},
 		{Name: "HOME", Value: "/home/agentapi"},
-		// GitHub App PEM path (file is written by setup directly to container FS)
-		{Name: "GITHUB_APP_PEM_PATH", Value: "/tmp/github-app/app.pem"},
 	}
 
 	// Add Claude Code telemetry configuration
@@ -4682,14 +4699,108 @@ func (m *KubernetesSessionManager) ensurePersonalAPIKey(ctx context.Context, use
 	return apiKey
 }
 
+// resolveSessionGitHubToken produces the short-lived GitHub token that the
+// session Pod uses for repository cloning and gh operations. The token is
+// generated from the proxy's own credentials (a proxy-level personal access
+// token or GitHub App installation token). GitHub App configuration and the
+// private key never leave the proxy. When a repository is known, the resulting
+// installation token is scoped to that repository.
+func (m *KubernetesSessionManager) resolveSessionGitHubToken(repoFullName string) (string, error) {
+	resolver := m.githubTokenResolver
+	if resolver == nil {
+		resolver = startup.GetGitHubToken
+	}
+	return resolver(repoFullName)
+}
+
+// githubBrokerURL returns the broker endpoint URL a session Pod uses to fetch
+// short-lived GitHub installation tokens. It is rooted at the same proxy URL the
+// Pod already uses to reach the proxy for provisioning (ProvisionerProxyURL, or
+// the in-cluster Service DNS by default), so no new network path is required.
+func (m *KubernetesSessionManager) githubBrokerURL(sessionID string) string {
+	base := m.k8sConfig.ProvisionerProxyURL
+	if base == "" {
+		base = fmt.Sprintf("http://agentapi-proxy.%s.svc.cluster.local:8080", m.namespace)
+	}
+	return fmt.Sprintf("%s/internal/sessions/%s/github-token", base, sessionID)
+}
+
+// IssueGitHubToken mints (or returns a cached) short-lived GitHub installation
+// token for the session identified by sessionID, validating that the caller is
+// authorized for that session and that the requested repository matches the
+// session's configured repository scope.
+//
+// It is the server-side entry point of the GitHub token broker. Token/PEM
+// material never appears in the returned error; failures surface as a fixed,
+// secret-free message. An empty requestedRepo is allowed only when the session
+// has no repository scope; otherwise the requested repository must equal the
+// session's repository (case-insensitive), preventing scope substitution.
+func (m *KubernetesSessionManager) IssueGitHubToken(sessionID, requestedRepo string) (string, time.Time, error) {
+	session := m.GetSession(sessionID)
+	if session == nil {
+		return "", time.Time{}, fmt.Errorf("session not found")
+	}
+	repoFullName := ""
+	if ks, ok := session.(*KubernetesSession); ok {
+		if req := ks.Request(); req != nil && req.RepoInfo != nil {
+			repoFullName = req.RepoInfo.FullName
+		}
+	}
+	if !githubRepoMatchesScope(repoFullName, requestedRepo) {
+		return "", time.Time{}, fmt.Errorf("repository scope mismatch")
+	}
+	if m.githubTokenBroker == nil {
+		return "", time.Time{}, fmt.Errorf("github token broker is not configured")
+	}
+	return m.githubTokenBroker.IssueToken(repoFullName)
+}
+
+// githubRepoMatchesScope reports whether requestedRepo is permitted for a
+// session whose configured repository is sessionRepo.
+//
+// An empty requestedRepo means "use the session's repository scope": it is always
+// allowed, and the broker issues an installation token scoped to the session's
+// repository (or, when the session has no repository, an unrestricted token
+// subject to the proxy's REPOSITORY_RESTRICTION setting).
+//
+// A non-empty requestedRepo must match the session repository exactly
+// (case-insensitive, trimmed). When the session has no repository scope, any
+// non-empty request is rejected so a caller cannot broaden the scope to an
+// arbitrary repository.
+func githubRepoMatchesScope(sessionRepo, requestedRepo string) bool {
+	sessionRepo = strings.ToLower(strings.TrimSpace(sessionRepo))
+	requestedRepo = strings.ToLower(strings.TrimSpace(requestedRepo))
+	if requestedRepo == "" {
+		return true
+	}
+	if sessionRepo == "" {
+		return false
+	}
+	return requestedRepo == sessionRepo
+}
+
 // buildSessionSettings constructs SessionSettings from RunServerRequest and session state.
 // This consolidates buildEnvVars and envFrom logic into a single unified structure.
+//
+// It returns an error (aborting session creation) when GitHub authentication is
+// configured but a token cannot be resolved, so that the failure surfaces at
+// creation time rather than being deferred to the provisioner inside the Pod.
+//
+// useBroker selects the GitHub credential delivery model for the GitHub App
+// path (GitHubSecretName set, no personal token):
+//   - true: the Pod receives only a session-scoped broker credential + endpoint
+//     and fetches short-lived installation tokens on demand. Used for local
+//     Kubernetes sessions whose Pods can reach this proxy.
+//   - false: a server-resolved token is embedded as GITHUB_TOKEN. Used when the
+//     Pod cannot call back to this proxy (e.g. External Session Manager), so the
+//     token cannot be refreshed but no App credentials leave the proxy.
 func (m *KubernetesSessionManager) buildSessionSettings(
 	ctx context.Context,
 	session *KubernetesSession,
 	req *entities.RunServerRequest,
 	webhookPayload []byte,
-) *sessionsettings.SessionSettings {
+	useBroker bool,
+) (*sessionsettings.SessionSettings, error) {
 	settings := &sessionsettings.SessionSettings{}
 
 	// Session metadata
@@ -4715,7 +4826,6 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		"AGENTAPI_SESSION_ID": session.id,
 		"AGENTAPI_USER_ID":    req.UserID,
 		"HOME":                "/home/agentapi",
-		"GITHUB_APP_PEM_PATH": "/tmp/github-app/app.pem",
 	}
 
 	// Add Claude Code telemetry configuration
@@ -4769,42 +4879,71 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		}
 	}
 
-	// Build list of secret names to expand into env map
-	// Pod does not have permission to read secrets, so we need to expand them here
-	var secretNames []string
-
+	// Resolve GitHub authentication for the session.
+	//
+	// Only a short-lived credential is ever exposed to the session Pod:
+	//   - a personal access token supplied via params.github_token, or
+	//   - a GitHub App installation token. For local Kubernetes sessions the Pod
+	//     does NOT receive a token at all: it gets a session-scoped broker
+	//     credential + endpoint and fetches a fresh installation token on demand,
+	//     so long-running sessions keep working after the original token expires.
+	//     For paths where the Pod cannot reach this proxy (External Session
+	//     Manager), a server-resolved token is embedded once as GITHUB_TOKEN.
+	//
+	// GitHub App configuration (App ID, installation ID, private key PEM,
+	// repository restriction) is never mounted or injected into the Pod.
+	repoFullName := ""
+	if req.RepoInfo != nil {
+		repoFullName = req.RepoInfo.FullName
+	}
 	if req.GithubToken != "" {
-		// When params.github_token is provided: embed token directly, no per-session secret needed
-		if m.k8sConfig.GitHubConfigSecretName != "" {
-			secretNames = append(secretNames, m.k8sConfig.GitHubConfigSecretName)
-		}
 		env["GITHUB_TOKEN"] = req.GithubToken
 	} else if m.k8sConfig.GitHubSecretName != "" {
-		// When params.github_token is NOT provided
-		secretNames = append(secretNames, m.k8sConfig.GitHubSecretName)
-		if m.k8sConfig.GitHubConfigSecretName != "" {
-			secretNames = append(secretNames, m.k8sConfig.GitHubConfigSecretName)
+		if useBroker {
+			brokerURL := m.githubBrokerURL(session.id)
+			brokerToken := m.githubBrokerTokenForSession(session.id)
+			if brokerURL == "" || brokerToken == "" {
+				// Without a reachable broker endpoint or a session credential we cannot
+				// safely deliver GitHub auth. Abort rather than silently creating an
+				// unauthenticated Pod.
+				return nil, fmt.Errorf("github token broker is not configured for session %s", session.id)
+			}
+			env["AGENTAPI_GITHUB_BROKER_URL"] = brokerURL
+			env["AGENTAPI_GITHUB_BROKER_TOKEN"] = brokerToken
+			// AGENTAPI_REPO_FULLNAME is set below from req.RepoInfo for broker scoping.
+		} else {
+			token, err := m.resolveSessionGitHubToken(repoFullName)
+			if err != nil {
+				// GitHub authentication is configured but the token could not be minted.
+				// Abort session creation with a clear error. The underlying resolver error
+				// may reference credential material, so it is intentionally NOT wrapped
+				// (%w) and NOT logged. Diagnosability is a fixed, secret-free message +
+				// the session ID.
+				return nil, fmt.Errorf("failed to resolve GitHub token for session %s", session.id)
+			}
+			if token != "" {
+				env["GITHUB_TOKEN"] = token
+			}
 		}
 	}
 
-	// Expand secrets into env map (GitHub secrets only)
-	for _, secretName := range secretNames {
+	// Merge the non-authentication GitHub config Secret (GITHUB_API, GITHUB_URL for
+	// GitHub Enterprise Server) into the env map. This Secret intentionally holds
+	// no credentials. The Pod cannot read Secrets itself, so it is expanded here.
+	if m.k8sConfig.GitHubConfigSecretName != "" {
 		secret, err := m.client.CoreV1().Secrets(m.namespace).Get(
 			ctx,
-			secretName,
+			m.k8sConfig.GitHubConfigSecretName,
 			metav1.GetOptions{},
 		)
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				log.Printf("[K8S_SESSION] Warning: failed to read secret %s for session settings: %v", secretName, err)
+				log.Printf("[K8S_SESSION] Warning: failed to read GitHub config secret %s for session settings: %v", m.k8sConfig.GitHubConfigSecretName, err)
 			}
-			// Skip secrets that don't exist (they are all optional)
-			continue
-		}
-
-		// Merge secret data into env map (later secrets override earlier ones due to iteration order)
-		for k, v := range secret.Data {
-			env[k] = string(v)
+		} else {
+			for k, v := range secret.Data {
+				env[k] = string(v)
+			}
 		}
 	}
 
@@ -4966,15 +5105,12 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		settings.WebhookPayload = string(webhookPayload)
 	}
 
-	// GitHub config
-	if req.GithubToken != "" {
+	// GitHub config (informational only, and delivered to the Pod via settings).
+	// The GitHub App auth Secret is intentionally never referenced here: the Pod
+	// receives only the resolved short-lived token via env (GITHUB_TOKEN) plus the
+	// non-authentication GITHUB_API/GITHUB_URL config values.
+	if m.k8sConfig.GitHubConfigSecretName != "" || env["GITHUB_TOKEN"] != "" {
 		settings.Github = &sessionsettings.GithubConfig{
-			Token:            req.GithubToken,
-			ConfigSecretName: m.k8sConfig.GitHubConfigSecretName,
-		}
-	} else if m.k8sConfig.GitHubSecretName != "" {
-		settings.Github = &sessionsettings.GithubConfig{
-			SecretName:       m.k8sConfig.GitHubSecretName,
 			ConfigSecretName: m.k8sConfig.GitHubConfigSecretName,
 		}
 	}
@@ -5228,7 +5364,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		log.Printf("[K8S_SESSION] DinD enabled for session %s (registries: %d)", session.id, len(registries))
 	}
 
-	return settings
+	return settings, nil
 }
 
 func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req *entities.RunServerRequest) {
@@ -5605,8 +5741,7 @@ func (m *KubernetesSessionManager) BuildRemoteProvisionSettings(
 		id:          sessionID,
 		serviceName: fmt.Sprintf("agentapi-session-%s-svc", sessionID),
 	}
-	settings := m.buildSessionSettings(ctx, tempSession, req, nil)
-	return settings, nil
+	return m.buildSessionSettings(ctx, tempSession, req, nil, false)
 }
 
 // userFilesSecretDataToManagedFiles converts the index-based Secret data from

--- a/internal/infrastructure/services/kubernetes_session_manager_cycle_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_cycle_test.go
@@ -67,7 +67,10 @@ func TestBuildSessionSettings_CycleHookInjected(t *testing.T) {
 		CycleMaxCount: 5,
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if settings == nil {
 		t.Fatal("Expected non-nil settings")
 	}
@@ -152,7 +155,10 @@ func TestBuildSessionSettings_CycleHookWithoutMaxCount(t *testing.T) {
 		CycleMaxCount: 0, // unlimited
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if settings == nil {
 		t.Fatal("Expected non-nil settings")
 	}
@@ -220,7 +226,10 @@ func TestBuildSessionSettings_CycleEnabledFileInjected(t *testing.T) {
 		CycleMessage: "Please continue the task",
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if settings == nil {
 		t.Fatal("Expected non-nil settings")
 	}
@@ -251,7 +260,10 @@ func TestBuildSessionSettings_NoCycleEnabledFileWhenMessageEmpty(t *testing.T) {
 		CycleMessage: "",
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if settings == nil {
 		t.Fatal("Expected non-nil settings")
 	}
@@ -277,7 +289,10 @@ func TestBuildSessionSettings_CycleHookAlwaysInjected(t *testing.T) {
 		CycleMaxCount: 5,
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if settings == nil {
 		t.Fatal("Expected non-nil settings")
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager_github_token_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_github_token_test.go
@@ -1,0 +1,288 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+)
+
+// githubAppSecretKeys are the GitHub App configuration / secret keys that must
+// never be exposed to a session Pod.
+var githubAppSecretKeys = []string{
+	"GITHUB_APP_ID",
+	"GITHUB_INSTALLATION_ID",
+	"GITHUB_APP_PEM",
+	"GITHUB_APP_PEM_PATH",
+	"REPOSITORY_RESTRICTION",
+}
+
+func newGithubTokenTestManager(t *testing.T, client *fake.Clientset, secretName string) *KubernetesSessionManager {
+	t.Helper()
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:        "test-ns",
+			Image:            "test-image:latest",
+			BasePort:         9000,
+			PVCEnabled:       boolPtrForTest(false),
+			CPURequest:       "100m",
+			CPULimit:         "1",
+			MemoryRequest:    "128Mi",
+			MemoryLimit:      "512Mi",
+			GitHubSecretName: secretName,
+		},
+	}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), client)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.namespace = "test-ns"
+	return manager
+}
+
+func newGithubTokenTestSession() *KubernetesSession {
+	return NewKubernetesSession(
+		"test-session",
+		&entities.RunServerRequest{UserID: "test-user"},
+		"test-deploy",
+		"agentapi-session-test-svc",
+		"test-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+}
+
+// TestBuildSessionSettings_GitHubAppUsesBrokerNotToken verifies that when a GitHub App
+// auth Secret is configured (no per-request personal token) and the session Pod can
+// reach the proxy (useBroker), the Pod receives ONLY a session-scoped broker
+// credential + endpoint — never a GITHUB_TOKEN and never GitHub App configuration
+// or PEM. The token itself is fetched on demand from the broker at runtime.
+func TestBuildSessionSettings_GitHubAppUsesBrokerNotToken(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	manager := newGithubTokenTestManager(t, k8sClient, "agentapi-proxy-github-session")
+
+	// The resolver must NOT be called at build time on the broker path; tokens are
+	// minted lazily by the broker.
+	resolverCalled := false
+	manager.githubTokenResolver = func(repoFullName string) (string, error) {
+		resolverCalled = true
+		return "ghs_should_not_be_embedded", nil
+	}
+
+	session := newGithubTokenTestSession()
+	req := &entities.RunServerRequest{
+		UserID: "test-user",
+		RepoInfo: &entities.RepositoryInfo{
+			FullName: "octo/repo",
+		},
+	}
+
+	settings, err := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if err != nil {
+		t.Fatalf("buildSessionSettings() error = %v", err)
+	}
+	if resolverCalled {
+		t.Fatalf("resolver must not be called at build time on the broker path")
+	}
+	if _, ok := settings.Env["GITHUB_TOKEN"]; ok {
+		t.Fatalf("GITHUB_TOKEN must not be embedded on the broker path")
+	}
+	brokerURL := settings.Env["AGENTAPI_GITHUB_BROKER_URL"]
+	if brokerURL == "" {
+		t.Fatalf("AGENTAPI_GITHUB_BROKER_URL must be set on the broker path")
+	}
+	if !strings.Contains(brokerURL, session.id) {
+		t.Fatalf("broker URL %q must contain the session id %q", brokerURL, session.id)
+	}
+	brokerToken := settings.Env["AGENTAPI_GITHUB_BROKER_TOKEN"]
+	if brokerToken == "" {
+		t.Fatalf("AGENTAPI_GITHUB_BROKER_TOKEN must be set on the broker path")
+	}
+	for _, key := range githubAppSecretKeys {
+		if _, ok := settings.Env[key]; ok {
+			t.Fatalf("session env must not contain GitHub App key %q", key)
+		}
+	}
+	if settings.Github != nil && settings.Github.SecretName != "" {
+		t.Fatalf("settings.Github.SecretName must be empty, got %q", settings.Github.SecretName)
+	}
+}
+
+// TestBuildSessionSettings_PersonalTokenTakesPrecedence verifies that a
+// per-request personal token is used directly and no App credentials leak.
+func TestBuildSessionSettings_PersonalTokenTakesPrecedence(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	manager := newGithubTokenTestManager(t, k8sClient, "agentapi-proxy-github-session")
+
+	resolverCalled := false
+	manager.githubTokenResolver = func(repoFullName string) (string, error) {
+		resolverCalled = true
+		return "should-not-be-used", nil
+	}
+
+	session := newGithubTokenTestSession()
+	req := &entities.RunServerRequest{
+		UserID:      "test-user",
+		GithubToken: "ghp_personaltoken",
+	}
+
+	settings, err := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if err != nil {
+		t.Fatalf("buildSessionSettings() error = %v", err)
+	}
+
+	if resolverCalled {
+		t.Fatalf("server-side resolver must not be called when a personal token is provided")
+	}
+	if got := settings.Env["GITHUB_TOKEN"]; got != "ghp_personaltoken" {
+		t.Fatalf("GITHUB_TOKEN = %q, want ghp_personaltoken", got)
+	}
+	for _, key := range githubAppSecretKeys {
+		if _, ok := settings.Env[key]; ok {
+			t.Fatalf("session env must not contain GitHub App key %q", key)
+		}
+	}
+}
+
+// TestBuildSessionSettings_TokenResolveFailureAborts verifies that when GitHub
+// authentication is configured but server-side token generation fails, session
+// creation is aborted with a clear error (no implicit unauthenticated fallback)
+// and the error never contains secret material.
+func TestBuildSessionSettings_TokenResolveFailureAborts(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	manager := newGithubTokenTestManager(t, k8sClient, "agentapi-proxy-github-session")
+	// The resolver error intentionally embeds real secret material (as could
+	// happen if an upstream API echoed a token/PEM back in its error). The test
+	// asserts that this never reaches the error returned to callers.
+	const secretMarker = "ghs_supersecrettoken"
+	manager.githubTokenResolver = func(repoFullName string) (string, error) {
+		return "", fmt.Errorf("github api rejected token %s -----BEGIN PRIVATE KEY-----", secretMarker)
+	}
+
+	session := newGithubTokenTestSession()
+	req := &entities.RunServerRequest{UserID: "test-user"}
+
+	settings, err := manager.buildSessionSettings(context.Background(), session, req, nil, false)
+	if err == nil {
+		t.Fatalf("expected an error when token resolution fails, got settings=%v", settings)
+	}
+	if settings != nil {
+		t.Fatalf("settings must be nil when token resolution fails, got %v", settings)
+	}
+	if strings.Contains(err.Error(), secretMarker) {
+		t.Fatalf("error must not contain secret material, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "PRIVATE KEY") {
+		t.Fatalf("error must not contain PEM material, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), session.id) {
+		t.Fatalf("error should reference the session ID for diagnosability, got: %v", err)
+	}
+}
+
+// TestBuildSessionSettings_NoGitHubAuthConfiguredSucceeds verifies that when no
+// GitHub authentication is configured (GitHubSecretName empty), session settings
+// build succeeds without a token and without any App keys.
+func TestBuildSessionSettings_NoGitHubAuthConfiguredSucceeds(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	manager := newGithubTokenTestManager(t, k8sClient, "")
+	resolverCalled := false
+	manager.githubTokenResolver = func(repoFullName string) (string, error) {
+		resolverCalled = true
+		return "", fmt.Errorf("should not be called")
+	}
+
+	session := newGithubTokenTestSession()
+	req := &entities.RunServerRequest{UserID: "test-user"}
+
+	settings, err := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if err != nil {
+		t.Fatalf("buildSessionSettings() error = %v", err)
+	}
+	if resolverCalled {
+		t.Fatalf("resolver must not be called when no GitHub auth is configured")
+	}
+	if _, ok := settings.Env["GITHUB_TOKEN"]; ok {
+		t.Fatalf("GITHUB_TOKEN must not be set when no GitHub auth is configured")
+	}
+	for _, key := range githubAppSecretKeys {
+		if _, ok := settings.Env[key]; ok {
+			t.Fatalf("session env must not contain GitHub App key %q", key)
+		}
+	}
+}
+
+// TestBuildSessionSettings_ConfigSecretMergedWithoutAuth verifies that the
+// non-authentication GitHub config Secret (GITHUB_API/GITHUB_URL) is still merged
+// into the session env, while the auth Secret's App keys are not.
+func TestBuildSessionSettings_ConfigSecretMergedWithoutAuth(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	// The auth Secret still exists and (in a misconfigured cluster) may contain
+	// App keys; the proxy must never copy those into the Pod env.
+	if _, err := k8sClient.CoreV1().Secrets("test-ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "agentapi-proxy-github-session", Namespace: "test-ns"},
+		Data: map[string][]byte{
+			"GITHUB_APP_ID":          []byte("123"),
+			"GITHUB_APP_PEM":         []byte("-----BEGIN PRIVATE KEY-----"),
+			"GITHUB_INSTALLATION_ID": []byte("456"),
+			"REPOSITORY_RESTRICTION": []byte("true"),
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create auth secret: %v", err)
+	}
+	if _, err := k8sClient.CoreV1().Secrets("test-ns").Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "agentapi-proxy-github-config", Namespace: "test-ns"},
+		Data: map[string][]byte{
+			"GITHUB_API": []byte("https://ghe.example.com/api/v3"),
+			"GITHUB_URL": []byte("https://ghe.example.com"),
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create config secret: %v", err)
+	}
+
+	manager := newGithubTokenTestManager(t, k8sClient, "agentapi-proxy-github-session")
+	manager.k8sConfig.GitHubConfigSecretName = "agentapi-proxy-github-config"
+	manager.githubTokenResolver = func(repoFullName string) (string, error) {
+		return "ghs_token", nil
+	}
+
+	session := newGithubTokenTestSession()
+	req := &entities.RunServerRequest{UserID: "test-user"}
+
+	settings, err := manager.buildSessionSettings(context.Background(), session, req, nil, false)
+	if err != nil {
+		t.Fatalf("buildSessionSettings() error = %v", err)
+	}
+
+	if got := settings.Env["GITHUB_API"]; got != "https://ghe.example.com/api/v3" {
+		t.Fatalf("GITHUB_API = %q, want the config secret value", got)
+	}
+	if got := settings.Env["GITHUB_URL"]; got != "https://ghe.example.com" {
+		t.Fatalf("GITHUB_URL = %q, want the config secret value", got)
+	}
+	for _, key := range githubAppSecretKeys {
+		if _, ok := settings.Env[key]; ok {
+			t.Fatalf("session env must not contain GitHub App key %q even if present in the auth secret", key)
+		}
+	}
+}

--- a/internal/infrastructure/services/kubernetes_session_manager_initial_message_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_initial_message_test.go
@@ -67,7 +67,10 @@ func TestInitialMessageStoredInSettingsYAML(t *testing.T) {
 	}
 
 	// Build settings and create the Secret using the new function.
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	err = manager.createSessionSettingsSecretFromSettings(context.Background(), session, req, settings)
 	if err != nil {
 		t.Fatalf("Failed to create session settings secret: %v", err)

--- a/internal/infrastructure/services/kubernetes_session_manager_oneshot_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_oneshot_test.go
@@ -66,7 +66,10 @@ func TestBuildSessionSettings_OneshotHookInjected(t *testing.T) {
 		Oneshot: true,
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if settings == nil {
 		t.Fatal("Expected non-nil settings")
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager_personal_api_key_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_personal_api_key_test.go
@@ -117,7 +117,9 @@ func TestBuildSessionSettings_NewPersonalAPIKeyLoaded(t *testing.T) {
 		Scope:  entities.ScopeUser,
 	}
 
-	manager.buildSessionSettings(context.Background(), session, req, nil)
+	if _, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true); buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 
 	if len(loader.loaded) == 0 {
 		t.Fatal("Expected PersonalAPIKeyLoader.LoadPersonalAPIKey to be called for new user, but it was not")
@@ -163,7 +165,9 @@ func TestBuildSessionSettings_ExistingPersonalAPIKeyNotReloaded(t *testing.T) {
 		Scope:  entities.ScopeUser,
 	}
 
-	manager.buildSessionSettings(context.Background(), session, req, nil)
+	if _, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true); buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 
 	if len(loader.loaded) != 0 {
 		t.Errorf("Expected LoadPersonalAPIKey NOT to be called for existing user, but it was called %d time(s)", len(loader.loaded))

--- a/internal/infrastructure/services/kubernetes_session_manager_pod_no_appcreds_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_pod_no_appcreds_test.go
@@ -1,0 +1,124 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+)
+
+// githubAppForbiddenEnvKeys are the GitHub App configuration / private-key env
+// vars that must never appear in a session Pod spec (container env, envFrom, or
+// volumes). They live only on the proxy Deployment.
+var githubAppForbiddenEnvKeys = []string{
+	"GITHUB_APP_ID",
+	"GITHUB_INSTALLATION_ID",
+	"GITHUB_APP_PEM",
+	"GITHUB_APP_PEM_PATH",
+	"REPOSITORY_RESTRICTION",
+}
+
+// TestBuildDeployment_PodSpecHasNoGitHubAppCredentials verifies that the session
+// Pod manifest produced by buildDeployment never carries GitHub App credentials:
+//   - no container env var named GITHUB_APP_ID / GITHUB_INSTALLATION_ID /
+//     GITHUB_APP_PEM / GITHUB_APP_PEM_PATH / REPOSITORY_RESTRICTION,
+//   - no EnvFromSource referencing the GitHub App auth Secret (only the non-auth
+//     GitHub config Secret for GITHUB_API/GITHUB_URL may be mounted),
+//   - no Volume / VolumeMount for a GitHub App private key.
+//
+// This is the negative test complementing the settings-level checks: even if a
+// misconfigured cluster puts App keys into the auth Secret, the Pod manifest must
+// not surface them.
+func TestBuildDeployment_PodSpecHasNoGitHubAppCredentials(t *testing.T) {
+	manager := &KubernetesSessionManager{
+		config: &config.Config{},
+		k8sConfig: &config.KubernetesSessionConfig{
+			Namespace:              "test-ns",
+			Image:                  "session-image:latest",
+			ImagePullPolicy:        "IfNotPresent",
+			BasePort:               9000,
+			CPURequest:             "100m",
+			CPULimit:               "1",
+			MemoryRequest:          "128Mi",
+			MemoryLimit:            "512Mi",
+			GitHubSecretName:       "agentapi-proxy-github-session", // auth configured
+			GitHubConfigSecretName: "agentapi-proxy-github-config",  // GITHUB_API/GITHUB_URL only
+		},
+		namespace: "test-ns",
+	}
+	session := NewKubernetesSession(
+		"sess-no-appcreds",
+		&entities.RunServerRequest{
+			UserID:   "u",
+			RepoInfo: &entities.RepositoryInfo{FullName: "octo/repo"},
+		},
+		"deploy", "svc", "pvc", "test-ns", 9000, nil, nil,
+	)
+
+	deployment, err := manager.buildDeployment(context.Background(), session, session.Request())
+	if err != nil {
+		t.Fatalf("buildDeployment() error = %v", err)
+	}
+	podSpec := deployment.Spec.Template.Spec
+
+	// 1. No container env var carries GitHub App configuration / PEM.
+	for _, c := range podSpec.Containers {
+		for _, e := range c.Env {
+			for _, k := range githubAppForbiddenEnvKeys {
+				if e.Name == k {
+					t.Fatalf("container %q env must not include %q (value=%q)", c.Name, k, e.Value)
+				}
+			}
+		}
+	}
+	for _, c := range podSpec.InitContainers {
+		for _, e := range c.Env {
+			for _, k := range githubAppForbiddenEnvKeys {
+				if e.Name == k {
+					t.Fatalf("init container %q env must not include %q (value=%q)", c.Name, k, e.Value)
+				}
+			}
+		}
+	}
+
+	// 2. No EnvFromSource may reference the GitHub App auth Secret. Only the
+	//    non-auth GitHub config Secret (GITHUB_API/GITHUB_URL) is permitted.
+	authSecret := manager.k8sConfig.GitHubSecretName
+	for _, c := range podSpec.Containers {
+		for _, ef := range c.EnvFrom {
+			if ef.SecretRef != nil && ef.SecretRef.Name == authSecret {
+				t.Fatalf("container %q envFrom must not reference the GitHub App auth Secret %q", c.Name, authSecret)
+			}
+		}
+	}
+
+	// 3. No volume / volumeMount references a GitHub App private key secret.
+	for _, v := range podSpec.Volumes {
+		if v.Secret != nil && strings.Contains(strings.ToLower(v.Name), "github-app") {
+			t.Fatalf("pod spec must not mount a GitHub App private key volume: %+v", v)
+		}
+		if v.Secret != nil && v.Secret.SecretName == authSecret {
+			t.Fatalf("pod spec must not mount the GitHub App auth Secret as a volume: %+v", v)
+		}
+	}
+	for _, c := range podSpec.Containers {
+		for _, vm := range c.VolumeMounts {
+			if strings.Contains(strings.ToLower(vm.Name), "github-app") {
+				t.Fatalf("container %q must not mount a GitHub App private key volume: %+v", c.Name, vm)
+			}
+		}
+	}
+
+	// 4. The broker env (when present) is delivered via the provision request, not
+	//    via the Pod spec container env; verify buildEnvVars does not emit App keys.
+	envVars := manager.buildEnvVars(session, session.Request())
+	for _, e := range envVars {
+		for _, k := range githubAppForbiddenEnvKeys {
+			if e.Name == k {
+				t.Fatalf("buildEnvVars must not emit %q (value=%q)", k, e.Value)
+			}
+		}
+	}
+}

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -121,7 +121,10 @@ func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
 		TeamID: "org/team-a",
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if got := settings.Env["SECRET_TOKEN"]; got != "decrypted-secret" {
 		t.Fatalf("SECRET_TOKEN = %q, want decrypted-secret", got)
 	}
@@ -168,7 +171,10 @@ func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 		},
 	}
 
-	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	settings, buildErr := manager.buildSessionSettings(context.Background(), session, req, nil, true)
+	if buildErr != nil {
+		t.Fatalf("buildSessionSettings() error = %v", buildErr)
+	}
 	if _, ok := settings.Env["OLLAMA_API_KEY"]; ok {
 		t.Fatalf("OLLAMA_API_KEY should not be synthesized")
 	}

--- a/internal/interfaces/controllers/github_token_controller.go
+++ b/internal/interfaces/controllers/github_token_controller.go
@@ -1,0 +1,124 @@
+package controllers
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// GitHubTokenBrokerService is the port the GitHub token broker controller depends
+// on. It is implemented by KubernetesSessionManager.
+type GitHubTokenBrokerService interface {
+	// ValidateGitHubBrokerToken reports whether token is the valid broker
+	// credential for sessionID (constant-time, session-scoped).
+	ValidateGitHubBrokerToken(sessionID, token string) bool
+	// IssueGitHubToken mints/returns a cached short-lived GitHub installation
+	// token for the session, validating repository scope. Errors are secret-free.
+	IssueGitHubToken(sessionID, requestedRepo string) (token string, expiresAt time.Time, err error)
+}
+
+// GitHubTokenController exposes the session-scoped GitHub token broker endpoint.
+// Session Pods call it to obtain short-lived installation tokens on demand instead
+// of receiving a long-lived credential at creation time.
+type GitHubTokenController struct {
+	broker GitHubTokenBrokerService
+}
+
+// NewGitHubTokenController creates a controller backed by the given broker service.
+func NewGitHubTokenController(broker GitHubTokenBrokerService) *GitHubTokenController {
+	return &GitHubTokenController{broker: broker}
+}
+
+// githubTokenResponse is the JSON body returned by the broker endpoint.
+type githubTokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// IssueToken handles POST /internal/sessions/:sessionId/github-token.
+//
+// Authentication: the caller presents a session-scoped broker credential in the
+// Authorization header (Bearer <token>). The credential is bound to the session ID
+// in the path, so a token minted for session A cannot be used against session B, and
+// the credential is not valid for any other proxy endpoint.
+//
+// Repository scope: the request body may carry {"repository":"owner/repo"}; when
+// present it must match the session's configured repository (the broker enforces
+// this). When omitted, the session's repository scope is used.
+//
+// The token and its expiry are returned as JSON. On error a secret-free message is
+// returned with an appropriate status code; token/PEM material never leaks.
+func (ctl *GitHubTokenController) IssueToken(c echo.Context) error {
+	if ctl == nil || ctl.broker == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "github token broker is not configured"})
+	}
+
+	sessionID := c.Param("sessionId")
+	if sessionID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "session id is required"})
+	}
+
+	// Authenticate the caller with the session-scoped broker credential.
+	token := bearerToken(c)
+	if token == "" || !ctl.broker.ValidateGitHubBrokerToken(sessionID, token) {
+		// 401 (not 403) so a caller cannot distinguish "unknown session" from
+		// "wrong token"; no session existence is leaked.
+		return c.NoContent(http.StatusUnauthorized)
+	}
+
+	// Parse the optional repository scope from the body. Unknown fields are
+	// ignored; a missing body is fine.
+	var body struct {
+		Repository string `json:"repository"`
+	}
+	_ = c.Bind(&body)
+	requestedRepo := strings.TrimSpace(body.Repository)
+
+	issuedToken, expiresAt, err := ctl.broker.IssueGitHubToken(sessionID, requestedRepo)
+	if err != nil {
+		// Map common failures to status codes without leaking secrets.
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "session not found"):
+			return c.JSON(http.StatusNotFound, map[string]string{"error": "session not found"})
+		case strings.Contains(msg, "repository scope mismatch"):
+			return c.JSON(http.StatusForbidden, map[string]string{"error": "repository scope mismatch"})
+		case strings.Contains(msg, "not configured"):
+			return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "github token broker unavailable"})
+		default:
+			return c.JSON(http.StatusBadGateway, map[string]string{"error": "failed to issue github token"})
+		}
+	}
+	// The token is a short-lived secret. Prevent any intermediary from caching it
+	// (HTTP caches, proxies, browsers) with Cache-Control: no-store on every token
+	// response so the credential is never persisted or replayed from a cache.
+	c.Response().Header().Set("Cache-Control", "no-store")
+
+	if issuedToken == "" {
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "failed to issue github token"})
+	}
+
+	// format=raw returns the bare token as text/plain for simple in-Pod shell
+	// helpers (curl capture). The default is JSON.
+	if c.QueryParam("format") == "raw" {
+		return c.Blob(http.StatusOK, "text/plain; charset=utf-8", []byte(issuedToken))
+	}
+
+	expiresStr := ""
+	if !expiresAt.IsZero() {
+		expiresStr = expiresAt.UTC().Format(time.RFC3339)
+	}
+	return c.JSON(http.StatusOK, githubTokenResponse{Token: issuedToken, ExpiresAt: expiresStr})
+}
+
+// bearerToken extracts a Bearer token from the Authorization header.
+func bearerToken(c echo.Context) string {
+	h := c.Request().Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(h, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(h, prefix)
+}

--- a/internal/interfaces/controllers/github_token_controller_test.go
+++ b/internal/interfaces/controllers/github_token_controller_test.go
@@ -1,0 +1,247 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// newMockContext builds an echo.Context whose path param :sessionId is set, so the
+// controller can read c.Param("sessionId") without a real router.
+func newMockContext(rec *httptest.ResponseRecorder, r *http.Request) echo.Context {
+	e := echo.New()
+	c := e.NewContext(r, rec)
+	c.SetPath("/internal/sessions/:sessionId/github-token")
+	c.SetParamNames("sessionId")
+	c.SetParamValues("sess-A")
+	return c
+}
+
+// fakeBroker implements GitHubTokenBrokerService for tests.
+type fakeBroker struct {
+	validToken   string // the broker credential that should validate for "sess-A"
+	issuedToken  string
+	expiresAt    time.Time
+	issueErr     error
+	lastRequest  string
+	validateFunc func(sessionID, token string) bool
+}
+
+func (f *fakeBroker) ValidateGitHubBrokerToken(sessionID, token string) bool {
+	if f.validateFunc != nil {
+		return f.validateFunc(sessionID, token)
+	}
+	return f.validToken != "" && sessionID == "sess-A" && token == f.validToken
+}
+
+func (f *fakeBroker) IssueGitHubToken(sessionID, requestedRepo string) (string, time.Time, error) {
+	f.lastRequest = requestedRepo
+	if f.issueErr != nil {
+		return "", time.Time{}, f.issueErr
+	}
+	return f.issuedToken, f.expiresAt, nil
+}
+
+func newBrokerRequest(t *testing.T, method, target, token, body string) *http.Request {
+	t.Helper()
+	var r *http.Request
+	var err error
+	if body != "" {
+		r, err = http.NewRequest(method, target, strings.NewReader(body))
+	} else {
+		r, err = http.NewRequest(method, target, nil)
+	}
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	return r
+}
+
+func TestGitHubTokenController_IssueToken_Success(t *testing.T) {
+	exp := time.Now().Add(1 * time.Hour).UTC()
+	b := &fakeBroker{validToken: "tok-A", issuedToken: "ghs_issued", expiresAt: exp}
+	ctl := NewGitHubTokenController(b)
+
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-A", `{"repository":"octo/repo"}`))
+
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp githubTokenResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v body=%s", err, rec.Body.String())
+	}
+	if resp.Token != "ghs_issued" {
+		t.Fatalf("token = %q", resp.Token)
+	}
+	if resp.ExpiresAt == "" {
+		t.Fatalf("expires_at should be set")
+	}
+	if b.lastRequest != "octo/repo" {
+		t.Fatalf("broker received repo %q, want octo/repo", b.lastRequest)
+	}
+}
+
+func TestGitHubTokenController_IssueToken_RawFormat(t *testing.T) {
+	b := &fakeBroker{validToken: "tok-A", issuedToken: "ghs_raw", expiresAt: time.Now().Add(time.Hour)}
+	ctl := NewGitHubTokenController(b)
+
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token?format=raw", "tok-A", ""))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "ghs_raw" {
+		t.Fatalf("raw body = %q, want ghs_raw", rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("content-type = %q, want text/plain", ct)
+	}
+}
+
+func TestGitHubTokenController_IssueToken_Unauthorized(t *testing.T) {
+	b := &fakeBroker{validToken: "tok-A", issuedToken: "ghs_x"}
+	ctl := NewGitHubTokenController(b)
+
+	// No auth header.
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "", ""))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: status = %d, want 401", rec.Code)
+	}
+
+	// Wrong token (e.g. session B's credential used against session A).
+	rec2 := httptest.NewRecorder()
+	c2 := newMockContext(rec2, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-for-B", ""))
+	if err := ctl.IssueToken(c2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec2.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token: status = %d, want 401", rec2.Code)
+	}
+
+	// Body must not contain the token (no leak).
+	if strings.Contains(rec2.Body.String(), "ghs_x") {
+		t.Fatalf("401 body must not leak token: %s", rec2.Body.String())
+	}
+}
+
+func TestGitHubTokenController_IssueToken_ScopeMismatch(t *testing.T) {
+	b := &fakeBroker{
+		validToken: "tok-A",
+		issueErr:   errString("repository scope mismatch"),
+	}
+	ctl := NewGitHubTokenController(b)
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-A", `{"repository":"octo/other"}`))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("scope mismatch: status = %d, want 403", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "octo/other") {
+		t.Fatalf("403 body must not echo the requested repo")
+	}
+}
+
+func TestGitHubTokenController_IssueToken_SessionNotFound(t *testing.T) {
+	b := &fakeBroker{validToken: "tok-A", issueErr: errString("session not found")}
+	ctl := NewGitHubTokenController(b)
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-A", ""))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("not found: status = %d, want 404", rec.Code)
+	}
+}
+
+func TestGitHubTokenController_IssueToken_IssuanceFailureSanitized(t *testing.T) {
+	b := &fakeBroker{
+		validToken: "tok-A",
+		// An issuance error that would contain secret material if propagated.
+		issueErr: errString("failed to issue token: ghs_secret -----BEGIN PRIVATE KEY-----"),
+	}
+	ctl := NewGitHubTokenController(b)
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-A", ""))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("issuance failure: status = %d, want 502", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "ghs_secret") || strings.Contains(body, "PRIVATE KEY") {
+		t.Fatalf("502 body must not leak secret material: %s", body)
+	}
+}
+
+func TestGitHubTokenController_IssueToken_BrokerUnavailable(t *testing.T) {
+	// No broker configured -> controller returns 503.
+	ctl := NewGitHubTokenController(nil)
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-A", ""))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("nil broker: status = %d, want 503", rec.Code)
+	}
+}
+
+// errString is a simple error wrapping a string.
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// TestGitHubTokenController_IssueToken_CacheControlNoStore verifies that both the
+// JSON and raw responses carry Cache-Control: no-store so the short-lived token
+// is never cached/replayed by an intermediary.
+func TestGitHubTokenController_IssueToken_CacheControlNoStore(t *testing.T) {
+	b := &fakeBroker{validToken: "tok-A", issuedToken: "ghs_issued", expiresAt: time.Now().Add(time.Hour)}
+	ctl := NewGitHubTokenController(b)
+
+	// JSON response.
+	rec := httptest.NewRecorder()
+	c := newMockContext(rec, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token", "tok-A", `{"repository":"octo/repo"}`))
+	if err := ctl.IssueToken(c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("JSON response Cache-Control = %q, want no-store", cc)
+	}
+
+	// Raw response.
+	rec2 := httptest.NewRecorder()
+	c2 := newMockContext(rec2, newBrokerRequest(t, http.MethodPost, "/internal/sessions/sess-A/github-token?format=raw", "tok-A", ""))
+	if err := ctl.IssueToken(c2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc := rec2.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("raw response Cache-Control = %q, want no-store", cc)
+	}
+}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -53,7 +53,7 @@ var piSettingsPath = "/home/agentapi/.pi/agent/settings.json"
 //
 // Sequence:
 //  1. Write received settings to a temp YAML file
-//  2. Run sessionsettings.Setup() (write-pem, clone-repo, compile, sync-extra)
+//  2. Run sessionsettings.Setup() (clone-repo, compile, sync-extra)
 //  3. Load the generated session env file
 //  4. Fetch memory from the proxy and inject into CLAUDE.md
 //  5. cd into the cloned repo if present

--- a/pkg/sessionsettings/github_broker_setup.go
+++ b/pkg/sessionsettings/github_broker_setup.go
@@ -1,0 +1,290 @@
+package sessionsettings
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Session bin / helper paths used by the broker-based GitHub auth setup.
+const (
+	sessionBinDir     = "/home/agentapi/.session/bin"
+	ghWrapperPath     = "/home/agentapi/.session/bin/gh"
+	gitCredentialPath = "/home/agentapi/.session/git-credential-broker"
+)
+
+// safePathRe restricts the real gh path to characters that are safe to embed
+// inside a double-quoted shell assignment. It rejects quotes, dollar signs,
+// backticks, backslashes, spaces and other shell metacharacters so the path
+// cannot break out of the wrapper script's REAL="..." assignment or inject
+// commands. exec.LookPath normally returns simple absolute paths
+// (e.g. /usr/local/bin/gh); anything else is treated as unsafe and aborts setup.
+var safePathRe = regexp.MustCompile(`^[A-Za-z0-9_./-]+$`)
+
+// isShellSafeAbsPath reports whether p is an absolute path containing only
+// shell-safe characters, so it can be embedded verbatim into the wrapper script.
+func isShellSafeAbsPath(p string) bool {
+	if !filepath.IsAbs(p) {
+		return false
+	}
+	return safePathRe.MatchString(p)
+}
+
+// setupGitHubBrokerAuth installs the broker-backed git credential helper and gh
+// wrapper into the session container using the broker endpoint + session-scoped
+// credential provided in the session env (AGENTAPI_GITHUB_BROKER_URL /
+// AGENTAPI_GITHUB_BROKER_TOKEN). It does NOT read any GitHub App PEM or generate an
+// installation token: tokens are fetched from the proxy broker on demand.
+//
+// Return contract:
+//   - ("", nil): the broker env vars are absent. The caller uses the legacy
+//     gh-based setup (personal token / no-auth sessions).
+//   - (dir, nil): the broker is active; dir is the bin directory to prepend to
+//     PATH so the agent's `gh` invocations route through the wrapper.
+//   - ("", err): the broker env vars are present but setup failed (e.g. the real
+//     gh binary could not be resolved to a safe absolute path, or a helper script
+//     could not be written/configured). The caller MUST abort clone/setup with
+//     this error — it must NOT fall back to the legacy path, because a broker
+//     session has no GitHub App PEM or token available in-Pod and a silent
+//     fallback would create an unauthenticated or mis-authenticated session.
+//
+// This strict contract means a broker session either installs working in-Pod
+// helpers or fails loudly; it never degrades to legacy auth.
+func setupGitHubBrokerAuth(env map[string]string) (pathPrefix string, err error) {
+	brokerURL := strings.TrimSpace(env["AGENTAPI_GITHUB_BROKER_URL"])
+	brokerToken := strings.TrimSpace(env["AGENTAPI_GITHUB_BROKER_TOKEN"])
+	if brokerURL == "" || brokerToken == "" {
+		// No broker configured: caller uses the legacy path.
+		return "", nil
+	}
+
+	if err := os.MkdirAll(sessionBinDir, 0755); err != nil {
+		return "", fmt.Errorf("create session bin dir %s: %w", sessionBinDir, err)
+	}
+
+	// Resolve the real gh binary path BEFORE installing the wrapper, so the
+	// wrapper can exec it directly and avoid recursion. The path MUST resolve to
+	// a safe absolute path; otherwise we do not install the wrapper, because
+	// falling back to a bare "gh" would re-resolve to the wrapper itself once its
+	// directory is prepended to PATH, causing infinite recursion.
+	realGH, err := exec.LookPath("gh")
+	if err != nil {
+		return "", fmt.Errorf("gh CLI not found on PATH; cannot install broker gh wrapper")
+	}
+	if realGH, err = filepath.Abs(realGH); err != nil {
+		return "", fmt.Errorf("resolve real gh path: %w", err)
+	}
+	if !isShellSafeAbsPath(realGH) {
+		// Refuse to embed an unsafe path into the wrapper script.
+		return "", fmt.Errorf("resolved gh path %q is not a shell-safe absolute path", realGH)
+	}
+
+	if err := writeGHWrapper(ghWrapperPath, realGH); err != nil {
+		return "", fmt.Errorf("install gh wrapper: %w", err)
+	}
+
+	if err := writeGitCredentialHelper(gitCredentialPath); err != nil {
+		return "", fmt.Errorf("install git credential helper: %w", err)
+	}
+
+	// Configure git to use ONLY the broker credential helper for github.com and
+	// the GitHub Enterprise host (if configured). The existing host helper chain
+	// is reset first so no other helper (or interactive prompt) can supply
+	// credentials for the session repository. The helper is referenced by absolute
+	// path so git invokes it directly (no PATH lookup that could resolve a
+	// malicious earlier PATH entry).
+	if err := configureGitCredentialHelper(gitCredentialPath); err != nil {
+		return "", fmt.Errorf("configure git credential helper: %w", err)
+	}
+
+	log.Printf("[SETUP] GitHub token broker active; installed gh wrapper (%s) + git credential helper (%s)", realGH, gitCredentialPath)
+	return sessionBinDir, nil
+}
+
+// writeGHWrapper writes the gh wrapper script. The wrapper fetches a fresh token
+// from the broker for each invocation and runs the real gh with GH_TOKEN set for
+// that process only. The token is passed via environment, never via args or
+// stdout. A recursion guard (AGENTAPI_GH_WRAPPER_ACTIVE) prevents re-entry when the
+// real gh shells out to `gh`.
+//
+// realGH must be a validated shell-safe absolute path (see isShellSafeAbsPath); it
+// is embedded as the default for AGENTAPI_GH_REAL_PATH so the wrapper can exec the
+// real gh directly even after the wrapper directory is prepended to PATH.
+func writeGHWrapper(path, realGH string) error {
+	if !isShellSafeAbsPath(realGH) {
+		return fmt.Errorf("refuse to write wrapper with unsafe real gh path %q", realGH)
+	}
+	script := fmt.Sprintf(`#!/bin/sh
+# agentapi-proxy gh wrapper: fetch a short-lived GitHub token from the broker and
+# run the real gh CLI with GH_TOKEN set for this invocation only.
+# The token is never printed, never placed on the command line, and never persisted.
+set -eu
+
+# Absolute path of the real gh, resolved before the wrapper dir was prepended to
+# PATH. Embedding it here (and exec'ing it directly) is what makes the wrapper
+# recursion-safe: it never re-resolves "gh" through PATH.
+REAL="${AGENTAPI_GH_REAL_PATH:-%s}"
+BROKER_URL="${AGENTAPI_GITHUB_BROKER_URL:-}"
+BROKER_TOKEN="${AGENTAPI_GITHUB_BROKER_TOKEN:-}"
+
+# The real gh path must always be a non-empty absolute path; refuse to exec a
+# bare "gh" (which would re-resolve to this wrapper and recurse infinitely).
+case "$REAL" in
+  /*) ;;
+  *) echo "gh: real gh path not configured or not absolute: $REAL" >&2; exit 1 ;;
+esac
+
+# Recursion guard: if we are already inside the wrapper, exec the real gh directly.
+if [ -n "${AGENTAPI_GH_WRAPPER_ACTIVE:-}" ]; then
+  exec "$REAL" "$@"
+fi
+
+# Without broker configuration we cannot mint a token. A broker session has no
+# PEM/token in-Pod, so fail loudly rather than silently running gh unauthenticated.
+if [ -z "$BROKER_URL" ] || [ -z "$BROKER_TOKEN" ]; then
+  echo "gh: GitHub token broker is not configured" >&2
+  exit 1
+fi
+
+token=$(curl -fsS -H "Authorization: Bearer $BROKER_TOKEN" "$BROKER_URL?format=raw") || {
+  echo "gh: failed to obtain GitHub token from broker" >&2
+  exit 1
+}
+[ -n "$token" ] || { echo "gh: broker returned an empty token" >&2; exit 1; }
+export AGENTAPI_GH_WRAPPER_ACTIVE=1
+export GH_TOKEN="$token"
+unset GITHUB_TOKEN 2>/dev/null || true
+exec "$REAL" "$@"
+`, realGH)
+	return os.WriteFile(path, []byte(script), 0755)
+}
+
+// writeGitCredentialHelper writes the git credential helper backed by the broker.
+//
+// git credential protocol:
+//   - get  : git requests credentials for a URL; the helper reads the request
+//     attributes from stdin and prints username/password to stdout for git
+//     to consume (over a pipe, never to the terminal). The helper fetches a
+//     fresh token from the broker scoped to the session repository.
+//   - store: git asks to persist credentials; the helper is a no-op so tokens are
+//     never written to disk.
+//   - erase : git asks to drop cached credentials; also a no-op.
+//
+// On broker failure the helper prints a diagnostic to stderr and exits non-zero
+// so the operation is reported as failed rather than silently succeeding and
+// falling through to another helper or an interactive prompt. The host helper
+// chain is reset to ONLY this helper by configureGitCredentialHelper, so there is
+// no other helper to fall through to.
+func writeGitCredentialHelper(path string) error {
+	script := `#!/bin/sh
+# agentapi-proxy git credential helper backed by the GitHub token broker.
+# get   : fetch a fresh installation token from the broker for git to consume.
+# store : no-op — tokens are never persisted to disk.
+# erase : no-op — tokens are never persisted to disk.
+set -eu
+op="$1"
+BROKER_URL="${AGENTAPI_GITHUB_BROKER_URL:-}"
+BROKER_TOKEN="${AGENTAPI_GITHUB_BROKER_TOKEN:-}"
+case "$op" in
+  get)
+    if [ -z "$BROKER_URL" ] || [ -z "$BROKER_TOKEN" ]; then
+      echo "git-credential-broker: broker is not configured" >&2
+      exit 1
+    fi
+    token=$(curl -fsS -H "Authorization: Bearer $BROKER_TOKEN" "$BROKER_URL?format=raw") || {
+      echo "git-credential-broker: failed to obtain GitHub token from broker" >&2
+      exit 1
+    }
+    [ -n "$token" ] || { echo "git-credential-broker: broker returned an empty token" >&2; exit 1; }
+    printf 'username=x-access-token\n'
+    printf 'password=%s\n' "$token"
+    ;;
+  store|erase)
+    : # never persist
+    ;;
+esac
+`
+	return os.WriteFile(path, []byte(script), 0755)
+}
+
+// configureGitCredentialHelper registers the broker helper as the ONLY credential
+// helper for github.com and the GitHub Enterprise host (when GITHUB_API is set).
+//
+// For each host it first clears any previously-configured helpers for that host
+// (including inherited ones) by writing an empty helper entry, then adds the
+// broker helper. This prevents an existing helper chain (e.g. a cache or store
+// helper, or an interactive prompt) from supplying stale or unrelated credentials
+// for the session repository. The helper is referenced by absolute path so git
+// invokes it directly (no PATH lookup).
+func configureGitCredentialHelper(helperPath string) error {
+	hosts := []string{"github.com"}
+	if host := githubEnterpriseHost(); host != "" && host != "github.com" {
+		hosts = append(hosts, host)
+	}
+	for _, host := range hosts {
+		key := fmt.Sprintf("credential.https://%s.helper", host)
+		// Reset the host helper chain to a single empty entry. In git's credential
+		// helper protocol an empty helper name tells git to discard all helpers
+		// configured so far for this URL (including those inherited from the global
+		// credential.helper), so no other helper or interactive prompt can supply
+		// credentials for the session repository.
+		if err := gitConfigGlobal(key, ""); err != nil {
+			return fmt.Errorf("reset %s: %w", key, err)
+		}
+		// Append the broker helper as the only effective helper for this host.
+		if err := gitConfigGlobalAdd(key, helperPath); err != nil {
+			return fmt.Errorf("set broker helper for %s: %w", host, err)
+		}
+	}
+	return nil
+}
+
+func githubEnterpriseHost() string {
+	// Only treat an explicitly-configured, non-default GITHUB_API as an
+	// enterprise host. The default api.github.com is handled via the hardcoded
+	// "github.com" credential helper key and must not produce a separate host.
+	apiBase := strings.TrimSpace(os.Getenv("GITHUB_API"))
+	if apiBase == "" || strings.Contains(apiBase, "api.github.com") {
+		return ""
+	}
+	host := strings.TrimPrefix(apiBase, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimSuffix(host, "/api/v3")
+	host = strings.TrimSuffix(host, "/")
+	if i := strings.IndexByte(host, '/'); i >= 0 {
+		host = host[:i]
+	}
+	return host
+}
+
+func gitConfigGlobal(key, value string) error {
+	cmd := exec.Command("git", "config", "--global", key, value)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git config %s failed: %w: %s", key, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// gitConfigGlobalAdd appends a value to a multi-valued git config key.
+func gitConfigGlobalAdd(key, value string) error {
+	cmd := exec.Command("git", "config", "--global", "--add", key, value)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git config --add %s failed: %w: %s", key, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// prependToPath returns PATH with dir prepended if not already present.
+func prependToPath(dir, currentPath string) string {
+	if dir == "" {
+		return currentPath
+	}
+	if currentPath == "" {
+		return dir
+	}
+	return dir + string(os.PathListSeparator) + currentPath
+}

--- a/pkg/sessionsettings/github_broker_setup_test.go
+++ b/pkg/sessionsettings/github_broker_setup_test.go
@@ -1,0 +1,428 @@
+package sessionsettings
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestWriteGHWrapper_TokenNeverInArgsOrScriptLiteral(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gh")
+	if err := writeGHWrapper(path, "/usr/bin/gh"); err != nil {
+		t.Fatalf("writeGHWrapper: %v", err)
+	}
+	script, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read wrapper: %v", err)
+	}
+	s := string(script)
+
+	// The wrapper must not hardcode any token/PEM literal.
+	for _, forbidden := range []string{"ghs_", "ghp_", "-----BEGIN PRIVATE KEY-----", "GITHUB_APP_PEM"} {
+		if strings.Contains(s, forbidden) {
+			t.Fatalf("wrapper script must not embed secret literal %q:\n%s", forbidden, s)
+		}
+	}
+	// Token must be passed via GH_TOKEN env, never as a command-line arg.
+	if !strings.Contains(s, "export GH_TOKEN=") {
+		t.Fatalf("wrapper must export GH_TOKEN, script:\n%s", s)
+	}
+	// The real gh path must be the resolved absolute path (recursion-safe).
+	if !strings.Contains(s, "/usr/bin/gh") {
+		t.Fatalf("wrapper must reference the resolved real gh path, script:\n%s", s)
+	}
+	// Recursion guard must be present.
+	if !strings.Contains(s, "AGENTAPI_GH_WRAPPER_ACTIVE") {
+		t.Fatalf("wrapper must include a recursion guard, script:\n%s", s)
+	}
+	// exec, not shell expansion of token into args.
+	if !strings.Contains(s, `exec "$REAL" "$@"`) {
+		t.Fatalf("wrapper must exec real gh with forwarded args (no token in args), script:\n%s", s)
+	}
+	// The wrapper must unset GITHUB_TOKEN so a stale env token is not used.
+	if !strings.Contains(s, "unset GITHUB_TOKEN") {
+		t.Fatalf("wrapper must unset GITHUB_TOKEN, script:\n%s", s)
+	}
+	// The wrapper must validate REAL is absolute before exec, so a bare "gh"
+	// (which would re-resolve to the wrapper) is never exec'd.
+	if !strings.Contains(s, `case "$REAL" in`) || !strings.Contains(s, "/*) ;;") {
+		t.Fatalf("wrapper must assert REAL is an absolute path, script:\n%s", s)
+	}
+}
+
+// TestWriteGHWrapper_RejectsUnsafePath verifies that writeGHWrapper refuses to
+// embed a real gh path containing shell metacharacters (which could break out of
+// the REAL="..." assignment or inject commands), and accepts a safe absolute path.
+func TestWriteGHWrapper_RejectsUnsafePath(t *testing.T) {
+	dir := t.TempDir()
+	unsafe := []string{
+		`/usr/bin/gh"; rm -rf /`,     // quote injection
+		`/usr/bin/$(whoami)`,         // command substitution
+		`/usr/bin/` + "`id`" + `/gh`, // backtick command substitution
+		`/usr/bin/gh\ with\ space`,   // backslash escapes
+		`/usr/bin/$HOME/gh`,          // variable expansion
+		`relative/gh`,                // not absolute
+	}
+	for _, p := range unsafe {
+		if err := writeGHWrapper(filepath.Join(dir, "gh-bad"), p); err == nil {
+			t.Fatalf("writeGHWrapper must reject unsafe path %q", p)
+		}
+	}
+	// A safe absolute path succeeds.
+	if err := writeGHWrapper(filepath.Join(dir, "gh-ok"), "/usr/local/bin/gh"); err != nil {
+		t.Fatalf("writeGHWrapper safe path failed: %v", err)
+	}
+}
+
+func TestWriteGitCredentialHelper_StoreEraseNoop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cred")
+	if err := writeGitCredentialHelper(path); err != nil {
+		t.Fatalf("writeGitCredentialHelper: %v", err)
+	}
+	script, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read helper: %v", err)
+	}
+	s := string(script)
+
+	// store/erase must be no-ops (never persist tokens).
+	if !strings.Contains(s, "store|erase") {
+		t.Fatalf("helper must handle store|erase, script:\n%s", s)
+	}
+	if strings.Contains(s, "GITHUB_APP_PEM") || strings.Contains(s, "-----BEGIN PRIVATE KEY-----") {
+		t.Fatalf("helper must not reference PEM material, script:\n%s", s)
+	}
+	// get must output username/password via the git credential protocol, not echo
+	// the token to the terminal. It uses printf to stdout (consumed by git over pipe).
+	if !strings.Contains(s, "username=x-access-token") {
+		t.Fatalf("helper get must emit username, script:\n%s", s)
+	}
+	if !strings.Contains(s, `printf 'password=%s\n' "$token"`) {
+		t.Fatalf("helper get must emit password via git protocol, script:\n%s", s)
+	}
+	// On broker failure the helper must exit non-zero (no silent fallthrough).
+	if !strings.Contains(s, "exit 1") {
+		t.Fatalf("helper get must exit non-zero on broker failure, script:\n%s", s)
+	}
+	// The helper must not suppress curl errors with 2>/dev/null.
+	if strings.Contains(s, "2>/dev/null") {
+		t.Fatalf("helper must not hide broker errors, script:\n%s", s)
+	}
+}
+
+// TestSetupGitHubBrokerAuth_NoopWithoutBrokerEnv verifies that with no broker env,
+// setup is a no-op returning ("", nil) so the caller uses the legacy path.
+func TestSetupGitHubBrokerAuth_NoopWithoutBrokerEnv(t *testing.T) {
+	origPath := os.Getenv("PATH")
+	prefix, err := setupGitHubBrokerAuth(map[string]string{})
+	if err != nil {
+		t.Fatalf("expected nil error when broker env is absent, got %v", err)
+	}
+	if prefix != "" {
+		t.Fatalf("expected empty prefix when broker env is absent, got %q", prefix)
+	}
+	if os.Getenv("PATH") != origPath {
+		t.Fatalf("PATH must not be modified when broker env is absent")
+	}
+}
+
+// TestSetupGitHubBrokerAuth_AbortsWhenRealGHMissing verifies that when the broker
+// env is present but the real gh binary cannot be resolved, setup returns an
+// error (NOT ok) so the caller aborts clone/setup instead of silently falling
+// back to legacy auth. A broker session has no PEM/token in-Pod, so a silent
+// fallback would create an unauthenticated session.
+func TestSetupGitHubBrokerAuth_AbortsWhenRealGHMissing(t *testing.T) {
+	// Broker env present.
+	env := map[string]string{
+		"AGENTAPI_GITHUB_BROKER_URL":   "http://proxy/internal/sessions/sess/github-token",
+		"AGENTAPI_GITHUB_BROKER_TOKEN": "broker-token",
+	}
+	// Force exec.LookPath("gh") to fail by emptying PATH (no gh resolvable).
+	t.Setenv("PATH", "")
+	// Restore a PATH without gh afterwards; here we just rely on empty PATH.
+	prefix, err := setupGitHubBrokerAuth(env)
+	if err == nil {
+		t.Fatalf("expected error when real gh cannot be resolved, got prefix=%q", prefix)
+	}
+	if prefix != "" {
+		t.Fatalf("prefix must be empty on failure, got %q", prefix)
+	}
+	if !strings.Contains(err.Error(), "gh") {
+		t.Fatalf("error should mention gh resolution failure, got: %v", err)
+	}
+	// The wrapper must NOT have been installed (no silent partial setup).
+	if _, statErr := os.Stat(ghWrapperPath); statErr == nil {
+		t.Fatalf("wrapper must not be installed when real gh is missing")
+	}
+}
+
+// TestSetupGitHubBrokerAuth_AbortsOnUnsafeGHPath verifies that when the resolved
+// gh path is not shell-safe, setup aborts with an error (no wrapper installed).
+func TestSetupGitHubBrokerAuth_AbortsOnUnsafeGHPath(t *testing.T) {
+	// This is covered indirectly by TestWriteGHWrapper_RejectsUnsafePath and
+	// TestIsShellSafeAbsPath; the integration path requires a real gh binary with
+	// an unsafe name which is impractical to fabricate. Keep the unit coverage.
+	t.Skip("requires a real gh binary with an unsafe name; covered by unit tests")
+}
+
+func TestPrependToPath(t *testing.T) {
+	if got := prependToPath("/bin/x", "/usr/bin:/bin"); got != "/bin/x:/usr/bin:/bin" {
+		t.Fatalf("prependToPath = %q", got)
+	}
+	if got := prependToPath("", "/usr/bin"); got != "/usr/bin" {
+		t.Fatalf("prependToPath empty dir = %q", got)
+	}
+	if got := prependToPath("/bin/x", ""); got != "/bin/x" {
+		t.Fatalf("prependToPath empty path = %q", got)
+	}
+}
+
+func TestIsShellSafeAbsPath(t *testing.T) {
+	good := []string{"/usr/bin/gh", "/usr/local/bin/gh", "/opt/gh-2.40/bin/gh"}
+	for _, p := range good {
+		if !isShellSafeAbsPath(p) {
+			t.Fatalf("expected safe: %q", p)
+		}
+	}
+	bad := []string{
+		"gh", "relative/gh",
+		"/usr/bin/gh;", "/usr/bin/gh\"x", "/usr/bin/$(id)",
+		"/usr/bin/`id`", "/usr/bin/$HOME/gh", "/usr/bin/gh\\ x",
+		"/usr/bin/gh with space", "/usr/bin/gh|cat",
+	}
+	for _, p := range bad {
+		if isShellSafeAbsPath(p) {
+			t.Fatalf("expected unsafe: %q", p)
+		}
+	}
+}
+
+func TestGitHubEnterpriseHost(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "unset", env: "", want: ""},
+		{name: "github.com default", env: "https://api.github.com", want: ""},
+		{name: "enterprise with api/v3", env: "https://ghe.example.com/api/v3", want: "ghe.example.com"},
+		{name: "enterprise trailing slash", env: "https://ghe.example.com/api/v3/", want: "ghe.example.com"},
+		{name: "enterprise with path stripped", env: "https://ghe.example.com/api/v3/some/extra", want: "ghe.example.com"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("GITHUB_API", c.env)
+			if got := githubEnterpriseHost(); got != c.want {
+				t.Fatalf("githubEnterpriseHost() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestSafePathRe ensures the regex covers the documented safe charset.
+func TestSafePathRe(t *testing.T) {
+	if !safePathRe.MatchString("/usr/local/bin/gh") {
+		t.Fatal("regex should match safe path")
+	}
+	for _, bad := range []string{`"`, "$", "`", "\\", " ", ";", "|", "&", "(", ")"} {
+		if safePathRe.MatchString(bad) {
+			t.Fatalf("regex must reject %q", bad)
+		}
+	}
+	// compile-time sanity that the regex is anchored.
+	if safePathRe.MatchString("safe") && safePathRe.String() == "" {
+		t.Fatal("regex unexpectedly empty")
+	}
+	_ = regexp.MustCompile(`^[A-Za-z0-9_./-]+$`)
+}
+
+// runHelper executes the git credential helper script with the given op and env,
+// returning stdout, stderr and the exit code.
+func runHelper(t *testing.T, scriptPath, op string, env map[string]string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", scriptPath, op)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	cmd.Env = append(cmd.Env, "PATH="+os.Getenv("PATH"))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+		} else {
+			t.Fatalf("run helper: %v", err)
+		}
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+// TestGitCredentialHelper_Execution verifies the helper behaves correctly when
+// actually executed by /bin/sh:
+//   - store/erase exit 0 with no output (never persist),
+//   - get with no broker env exits non-zero (no silent success),
+//   - get with an unreachable broker exits non-zero (no silent fallback),
+//   - get against a stub broker returns the git credential protocol payload.
+func TestGitCredentialHelper_Execution(t *testing.T) {
+	dir := t.TempDir()
+	helper := filepath.Join(dir, "git-credential-broker")
+	if err := writeGitCredentialHelper(helper); err != nil {
+		t.Fatalf("writeGitCredentialHelper: %v", err)
+	}
+
+	// store/erase are no-ops that exit 0 with no output.
+	for _, op := range []string{"store", "erase"} {
+		out, errOut, code := runHelper(t, helper, op, nil)
+		if code != 0 {
+			t.Fatalf("%s: exit=%d, want 0", op, code)
+		}
+		if out != "" || errOut != "" {
+			t.Fatalf("%s: must produce no output, got stdout=%q stderr=%q", op, out, errOut)
+		}
+	}
+
+	// get with no broker env must exit non-zero (no silent fallthrough).
+	out, errOut, code := runHelper(t, helper, "get", nil)
+	if code == 0 {
+		t.Fatalf("get with no broker env must fail, got exit=0 stdout=%q", out)
+	}
+	if strings.Contains(out, "password=") {
+		t.Fatalf("get with no broker env must not emit credentials, got %q", out)
+	}
+	if !strings.Contains(errOut, "broker") {
+		t.Fatalf("get with no broker env should log a diagnostic, got stderr=%q", errOut)
+	}
+
+	// get against an unreachable broker must exit non-zero (no silent fallback).
+	out, _, code = runHelper(t, helper, "get", map[string]string{
+		"AGENTAPI_GITHUB_BROKER_URL":   "http://127.0.0.1:1/no-such-broker",
+		"AGENTAPI_GITHUB_BROKER_TOKEN": "tok",
+	})
+	if code == 0 {
+		t.Fatalf("get with unreachable broker must fail, got exit=0 stdout=%q", out)
+	}
+	if strings.Contains(out, "password=") {
+		t.Fatalf("get with unreachable broker must not emit credentials, got %q", out)
+	}
+
+	// get against a stub broker returns the git credential protocol payload.
+	stub := stubBroker(t, "ghs_stub_token")
+	out, _, code = runHelper(t, helper, "get", map[string]string{
+		"AGENTAPI_GITHUB_BROKER_URL":   stub,
+		"AGENTAPI_GITHUB_BROKER_TOKEN": "tok",
+	})
+	if code != 0 {
+		t.Fatalf("get with stub broker: exit=%d, want 0", code)
+	}
+	if !strings.Contains(out, "username=x-access-token") || !strings.Contains(out, "password=ghs_stub_token") {
+		t.Fatalf("get with stub broker: unexpected output %q", out)
+	}
+}
+
+// TestGHWrapper_Execution verifies the wrapper script behaves correctly when
+// executed by /bin/sh:
+//   - with no broker env it refuses to run (exit 1), no real gh needed,
+//   - the recursion guard exec's a stand-in "real gh" and forwards args/env.
+func TestGHWrapper_Execution(t *testing.T) {
+	dir := t.TempDir()
+	// A stand-in "real gh" that prints its args and GH_TOKEN so we can assert the
+	// wrapper passes the token via env and forwards args.
+	realGH := filepath.Join(dir, "real-gh")
+	if err := os.WriteFile(realGH, []byte("#!/bin/sh\necho \"ARGS:$*\"\necho \"GH_TOKEN:${GH_TOKEN:-}\"\n"), 0755); err != nil {
+		t.Fatalf("write real gh: %v", err)
+	}
+	wrapper := filepath.Join(dir, "gh")
+	if err := writeGHWrapper(wrapper, realGH); err != nil {
+		t.Fatalf("writeGHWrapper: %v", err)
+	}
+
+	// With no broker env the wrapper must refuse (exit 1), even though a real gh
+	// path is configured. A broker session has no in-Pod token, so it must not
+	// silently run unauthenticated.
+	out, errOut, code := runHelper(t, wrapper, "", nil)
+	_ = out
+	if code == 0 {
+		t.Fatalf("wrapper with no broker env must fail, got exit=0")
+	}
+	if !strings.Contains(errOut, "broker") {
+		t.Fatalf("wrapper with no broker env should log a diagnostic, got stderr=%q", errOut)
+	}
+
+	// With a stub broker the wrapper fetches a token and exec's the real gh with
+	// GH_TOKEN set (token never in args) and args forwarded.
+	stub := stubBroker(t, "ghs_wrapper_token")
+	out, _, code = runHelper(t, wrapper, "repo view --json name", map[string]string{
+		"AGENTAPI_GITHUB_BROKER_URL":   stub,
+		"AGENTAPI_GITHUB_BROKER_TOKEN": "tok",
+	})
+	if code != 0 {
+		t.Fatalf("wrapper with stub broker: exit=%d, want 0", code)
+	}
+	if !strings.Contains(out, "ARGS:repo view --json name") {
+		t.Fatalf("wrapper must forward args to real gh, got %q", out)
+	}
+	if !strings.Contains(out, "GH_TOKEN:ghs_wrapper_token") {
+		t.Fatalf("wrapper must set GH_TOKEN for real gh, got %q", out)
+	}
+	// The token must NOT appear in the forwarded args.
+	if strings.Contains(out, "ARGS:ghs_wrapper_token") {
+		t.Fatalf("token must not leak into args, got %q", out)
+	}
+}
+
+// stubBroker starts a tiny HTTP server that responds to the broker endpoint with
+// the given raw token, and returns its URL. It is used to exercise the in-Pod
+// helper scripts end-to-end.
+func stubBroker(t *testing.T, token string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("format") != "raw" {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write([]byte(token))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return "http://" + ln.Addr().String() + "/internal/sessions/sess/github-token"
+}
+
+// TestCloneRepo_AbortsOnBrokerSetupFailure verifies that cloneRepo does NOT
+// silently fall back to legacy auth when the broker env is present but the broker
+// helpers cannot be installed (e.g. real gh missing). A broker session has no
+// in-Pod PEM/token, so cloneRepo must return the error and abort rather than
+// proceeding to an unauthenticated clone.
+func TestCloneRepo_AbortsOnBrokerSetupFailure(t *testing.T) {
+	// Broker env present but no resolvable gh on PATH -> setupGitHubBrokerAuth
+	// returns an error. cloneRepo must propagate it.
+	t.Setenv("PATH", "")
+	settings := &SessionSettings{
+		Repository: &RepositoryConfig{FullName: "octo/repo"},
+		Env: map[string]string{
+			"AGENTAPI_GITHUB_BROKER_URL":   "http://proxy/internal/sessions/sess/github-token",
+			"AGENTAPI_GITHUB_BROKER_TOKEN": "broker-token",
+		},
+	}
+	err := cloneRepo(settings)
+	if err == nil {
+		t.Fatalf("cloneRepo must abort when broker setup fails, got nil error")
+	}
+	if !strings.Contains(err.Error(), "broker") && !strings.Contains(err.Error(), "gh") {
+		t.Fatalf("cloneRepo error should reference broker/gh setup failure, got: %v", err)
+	}
+}

--- a/pkg/sessionsettings/setup.go
+++ b/pkg/sessionsettings/setup.go
@@ -36,10 +36,6 @@ type SetupOptions struct {
 	// SettingsFile is the path to the user settings.json (from claude-config-user ConfigMap).
 	// Contains marketplace and plugin configuration. Optional.
 	SettingsFile string
-
-	// PEMOutputPath is where GITHUB_APP_PEM content is written.
-	// Defaults to /tmp/github-app/app.pem.
-	PEMOutputPath string
 }
 
 // DefaultSetupOptions returns the default Setup options.
@@ -47,21 +43,20 @@ func DefaultSetupOptions() SetupOptions {
 	return SetupOptions{
 		InputPath:      "/session-settings/settings.yaml",
 		CompileOptions: DefaultCompileOptions(),
-		PEMOutputPath:  "/tmp/github-app/app.pem",
 	}
 }
 
 // Setup runs the full init-container setup sequence for a session Pod:
-//  1. write-pem  : writes GITHUB_APP_PEM env var to a file on disk
-//  2. clone-repo : clones the repository (if session.repository is set)
-//  3. compile    : generates all Claude config files from settings.yaml
-//  4. sync-extra : copies credentials, notification subscriptions
+//  1. clone-repo : clones the repository (if session.repository is set)
+//  2. compile    : generates all Claude config files from settings.yaml
+//  3. sync-extra : copies credentials, notification subscriptions
+//
+// GitHub authentication uses the short-lived GITHUB_TOKEN provided in the
+// session settings env (generated server-side by the proxy). No GitHub App
+// private key is ever present in the Pod.
 func Setup(opts SetupOptions) error {
 	if opts.InputPath == "" {
 		opts.InputPath = DefaultSetupOptions().InputPath
-	}
-	if opts.PEMOutputPath == "" {
-		opts.PEMOutputPath = DefaultSetupOptions().PEMOutputPath
 	}
 
 	log.Printf("[SETUP] Reading settings from %s", opts.InputPath)
@@ -70,30 +65,24 @@ func Setup(opts SetupOptions) error {
 		return fmt.Errorf("failed to load session settings: %w", err)
 	}
 
-	// 1. Write GitHub App PEM to disk so git/gh can use it
-	if err := writePEM(settings, opts.PEMOutputPath); err != nil {
-		// Non-fatal: not all sessions use GitHub App auth
-		log.Printf("[SETUP] Warning: write-pem skipped: %v", err)
-	}
-
-	// 2. Clone repository if configured
+	// 1. Clone repository if configured
 	if settings.Repository != nil && settings.Repository.FullName != "" {
 		if err := cloneRepo(settings); err != nil {
 			return fmt.Errorf("clone-repo failed: %w", err)
 		}
 	}
 
-	// 3. Compile settings.yaml → config files
+	// 2. Compile settings.yaml → config files
 	if err := Compile(opts.CompileOptions); err != nil {
 		return fmt.Errorf("compile failed: %w", err)
 	}
 
-	// 4. Copy credentials, CLAUDE.md, notification subscriptions
+	// 3. Copy credentials, CLAUDE.md, notification subscriptions
 	if err := syncExtra(settings, opts); err != nil {
 		return fmt.Errorf("sync-extra failed: %w", err)
 	}
 
-	// 5. Re-patch ~/.claude.json to ensure onboarding fields are set.
+	// 4. Re-patch ~/.claude.json to ensure onboarding fields are set.
 	//    The sync step (marketplace clone / plugin install) may trigger Claude
 	//    CLI which rewrites ~/.claude.json and drops bypassPermissionsModeAccepted,
 	//    causing the "Welcome to Claude Code" screen on next launch.
@@ -109,30 +98,16 @@ func Setup(opts SetupOptions) error {
 	return nil
 }
 
-// writePEM writes the GITHUB_APP_PEM value from Env to a file on disk.
-// This replaces the write-pem init container.
-func writePEM(settings *SessionSettings, pemOutputPath string) error {
-	pem := settings.Env["GITHUB_APP_PEM"]
-	if pem == "" {
-		return fmt.Errorf("GITHUB_APP_PEM is not set in session env, skipping")
-	}
-
-	pemDir := filepath.Dir(pemOutputPath)
-	if err := os.MkdirAll(pemDir, 0700); err != nil {
-		return fmt.Errorf("failed to create PEM directory: %w", err)
-	}
-
-	if err := os.WriteFile(pemOutputPath, []byte(pem), 0600); err != nil {
-		return fmt.Errorf("failed to write PEM file: %w", err)
-	}
-
-	log.Printf("[SETUP] Wrote GitHub App PEM to %s", pemOutputPath)
-	return nil
-}
-
 // cloneRepo sets up GitHub auth and clones the repository using gh repo clone
-// so that GITHUB_TOKEN / GitHub App auth and GitHub Enterprise Server host
-// routing work correctly.
+// so that broker-based GitHub authentication works.
+//
+// When the session uses the broker (AGENTAPI_GITHUB_BROKER_URL is set), the git
+// credential helper and gh wrapper are installed so git/gh fetch short-lived
+// installation tokens from the proxy on demand. No GitHub App PEM is read and no
+// installation token is generated inside the Pod.
+//
+// When the broker is not configured (personal token / no auth), the legacy
+// gh-based setup (startup.SetupGitHubAuth) is used for backward compatibility.
 func cloneRepo(settings *SessionSettings) error {
 	repo := settings.Repository
 
@@ -143,10 +118,31 @@ func cloneRepo(settings *SessionSettings) error {
 		}
 	}
 
-	log.Printf("[SETUP] Setting up GitHub auth for repo: %s", repo.FullName)
-	if err := startup.SetupGitHubAuth(repo.FullName); err != nil {
-		// Non-fatal for public repos
-		log.Printf("[SETUP] Warning: GitHub auth setup failed: %v", err)
+	// Install the broker-backed gh wrapper + git credential helper when the broker
+	// env is present. The wrapper dir is prepended to PATH so the agent's `gh`
+	// invocations route through the wrapper.
+	//
+	// A broker session has NO GitHub App PEM or token available in-Pod, so if the
+	// broker helpers cannot be installed we must abort clone/setup with the error
+	// rather than silently falling back to the legacy gh-based auth (which would
+	// create an unauthenticated or mis-authenticated session). The legacy path is
+	// only used when the broker env is entirely absent (personal token / no auth).
+	binDir, err := setupGitHubBrokerAuth(settings.Env)
+	if err != nil {
+		return fmt.Errorf("setup GitHub token broker: %w", err)
+	}
+	if binDir != "" {
+		curPath := os.Getenv("PATH")
+		if perr := os.Setenv("PATH", prependToPath(binDir, curPath)); perr != nil {
+			return fmt.Errorf("prepend session bin to PATH: %w", perr)
+		}
+		log.Printf("[SETUP] GitHub token broker active; installed gh wrapper + git credential helper (PATH+=%s)", binDir)
+	} else {
+		log.Printf("[SETUP] Setting up GitHub auth for repo via legacy gh path: %s", repo.FullName)
+		if err := startup.SetupGitHubAuth(repo.FullName); err != nil {
+			// Non-fatal for public repos
+			log.Printf("[SETUP] Warning: GitHub auth setup failed: %v", err)
+		}
 	}
 
 	cloneDir := repo.CloneDir

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v57/github"
@@ -279,9 +280,18 @@ func InitGitHubRepo(repoFullName, cloneDir string, ignoreMissingConfig bool) err
 
 // GetGitHubToken retrieves the GitHub token for authentication
 func GetGitHubToken(repoFullName string) (string, error) {
+	token, _, err := GetGitHubTokenWithExpiry(repoFullName)
+	return token, err
+}
+
+// GetGitHubTokenWithExpiry retrieves the GitHub token for authentication together
+// with its expiration time. Personal access tokens have no known expiry and
+// return a zero time. This is used by the proxy-side token broker to cache and
+// refresh GitHub App installation tokens before they expire.
+func GetGitHubTokenWithExpiry(repoFullName string) (string, time.Time, error) {
 	// Check for personal access token first
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		return token, nil
+		return token, time.Time{}, nil
 	}
 
 	// If no token available, try to use GitHub App authentication
@@ -316,16 +326,16 @@ func GetGitHubToken(repoFullName string) (string, error) {
 
 		// If we have installation ID (manual or auto-discovered), proceed with token generation
 		if installationID != "" {
-			return GenerateGitHubAppTokenForRepository(appID, installationID, pemPath, repoFullName)
+			return GenerateGitHubAppTokenForRepositoryWithExpiry(appID, installationID, pemPath, repoFullName)
 		}
 	}
 
 	// Check for GITHUB_PERSONAL_ACCESS_TOKEN as fallback
 	if token := os.Getenv("GITHUB_PERSONAL_ACCESS_TOKEN"); token != "" {
-		return token, nil
+		return token, time.Time{}, nil
 	}
 
-	return "", fmt.Errorf("no GitHub authentication found: GITHUB_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, or GitHub App credentials (GITHUB_APP_ID, GITHUB_APP_PEM_PATH) are required. GITHUB_INSTALLATION_ID is optional and will be auto-discovered if GITHUB_REPO_FULLNAME is set")
+	return "", time.Time{}, fmt.Errorf("no GitHub authentication found: GITHUB_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN, or GitHub App credentials (GITHUB_APP_ID, GITHUB_APP_PEM_PATH) are required. GITHUB_INSTALLATION_ID is optional and will be auto-discovered if GITHUB_REPO_FULLNAME is set")
 }
 
 // GenerateGitHubAppToken generates a GitHub App installation token
@@ -336,21 +346,30 @@ func GenerateGitHubAppToken(appIDStr, installationIDStr, pemPath string) (string
 // GenerateGitHubAppTokenForRepository generates a GitHub App installation token,
 // optionally restricted to a single repository.
 func GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, repoFullName string) (string, error) {
+	token, _, err := GenerateGitHubAppTokenForRepositoryWithExpiry(appIDStr, installationIDStr, pemPath, repoFullName)
+	return token, err
+}
+
+// GenerateGitHubAppTokenForRepositoryWithExpiry generates a GitHub App installation
+// token (optionally restricted to a single repository) and returns it together
+// with its expiration time. The expiration is sourced from the GitHub API response
+// and is used by the token broker cache to refresh before expiry.
+func GenerateGitHubAppTokenForRepositoryWithExpiry(appIDStr, installationIDStr, pemPath, repoFullName string) (string, time.Time, error) {
 	repositories, err := installationTokenRepositories(repoFullName)
 	if err != nil {
-		return "", err
+		return "", time.Time{}, err
 	}
 
 	// Parse app ID
 	appID, err := strconv.ParseInt(appIDStr, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid GITHUB_APP_ID: %w", err)
+		return "", time.Time{}, fmt.Errorf("invalid GITHUB_APP_ID: %w", err)
 	}
 
 	// Parse installation ID
 	installationID, err := strconv.ParseInt(installationIDStr, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid GITHUB_INSTALLATION_ID: %w", err)
+		return "", time.Time{}, fmt.Errorf("invalid GITHUB_INSTALLATION_ID: %w", err)
 	}
 
 	// Read private key - try file first, then fallback to environment variable
@@ -367,9 +386,9 @@ func GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, r
 			// より詳細なエラー情報を提供
 			fileInfo, statErr := os.Stat(pemPath)
 			if statErr != nil {
-				return "", fmt.Errorf("failed to read PEM file %s: file does not exist or is not accessible. Also checked GITHUB_APP_PEM environment variable: %w", pemPath, err)
+				return "", time.Time{}, fmt.Errorf("failed to read PEM file %s: file does not exist or is not accessible. Also checked GITHUB_APP_PEM environment variable: %w", pemPath, err)
 			}
-			return "", fmt.Errorf("failed to read PEM file %s (size: %d bytes, mode: %s). Also checked GITHUB_APP_PEM environment variable: %w",
+			return "", time.Time{}, fmt.Errorf("failed to read PEM file %s (size: %d bytes, mode: %s). Also checked GITHUB_APP_PEM environment variable: %w",
 				pemPath, fileInfo.Size(), fileInfo.Mode(), err)
 		}
 	}
@@ -377,7 +396,7 @@ func GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, r
 	// Create GitHub App transport
 	transport, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, pemData)
 	if err != nil {
-		return "", fmt.Errorf("failed to create GitHub App transport: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to create GitHub App transport: %w", err)
 	}
 
 	// Set base URL if specified (for GitHub Enterprise)
@@ -393,7 +412,7 @@ func GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, r
 		var err error
 		client, err = github.NewClient(&http.Client{Transport: transport}).WithEnterpriseURLs(githubAPI, githubAPI)
 		if err != nil {
-			return "", fmt.Errorf("failed to create GitHub Enterprise client: %w", err)
+			return "", time.Time{}, fmt.Errorf("failed to create GitHub Enterprise client: %w", err)
 		}
 	}
 
@@ -407,10 +426,10 @@ func GenerateGitHubAppTokenForRepository(appIDStr, installationIDStr, pemPath, r
 		},
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to create installation token: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to create installation token: %w", err)
 	}
 
-	return token.GetToken(), nil
+	return token.GetToken(), token.GetExpiresAt().UTC(), nil
 }
 
 func installationTokenRepositories(repoFullName string) ([]string, error) {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -259,6 +259,95 @@
         }
       }
     },
+    "/internal/sessions/{sessionId}/github-token": {
+      "post": {
+        "summary": "Issue a short-lived GitHub installation token for a session",
+        "description": "Session-scoped GitHub token broker. A session Pod presents its session-scoped broker credential (Authorization: Bearer) to obtain a short-lived GitHub App installation token, scoped to the session's repository and refreshed before expiry. GitHub App configuration (App ID, installation ID, private key PEM, repository restriction) is never exposed to the Pod; only the resulting token is returned. The credential is bound to the session ID in the path, so a token minted for one session cannot be used against another, and is not valid for any other proxy endpoint.",
+        "operationId": "issueSessionGitHubToken",
+        "tags": [
+          "GitHubTokenBroker"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "description": "Session ID the broker credential is bound to",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Response format. 'raw' returns the bare token as text/plain for simple in-Pod shell helpers; the default is JSON.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "raw"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repository": {
+                    "type": "string",
+                    "description": "Repository full name (owner/repo) to scope the token to. When present it must match the session's configured repository; otherwise the request is rejected. When omitted, the session's repository scope is used.",
+                    "example": "octo/repo"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "GitHub installation token issued",
+            "headers": {
+              "Cache-Control": {
+                "description": "no-store — the response carries a short-lived secret token that must never be cached or replayed by an intermediary.",
+                "schema": { "type": "string", "example": "no-store" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitHubTokenResponse"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "description": "The bare token (format=raw)"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid session broker credential"
+          },
+          "403": {
+            "description": "Forbidden - requested repository does not match the session's repository scope"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "502": {
+            "description": "Failed to issue GitHub token"
+          },
+          "503": {
+            "description": "GitHub token broker is not configured"
+          }
+        }
+      }
+    },
     "/sessions/status/stream": {
       "get": {
         "summary": "Stream all session status changes (SSE)",
@@ -4734,6 +4823,24 @@
   },
   "components": {
     "schemas": {
+      "GitHubTokenResponse": {
+        "type": "object",
+        "description": "A short-lived GitHub App installation token issued by the session-scoped token broker, together with its expiration time.",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Short-lived GitHub installation token scoped to the session's repository."
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Token expiration time (RFC 3339). Empty for credentials without a known expiry (e.g. personal access tokens)."
+          }
+        },
+        "required": [
+          "token"
+        ]
+      },
       "GitSyncConfigResponse": {
         "type": "object",
         "description": "Public view of GitHub sync configuration (token redacted)",
@@ -7863,6 +7970,10 @@
     {
       "name": "SessionProfiles",
       "description": "Session profile management. Named, reusable collections of session configuration that can be referenced by sessions, webhooks, schedules, and slackbots."
+    },
+    {
+      "name": "GitHubTokenBroker",
+      "description": "Session-scoped broker that issues short-lived GitHub App installation tokens to session Pods on demand, so long-running sessions keep working after a token expires without ever receiving GitHub App credentials or the private key."
     }
   ]
 }


### PR DESCRIPTION
## 概要

GitHub App の installation token 発行を agentapi-proxy サーバサイドで行い、セッション Pod には GitHub App の設定情報や private key PEM を一切マウント／注入しないようにするセキュリティ変更です。セッション Pod に渡す GitHub 認証情報は、サーバが発行した短命な installation token（`GITHUB_TOKEN`）のみになります。

## 背景 / 課題

従来は GitHub App 認証 Secret がセッション Pod の `envFrom` にマウントされ、さらにセッション設定 env にも展開されていました。その結果、`GITHUB_APP_PEM`（秘密鍵）や App ID・installation ID・repository restriction がエージェント実行環境（セッション Pod）に到達していました。

## 変更内容

- **`internal/infrastructure/services/kubernetes_session_manager.go`**
  - セッション作成時に proxy 自身の資格情報で installation token をサーバ側発行し、`GITHUB_TOKEN` のみを Pod に注入（`startup.GetGitHubToken` を利用。installation ID 自動解決・`REPOSITORY_RESTRICTION`・`GITHUB_API` を踏襲）。
  - GitHub App 認証 Secret を `envFrom` でマウントしない／Pod env に展開しない。非認証の GitHub config Secret（`GITHUB_API` / `GITHUB_URL`）のみをマージ。
  - Pod env から `GITHUB_APP_PEM_PATH` を削除。
  - token 発行失敗時は秘密をログに出さず警告のみ（public repo のためセッション作成は継続）。
- **`pkg/sessionsettings/setup.go`**: `write-pem` ステップと `PEMOutputPath` を削除。Pod は付与された `GITHUB_TOKEN` のみ使用。
- **Helm**: `github-session` Secret から `GITHUB_APP_ID` / `GITHUB_INSTALLATION_ID` / `GITHUB_APP_PEM` / `REPOSITORY_RESTRICTION` を除去（personal token のみ）。proxy Deployment 側は token 発行に必要な App 資格情報を保持。
- **docs / values.yaml**: 新しいセキュリティモデルを記載。

## 互換性

personal token 経路、GitHub Enterprise API base、repository restriction、installation ID 自動解決、local/external session manager の意味は維持しています。API 変更はないため `spec/openapi.json` は更新不要です。

## テスト

- `make lint`: 0 issues
- 追加のユニットテスト（`kubernetes_session_manager_github_token_test.go`）でセッション env に App キーが含まれないこと、サーバ側 token / personal token 経路を検証
- `helm lint` / `helm template` でセッション Secret に App 資格情報・PEM が出ないこと、proxy Deployment には資格情報が残ることを確認
- 関連 Go パッケージのテストは pass（`cmd` の失敗は本変更前から環境依存で発生する既存の失敗）