### PR TITLE
fix: normalize YAML maps in session affinity

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2309,7 +2309,11 @@ func sessionAffinity(value map[string]interface{}) (*corev1.Affinity, error) {
 	if len(value) == 0 {
 		return nil, nil
 	}
-	data, err := json.Marshal(value)
+	normalized, err := normalizeJSONValue(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize session affinity: %w", err)
+	}
+	data, err := json.Marshal(normalized)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal session affinity: %w", err)
 	}
@@ -2318,6 +2322,47 @@ func sessionAffinity(value map[string]interface{}) (*corev1.Affinity, error) {
 		return nil, fmt.Errorf("failed to parse session affinity: %w", err)
 	}
 	return &affinity, nil
+}
+
+func normalizeJSONValue(value interface{}) (interface{}, error) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		normalized := make(map[string]interface{}, len(typed))
+		for key, item := range typed {
+			value, err := normalizeJSONValue(item)
+			if err != nil {
+				return nil, err
+			}
+			normalized[key] = value
+		}
+		return normalized, nil
+	case map[interface{}]interface{}:
+		normalized := make(map[string]interface{}, len(typed))
+		for key, item := range typed {
+			stringKey, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("affinity map key must be a string, got %T", key)
+			}
+			value, err := normalizeJSONValue(item)
+			if err != nil {
+				return nil, err
+			}
+			normalized[stringKey] = value
+		}
+		return normalized, nil
+	case []interface{}:
+		normalized := make([]interface{}, len(typed))
+		for index, item := range typed {
+			value, err := normalizeJSONValue(item)
+			if err != nil {
+				return nil, err
+			}
+			normalized[index] = value
+		}
+		return normalized, nil
+	default:
+		return value, nil
+	}
 }
 
 func (m *KubernetesSessionManager) applySessionPodTemplateFile(template *corev1.PodTemplateSpec) error {

--- a/internal/infrastructure/services/kubernetes_session_manager_affinity_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_affinity_test.go
@@ -1,0 +1,51 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSessionAffinityNormalizesYAMLMaps(t *testing.T) {
+	value := map[string]interface{}{
+		"nodeAffinity": map[interface{}]interface{}{
+			"preferredDuringSchedulingIgnoredDuringExecution": []interface{}{
+				map[interface{}]interface{}{
+					"weight": 100,
+					"preference": map[interface{}]interface{}{
+						"matchExpressions": []interface{}{
+							map[interface{}]interface{}{
+								"key":      "kubernetes.io/hostname",
+								"operator": "In",
+								"values":   []interface{}{"ai-worker"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	affinity, err := sessionAffinity(value)
+	require.NoError(t, err)
+	require.NotNil(t, affinity)
+	require.NotNil(t, affinity.NodeAffinity)
+	terms := affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, terms, 1)
+	assert.Equal(t, int32(100), terms[0].Weight)
+	assert.Equal(t, []corev1.NodeSelectorRequirement{{
+		Key:      "kubernetes.io/hostname",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{"ai-worker"},
+	}}, terms[0].Preference.MatchExpressions)
+}
+
+func TestSessionAffinityRejectsNonStringMapKey(t *testing.T) {
+	_, err := sessionAffinity(map[string]interface{}{
+		"nodeAffinity": map[interface{}]interface{}{1: "invalid"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "affinity map key must be a string")
+}


### PR DESCRIPTION
## Summary
- recursively normalize YAML-decoded `map[interface{}]interface{}` values before JSON conversion
- reject non-string affinity map keys with a clear error
- add regression coverage for preferred node affinity using `kubernetes.io/hostname=ai-worker`

## Validation
- `git diff --check` passed
- local `make lint` and `make test` could not run because the Go toolchain is absent from this agent environment; CI will perform both checks