### PR TITLE
fix: disable nested Codex sandbox for ACP sessions

### DIFF
--- a/config/codex-config.toml
+++ b/config/codex-config.toml
@@ -2,3 +2,6 @@
 # approval-mode = "full-auto" bypasses interactive permission prompts,
 # equivalent to bypassPermissionsModeAccepted in Claude Code's .claude.json.
 approval-mode = "full-auto"
+# Session containers are already isolated by agentapi-proxy. Keep Codex's own
+# nested Linux sandbox disabled for direct Codex invocations as well.
+sandbox_mode = "danger-full-access"

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -5019,6 +5019,14 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		session.SetResolvedAPIKey(apiKey)
 	}
 
+	// codex-acp explicitly sends its selected sandbox policy with every turn,
+	// overriding sandbox_mode from ~/.codex/config.toml. Session Pods are already
+	// isolated by agentapi-proxy, so start the adapter in its full-access mode to
+	// avoid attempting to create a nested bubblewrap sandbox.
+	if req.AgentType == "codex-acp" {
+		env["INITIAL_AGENT_MODE"] = "agent-full-access"
+	}
+
 	settings.Env = env
 
 	settings.Pi = sessionsettings.PiConfig{
@@ -5094,7 +5102,7 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			ConfigTOML: "approval-mode = \"full-auto\"\nsandbox_mode = \"danger-full-access\"\n",
 			MCPServers: materialized.MCPServers,
 		}
-		log.Printf("[K8S_SESSION] Injected Codex hooks and set approval-mode=full-auto, sandbox_mode=danger-full-access for session %s", session.id)
+		log.Printf("[K8S_SESSION] Injected Codex hooks and set INITIAL_AGENT_MODE=agent-full-access, approval-mode=full-auto, sandbox_mode=danger-full-access for session %s", session.id)
 	}
 
 	// Repository info

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -146,6 +146,53 @@ func TestBuildSessionSettings_TeamSettingsUsesRepositoryEnvVars(t *testing.T) {
 	}
 }
 
+func TestBuildSessionSettings_CodexACPDisablesNestedSandbox(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	cfg := &config.Config{
+		KubernetesSession: config.KubernetesSessionConfig{
+			Namespace:     "test-ns",
+			Image:         "test-image:latest",
+			BasePort:      9000,
+			PVCEnabled:    boolPtrForTest(false),
+			CPURequest:    "100m",
+			CPULimit:      "1",
+			MemoryRequest: "128Mi",
+			MemoryLimit:   "512Mi",
+		},
+	}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.namespace = "test-ns"
+
+	req := &entities.RunServerRequest{
+		UserID:    "test-user",
+		AgentType: "codex-acp",
+	}
+	session := NewKubernetesSession(
+		"test-session",
+		req,
+		"test-deploy",
+		"agentapi-session-test-svc",
+		"test-pvc",
+		"test-ns",
+		9000,
+		nil,
+		nil,
+	)
+
+	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	if got := settings.Env["INITIAL_AGENT_MODE"]; got != "agent-full-access" {
+		t.Fatalf("INITIAL_AGENT_MODE = %q, want agent-full-access", got)
+	}
+	if !strings.Contains(settings.Codex.ConfigTOML, `sandbox_mode = "danger-full-access"`) {
+		t.Fatalf("Codex config does not disable the nested sandbox: %q", settings.Codex.ConfigTOML)
+	}
+}
+
 func TestBuildSessionSettings_PiOllamaConfiguresCloudProvider(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},


### PR DESCRIPTION
## Summary

- set `INITIAL_AGENT_MODE=agent-full-access` for `codex-acp` session Pods
- keep the image-level Codex default at `sandbox_mode = "danger-full-access"`
- add a regression test for generated Codex ACP session settings

## Why

`codex-acp` sends the selected agent mode sandbox policy on every turn. Its default `agent` mode therefore overrides `~/.codex/config.toml` with `workspace-write`, causing Codex to initialize a nested bubblewrap sandbox inside an already isolated session container. In the session environment that initialization fails with `bwrap: Failed to make / slave: Permission denied`.

## Verification

- `make lint`
- `env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT make test`
- `make build`

The Kubernetes variables are removed for tests so the `cmd` package uses its CI/non-cluster path instead of connecting to the live session cluster.