### PR TITLE
fix: preserve default sandbox count mode

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2552,6 +2552,7 @@ func (m *KubernetesSessionManager) resolveSandboxParams(ctx context.Context, req
 		Enabled:        req.Sandbox.Enabled,
 		AllowedDomains: req.Sandbox.AllowedDomains,
 		DeniedDomains:  req.Sandbox.DeniedDomains,
+		CountMode:      req.Sandbox.CountMode,
 	}
 	if req.Sandbox.PolicyID == "" || m.sandboxPolicyRepo == nil {
 		return effective

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -78,6 +78,22 @@ func TestBuildSandboxContainersGeneratesRulesThenRestoresWithIptablesImage(t *te
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
 }
 
+func TestResolveSandboxParamsPreservesSessionCountModeWithoutPolicy(t *testing.T) {
+	manager := &KubernetesSessionManager{}
+	req := &entities.RunServerRequest{
+		Sandbox: &entities.SandboxParams{
+			Enabled:   true,
+			CountMode: true,
+		},
+	}
+
+	effective := manager.resolveSandboxParams(context.Background(), req)
+
+	assert.NotNil(t, effective)
+	assert.True(t, effective.Enabled)
+	assert.True(t, effective.CountMode)
+}
+
 func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 	manager := &KubernetesSessionManager{
 		config: &config.Config{


### PR DESCRIPTION
## Summary
- preserve session-level sandbox count mode while resolving effective Kubernetes sandbox settings
- add a regression test for sessions without a sandbox policy

## Verification
- `make lint`
- `make test`
- focused race-detector test for sandbox resolution

## Context
Sessions without an explicit sandbox policy are intended to run in count mode. The launch path set `CountMode=true`, but `resolveSandboxParams` dropped that value, causing the network filter to enforce deny-all mode.