### PR TITLE
fix: apply sandbox policy when adopting stock sessions

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -348,6 +349,7 @@ func (m *KubernetesSessionManager) StopStatusSubscriber() {
 // If no stock is available, a new session is created from scratch.
 func (m *KubernetesSessionManager) allocateSessionDirect(ctx context.Context, id string, req *entities.RunServerRequest, webhookPayload []byte) (entities.Session, error) {
 	req.AgentType = supportedAgentTypeOrDefault(req.AgentType)
+	applySandboxDefaults(req)
 
 	// Attempt to adopt a stock session matching the requested pod capabilities
 	// before creating a new one.
@@ -513,7 +515,7 @@ func (m *KubernetesSessionManager) CreateStockSession(ctx context.Context, dind 
 	// Stock sessions have no owner; the minimal request holds pod capabilities only.
 	// Sandbox is always enabled; only DinD is configurable.
 	minimalReq := &entities.RunServerRequest{
-		Sandbox: &entities.SandboxParams{Enabled: true},
+		Sandbox: stockSandboxParams(),
 	}
 	if dind {
 		minimalReq.Docker = &entities.DockerParams{Enabled: true}
@@ -824,6 +826,16 @@ func (m *KubernetesSessionManager) adoptStockSession(
 	m.mutex.Unlock()
 
 	log.Printf("[K8S_SESSION] Adopting stock session %s in namespace %s", stockID, m.namespace)
+
+	effectiveSandbox := m.resolveSandboxParams(ctx, req)
+	if err := applySandboxPolicyToProvisioner(ctx, stockSvc, effectiveSandbox); err != nil {
+		if delErr := m.deleteSessionResources(ctx, session); delErr != nil {
+			log.Printf("[K8S_SESSION] Failed to cleanup stock session after sandbox policy error: %v", delErr)
+		}
+		m.cleanupSession(stockID)
+		cancel()
+		return nil, fmt.Errorf("failed to apply sandbox policy to stock session: %w", err)
+	}
 
 	// Check whether the stock already has a PVC; if not, we leave it as EmptyDir.
 	_, pvcErr := m.client.CoreV1().PersistentVolumeClaims(m.namespace).Get(ctx, pvcName, metav1.GetOptions{})
@@ -2568,6 +2580,71 @@ func (m *KubernetesSessionManager) resolveSandboxParams(ctx context.Context, req
 		effective.CountMode = true
 	}
 	return effective
+}
+
+func stockSandboxParams() *entities.SandboxParams {
+	return &entities.SandboxParams{Enabled: true, CountMode: true}
+}
+
+func applySandboxDefaults(req *entities.RunServerRequest) {
+	if req.Sandbox == nil {
+		req.Sandbox = &entities.SandboxParams{Enabled: true, CountMode: true}
+		return
+	}
+	req.Sandbox.Enabled = true
+	if req.Sandbox.PolicyID == "" && len(req.Sandbox.AllowedDomains) == 0 && len(req.Sandbox.DeniedDomains) == 0 {
+		req.Sandbox.CountMode = true
+	}
+}
+
+func applySandboxPolicyToProvisioner(ctx context.Context, stockSvc *corev1.Service, sandbox *entities.SandboxParams) error {
+	body, err := json.Marshal(struct {
+		Allowed   []string `json:"allowed,omitempty"`
+		Denied    []string `json:"denied,omitempty"`
+		CountMode bool     `json:"count_mode,omitempty"`
+	}{
+		Allowed:   sandbox.AllowedDomains,
+		Denied:    sandbox.DeniedDomains,
+		CountMode: sandbox.CountMode,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal sandbox policy: %w", err)
+	}
+
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d/sandbox-policy", stockSvc.Name, stockSvc.Namespace, ProvisionerPort)
+	client := &http.Client{Timeout: 2 * time.Second}
+	var lastErr error
+	for attempt := 0; attempt < 10; attempt++ {
+		if err := postSandboxPolicy(ctx, client, url, body); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return lastErr
+}
+
+func postSandboxPolicy(ctx context.Context, client *http.Client, url string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create sandbox policy request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post sandbox policy: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return fmt.Errorf("post sandbox policy returned %s: %s", resp.Status, strings.TrimSpace(string(responseBody)))
+	}
+	return nil
 }
 
 // buildSandboxContainers returns the init containers (iptables rule generation

--- a/internal/infrastructure/services/kubernetes_session_manager_stock_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_stock_sandbox_test.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+func TestStockSandboxParamsUsesCountMode(t *testing.T) {
+	sandbox := stockSandboxParams()
+
+	assert.True(t, sandbox.Enabled)
+	assert.True(t, sandbox.CountMode)
+	assert.Empty(t, sandbox.AllowedDomains)
+	assert.Empty(t, sandbox.DeniedDomains)
+}
+
+func TestApplySandboxDefaultsUsesCountModeWithoutRules(t *testing.T) {
+	req := &entities.RunServerRequest{}
+
+	applySandboxDefaults(req)
+
+	assert.NotNil(t, req.Sandbox)
+	assert.True(t, req.Sandbox.Enabled)
+	assert.True(t, req.Sandbox.CountMode)
+}
+
+func TestApplySandboxDefaultsPreservesEnforcedRules(t *testing.T) {
+	req := &entities.RunServerRequest{Sandbox: &entities.SandboxParams{
+		AllowedDomains: []string{"slack.com"},
+	}}
+
+	applySandboxDefaults(req)
+
+	assert.True(t, req.Sandbox.Enabled)
+	assert.False(t, req.Sandbox.CountMode)
+}
+
+func TestPostSandboxPolicy(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("request = %s content-type=%q", r.Method, r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := postSandboxPolicy(context.Background(), server.Client(), server.URL, []byte(`{"allowed":["slack.com"]}`))
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"allowed":["slack.com"]}`, gotBody)
+}

--- a/pkg/provisioner/server.go
+++ b/pkg/provisioner/server.go
@@ -88,6 +88,8 @@ type StatusResponse struct {
 type Server struct {
 	port         int
 	settingsFile string // path to optional auto-provision settings file
+	httpClient   *http.Client
+	filterURL    string
 
 	mu        sync.RWMutex
 	status    Status
@@ -107,6 +109,8 @@ func New(port int, settingsFile string) *Server {
 	return &Server{
 		port:         port,
 		settingsFile: settingsFile,
+		httpClient:   http.DefaultClient,
+		filterURL:    "http://127.0.0.1:3129",
 		status:       StatusPending,
 		phase:        "starting",
 		phaseTime:    time.Now(),
@@ -147,6 +151,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/status", s.handleStatus)
 	mux.HandleFunc("/sandbox-domains", s.handleSandboxDomains)
+	mux.HandleFunc("/sandbox-policy", s.handleSandboxPolicy)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", s.port),
@@ -247,7 +252,7 @@ func (s *Server) handleSandboxDomains(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := http.Get("http://127.0.0.1:3129/domains") //nolint:noctx
+	resp, err := s.client().Get(s.controlURL() + "/domains") //nolint:noctx
 	if err != nil {
 		http.Error(w, "network filter not available", http.StatusServiceUnavailable)
 		return
@@ -257,6 +262,47 @@ func (s *Server) handleSandboxDomains(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+// handleSandboxPolicy replaces the running network filter policy. This is used
+// when a pre-warmed stock Pod is adopted for a session with its own sandbox
+// policy, allowing the policy to change without restarting the Pod.
+func (s *Server) handleSandboxPolicy(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, s.controlURL()+"/policy", r.Body)
+	if err != nil {
+		http.Error(w, "invalid network filter request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client().Do(req)
+	if err != nil {
+		http.Error(w, "network filter not available", http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func (s *Server) client() *http.Client {
+	if s.httpClient != nil {
+		return s.httpClient
+	}
+	return http.DefaultClient
+}
+
+func (s *Server) controlURL() string {
+	if s.filterURL != "" {
+		return s.filterURL
+	}
+	return "http://127.0.0.1:3129"
 }
 
 // runStartupScript executes the common startup pre-script as soon as the Pod

--- a/pkg/provisioner/server_sandbox_test.go
+++ b/pkg/provisioner/server_sandbox_test.go
@@ -1,0 +1,50 @@
+package provisioner
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleSandboxPolicyForwardsToNetworkFilter(t *testing.T) {
+	var gotMethod, gotContentType, gotBody string
+	filter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("policy configured"))
+	}))
+	defer filter.Close()
+
+	server := &Server{httpClient: filter.Client(), filterURL: filter.URL}
+	req := httptest.NewRequest(http.MethodPost, "/sandbox-policy", strings.NewReader(`{"allowed":["slack.com"],"count_mode":false}`))
+	resp := httptest.NewRecorder()
+
+	server.handleSandboxPolicy(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusOK)
+	}
+	if gotMethod != http.MethodPost || gotContentType != "application/json" {
+		t.Fatalf("forwarded request = %s %q", gotMethod, gotContentType)
+	}
+	if gotBody != `{"allowed":["slack.com"],"count_mode":false}` {
+		t.Fatalf("forwarded body = %q", gotBody)
+	}
+}
+
+func TestHandleSandboxPolicyReturnsServiceUnavailable(t *testing.T) {
+	server := &Server{filterURL: "http://127.0.0.1:1", httpClient: &http.Client{}}
+	req := httptest.NewRequest(http.MethodPost, "/sandbox-policy", strings.NewReader(`{}`))
+	resp := httptest.NewRecorder()
+
+	server.handleSandboxPolicy(resp, req)
+
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusServiceUnavailable)
+	}
+}


### PR DESCRIPTION
## Summary
- start pre-warmed stock sessions in sandbox count mode
- apply the resolved session sandbox policy dynamically through nfa `POST /policy` before provisioning an adopted stock session
- clean up claimed stock resources when policy application fails
- add regression tests for count-mode defaults and provisioner policy forwarding

## Verification
- `make lint`
- `env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT mise x go zig -- env CC='zig cc' make test`
- `mise x go zig -- env CC='zig cc' CGO_ENABLED=1 go test -race ./pkg/provisioner ./internal/infrastructure/services`

The Kubernetes service environment is removed only for tests so the existing graceful-shutdown test uses the fake Kubernetes client instead of restoring live in-cluster sessions.