### PR TITLE
feat: configure Pi defaults from environment

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4877,9 +4877,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 
 	settings.Env = env
 
-	if req.AgentType == "pi-ollama" {
-		settings.Pi = sessionsettings.PiConfig{SettingsJSON: buildPiSettingsJSON(env)}
-	}
+	settings.Pi = sessionsettings.PiConfig{SettingsJSON: buildPiSettingsJSON(env)}
 
 	// Claude config
 	settingsJSON := materialized.SettingsJSON

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -5252,6 +5252,9 @@ func buildPiSettingsJSON(env map[string]string) map[string]interface{} {
 
 func buildPiModelsJSON(env map[string]string) map[string]interface{} {
 	provider := strings.TrimSpace(env["PI_CUSTOM_MODEL_PROVIDER"])
+	if provider == "" {
+		provider = strings.TrimSpace(env["PI_CUSTOM_PROVIDER"])
+	}
 	modelID := strings.TrimSpace(env["PI_CUSTOM_MODEL_ID"])
 	baseURL := strings.TrimSpace(env["PI_CUSTOM_MODEL_BASE_URL"])
 	if provider == "" || modelID == "" || baseURL == "" {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4877,7 +4877,10 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 
 	settings.Env = env
 
-	settings.Pi = sessionsettings.PiConfig{SettingsJSON: buildPiSettingsJSON(env)}
+	settings.Pi = sessionsettings.PiConfig{
+		SettingsJSON: buildPiSettingsJSON(env),
+		ModelsJSON:   buildPiModelsJSON(env),
+	}
 
 	// Claude config
 	settingsJSON := materialized.SettingsJSON
@@ -5245,6 +5248,68 @@ func buildPiSettingsJSON(env map[string]string) map[string]interface{} {
 		}
 	}
 	return settings
+}
+
+func buildPiModelsJSON(env map[string]string) map[string]interface{} {
+	provider := strings.TrimSpace(env["PI_CUSTOM_MODEL_PROVIDER"])
+	modelID := strings.TrimSpace(env["PI_CUSTOM_MODEL_ID"])
+	baseURL := strings.TrimSpace(env["PI_CUSTOM_MODEL_BASE_URL"])
+	if provider == "" || modelID == "" || baseURL == "" {
+		return nil
+	}
+
+	api := strings.TrimSpace(env["PI_CUSTOM_MODEL_API"])
+	if api == "" {
+		api = "openai-completions"
+	}
+	name := strings.TrimSpace(env["PI_CUSTOM_MODEL_NAME"])
+	if name == "" {
+		name = modelID
+	}
+
+	model := map[string]interface{}{
+		"id":            modelID,
+		"name":          name,
+		"reasoning":     parsePiCustomModelBool(env["PI_CUSTOM_MODEL_REASONING"], false),
+		"input":         []interface{}{"text"},
+		"contextWindow": parsePiCustomModelInt(env["PI_CUSTOM_MODEL_CONTEXT_WINDOW"], 128000),
+		"maxTokens":     parsePiCustomModelInt(env["PI_CUSTOM_MODEL_MAX_TOKENS"], 16384),
+	}
+	providerConfig := map[string]interface{}{
+		"baseUrl": baseURL,
+		"api":     api,
+		"models":  []interface{}{model},
+	}
+
+	apiKeyEnv := strings.TrimSpace(env["PI_CUSTOM_MODEL_API_KEY_ENV"])
+	if regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(apiKeyEnv) {
+		providerConfig["apiKey"] = "$" + apiKeyEnv
+	}
+
+	return map[string]interface{}{
+		"providers": map[string]interface{}{
+			provider: providerConfig,
+		},
+	}
+}
+
+func parsePiCustomModelInt(value string, fallback int) int {
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func parsePiCustomModelBool(value string, fallback bool) bool {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+	if err != nil {
+		return fallback
+	}
+	return parsed
 }
 
 func (m *KubernetesSessionManager) injectSciaProxyEnv(env map[string]string, req *entities.RunServerRequest) {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -4877,6 +4877,10 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 
 	settings.Env = env
 
+	if req.AgentType == "pi-ollama" {
+		settings.Pi = sessionsettings.PiConfig{SettingsJSON: buildPiSettingsJSON(env)}
+	}
+
 	// Claude config
 	settingsJSON := materialized.SettingsJSON
 
@@ -5228,6 +5232,20 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		log.Printf("[K8S_SESSION] DinD enabled for session %s (registries: %d)", session.id, len(registries))
 	}
 
+	return settings
+}
+
+func buildPiSettingsJSON(env map[string]string) map[string]interface{} {
+	settings := make(map[string]interface{})
+	for envName, settingName := range map[string]string{
+		"PI_DEFAULT_PROVIDER":       "defaultProvider",
+		"PI_DEFAULT_MODEL":          "defaultModel",
+		"PI_DEFAULT_THINKING_LEVEL": "defaultThinkingLevel",
+	} {
+		if value := strings.TrimSpace(env[envName]); value != "" {
+			settings[settingName] = value
+		}
+	}
 	return settings
 }
 

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -120,8 +120,11 @@ func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
 		Scope:  entities.ScopeTeam,
 		TeamID: "org/team-a",
 		Environment: map[string]string{
-			"PI_DEFAULT_PROVIDER": "ollama-cloud",
-			"PI_DEFAULT_MODEL":    "glm-5:cloud",
+			"PI_DEFAULT_PROVIDER":      "ollama-cloud",
+			"PI_DEFAULT_MODEL":         "glm-5:cloud",
+			"PI_CUSTOM_MODEL_PROVIDER": "ollama-cloud",
+			"PI_CUSTOM_MODEL_ID":       "glm-5.2:cloud",
+			"PI_CUSTOM_MODEL_BASE_URL": "https://ollama.com/v1",
 		},
 	}
 
@@ -134,6 +137,12 @@ func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
 	}
 	if got := settings.Pi.SettingsJSON["defaultModel"]; got != "glm-5:cloud" {
 		t.Fatalf("defaultModel = %v", got)
+	}
+	providers := settings.Pi.ModelsJSON["providers"].(map[string]interface{})
+	provider := providers["ollama-cloud"].(map[string]interface{})
+	models := provider["models"].([]interface{})
+	if got := models[0].(map[string]interface{})["id"]; got != "glm-5.2:cloud" {
+		t.Fatalf("custom model ID = %v", got)
 	}
 }
 
@@ -238,5 +247,62 @@ func TestBuildPiSettingsJSONSkipsEmptyValues(t *testing.T) {
 
 	if len(got) != 1 || got["defaultModel"] != "qwen3-coder" {
 		t.Fatalf("unexpected Pi settings: %#v", got)
+	}
+}
+
+func TestBuildPiModelsJSON(t *testing.T) {
+	got := buildPiModelsJSON(map[string]string{
+		"PI_CUSTOM_MODEL_PROVIDER":       "ollama-cloud",
+		"PI_CUSTOM_MODEL_ID":             "glm-5.2:cloud",
+		"PI_CUSTOM_MODEL_NAME":           "GLM-5.2",
+		"PI_CUSTOM_MODEL_BASE_URL":       "https://ollama.com/v1",
+		"PI_CUSTOM_MODEL_API":            "openai-completions",
+		"PI_CUSTOM_MODEL_API_KEY_ENV":    "OLLAMA_API_KEY",
+		"PI_CUSTOM_MODEL_REASONING":      "true",
+		"PI_CUSTOM_MODEL_CONTEXT_WINDOW": "999424",
+		"PI_CUSTOM_MODEL_MAX_TOKENS":     "32768",
+	})
+
+	providers := got["providers"].(map[string]interface{})
+	provider := providers["ollama-cloud"].(map[string]interface{})
+	if provider["baseUrl"] != "https://ollama.com/v1" || provider["apiKey"] != "$OLLAMA_API_KEY" {
+		t.Fatalf("unexpected provider config: %#v", provider)
+	}
+	models := provider["models"].([]interface{})
+	model := models[0].(map[string]interface{})
+	if model["id"] != "glm-5.2:cloud" || model["reasoning"] != true {
+		t.Fatalf("unexpected model config: %#v", model)
+	}
+	if model["contextWindow"] != 999424 || model["maxTokens"] != 32768 {
+		t.Fatalf("unexpected model limits: %#v", model)
+	}
+}
+
+func TestBuildPiModelsJSONDefaults(t *testing.T) {
+	got := buildPiModelsJSON(map[string]string{
+		"PI_CUSTOM_MODEL_PROVIDER": "custom",
+		"PI_CUSTOM_MODEL_ID":       "model-1",
+		"PI_CUSTOM_MODEL_BASE_URL": "https://example.com/v1",
+	})
+	provider := got["providers"].(map[string]interface{})["custom"].(map[string]interface{})
+	model := provider["models"].([]interface{})[0].(map[string]interface{})
+	if provider["api"] != "openai-completions" {
+		t.Fatalf("api = %v", provider["api"])
+	}
+	if model["name"] != "model-1" || model["reasoning"] != false {
+		t.Fatalf("unexpected defaults: %#v", model)
+	}
+	if model["contextWindow"] != 128000 || model["maxTokens"] != 16384 {
+		t.Fatalf("unexpected default limits: %#v", model)
+	}
+}
+
+func TestBuildPiModelsJSONRequiresProviderModelAndBaseURL(t *testing.T) {
+	got := buildPiModelsJSON(map[string]string{
+		"PI_CUSTOM_MODEL_PROVIDER": "ollama-cloud",
+		"PI_CUSTOM_MODEL_ID":       "glm-5.2:cloud",
+	})
+	if got != nil {
+		t.Fatalf("expected incomplete custom model config to be ignored, got %#v", got)
 	}
 }

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -164,7 +164,10 @@ func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 		UserID:    "test-user",
 		AgentType: "pi-ollama",
 		Environment: map[string]string{
-			"OPENAI_API_KEY": "openai-key",
+			"OPENAI_API_KEY":            "openai-key",
+			"PI_DEFAULT_PROVIDER":       "ollama-cloud",
+			"PI_DEFAULT_MODEL":          "qwen3-coder",
+			"PI_DEFAULT_THINKING_LEVEL": "high",
 		},
 	}
 
@@ -175,6 +178,15 @@ func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 	if got := settings.Env["PI_ACP_PI_COMMAND"]; got != piOllamaCommandPath {
 		t.Fatalf("PI_ACP_PI_COMMAND = %q", got)
 	}
+	if got := settings.Pi.SettingsJSON["defaultProvider"]; got != "ollama-cloud" {
+		t.Fatalf("defaultProvider = %v", got)
+	}
+	if got := settings.Pi.SettingsJSON["defaultModel"]; got != "qwen3-coder" {
+		t.Fatalf("defaultModel = %v", got)
+	}
+	if got := settings.Pi.SettingsJSON["defaultThinkingLevel"]; got != "high" {
+		t.Fatalf("defaultThinkingLevel = %v", got)
+	}
 	if settings.Startup.PreScript == "" {
 		t.Fatalf("expected pi-ollama startup pre-script")
 	}
@@ -183,5 +195,38 @@ func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 	}
 	if !strings.Contains(settings.Startup.PreScript, "node_modules/pi-mcp-adapter") {
 		t.Fatalf("expected pi-ollama pre-script to skip pi-mcp-adapter install when package is baked into the image")
+	}
+}
+
+func TestBuildPiSettingsJSON(t *testing.T) {
+	got := buildPiSettingsJSON(map[string]string{
+		"PI_DEFAULT_PROVIDER":       "ollama-cloud",
+		"PI_DEFAULT_MODEL":          "qwen3-coder",
+		"PI_DEFAULT_THINKING_LEVEL": " high ",
+		"UNRELATED":                 "ignored",
+	})
+
+	if got["defaultProvider"] != "ollama-cloud" {
+		t.Fatalf("defaultProvider = %v", got["defaultProvider"])
+	}
+	if got["defaultModel"] != "qwen3-coder" {
+		t.Fatalf("defaultModel = %v", got["defaultModel"])
+	}
+	if got["defaultThinkingLevel"] != "high" {
+		t.Fatalf("defaultThinkingLevel = %v", got["defaultThinkingLevel"])
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 Pi settings, got %d", len(got))
+	}
+}
+
+func TestBuildPiSettingsJSONSkipsEmptyValues(t *testing.T) {
+	got := buildPiSettingsJSON(map[string]string{
+		"PI_DEFAULT_PROVIDER": " ",
+		"PI_DEFAULT_MODEL":    "qwen3-coder",
+	})
+
+	if len(got) != 1 || got["defaultModel"] != "qwen3-coder" {
+		t.Fatalf("unexpected Pi settings: %#v", got)
 	}
 }

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -119,11 +119,21 @@ func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
 		UserID: "test-user",
 		Scope:  entities.ScopeTeam,
 		TeamID: "org/team-a",
+		Environment: map[string]string{
+			"PI_DEFAULT_PROVIDER": "ollama-cloud",
+			"PI_DEFAULT_MODEL":    "glm-5:cloud",
+		},
 	}
 
 	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
 	if got := settings.Env["SECRET_TOKEN"]; got != "decrypted-secret" {
 		t.Fatalf("SECRET_TOKEN = %q, want decrypted-secret", got)
+	}
+	if got := settings.Pi.SettingsJSON["defaultProvider"]; got != "ollama-cloud" {
+		t.Fatalf("defaultProvider = %v", got)
+	}
+	if got := settings.Pi.SettingsJSON["defaultModel"]; got != "glm-5:cloud" {
+		t.Fatalf("defaultModel = %v", got)
 	}
 }
 

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -280,7 +280,7 @@ func TestBuildPiModelsJSON(t *testing.T) {
 
 func TestBuildPiModelsJSONDefaults(t *testing.T) {
 	got := buildPiModelsJSON(map[string]string{
-		"PI_CUSTOM_MODEL_PROVIDER": "custom",
+		"PI_CUSTOM_PROVIDER":       "custom",
 		"PI_CUSTOM_MODEL_ID":       "model-1",
 		"PI_CUSTOM_MODEL_BASE_URL": "https://example.com/v1",
 	})
@@ -294,6 +294,19 @@ func TestBuildPiModelsJSONDefaults(t *testing.T) {
 	}
 	if model["contextWindow"] != 128000 || model["maxTokens"] != 16384 {
 		t.Fatalf("unexpected default limits: %#v", model)
+	}
+}
+
+func TestBuildPiModelsJSONPrefersCanonicalProviderVariable(t *testing.T) {
+	got := buildPiModelsJSON(map[string]string{
+		"PI_CUSTOM_MODEL_PROVIDER": "canonical",
+		"PI_CUSTOM_PROVIDER":       "alias",
+		"PI_CUSTOM_MODEL_ID":       "model-1",
+		"PI_CUSTOM_MODEL_BASE_URL": "https://example.com/v1",
+	})
+	providers := got["providers"].(map[string]interface{})
+	if _, ok := providers["canonical"]; !ok {
+		t.Fatalf("expected canonical provider variable to take precedence: %#v", providers)
 	}
 }
 

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -84,8 +84,8 @@ func Compile(opts CompileOptions) error {
 		return fmt.Errorf("failed to generate Pi MCP config: %w", err)
 	}
 
-	// 3g. Generate ~/.pi/agent/settings.json (Pi sessions only)
-	if err := generatePiSettingsJSON(opts.OutputDir, settings.Session.AgentType, settings.Pi.SettingsJSON); err != nil {
+	// 3g. Generate ~/.pi/agent/settings.json when managed Pi settings are present.
+	if err := generatePiSettingsJSON(opts.OutputDir, settings.Pi.SettingsJSON); err != nil {
 		return fmt.Errorf("failed to generate Pi settings.json: %w", err)
 	}
 
@@ -192,8 +192,8 @@ func generatePiMCPConfig(outputDir string, agentType string, mcpServers map[stri
 }
 
 // generatePiSettingsJSON merges managed Pi settings into ~/.pi/agent/settings.json.
-func generatePiSettingsJSON(outputDir, agentType string, settingsJSON map[string]interface{}) error {
-	if agentType != "pi-ollama" || len(settingsJSON) == 0 {
+func generatePiSettingsJSON(outputDir string, settingsJSON map[string]interface{}) error {
+	if len(settingsJSON) == 0 {
 		return nil
 	}
 

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -84,6 +84,11 @@ func Compile(opts CompileOptions) error {
 		return fmt.Errorf("failed to generate Pi MCP config: %w", err)
 	}
 
+	// 3g. Generate ~/.pi/agent/settings.json (Pi sessions only)
+	if err := generatePiSettingsJSON(opts.OutputDir, settings.Session.AgentType, settings.Pi.SettingsJSON); err != nil {
+		return fmt.Errorf("failed to generate Pi settings.json: %w", err)
+	}
+
 	// 4. Generate env file
 	if err := generateEnvFile(opts.EnvFilePath, settings.Env); err != nil {
 		return fmt.Errorf("failed to generate env file: %w", err)
@@ -183,6 +188,48 @@ func generatePiMCPConfig(outputDir string, agentType string, mcpServers map[stri
 	}
 
 	log.Printf("[COMPILE-SETTINGS] Generated %s", configPath)
+	return nil
+}
+
+// generatePiSettingsJSON merges managed Pi settings into ~/.pi/agent/settings.json.
+func generatePiSettingsJSON(outputDir, agentType string, settingsJSON map[string]interface{}) error {
+	if agentType != "pi-ollama" || len(settingsJSON) == 0 {
+		return nil
+	}
+
+	piDir := filepath.Join(outputDir, ".pi", "agent")
+	if err := os.MkdirAll(piDir, 0755); err != nil {
+		return fmt.Errorf("failed to create Pi agent directory: %w", err)
+	}
+
+	settingsPath := filepath.Join(piDir, "settings.json")
+	existing := make(map[string]interface{})
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("failed to parse existing Pi settings.json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read existing Pi settings.json: %w", err)
+	}
+
+	for key, value := range settingsJSON {
+		existing[key] = value
+	}
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Pi settings.json: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.WriteFile(settingsPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write Pi settings.json: %w", err)
+	}
+	if err := os.Chmod(settingsPath, 0600); err != nil {
+		return fmt.Errorf("failed to set Pi settings.json permissions: %w", err)
+	}
+
+	log.Printf("[COMPILE-SETTINGS] Generated %s with %d managed setting(s)", settingsPath, len(settingsJSON))
 	return nil
 }
 

--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -89,6 +89,11 @@ func Compile(opts CompileOptions) error {
 		return fmt.Errorf("failed to generate Pi settings.json: %w", err)
 	}
 
+	// 3h. Generate ~/.pi/agent/models.json when a custom model is configured.
+	if err := generatePiModelsJSON(opts.OutputDir, settings.Pi.ModelsJSON); err != nil {
+		return fmt.Errorf("failed to generate Pi models.json: %w", err)
+	}
+
 	// 4. Generate env file
 	if err := generateEnvFile(opts.EnvFilePath, settings.Env); err != nil {
 		return fmt.Errorf("failed to generate env file: %w", err)
@@ -231,6 +236,98 @@ func generatePiSettingsJSON(outputDir string, settingsJSON map[string]interface{
 
 	log.Printf("[COMPILE-SETTINGS] Generated %s with %d managed setting(s)", settingsPath, len(settingsJSON))
 	return nil
+}
+
+// generatePiModelsJSON merges managed custom models into ~/.pi/agent/models.json.
+func generatePiModelsJSON(outputDir string, modelsJSON map[string]interface{}) error {
+	if len(modelsJSON) == 0 {
+		return nil
+	}
+
+	piDir := filepath.Join(outputDir, ".pi", "agent")
+	if err := os.MkdirAll(piDir, 0755); err != nil {
+		return fmt.Errorf("failed to create Pi agent directory: %w", err)
+	}
+
+	modelsPath := filepath.Join(piDir, "models.json")
+	existing := make(map[string]interface{})
+	if data, err := os.ReadFile(modelsPath); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("failed to parse existing Pi models.json: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read existing Pi models.json: %w", err)
+	}
+
+	mergePiModelProviders(existing, modelsJSON)
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal Pi models.json: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(modelsPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write Pi models.json: %w", err)
+	}
+	if err := os.Chmod(modelsPath, 0600); err != nil {
+		return fmt.Errorf("failed to set Pi models.json permissions: %w", err)
+	}
+
+	log.Printf("[COMPILE-SETTINGS] Generated %s", modelsPath)
+	return nil
+}
+
+func mergePiModelProviders(target, managed map[string]interface{}) {
+	targetProviders, _ := target["providers"].(map[string]interface{})
+	if targetProviders == nil {
+		targetProviders = make(map[string]interface{})
+		target["providers"] = targetProviders
+	}
+	managedProviders, _ := managed["providers"].(map[string]interface{})
+	for providerName, value := range managedProviders {
+		managedProvider, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		existingProvider, _ := targetProviders[providerName].(map[string]interface{})
+		if existingProvider == nil {
+			existingProvider = make(map[string]interface{})
+		}
+		for key, managedValue := range managedProvider {
+			if key == "models" {
+				existingProvider[key] = mergePiModels(existingProvider[key], managedValue)
+				continue
+			}
+			existingProvider[key] = managedValue
+		}
+		targetProviders[providerName] = existingProvider
+	}
+}
+
+func mergePiModels(existingValue, managedValue interface{}) []interface{} {
+	existing, _ := existingValue.([]interface{})
+	managed, _ := managedValue.([]interface{})
+	result := append([]interface{}(nil), existing...)
+	indexes := make(map[string]int, len(result))
+	for i, value := range result {
+		if model, ok := value.(map[string]interface{}); ok {
+			if id, ok := model["id"].(string); ok {
+				indexes[id] = i
+			}
+		}
+	}
+	for _, value := range managed {
+		model, ok := value.(map[string]interface{})
+		id, hasID := model["id"].(string)
+		if ok && hasID {
+			if index, exists := indexes[id]; exists {
+				result[index] = value
+				continue
+			}
+			indexes[id] = len(result)
+		}
+		result = append(result, value)
+	}
+	return result
 }
 
 // generateSettingsJSON creates ~/.claude/settings.json.

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -1081,7 +1081,7 @@ func TestGeneratePiSettingsJSON(t *testing.T) {
 		settingsPath := filepath.Join(piDir, "settings.json")
 		require.NoError(t, os.WriteFile(settingsPath, []byte(`{"theme":"dark","defaultModel":"old-model"}`), 0644))
 
-		err := generatePiSettingsJSON(outputDir, "pi-ollama", map[string]interface{}{
+		err := generatePiSettingsJSON(outputDir, map[string]interface{}{
 			"defaultProvider":      "ollama-cloud",
 			"defaultModel":         "qwen3-coder",
 			"defaultThinkingLevel": "high",
@@ -1102,18 +1102,23 @@ func TestGeneratePiSettingsJSON(t *testing.T) {
 		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 	})
 
-	t.Run("skips non-Pi sessions", func(t *testing.T) {
+	t.Run("writes settings regardless of agent type", func(t *testing.T) {
 		outputDir := t.TempDir()
-		err := generatePiSettingsJSON(outputDir, "codex-acp", map[string]interface{}{
+		err := generatePiSettingsJSON(outputDir, map[string]interface{}{
 			"defaultModel": "qwen3-coder",
 		})
 		require.NoError(t, err)
-		assert.NoFileExists(t, filepath.Join(outputDir, ".pi", "agent", "settings.json"))
+
+		data, err := os.ReadFile(filepath.Join(outputDir, ".pi", "agent", "settings.json"))
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "qwen3-coder", got["defaultModel"])
 	})
 
 	t.Run("skips empty settings", func(t *testing.T) {
 		outputDir := t.TempDir()
-		require.NoError(t, generatePiSettingsJSON(outputDir, "pi-ollama", nil))
+		require.NoError(t, generatePiSettingsJSON(outputDir, nil))
 		assert.NoFileExists(t, filepath.Join(outputDir, ".pi", "agent", "settings.json"))
 	})
 
@@ -1123,7 +1128,7 @@ func TestGeneratePiSettingsJSON(t *testing.T) {
 		require.NoError(t, os.MkdirAll(piDir, 0755))
 		require.NoError(t, os.WriteFile(filepath.Join(piDir, "settings.json"), []byte(`not-json`), 0600))
 
-		err := generatePiSettingsJSON(outputDir, "pi-ollama", map[string]interface{}{
+		err := generatePiSettingsJSON(outputDir, map[string]interface{}{
 			"defaultModel": "qwen3-coder",
 		})
 		require.ErrorContains(t, err, "failed to parse existing Pi settings.json")

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -1073,6 +1073,63 @@ func TestCompile_PiMCPConfig(t *testing.T) {
 	})
 }
 
+func TestGeneratePiSettingsJSON(t *testing.T) {
+	t.Run("merges managed settings into existing file", func(t *testing.T) {
+		outputDir := t.TempDir()
+		piDir := filepath.Join(outputDir, ".pi", "agent")
+		require.NoError(t, os.MkdirAll(piDir, 0755))
+		settingsPath := filepath.Join(piDir, "settings.json")
+		require.NoError(t, os.WriteFile(settingsPath, []byte(`{"theme":"dark","defaultModel":"old-model"}`), 0644))
+
+		err := generatePiSettingsJSON(outputDir, "pi-ollama", map[string]interface{}{
+			"defaultProvider":      "ollama-cloud",
+			"defaultModel":         "qwen3-coder",
+			"defaultThinkingLevel": "high",
+		})
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(settingsPath)
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "dark", got["theme"])
+		assert.Equal(t, "ollama-cloud", got["defaultProvider"])
+		assert.Equal(t, "qwen3-coder", got["defaultModel"])
+		assert.Equal(t, "high", got["defaultThinkingLevel"])
+
+		info, err := os.Stat(settingsPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	})
+
+	t.Run("skips non-Pi sessions", func(t *testing.T) {
+		outputDir := t.TempDir()
+		err := generatePiSettingsJSON(outputDir, "codex-acp", map[string]interface{}{
+			"defaultModel": "qwen3-coder",
+		})
+		require.NoError(t, err)
+		assert.NoFileExists(t, filepath.Join(outputDir, ".pi", "agent", "settings.json"))
+	})
+
+	t.Run("skips empty settings", func(t *testing.T) {
+		outputDir := t.TempDir()
+		require.NoError(t, generatePiSettingsJSON(outputDir, "pi-ollama", nil))
+		assert.NoFileExists(t, filepath.Join(outputDir, ".pi", "agent", "settings.json"))
+	})
+
+	t.Run("rejects invalid existing settings", func(t *testing.T) {
+		outputDir := t.TempDir()
+		piDir := filepath.Join(outputDir, ".pi", "agent")
+		require.NoError(t, os.MkdirAll(piDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(piDir, "settings.json"), []byte(`not-json`), 0600))
+
+		err := generatePiSettingsJSON(outputDir, "pi-ollama", map[string]interface{}{
+			"defaultModel": "qwen3-coder",
+		})
+		require.ErrorContains(t, err, "failed to parse existing Pi settings.json")
+	})
+}
+
 func TestCompile_MissingInput(t *testing.T) {
 	opts := CompileOptions{
 		InputPath:   "/nonexistent/settings.yaml",

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -1135,6 +1135,60 @@ func TestGeneratePiSettingsJSON(t *testing.T) {
 	})
 }
 
+func TestGeneratePiModelsJSON(t *testing.T) {
+	outputDir := t.TempDir()
+	piDir := filepath.Join(outputDir, ".pi", "agent")
+	require.NoError(t, os.MkdirAll(piDir, 0755))
+	modelsPath := filepath.Join(piDir, "models.json")
+	require.NoError(t, os.WriteFile(modelsPath, []byte(`{
+		"providers": {
+			"ollama-cloud": {
+				"headers": {"x-existing": "preserved"},
+				"models": [{"id": "existing-model"}]
+			},
+			"other": {"baseUrl": "https://other.example/v1"}
+		}
+	}`), 0644))
+
+	err := generatePiModelsJSON(outputDir, map[string]interface{}{
+		"providers": map[string]interface{}{
+			"ollama-cloud": map[string]interface{}{
+				"baseUrl": "https://ollama.com/v1",
+				"api":     "openai-completions",
+				"apiKey":  "$OLLAMA_API_KEY",
+				"models": []interface{}{
+					map[string]interface{}{"id": "glm-5.2:cloud", "reasoning": true},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(modelsPath)
+	require.NoError(t, err)
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	providers := got["providers"].(map[string]interface{})
+	assert.Contains(t, providers, "other")
+	provider := providers["ollama-cloud"].(map[string]interface{})
+	assert.Contains(t, provider, "headers")
+	assert.Equal(t, "$OLLAMA_API_KEY", provider["apiKey"])
+	models := provider["models"].([]interface{})
+	require.Len(t, models, 2)
+	assert.Equal(t, "existing-model", models[0].(map[string]interface{})["id"])
+	assert.Equal(t, "glm-5.2:cloud", models[1].(map[string]interface{})["id"])
+
+	info, err := os.Stat(modelsPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestGeneratePiModelsJSONSkipsEmptyConfig(t *testing.T) {
+	outputDir := t.TempDir()
+	require.NoError(t, generatePiModelsJSON(outputDir, nil))
+	assert.NoFileExists(t, filepath.Join(outputDir, ".pi", "agent", "models.json"))
+}
+
 func TestCompile_MissingInput(t *testing.T) {
 	opts := CompileOptions{
 		InputPath:   "/nonexistent/settings.yaml",

--- a/pkg/sessionsettings/pi_ollama_refresh.go
+++ b/pkg/sessionsettings/pi_ollama_refresh.go
@@ -1,0 +1,151 @@
+package sessionsettings
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultOllamaCloudBaseURL = "https://ollama.com"
+	ollamaCloudRefreshWorkers = 8
+)
+
+type ollamaCloudModelList struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
+type ollamaCloudModelCache struct {
+	Timestamp int64                      `json:"timestamp"`
+	Models    map[string]json.RawMessage `json:"models"`
+}
+
+func shouldRefreshPiOllamaCloud(settings *SessionSettings) bool {
+	if settings == nil {
+		return false
+	}
+	if settings.Session.AgentType == "pi-ollama" {
+		return true
+	}
+	for _, key := range []string{"PI_DEFAULT_PROVIDER", "PI_CUSTOM_MODEL_PROVIDER", "PI_CUSTOM_PROVIDER"} {
+		if strings.EqualFold(strings.TrimSpace(settings.Env[key]), "ollama-cloud") {
+			return true
+		}
+	}
+	return false
+}
+
+func refreshPiOllamaCloudCache(env map[string]string, outputDir string) error {
+	baseURL := strings.TrimRight(strings.TrimSpace(env["OLLAMA_API_BASE"]), "/")
+	if baseURL == "" {
+		baseURL = defaultOllamaCloudBaseURL
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	apiKey := env["OLLAMA_API_KEY"]
+
+	var list ollamaCloudModelList
+	if err := ollamaCloudRequest(client, http.MethodGet, baseURL+"/v1/models", apiKey, nil, &list); err != nil {
+		return fmt.Errorf("list models: %w", err)
+	}
+
+	models := make(map[string]json.RawMessage)
+	var mu sync.Mutex
+	jobs := make(chan string)
+	workers := min(ollamaCloudRefreshWorkers, len(list.Data))
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for id := range jobs {
+				body, err := json.Marshal(map[string]string{"model": id})
+				if err != nil {
+					continue
+				}
+				var detail json.RawMessage
+				if err := ollamaCloudRequest(client, http.MethodPost, baseURL+"/api/show", apiKey, body, &detail); err != nil {
+					continue
+				}
+				mu.Lock()
+				models[id] = detail
+				mu.Unlock()
+			}
+		}()
+	}
+	for _, model := range list.Data {
+		if model.ID != "" {
+			jobs <- model.ID
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	if len(models) == 0 {
+		return fmt.Errorf("no model details were retrieved")
+	}
+	cache, err := json.MarshalIndent(ollamaCloudModelCache{Timestamp: time.Now().UnixMilli(), Models: models}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cache: %w", err)
+	}
+
+	cacheDir := filepath.Join(outputDir, ".pi", "agent", "cache")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return fmt.Errorf("create cache directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(cacheDir, ".ollama-cloud-models-*")
+	if err != nil {
+		return fmt.Errorf("create temporary cache: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("set cache permissions: %w", err)
+	}
+	if _, err := tmp.Write(cache); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close cache: %w", err)
+	}
+	if err := os.Rename(tmpName, filepath.Join(cacheDir, "ollama-cloud-models.json")); err != nil {
+		return fmt.Errorf("replace cache: %w", err)
+	}
+	return nil
+}
+
+func ollamaCloudRequest(client *http.Client, method, url, apiKey string, body []byte, target any) error {
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(message)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/pkg/sessionsettings/pi_ollama_refresh.go
+++ b/pkg/sessionsettings/pi_ollama_refresh.go
@@ -36,8 +36,8 @@ func shouldRefreshPiOllamaCloud(settings *SessionSettings) bool {
 	if settings.Session.AgentType == "pi-ollama" {
 		return true
 	}
-	for _, key := range []string{"PI_DEFAULT_PROVIDER", "PI_CUSTOM_MODEL_PROVIDER", "PI_CUSTOM_PROVIDER"} {
-		if strings.EqualFold(strings.TrimSpace(settings.Env[key]), "ollama-cloud") {
+	for key, value := range settings.Env {
+		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(key)), "PI_") && strings.TrimSpace(value) != "" {
 			return true
 		}
 	}

--- a/pkg/sessionsettings/pi_ollama_refresh_test.go
+++ b/pkg/sessionsettings/pi_ollama_refresh_test.go
@@ -1,0 +1,103 @@
+package sessionsettings
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShouldRefreshPiOllamaCloud(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *SessionSettings
+		want     bool
+	}{
+		{name: "nil", settings: nil, want: false},
+		{name: "pi ollama agent", settings: &SessionSettings{Session: SessionMeta{AgentType: "pi-ollama"}}, want: true},
+		{name: "default provider", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_PROVIDER": "ollama-cloud"}}, want: true},
+		{name: "custom provider alias", settings: &SessionSettings{Env: map[string]string{"PI_CUSTOM_PROVIDER": "OLLAMA-CLOUD"}}, want: true},
+		{name: "other provider", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_PROVIDER": "openai"}}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRefreshPiOllamaCloud(tt.settings); got != tt.want {
+				t.Fatalf("shouldRefreshPiOllamaCloud() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshPiOllamaCloudCache(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("unexpected authorization header: %q", r.Header.Get("Authorization"))
+		}
+		switch r.URL.Path {
+		case "/v1/models":
+			if err := json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"id": "glm-5.2:cloud"}}}); err != nil {
+				t.Errorf("encode model list: %v", err)
+			}
+		case "/api/show":
+			if err := json.NewEncoder(w).Encode(map[string]any{"capabilities": []string{"tools"}, "model_info": map[string]any{"family": "glm"}}); err != nil {
+				t.Errorf("encode model details: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	err := refreshPiOllamaCloudCache(map[string]string{"OLLAMA_API_BASE": server.URL, "OLLAMA_API_KEY": "test-key"}, outputDir)
+	if err != nil {
+		t.Fatalf("refreshPiOllamaCloudCache() error = %v", err)
+	}
+	cachePath := filepath.Join(outputDir, ".pi", "agent", "cache", "ollama-cloud-models.json")
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cache ollamaCloudModelCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.Models["glm-5.2:cloud"]; !ok {
+		t.Fatalf("cache does not contain glm-5.2:cloud: %s", data)
+	}
+	info, err := os.Stat(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("cache mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestRefreshPiOllamaCloudCachePreservesExistingCacheOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	cachePath := filepath.Join(outputDir, ".pi", "agent", "cache", "ollama-cloud-models.json")
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath, []byte("existing"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := refreshPiOllamaCloudCache(map[string]string{"OLLAMA_API_BASE": server.URL}, outputDir); err == nil {
+		t.Fatal("refreshPiOllamaCloudCache() error = nil, want error")
+	}
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "existing" {
+		t.Fatalf("cache was replaced: %q", data)
+	}
+}

--- a/pkg/sessionsettings/pi_ollama_refresh_test.go
+++ b/pkg/sessionsettings/pi_ollama_refresh_test.go
@@ -18,8 +18,11 @@ func TestShouldRefreshPiOllamaCloud(t *testing.T) {
 		{name: "nil", settings: nil, want: false},
 		{name: "pi ollama agent", settings: &SessionSettings{Session: SessionMeta{AgentType: "pi-ollama"}}, want: true},
 		{name: "default provider", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_PROVIDER": "ollama-cloud"}}, want: true},
-		{name: "custom provider alias", settings: &SessionSettings{Env: map[string]string{"PI_CUSTOM_PROVIDER": "OLLAMA-CLOUD"}}, want: true},
-		{name: "other provider", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_PROVIDER": "openai"}}, want: false},
+		{name: "model only", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_MODEL": "glm-5.2:cloud"}}, want: true},
+		{name: "other provider", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_PROVIDER": "openai"}}, want: true},
+		{name: "case insensitive prefix", settings: &SessionSettings{Env: map[string]string{"pi_custom_model": "glm-5.2:cloud"}}, want: true},
+		{name: "empty pi value", settings: &SessionSettings{Env: map[string]string{"PI_DEFAULT_MODEL": ""}}, want: false},
+		{name: "unrelated variable", settings: &SessionSettings{Env: map[string]string{"OLLAMA_API_KEY": "secret"}}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sessionsettings/setup.go
+++ b/pkg/sessionsettings/setup.go
@@ -88,6 +88,17 @@ func Setup(opts SetupOptions) error {
 		return fmt.Errorf("compile failed: %w", err)
 	}
 
+	outputDir := opts.CompileOptions.OutputDir
+	if outputDir == "" {
+		outputDir = DefaultCompileOptions().OutputDir
+	}
+	if shouldRefreshPiOllamaCloud(settings) {
+		if err := refreshPiOllamaCloudCache(settings.Env, outputDir); err != nil {
+			// Non-fatal: pi-ollama-cloud can continue with its bundled or existing cache.
+			log.Printf("[SETUP] Warning: failed to refresh Ollama Cloud models: %v", err)
+		}
+	}
+
 	// 4. Copy credentials, CLAUDE.md, notification subscriptions
 	if err := syncExtra(settings, opts); err != nil {
 		return fmt.Errorf("sync-extra failed: %w", err)
@@ -97,10 +108,6 @@ func Setup(opts SetupOptions) error {
 	//    The sync step (marketplace clone / plugin install) may trigger Claude
 	//    CLI which rewrites ~/.claude.json and drops bypassPermissionsModeAccepted,
 	//    causing the "Welcome to Claude Code" screen on next launch.
-	outputDir := opts.CompileOptions.OutputDir
-	if outputDir == "" {
-		outputDir = DefaultCompileOptions().OutputDir
-	}
 	if err := patchClaudeJSON(outputDir, settings.Claude.ClaudeJSON); err != nil {
 		log.Printf("[SETUP] Warning: failed to re-patch .claude.json: %v", err)
 	}

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -246,8 +246,10 @@ type CodexConfig struct {
 
 // PiConfig holds Pi coding agent-specific configuration data.
 type PiConfig struct {
-	// SettingsJSON is merged into ~/.pi/agent/settings.json for Pi sessions.
+	// SettingsJSON is merged into ~/.pi/agent/settings.json.
 	SettingsJSON map[string]interface{} `yaml:"settings_json,omitempty" json:"settings_json,omitempty"`
+	// ModelsJSON is merged into ~/.pi/agent/models.json.
+	ModelsJSON map[string]interface{} `yaml:"models_json,omitempty" json:"models_json,omitempty"`
 }
 
 // RepositoryConfig holds repository information.

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -157,6 +157,7 @@ type SessionSettings struct {
 	Env            map[string]string    `yaml:"env,omitempty"             json:"env,omitempty"`
 	Claude         ClaudeConfig         `yaml:"claude,omitempty"          json:"claude,omitempty"`
 	Codex          CodexConfig          `yaml:"codex,omitempty"           json:"codex,omitempty"`
+	Pi             PiConfig             `yaml:"pi,omitempty"              json:"pi,omitempty"`
 	Repository     *RepositoryConfig    `yaml:"repository,omitempty"      json:"repository,omitempty"`
 	InitialMessage string               `yaml:"initial_message,omitempty" json:"initial_message,omitempty"`
 	WebhookPayload string               `yaml:"webhook_payload,omitempty" json:"webhook_payload,omitempty"`
@@ -241,6 +242,12 @@ type CodexConfig struct {
 	// array-of-tables entry so the Codex CLI can read them natively.
 	// The map format mirrors ClaudeConfig.MCPServers for consistency.
 	MCPServers map[string]interface{} `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+}
+
+// PiConfig holds Pi coding agent-specific configuration data.
+type PiConfig struct {
+	// SettingsJSON is merged into ~/.pi/agent/settings.json for Pi sessions.
+	SettingsJSON map[string]interface{} `yaml:"settings_json,omitempty" json:"settings_json,omitempty"`
 }
 
 // RepositoryConfig holds repository information.


### PR DESCRIPTION
## Summary
- map `PI_DEFAULT_PROVIDER`, `PI_DEFAULT_MODEL`, and `PI_DEFAULT_THINKING_LEVEL` into Pi settings for any agent type
- generate `~/.pi/agent/settings.json` whenever managed Pi defaults are present
- configure one Pi custom model from `PI_CUSTOM_MODEL_*` environment variables and generate `~/.pi/agent/models.json`
- accept `PI_CUSTOM_PROVIDER` as a compatibility alias for `PI_CUSTOM_MODEL_PROVIDER`
- reference API credentials as `$<ENV_NAME>` instead of writing secret values into models.json
- preserve existing providers and upsert models by ID; enforce `0600` file permissions

## Custom model variables
Required: `PI_CUSTOM_MODEL_PROVIDER` (or `PI_CUSTOM_PROVIDER`), `PI_CUSTOM_MODEL_ID`, `PI_CUSTOM_MODEL_BASE_URL`

Optional: `PI_CUSTOM_MODEL_NAME`, `PI_CUSTOM_MODEL_API`, `PI_CUSTOM_MODEL_API_KEY_ENV`, `PI_CUSTOM_MODEL_REASONING`, `PI_CUSTOM_MODEL_CONTEXT_WINDOW`, `PI_CUSTOM_MODEL_MAX_TOKENS`

## Testing
- `mise exec -- make lint`
- `env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT mise exec -- make test`

The Kubernetes service variables are unset for the full test run because existing `cmd` shutdown tests send SIGINT after a fixed 100ms and otherwise race with in-cluster initialization.