### PR TITLE
feat: configure affinity for session pods

### DIFF
--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -354,7 +354,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME
               value: {{ printf "%s-github-config" (include "agentapi-proxy.fullname" .) | quote }}
             {{- end }}
-            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations }}
+            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.affinity .Values.kubernetesSession.tolerations }}
             - name: AGENTAPI_K8S_SESSION_CONFIG_FILE
               value: "/etc/k8s-session-config/k8s-session-config.yaml"
             {{- end }}
@@ -584,7 +584,7 @@ spec:
               mountPath: /etc/github-app
               readOnly: true
             {{- end }}
-            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
+            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.affinity .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
             - name: k8s-session-config
               mountPath: /etc/k8s-session-config
               readOnly: true
@@ -632,7 +632,7 @@ spec:
             secretName: {{ .Values.github.app.privateKey.secretName }}
             defaultMode: 0440
         {{- end }}
-        {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
+        {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.affinity .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
         - name: k8s-session-config
           configMap:
             name: {{ include "agentapi-proxy.fullname" . }}-k8s-session-config

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -354,7 +354,7 @@ spec:
             - name: AGENTAPI_K8S_SESSION_GITHUB_CONFIG_SECRET_NAME
               value: {{ printf "%s-github-config" (include "agentapi-proxy.fullname" .) | quote }}
             {{- end }}
-            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations }}
+            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations }}
             - name: AGENTAPI_K8S_SESSION_CONFIG_FILE
               value: "/etc/k8s-session-config/k8s-session-config.yaml"
             {{- end }}
@@ -584,7 +584,7 @@ spec:
               mountPath: /etc/github-app
               readOnly: true
             {{- end }}
-            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
+            {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
             - name: k8s-session-config
               mountPath: /etc/k8s-session-config
               readOnly: true
@@ -632,7 +632,7 @@ spec:
             secretName: {{ .Values.github.app.privateKey.secretName }}
             defaultMode: 0440
         {{- end }}
-        {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
+        {{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
         - name: k8s-session-config
           configMap:
             name: {{ include "agentapi-proxy.fullname" . }}-k8s-session-config

--- a/helm/agentapi-proxy/templates/k8s-session-configmap.yaml
+++ b/helm/agentapi-proxy/templates/k8s-session-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
+{{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +11,12 @@ data:
       {{- if .Values.kubernetesSession.nodeSelector }}
       node_selector:
         {{- range $key, $value := .Values.kubernetesSession.nodeSelector }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.kubernetesSession.preferredNodeSelector }}
+      preferred_node_selector:
+        {{- range $key, $value := .Values.kubernetesSession.preferredNodeSelector }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}

--- a/helm/agentapi-proxy/templates/k8s-session-configmap.yaml
+++ b/helm/agentapi-proxy/templates/k8s-session-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.preferredNodeSelector .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
+{{- if or .Values.kubernetesSession.nodeSelector .Values.kubernetesSession.affinity .Values.kubernetesSession.tolerations .Values.kubernetesSession.podTemplate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,11 +14,9 @@ data:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
-      {{- if .Values.kubernetesSession.preferredNodeSelector }}
-      preferred_node_selector:
-        {{- range $key, $value := .Values.kubernetesSession.preferredNodeSelector }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
+      {{- if .Values.kubernetesSession.affinity }}
+      affinity:
+        {{- toYaml .Values.kubernetesSession.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.kubernetesSession.tolerations }}
       tolerations:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -561,10 +561,17 @@ kubernetesSession:
   #   kubernetes.io/arch: amd64
   nodeSelector: {}
 
-  # Soft preference; pods fall back to other nodes when none match.
-  # preferredNodeSelector:
-  #   node-pool: agent
-  preferredNodeSelector: {}
+  # Kubernetes affinity rules for session pods. Example soft preference:
+  # affinity:
+  #   nodeAffinity:
+  #     preferredDuringSchedulingIgnoredDuringExecution:
+  #       - weight: 100
+  #         preference:
+  #           matchExpressions:
+  #             - key: node-pool
+  #               operator: In
+  #               values: [agent]
+  affinity: {}
 
   # Tolerations for session pods
   # Example:

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -561,6 +561,11 @@ kubernetesSession:
   #   kubernetes.io/arch: amd64
   nodeSelector: {}
 
+  # Soft preference; pods fall back to other nodes when none match.
+  # preferredNodeSelector:
+  #   node-pool: agent
+  preferredNodeSelector: {}
+
   # Tolerations for session pods
   # Example:
   # tolerations:

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2288,6 +2288,7 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 					Containers:     containers,
 					Volumes:        volumes,
 					NodeSelector:   m.k8sConfig.NodeSelector,
+					Affinity:       preferredNodeAffinity(m.k8sConfig.PreferredNodeSelector),
 					Tolerations:    tolerations,
 				},
 			},
@@ -2297,6 +2298,31 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 		return nil, err
 	}
 	return deployment, nil
+}
+
+func preferredNodeAffinity(selector map[string]string) *corev1.Affinity {
+	if len(selector) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(selector))
+	for key := range selector {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	requirements := make([]corev1.NodeSelectorRequirement, 0, len(keys))
+	for _, key := range keys {
+		requirements = append(requirements, corev1.NodeSelectorRequirement{
+			Key: key, Operator: corev1.NodeSelectorOpIn, Values: []string{selector[key]},
+		})
+	}
+	return &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+			Weight: 100,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: requirements,
+			},
+		}},
+	}}
 }
 
 func (m *KubernetesSessionManager) applySessionPodTemplateFile(template *corev1.PodTemplateSpec) error {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2257,6 +2256,11 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 		podAnnotations["prometheus.io/path"] = "/metrics"
 	}
 
+	affinity, err := sessionAffinity(m.k8sConfig.Affinity)
+	if err != nil {
+		return nil, err
+	}
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            session.DeploymentName(),
@@ -2288,7 +2292,7 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 					Containers:     containers,
 					Volumes:        volumes,
 					NodeSelector:   m.k8sConfig.NodeSelector,
-					Affinity:       preferredNodeAffinity(m.k8sConfig.PreferredNodeSelector),
+					Affinity:       affinity,
 					Tolerations:    tolerations,
 				},
 			},
@@ -2300,29 +2304,19 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	return deployment, nil
 }
 
-func preferredNodeAffinity(selector map[string]string) *corev1.Affinity {
-	if len(selector) == 0 {
-		return nil
+func sessionAffinity(value map[string]interface{}) (*corev1.Affinity, error) {
+	if len(value) == 0 {
+		return nil, nil
 	}
-	keys := make([]string, 0, len(selector))
-	for key := range selector {
-		keys = append(keys, key)
+	data, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal session affinity: %w", err)
 	}
-	sort.Strings(keys)
-	requirements := make([]corev1.NodeSelectorRequirement, 0, len(keys))
-	for _, key := range keys {
-		requirements = append(requirements, corev1.NodeSelectorRequirement{
-			Key: key, Operator: corev1.NodeSelectorOpIn, Values: []string{selector[key]},
-		})
+	var affinity corev1.Affinity
+	if err := json.Unmarshal(data, &affinity); err != nil {
+		return nil, fmt.Errorf("failed to parse session affinity: %w", err)
 	}
-	return &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{
-		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
-			Weight: 100,
-			Preference: corev1.NodeSelectorTerm{
-				MatchExpressions: requirements,
-			},
-		}},
-	}}
+	return &affinity, nil
 }
 
 func (m *KubernetesSessionManager) applySessionPodTemplateFile(template *corev1.PodTemplateSpec) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -327,6 +327,8 @@ type KubernetesSessionConfig struct {
 	// NodeSelector is a selector which must be true for the pod to fit on a node
 	// Example: {"disktype": "ssd", "kubernetes.io/arch": "amd64"}
 	NodeSelector map[string]string `json:"node_selector,omitempty" mapstructure:"node_selector" yaml:"node_selector"`
+	// PreferredNodeSelector is a soft node scheduling preference.
+	PreferredNodeSelector map[string]string `json:"preferred_node_selector,omitempty" mapstructure:"preferred_node_selector" yaml:"preferred_node_selector"`
 	// Tolerations are tolerations for session pods to schedule onto nodes with matching taints
 	Tolerations []Toleration `json:"tolerations,omitempty" mapstructure:"tolerations" yaml:"tolerations"`
 
@@ -1711,8 +1713,9 @@ func loadAuthConfigFromFile(config *Config, filename string) error {
 // K8sSessionConfigOverride represents kubernetes session configuration overrides from external file
 type K8sSessionConfigOverride struct {
 	KubernetesSession *struct {
-		NodeSelector map[string]string `json:"node_selector,omitempty" yaml:"node_selector"`
-		Tolerations  []Toleration      `json:"tolerations,omitempty" yaml:"tolerations"`
+		NodeSelector          map[string]string `json:"node_selector,omitempty" yaml:"node_selector"`
+		PreferredNodeSelector map[string]string `json:"preferred_node_selector,omitempty" yaml:"preferred_node_selector"`
+		Tolerations           []Toleration      `json:"tolerations,omitempty" yaml:"tolerations"`
 	} `json:"kubernetes_session,omitempty" yaml:"kubernetes_session"`
 }
 
@@ -1748,6 +1751,10 @@ func loadK8sSessionConfigFromFile(config *Config, filename string) error {
 		if k8sOverride.KubernetesSession.NodeSelector != nil {
 			config.KubernetesSession.NodeSelector = k8sOverride.KubernetesSession.NodeSelector
 			log.Printf("[CONFIG] Applied kubernetes session node_selector: %v", config.KubernetesSession.NodeSelector)
+		}
+		if k8sOverride.KubernetesSession.PreferredNodeSelector != nil {
+			config.KubernetesSession.PreferredNodeSelector = k8sOverride.KubernetesSession.PreferredNodeSelector
+			log.Printf("[CONFIG] Applied kubernetes session preferred_node_selector: %v", config.KubernetesSession.PreferredNodeSelector)
 		}
 		if k8sOverride.KubernetesSession.Tolerations != nil {
 			config.KubernetesSession.Tolerations = k8sOverride.KubernetesSession.Tolerations

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -327,8 +327,8 @@ type KubernetesSessionConfig struct {
 	// NodeSelector is a selector which must be true for the pod to fit on a node
 	// Example: {"disktype": "ssd", "kubernetes.io/arch": "amd64"}
 	NodeSelector map[string]string `json:"node_selector,omitempty" mapstructure:"node_selector" yaml:"node_selector"`
-	// PreferredNodeSelector is a soft node scheduling preference.
-	PreferredNodeSelector map[string]string `json:"preferred_node_selector,omitempty" mapstructure:"preferred_node_selector" yaml:"preferred_node_selector"`
+	// Affinity configures Kubernetes affinity rules for session pods.
+	Affinity map[string]interface{} `json:"affinity,omitempty" mapstructure:"affinity" yaml:"affinity"`
 	// Tolerations are tolerations for session pods to schedule onto nodes with matching taints
 	Tolerations []Toleration `json:"tolerations,omitempty" mapstructure:"tolerations" yaml:"tolerations"`
 
@@ -1714,7 +1714,7 @@ func loadAuthConfigFromFile(config *Config, filename string) error {
 type K8sSessionConfigOverride struct {
 	KubernetesSession *struct {
 		NodeSelector          map[string]string `json:"node_selector,omitempty" yaml:"node_selector"`
-		PreferredNodeSelector map[string]string `json:"preferred_node_selector,omitempty" yaml:"preferred_node_selector"`
+		Affinity     map[string]interface{} `json:"affinity,omitempty" yaml:"affinity"`
 		Tolerations           []Toleration      `json:"tolerations,omitempty" yaml:"tolerations"`
 	} `json:"kubernetes_session,omitempty" yaml:"kubernetes_session"`
 }
@@ -1752,9 +1752,9 @@ func loadK8sSessionConfigFromFile(config *Config, filename string) error {
 			config.KubernetesSession.NodeSelector = k8sOverride.KubernetesSession.NodeSelector
 			log.Printf("[CONFIG] Applied kubernetes session node_selector: %v", config.KubernetesSession.NodeSelector)
 		}
-		if k8sOverride.KubernetesSession.PreferredNodeSelector != nil {
-			config.KubernetesSession.PreferredNodeSelector = k8sOverride.KubernetesSession.PreferredNodeSelector
-			log.Printf("[CONFIG] Applied kubernetes session preferred_node_selector: %v", config.KubernetesSession.PreferredNodeSelector)
+		if k8sOverride.KubernetesSession.Affinity != nil {
+			config.KubernetesSession.Affinity = k8sOverride.KubernetesSession.Affinity
+			log.Printf("[CONFIG] Applied kubernetes session affinity: %v", config.KubernetesSession.Affinity)
 		}
 		if k8sOverride.KubernetesSession.Tolerations != nil {
 			config.KubernetesSession.Tolerations = k8sOverride.KubernetesSession.Tolerations


### PR DESCRIPTION
## Summary
- add Kubernetes-native `kubernetesSession.affinity` Helm configuration
- pass affinity rules through the session config into session Pod `spec.affinity`
- support soft node preference with `nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution`
- preserve fallback scheduling when matching nodes are unavailable

## Example
```yaml
kubernetesSession:
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 100
          preference:
            matchExpressions:
              - key: node-pool
                operator: In
                values: [agent]
```

## Validation
- `git diff --check` passed
- `make lint` could not run: Go toolchain is not installed in the agent environment
- `make test` could not run: Go toolchain is not installed in the agent environment