### PR TITLE
feat: nfa v0.12.0 で IP/CIDR allowlist を適用

### DIFF
--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -491,9 +491,9 @@ kubernetesSession:
   image: ""
 
   # Container image for the network-filter sidecar and initContainer (sandbox feature)
-  networkFilterImage: "ghcr.io/takutakahashi/nfa:0.7.0"
+  networkFilterImage: "ghcr.io/takutakahashi/nfa:0.12.0"
 
-  # Container image for restoring generated sandbox iptables rules.
+  # Deprecated: nfa v0.12.0+ applies sandbox iptables rules directly.
   sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"
 
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -493,7 +493,7 @@ kubernetesSession:
   # Container image for the network-filter sidecar and initContainer (sandbox feature)
   networkFilterImage: "ghcr.io/takutakahashi/nfa:0.12.0"
 
-  # Deprecated: nfa v0.12.0+ applies sandbox iptables rules directly.
+  # Container image for restoring generated sandbox iptables rules.
   sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"
 
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -37,8 +37,9 @@ type SandboxParams struct {
 	// PolicyID references a SandboxPolicy resource whose domain lists are merged into the session.
 	// Session-level AllowedDomains and DeniedDomains are appended on top of the policy.
 	PolicyID string `json:"policy_id,omitempty"`
-	// AllowedDomains is the list of hostnames whose traffic is permitted (allowlist mode).
-	// When non-empty, all other domains are blocked. Takes precedence over DeniedDomains.
+	// AllowedDomains is the list of hostnames, IPv4 addresses, and IPv4 CIDR ranges whose
+	// traffic is permitted (allowlist mode). IP addresses and ranges bypass the proxy via
+	// direct iptables rules. Takes precedence over DeniedDomains.
 	AllowedDomains []string `json:"allowed_domains,omitempty"`
 	// DeniedDomains is the list of hostnames whose traffic should be blocked (denylist mode).
 	// Used only when AllowedDomains is empty.

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2174,7 +2174,7 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	volumes := m.buildVolumes(session)
 	if sandboxEnabled {
 		volumes = append(volumes, corev1.Volume{
-			Name: "sandbox-nfa-config",
+			Name: "sandbox-iptables",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -2713,8 +2713,8 @@ func postSandboxPolicy(ctx context.Context, client *http.Client, url string, bod
 	return nil
 }
 
-// buildSandboxContainers returns the init container (nfa config + iptables setup)
-// and sidecar (network-filter proxy) needed for session network sandboxing.
+// buildSandboxContainers returns the init containers (iptables rule generation
+// and restore) and sidecar (network-filter proxy) needed for session network sandboxing.
 // The sidecar runs as UID 0 (root) so that iptables rules can skip its traffic
 // via the "--uid-owner 0" match, preventing redirect loops.
 func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.SandboxParams) ([]corev1.Container, *corev1.Container, []corev1.EnvVar) {
@@ -2740,15 +2740,37 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 
 	initResources := buildResourceRequirements(m.k8sConfig.NetworkFilterInitCPURequest, m.k8sConfig.NetworkFilterInitCPULimit, m.k8sConfig.NetworkFilterInitMemoryRequest, m.k8sConfig.NetworkFilterInitMemoryLimit)
 
-	setupRulesInitContainer := corev1.Container{
-		Name:            "network-filter-setup",
+	generateRulesInitContainer := corev1.Container{
+		Name:            "network-filter-generate-iptables",
 		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Command: []string{"/bin/sh", "-ec", `
-printf '%s' "$NFA_CONFIG" > /etc/nfa/config.yaml
-exec nfa setup-iptables --apply --config /etc/nfa/config.yaml
+printf '%s' "$NFA_CONFIG" > /tmp/nfa-config.yaml
+exec nfa setup-iptables --output /etc/iptables/rules.v4 --config /tmp/nfa-config.yaml
 `},
 		Env: []corev1.EnvVar{{Name: "NFA_CONFIG", Value: nfaConfig}},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:    &rootUID,
+			RunAsNonRoot: &falseVal,
+		},
+		Resources: initResources,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "sandbox-iptables",
+				MountPath: "/etc/iptables",
+			},
+		},
+	}
+
+	sandboxInitImage := m.k8sConfig.SandboxInitImage
+	if sandboxInitImage == "" {
+		sandboxInitImage = m.k8sConfig.Image
+	}
+	restoreRulesInitContainer := corev1.Container{
+		Name:            "network-filter-setup",
+		Image:           sandboxInitImage,
+		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
+		Command:         []string{"iptables-restore", "/etc/iptables/rules.v4"},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    &rootUID,
 			RunAsNonRoot: &falseVal,
@@ -2759,8 +2781,9 @@ exec nfa setup-iptables --apply --config /etc/nfa/config.yaml
 		Resources: initResources,
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      "sandbox-nfa-config",
-				MountPath: "/etc/nfa",
+				Name:      "sandbox-iptables",
+				MountPath: "/etc/iptables",
+				ReadOnly:  true,
 			},
 		},
 	}
@@ -2771,24 +2794,17 @@ exec nfa setup-iptables --apply --config /etc/nfa/config.yaml
 		Name:            "network-filter",
 		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"nfa", "proxy", "--config", "/etc/nfa/config.yaml", "--deferred-policy"},
+		Command:         []string{"nfa", "proxy", "--deferred-policy"},
 		Env:             filterEnvVars,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &rootUID,
 			RunAsNonRoot:             &falseVal,
 			AllowPrivilegeEscalation: &falseVal,
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"NET_ADMIN"},
-			},
 		},
 		Resources: buildResourceRequirements(m.k8sConfig.NetworkFilterCPURequest, m.k8sConfig.NetworkFilterCPULimit, m.k8sConfig.NetworkFilterMemoryRequest, m.k8sConfig.NetworkFilterMemoryLimit),
 		Ports: []corev1.ContainerPort{
 			{Name: "proxy", ContainerPort: int32(nfaProxyPort), Protocol: corev1.ProtocolTCP},
 		},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      "sandbox-nfa-config",
-			MountPath: "/etc/nfa",
-		}},
 	}
 
 	// Inject HTTP_PROXY / HTTPS_PROXY env vars into the main container so that
@@ -2807,7 +2823,7 @@ exec nfa setup-iptables --apply --config /etc/nfa/config.yaml
 		{Name: "no_proxy", Value: noProxy},
 	}
 
-	return []corev1.Container{setupRulesInitContainer}, &sidecar, proxyEnvVars
+	return []corev1.Container{generateRulesInitContainer, restoreRulesInitContainer}, &sidecar, proxyEnvVars
 }
 
 func buildNFAConfig(sandbox *entities.SandboxParams) string {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2174,7 +2174,7 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	volumes := m.buildVolumes(session)
 	if sandboxEnabled {
 		volumes = append(volumes, corev1.Volume{
-			Name: "sandbox-iptables",
+			Name: "sandbox-nfa-config",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -2713,8 +2713,8 @@ func postSandboxPolicy(ctx context.Context, client *http.Client, url string, bod
 	return nil
 }
 
-// buildSandboxContainers returns the init containers (iptables rule generation
-// and restore) and sidecar (network-filter proxy) needed for session network sandboxing.
+// buildSandboxContainers returns the init container (nfa config + iptables setup)
+// and sidecar (network-filter proxy) needed for session network sandboxing.
 // The sidecar runs as UID 0 (root) so that iptables rules can skip its traffic
 // via the "--uid-owner 0" match, preventing redirect loops.
 func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.SandboxParams) ([]corev1.Container, *corev1.Container, []corev1.EnvVar) {
@@ -2736,36 +2736,19 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 	falseVal := false
 
 	nfaImage := m.k8sConfig.NetworkFilterImage
+	nfaConfig := buildNFAConfig(sandbox)
 
 	initResources := buildResourceRequirements(m.k8sConfig.NetworkFilterInitCPURequest, m.k8sConfig.NetworkFilterInitCPULimit, m.k8sConfig.NetworkFilterInitMemoryRequest, m.k8sConfig.NetworkFilterInitMemoryLimit)
 
-	generateRulesInitContainer := corev1.Container{
-		Name:            "network-filter-generate-iptables",
+	setupRulesInitContainer := corev1.Container{
+		Name:            "network-filter-setup",
 		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"nfa", "setup-iptables", "--output", "/etc/iptables/rules.v4"},
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:    &rootUID,
-			RunAsNonRoot: &falseVal,
-		},
-		Resources: initResources,
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "sandbox-iptables",
-				MountPath: "/etc/iptables",
-			},
-		},
-	}
-
-	sandboxInitImage := m.k8sConfig.SandboxInitImage
-	if sandboxInitImage == "" {
-		sandboxInitImage = m.k8sConfig.Image
-	}
-	restoreRulesInitContainer := corev1.Container{
-		Name:            "network-filter-setup",
-		Image:           sandboxInitImage,
-		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"iptables-restore", "/etc/iptables/rules.v4"},
+		Command: []string{"/bin/sh", "-ec", `
+printf '%s' "$NFA_CONFIG" > /etc/nfa/config.yaml
+exec nfa setup-iptables --apply --config /etc/nfa/config.yaml
+`},
+		Env: []corev1.EnvVar{{Name: "NFA_CONFIG", Value: nfaConfig}},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:    &rootUID,
 			RunAsNonRoot: &falseVal,
@@ -2776,9 +2759,8 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 		Resources: initResources,
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      "sandbox-iptables",
-				MountPath: "/etc/iptables",
-				ReadOnly:  true,
+				Name:      "sandbox-nfa-config",
+				MountPath: "/etc/nfa",
 			},
 		},
 	}
@@ -2789,17 +2771,24 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 		Name:            "network-filter",
 		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
-		Command:         []string{"nfa", "proxy", "--deferred-policy"},
+		Command:         []string{"nfa", "proxy", "--config", "/etc/nfa/config.yaml", "--deferred-policy"},
 		Env:             filterEnvVars,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &rootUID,
 			RunAsNonRoot:             &falseVal,
 			AllowPrivilegeEscalation: &falseVal,
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN"},
+			},
 		},
 		Resources: buildResourceRequirements(m.k8sConfig.NetworkFilterCPURequest, m.k8sConfig.NetworkFilterCPULimit, m.k8sConfig.NetworkFilterMemoryRequest, m.k8sConfig.NetworkFilterMemoryLimit),
 		Ports: []corev1.ContainerPort{
 			{Name: "proxy", ContainerPort: int32(nfaProxyPort), Protocol: corev1.ProtocolTCP},
 		},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "sandbox-nfa-config",
+			MountPath: "/etc/nfa",
+		}},
 	}
 
 	// Inject HTTP_PROXY / HTTPS_PROXY env vars into the main container so that
@@ -2818,7 +2807,33 @@ func (m *KubernetesSessionManager) buildSandboxContainers(sandbox *entities.Sand
 		{Name: "no_proxy", Value: noProxy},
 	}
 
-	return []corev1.Container{generateRulesInitContainer, restoreRulesInitContainer}, &sidecar, proxyEnvVars
+	return []corev1.Container{setupRulesInitContainer}, &sidecar, proxyEnvVars
+}
+
+func buildNFAConfig(sandbox *entities.SandboxParams) string {
+	mode := "denylist"
+	domains := []string(nil)
+	countMode := false
+	if sandbox != nil {
+		countMode = sandbox.CountMode
+		switch {
+		case len(sandbox.AllowedDomains) > 0:
+			mode = "allowlist"
+			domains = sandbox.AllowedDomains
+		case len(sandbox.DeniedDomains) > 0:
+			domains = sandbox.DeniedDomains
+		default:
+			mode = "allowlist"
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "filter:\n  mode: %s\n  countMode: %t\n  domains:\n", mode, countMode)
+	for _, domain := range domains {
+		fmt.Fprintf(&b, "    - %s\n", strconv.Quote(domain))
+	}
+	b.WriteString("deferredPolicy: true\n")
+	return b.String()
 }
 
 const (

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 )
 
-func TestBuildSandboxContainersGeneratesRulesThenRestoresWithIptablesImage(t *testing.T) {
+func TestBuildSandboxContainersAppliesNFAConfigWithIPAllowlist(t *testing.T) {
 	manager := &KubernetesSessionManager{
 		k8sConfig: &config.KubernetesSessionConfig{
 			Image:                          "session-image:latest",
 			ImagePullPolicy:                "IfNotPresent",
-			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.7.0",
+			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.0",
 			SandboxInitImage:               "gcr.io/istio-release/iptables:latest",
 			NetworkFilterCPURequest:        "250m",
 			NetworkFilterCPULimit:          "1000m",
@@ -33,16 +33,23 @@ func TestBuildSandboxContainersGeneratesRulesThenRestoresWithIptablesImage(t *te
 
 	initContainers, sidecar, proxyEnvVars := manager.buildSandboxContainers(&entities.SandboxParams{
 		Enabled:        true,
-		AllowedDomains: []string{"example.com"},
+		AllowedDomains: []string{"example.com", "192.0.2.10", "198.51.100.0/24"},
 		CountMode:      true,
 	})
 
-	assert.Len(t, initContainers, 2)
+	assert.Len(t, initContainers, 1)
 
-	generate := initContainers[0]
-	assert.Equal(t, "network-filter-generate-iptables", generate.Name)
-	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.7.0", generate.Image)
-	assert.Equal(t, []string{"nfa", "setup-iptables", "--output", "/etc/iptables/rules.v4"}, generate.Command)
+	setup := initContainers[0]
+	assert.Equal(t, "network-filter-setup", setup.Name)
+	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.0", setup.Image)
+	assert.Equal(t, "/bin/sh", setup.Command[0])
+	assert.Contains(t, setup.Command[2], "nfa setup-iptables --apply --config /etc/nfa/config.yaml")
+	assert.Contains(t, setup.Env, corev1.EnvVar{
+		Name: "NFA_CONFIG",
+		Value: "filter:\n  mode: allowlist\n  countMode: true\n  domains:\n" +
+			"    - \"example.com\"\n    - \"192.0.2.10\"\n    - \"198.51.100.0/24\"\n" +
+			"deferredPolicy: true\n",
+	})
 	assert.Equal(t, corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -52,29 +59,20 @@ func TestBuildSandboxContainersGeneratesRulesThenRestoresWithIptablesImage(t *te
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		},
-	}, generate.Resources)
+	}, setup.Resources)
 	assert.Equal(t, []corev1.VolumeMount{{
-		Name:      "sandbox-iptables",
-		MountPath: "/etc/iptables",
-	}}, generate.VolumeMounts)
-
-	restore := initContainers[1]
-	assert.Equal(t, "network-filter-setup", restore.Name)
-	assert.Equal(t, "gcr.io/istio-release/iptables:latest", restore.Image)
-	assert.Equal(t, []string{"iptables-restore", "/etc/iptables/rules.v4"}, restore.Command)
-	assert.Equal(t, generate.Resources, restore.Resources)
-	assert.Equal(t, []corev1.VolumeMount{{
-		Name:      "sandbox-iptables",
-		MountPath: "/etc/iptables",
-		ReadOnly:  true,
-	}}, restore.VolumeMounts)
-	assert.Contains(t, restore.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"))
+		Name:      "sandbox-nfa-config",
+		MountPath: "/etc/nfa",
+	}}, setup.VolumeMounts)
+	assert.Contains(t, setup.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"))
 
 	assert.NotNil(t, sidecar)
 	assert.Equal(t, "network-filter", sidecar.Name)
 	assert.NotEmpty(t, sidecar.Resources.Requests)
 	assert.NotEmpty(t, sidecar.Resources.Limits)
+	assert.Equal(t, []string{"nfa", "proxy", "--config", "/etc/nfa/config.yaml", "--deferred-policy"}, sidecar.Command)
 	assert.Contains(t, sidecar.Env, corev1.EnvVar{Name: "NETWORK_FILTER_COUNT_MODE", Value: "true"})
+	assert.Contains(t, sidecar.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"))
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
 }
 
@@ -122,7 +120,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			CPULimit:                       "1",
 			MemoryRequest:                  "128Mi",
 			MemoryLimit:                    "512Mi",
-			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.7.0",
+			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.0",
 			SandboxInitImage:               "gcr.io/istio-release/iptables:latest",
 			NetworkFilterInitMemoryRequest: "32Mi",
 			NetworkFilterInitMemoryLimit:   "64Mi",
@@ -291,7 +289,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			CPULimit:                       "1",
 			MemoryRequest:                  "128Mi",
 			MemoryLimit:                    "512Mi",
-			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.7.0",
+			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.0",
 			SandboxInitImage:               "gcr.io/istio-release/iptables:latest",
 			NetworkFilterInitMemoryRequest: "32Mi",
 			NetworkFilterInitMemoryLimit:   "64Mi",

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 )
 
-func TestBuildSandboxContainersAppliesNFAConfigWithIPAllowlist(t *testing.T) {
+func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptablesImage(t *testing.T) {
 	manager := &KubernetesSessionManager{
 		k8sConfig: &config.KubernetesSessionConfig{
 			Image:                          "session-image:latest",
@@ -37,14 +37,14 @@ func TestBuildSandboxContainersAppliesNFAConfigWithIPAllowlist(t *testing.T) {
 		CountMode:      true,
 	})
 
-	assert.Len(t, initContainers, 1)
+	assert.Len(t, initContainers, 2)
 
-	setup := initContainers[0]
-	assert.Equal(t, "network-filter-setup", setup.Name)
-	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.0", setup.Image)
-	assert.Equal(t, "/bin/sh", setup.Command[0])
-	assert.Contains(t, setup.Command[2], "nfa setup-iptables --apply --config /etc/nfa/config.yaml")
-	assert.Contains(t, setup.Env, corev1.EnvVar{
+	generate := initContainers[0]
+	assert.Equal(t, "network-filter-generate-iptables", generate.Name)
+	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.0", generate.Image)
+	assert.Equal(t, "/bin/sh", generate.Command[0])
+	assert.Contains(t, generate.Command[2], "nfa setup-iptables --output /etc/iptables/rules.v4 --config /tmp/nfa-config.yaml")
+	assert.Contains(t, generate.Env, corev1.EnvVar{
 		Name: "NFA_CONFIG",
 		Value: "filter:\n  mode: allowlist\n  countMode: true\n  domains:\n" +
 			"    - \"example.com\"\n    - \"192.0.2.10\"\n    - \"198.51.100.0/24\"\n" +
@@ -59,20 +59,33 @@ func TestBuildSandboxContainersAppliesNFAConfigWithIPAllowlist(t *testing.T) {
 			corev1.ResourceCPU:    resource.MustParse("100m"),
 			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		},
-	}, setup.Resources)
+	}, generate.Resources)
 	assert.Equal(t, []corev1.VolumeMount{{
-		Name:      "sandbox-nfa-config",
-		MountPath: "/etc/nfa",
-	}}, setup.VolumeMounts)
-	assert.Contains(t, setup.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"))
+		Name:      "sandbox-iptables",
+		MountPath: "/etc/iptables",
+	}}, generate.VolumeMounts)
+	assert.Empty(t, generate.SecurityContext.Capabilities)
+
+	restore := initContainers[1]
+	assert.Equal(t, "network-filter-setup", restore.Name)
+	assert.Equal(t, "gcr.io/istio-release/iptables:latest", restore.Image)
+	assert.Equal(t, []string{"iptables-restore", "/etc/iptables/rules.v4"}, restore.Command)
+	assert.Equal(t, generate.Resources, restore.Resources)
+	assert.Equal(t, []corev1.VolumeMount{{
+		Name:      "sandbox-iptables",
+		MountPath: "/etc/iptables",
+		ReadOnly:  true,
+	}}, restore.VolumeMounts)
+	assert.Contains(t, restore.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"))
 
 	assert.NotNil(t, sidecar)
 	assert.Equal(t, "network-filter", sidecar.Name)
 	assert.NotEmpty(t, sidecar.Resources.Requests)
 	assert.NotEmpty(t, sidecar.Resources.Limits)
-	assert.Equal(t, []string{"nfa", "proxy", "--config", "/etc/nfa/config.yaml", "--deferred-policy"}, sidecar.Command)
+	assert.Equal(t, []string{"nfa", "proxy", "--deferred-policy"}, sidecar.Command)
 	assert.Contains(t, sidecar.Env, corev1.EnvVar{Name: "NETWORK_FILTER_COUNT_MODE", Value: "true"})
-	assert.Contains(t, sidecar.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"))
+	assert.Nil(t, sidecar.SecurityContext.Capabilities)
+	assert.Empty(t, sidecar.VolumeMounts)
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,8 +366,10 @@ type KubernetesSessionConfig struct {
 	// Defaults to "bot-token"
 	SlackBotTokenSecretKey string `json:"slack_bot_token_secret_key" mapstructure:"slack_bot_token_secret_key"`
 
-	// SandboxInitImage is deprecated and retained for configuration compatibility.
-	// nfa v0.12.0+ applies iptables rules directly from the network-filter init container.
+	// SandboxInitImage is the container image used for the network-filter-setup init container
+	// that restores generated iptables rules for session network sandboxing.
+	// If empty, falls back to Image (the session pod image).
+	// The image must provide iptables-restore. A shell is not required.
 	SandboxInitImage string `json:"sandbox_init_image" mapstructure:"sandbox_init_image"`
 
 	// SandboxIptablesConfigMapName is deprecated. Sandbox iptables rules are now
@@ -376,8 +378,8 @@ type KubernetesSessionConfig struct {
 
 	// NetworkFilterImage is the container image for the iptables rule generation init
 	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:0.12.0.
-	// The init container reads the generated policy config and runs "nfa setup-iptables --apply";
-	// the sidecar reads the same config and runs "nfa proxy --deferred-policy".
+	// The init container reads the generated policy config and runs "nfa setup-iptables --output";
+	// the sidecar runs "nfa proxy --deferred-policy".
 	NetworkFilterImage string `json:"network_filter_image" mapstructure:"network_filter_image"`
 
 	// Network filter sidecar resource configuration

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,10 +366,8 @@ type KubernetesSessionConfig struct {
 	// Defaults to "bot-token"
 	SlackBotTokenSecretKey string `json:"slack_bot_token_secret_key" mapstructure:"slack_bot_token_secret_key"`
 
-	// SandboxInitImage is the container image used for the network-filter-setup init container
-	// that restores generated iptables rules for session network sandboxing.
-	// If empty, falls back to Image (the session pod image).
-	// The image must provide iptables-restore. A shell is not required.
+	// SandboxInitImage is deprecated and retained for configuration compatibility.
+	// nfa v0.12.0+ applies iptables rules directly from the network-filter init container.
 	SandboxInitImage string `json:"sandbox_init_image" mapstructure:"sandbox_init_image"`
 
 	// SandboxIptablesConfigMapName is deprecated. Sandbox iptables rules are now
@@ -377,9 +375,9 @@ type KubernetesSessionConfig struct {
 	SandboxIptablesConfigMapName string `json:"sandbox_iptables_configmap_name" mapstructure:"sandbox_iptables_configmap_name"`
 
 	// NetworkFilterImage is the container image for the iptables rule generation init
-	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:0.7.0.
-	// The init container runs "nfa setup-iptables --output"; the sidecar runs
-	// "nfa proxy --deferred-policy" to enforce domain filtering.
+	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:0.12.0.
+	// The init container reads the generated policy config and runs "nfa setup-iptables --apply";
+	// the sidecar reads the same config and runs "nfa proxy --deferred-policy".
 	NetworkFilterImage string `json:"network_filter_image" mapstructure:"network_filter_image"`
 
 	// Network filter sidecar resource configuration
@@ -1260,7 +1258,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
-	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.7.0")
+	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.12.0")
 	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
 	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
 	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5579,10 +5579,12 @@
             "items": {
               "type": "string"
             },
-            "description": "Allowlist mode: only listed domains are permitted; all others are blocked. Supports wildcard prefixes (e.g. '*.example.com'). Takes precedence over denied_domains when set.",
+            "description": "Allowlist mode: only listed destinations are permitted; all others are blocked. Supports hostname wildcard prefixes (e.g. '*.example.com'), exact IPv4 addresses, and IPv4 CIDR ranges. IP addresses and CIDR ranges are installed as direct iptables allow rules by the init container. Takes precedence over denied_domains when set.",
             "example": [
               "api.example.com",
-              "*.trusted.com"
+              "*.trusted.com",
+              "192.0.2.10",
+              "198.51.100.0/24"
             ]
           },
           "denied_domains": {


### PR DESCRIPTION
## Summary
- network filter image のデフォルトを nfa v0.12.0 に更新
- 既存の2 initContainer 構成を維持
- nfa initContainer が生成した config を読み、IP/CIDR allowlist を含む rules.v4 を生成
- 従来どおり専用 iptables image が iptables-restore を実行
- sidecar の command、volume、SecurityContext は変更せず NET_ADMIN を付与しない
- OpenAPI の allowed_domains に IPv4/CIDR 対応を明記

## Test plan
- `make lint`
- `env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT -u KUBERNETES_PORT make test`

`make test` は Pod に注入された Kubernetes service 環境変数があると `cmd` の signal-based server test がテストプロセスを interrupt するため、Kubernetes 判定用の環境変数を外して実行しました。