### PR TITLE
fix: network-filter sidecar に NET_ADMIN を付与

### DIFF
--- a/cmd/agent_provisioner.go
+++ b/cmd/agent_provisioner.go
@@ -78,6 +78,7 @@ func runAgentProvisioner(cmd *cobra.Command, args []string) error {
 			SessionID: os.Getenv("AGENTAPI_SESSION_ID"),
 			PodName:   os.Getenv("POD_NAME"),
 			Namespace: os.Getenv("POD_NAMESPACE"),
+			CAFile:    os.Getenv("NODE_EXTRA_CA_CERTS"),
 		})
 	}()
 

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -493,7 +493,7 @@ kubernetesSession:
   # Container image for the network-filter sidecar and initContainer (sandbox feature)
   networkFilterImage: "ghcr.io/takutakahashi/nfa:0.12.0"
 
-  # Container image for restoring generated sandbox iptables rules.
+  # Deprecated: networkFilterImage is used to restore sandbox iptables rules.
   sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"
 
   # Resource configuration for the network-filter sidecar and initContainer (sandbox feature)

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2632,18 +2632,17 @@ func (m *KubernetesSessionManager) resolveSandboxParams(ctx context.Context, req
 		DeniedDomains:  req.Sandbox.DeniedDomains,
 		CountMode:      req.Sandbox.CountMode,
 	}
-	if req.Sandbox.PolicyID == "" || m.sandboxPolicyRepo == nil {
-		return effective
-	}
-	policy, err := m.sandboxPolicyRepo.GetByID(ctx, req.Sandbox.PolicyID)
-	if err != nil {
-		log.Printf("[K8S_SESSION] sandbox policy %s not found, ignoring: %v", req.Sandbox.PolicyID, err)
-		return effective
-	}
-	effective.AllowedDomains = append(policy.AllowedDomains(), effective.AllowedDomains...)
-	effective.DeniedDomains = append(policy.DeniedDomains(), effective.DeniedDomains...)
-	if policy.CountMode() {
-		effective.CountMode = true
+	if req.Sandbox.PolicyID != "" && m.sandboxPolicyRepo != nil {
+		policy, err := m.sandboxPolicyRepo.GetByID(ctx, req.Sandbox.PolicyID)
+		if err != nil {
+			log.Printf("[K8S_SESSION] sandbox policy %s not found, ignoring: %v", req.Sandbox.PolicyID, err)
+		} else {
+			effective.AllowedDomains = append(policy.AllowedDomains(), effective.AllowedDomains...)
+			effective.DeniedDomains = append(policy.DeniedDomains(), effective.DeniedDomains...)
+			if policy.CountMode() {
+				effective.CountMode = true
+			}
+		}
 	}
 	return effective
 }
@@ -2762,13 +2761,9 @@ exec nfa setup-iptables --output /etc/iptables/rules.v4 --config /tmp/nfa-config
 		},
 	}
 
-	sandboxInitImage := m.k8sConfig.SandboxInitImage
-	if sandboxInitImage == "" {
-		sandboxInitImage = m.k8sConfig.Image
-	}
 	restoreRulesInitContainer := corev1.Container{
 		Name:            "network-filter-setup",
-		Image:           sandboxInitImage,
+		Image:           nfaImage,
 		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
 		Command:         []string{"iptables-restore", "/etc/iptables/rules.v4"},
 		SecurityContext: &corev1.SecurityContext{
@@ -2814,9 +2809,10 @@ exec nfa setup-iptables --output /etc/iptables/rules.v4 --config /tmp/nfa-config
 	// proxy-aware clients (curl, Go's http.Client, pip, npm, etc.) route all
 	// HTTP and HTTPS traffic through the sidecar via CONNECT tunnels.
 	// This covers non-standard ports and avoids SNI-peeking for HTTPS.
-	// K8s cluster-internal addresses (.svc.cluster.local, 10.x.x.x) and Anthropic API
-	// endpoints bypass the proxy so that stop hooks and Claude API calls always succeed.
-	noProxy := "127.0.0.1,localhost,.svc.cluster.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,anthropic.com,*.anthropic.com"
+	// Cluster-internal requests must pass through nfa: direct connections would be
+	// rejected by the sandbox's default TCP rule. nfa always bypasses *.svc.cluster.local.
+	// Anthropic API endpoints bypass the proxy so Claude API calls always succeed.
+	noProxy := "127.0.0.1,localhost,anthropic.com,*.anthropic.com"
 	proxyEnvVars := []corev1.EnvVar{
 		{Name: "HTTP_PROXY", Value: proxyAddr},
 		{Name: "HTTPS_PROXY", Value: proxyAddr},

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2018,13 +2018,15 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 		if apiKey := m.ensurePersonalAPIKey(ctx, req.UserID); apiKey != nil {
 			sciaUserToken = apiKey.APIKey()
 		}
-		sciaInitContainer, sciaSidecar, _ = m.buildSciaSidecarContainers(req, sandboxEnabled, sciaUserToken)
+		var sciaEnvVars []corev1.EnvVar
+		sciaInitContainer, sciaSidecar, sciaEnvVars = m.buildSciaSidecarContainers(req, sandboxEnabled, sciaUserToken)
 		initContainers = append(initContainers, *sciaInitContainer)
 		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED", Value: "true"})
-		// SessionSettings injects the scia proxy variables for the actual agent
-		// process after provisioning. Keep the nfa proxy variables on the
-		// provisioner itself so its cluster-internal API calls are not rejected by
-		// the sandbox's default TCP rule.
+		// Route provisioner traffic through SCIA from startup. The actual agent gets
+		// the same route from SessionSettings after provisioning. Keep cluster
+		// services out of NO_PROXY so provisioner management calls are observed by
+		// SCIA before SCIA chains them through nfa.
+		sandboxEnvVars = provisionerSciaEnvVars(sciaEnvVars)
 	}
 
 	// Build DinD sidecar if Docker-in-Docker is enabled.
@@ -2302,6 +2304,22 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 		return nil, err
 	}
 	return deployment, nil
+}
+
+func provisionerSciaEnvVars(envVars []corev1.EnvVar) []corev1.EnvVar {
+	result := make([]corev1.EnvVar, len(envVars))
+	copy(result, envVars)
+	for i := range result {
+		switch result[i].Name {
+		case "NO_PROXY", "no_proxy":
+			result[i].Value = "127.0.0.1,localhost"
+		case "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO":
+			// The combined bundle is created later by the provisioner. Use SCIA's
+			// generated CA directly during the initial pull phase.
+			result[i].Value = sciaCAPath
+		}
+	}
+	return result
 }
 
 func sessionAffinity(value map[string]interface{}) (*corev1.Affinity, error) {

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2021,11 +2021,10 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 		sciaInitContainer, sciaSidecar, _ = m.buildSciaSidecarContainers(req, sandboxEnabled, sciaUserToken)
 		initContainers = append(initContainers, *sciaInitContainer)
 		envVars = append(envVars, corev1.EnvVar{Name: "AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED", Value: "true"})
-		// Do not inject sidecar proxy variables into the Pod-level container env.
-		// Kubernetes starts regular containers in parallel, so startup scripts can
-		// race the scia sidecar listener. SessionSettings injects the same proxy
-		// variables for the actual agent process after provisioning.
-		sandboxEnvVars = nil
+		// SessionSettings injects the scia proxy variables for the actual agent
+		// process after provisioning. Keep the nfa proxy variables on the
+		// provisioner itself so its cluster-internal API calls are not rejected by
+		// the sandbox's default TCP rule.
 	}
 
 	// Build DinD sidecar if Docker-in-Docker is enabled.

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2800,6 +2800,9 @@ exec nfa setup-iptables --output /etc/iptables/rules.v4 --config /tmp/nfa-config
 			RunAsUser:                &rootUID,
 			RunAsNonRoot:             &falseVal,
 			AllowPrivilegeEscalation: &falseVal,
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN"},
+			},
 		},
 		Resources: buildResourceRequirements(m.k8sConfig.NetworkFilterCPURequest, m.k8sConfig.NetworkFilterCPULimit, m.k8sConfig.NetworkFilterMemoryRequest, m.k8sConfig.NetworkFilterMemoryLimit),
 		Ports: []corev1.ContainerPort{

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2632,17 +2632,18 @@ func (m *KubernetesSessionManager) resolveSandboxParams(ctx context.Context, req
 		DeniedDomains:  req.Sandbox.DeniedDomains,
 		CountMode:      req.Sandbox.CountMode,
 	}
-	if req.Sandbox.PolicyID != "" && m.sandboxPolicyRepo != nil {
-		policy, err := m.sandboxPolicyRepo.GetByID(ctx, req.Sandbox.PolicyID)
-		if err != nil {
-			log.Printf("[K8S_SESSION] sandbox policy %s not found, ignoring: %v", req.Sandbox.PolicyID, err)
-		} else {
-			effective.AllowedDomains = append(policy.AllowedDomains(), effective.AllowedDomains...)
-			effective.DeniedDomains = append(policy.DeniedDomains(), effective.DeniedDomains...)
-			if policy.CountMode() {
-				effective.CountMode = true
-			}
-		}
+	if req.Sandbox.PolicyID == "" || m.sandboxPolicyRepo == nil {
+		return effective
+	}
+	policy, err := m.sandboxPolicyRepo.GetByID(ctx, req.Sandbox.PolicyID)
+	if err != nil {
+		log.Printf("[K8S_SESSION] sandbox policy %s not found, ignoring: %v", req.Sandbox.PolicyID, err)
+		return effective
+	}
+	effective.AllowedDomains = append(policy.AllowedDomains(), effective.AllowedDomains...)
+	effective.DeniedDomains = append(policy.DeniedDomains(), effective.DeniedDomains...)
+	if policy.CountMode() {
+		effective.CountMode = true
 	}
 	return effective
 }

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -84,7 +84,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 	assert.NotEmpty(t, sidecar.Resources.Limits)
 	assert.Equal(t, []string{"nfa", "proxy", "--deferred-policy"}, sidecar.Command)
 	assert.Contains(t, sidecar.Env, corev1.EnvVar{Name: "NETWORK_FILTER_COUNT_MODE", Value: "true"})
-	assert.Nil(t, sidecar.SecurityContext.Capabilities)
+	assert.Equal(t, []corev1.Capability{"NET_ADMIN"}, sidecar.SecurityContext.Capabilities.Add)
 	assert.Empty(t, sidecar.VolumeMounts)
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
 }

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -195,12 +195,11 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 	}
 
 	main := podSpec.Containers[0]
-	assert.Contains(t, main.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
-	assert.Contains(t, main.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "http://127.0.0.1:3128"})
-	assert.Contains(t, main.Env, corev1.EnvVar{Name: "NO_PROXY", Value: "127.0.0.1,localhost,anthropic.com,*.anthropic.com"})
-	assert.NotContains(t, main.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:18081"})
-	assert.NotContains(t, main.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "http://127.0.0.1:18081"})
-	assert.NotContains(t, main.Env, corev1.EnvVar{Name: "SSL_CERT_FILE", Value: sciaCABundlePath})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:18081"})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "http://127.0.0.1:18081"})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "NO_PROXY", Value: "127.0.0.1,localhost"})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "SSL_CERT_FILE", Value: sciaCAPath})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "NODE_EXTRA_CA_CERTS", Value: sciaCAPath})
 	assert.Contains(t, main.VolumeMounts, corev1.VolumeMount{Name: "scia-mitm-ca", MountPath: "/etc/scia/mitm", ReadOnly: true})
 
 	env := map[string]string{"AGENTAPI_USER_ID": "takutakahashi"}

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -68,7 +68,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 
 	restore := initContainers[1]
 	assert.Equal(t, "network-filter-setup", restore.Name)
-	assert.Equal(t, "gcr.io/istio-release/iptables:latest", restore.Image)
+	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.0", restore.Image)
 	assert.Equal(t, []string{"iptables-restore", "/etc/iptables/rules.v4"}, restore.Command)
 	assert.Equal(t, generate.Resources, restore.Resources)
 	assert.Equal(t, []corev1.VolumeMount{{
@@ -87,6 +87,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 	assert.Equal(t, []corev1.Capability{"NET_ADMIN"}, sidecar.SecurityContext.Capabilities.Add)
 	assert.Empty(t, sidecar.VolumeMounts)
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
+	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "NO_PROXY", Value: "127.0.0.1,localhost,anthropic.com,*.anthropic.com"})
 }
 
 func TestResolveSandboxParamsPreservesSessionCountModeWithoutPolicy(t *testing.T) {

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -195,6 +195,9 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 	}
 
 	main := podSpec.Containers[0]
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "http://127.0.0.1:3128"})
+	assert.Contains(t, main.Env, corev1.EnvVar{Name: "NO_PROXY", Value: "127.0.0.1,localhost,anthropic.com,*.anthropic.com"})
 	assert.NotContains(t, main.Env, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:18081"})
 	assert.NotContains(t, main.Env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: "http://127.0.0.1:18081"})
 	assert.NotContains(t, main.Env, corev1.EnvVar{Name: "SSL_CERT_FILE", Value: sciaCABundlePath})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,10 +366,8 @@ type KubernetesSessionConfig struct {
 	// Defaults to "bot-token"
 	SlackBotTokenSecretKey string `json:"slack_bot_token_secret_key" mapstructure:"slack_bot_token_secret_key"`
 
-	// SandboxInitImage is the container image used for the network-filter-setup init container
-	// that restores generated iptables rules for session network sandboxing.
-	// If empty, falls back to Image (the session pod image).
-	// The image must provide iptables-restore. A shell is not required.
+	// SandboxInitImage is deprecated. The network filter image is also used to
+	// restore rules so initial setup and runtime updates use the same iptables backend.
 	SandboxInitImage string `json:"sandbox_init_image" mapstructure:"sandbox_init_image"`
 
 	// SandboxIptablesConfigMapName is deprecated. Sandbox iptables rules are now

--- a/pkg/provisioner/pull_client.go
+++ b/pkg/provisioner/pull_client.go
@@ -3,6 +3,8 @@ package provisioner
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -21,6 +23,7 @@ type PullClientConfig struct {
 	SessionID string
 	PodName   string
 	Namespace string
+	CAFile    string
 }
 
 type pullProvisionRequest struct {
@@ -38,7 +41,10 @@ func RunPullClient(ctx context.Context, srv *Server, cfg PullClientConfig) error
 	if cfg.ProxyURL == "" || cfg.Token == "" || cfg.SessionID == "" {
 		return fmt.Errorf("pull provisioner requires proxy URL, token, and session ID")
 	}
-	client := &http.Client{Timeout: 35 * time.Second}
+	client, err := newPullHTTPClient(ctx, cfg.CAFile)
+	if err != nil {
+		return err
+	}
 	if err := postJSON(ctx, client, cfg, "/internal/session-provisioners/connect", map[string]interface{}{
 		"session_id": cfg.SessionID,
 		"pod_name":   cfg.PodName,
@@ -79,6 +85,35 @@ func RunPullClient(ctx context.Context, srv *Server, cfg PullClientConfig) error
 		srv.runProvision(ctx, provisionReq.Settings)
 		<-ctx.Done()
 		return ctx.Err()
+	}
+}
+
+func newPullHTTPClient(ctx context.Context, caFile string) (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if caFile == "" {
+		return &http.Client{Timeout: 35 * time.Second, Transport: transport}, nil
+	}
+
+	for {
+		caPEM, err := os.ReadFile(caFile)
+		if err == nil {
+			roots, rootsErr := x509.SystemCertPool()
+			if rootsErr != nil || roots == nil {
+				roots = x509.NewCertPool()
+			}
+			if !roots.AppendCertsFromPEM(caPEM) {
+				return nil, fmt.Errorf("pull provisioner CA file %s contains no certificates", caFile)
+			}
+			transport.TLSClientConfig = &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
+			return &http.Client{Timeout: 35 * time.Second, Transport: transport}, nil
+		}
+
+		log.Printf("[PROVISIONER] Waiting for SCIA CA %s: %v", caFile, err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
 	}
 }
 

--- a/pkg/provisioner/pull_client_test.go
+++ b/pkg/provisioner/pull_client_test.go
@@ -1,0 +1,32 @@
+package provisioner
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPullHTTPClientLoadsSCIACA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	caFile := filepath.Join(t.TempDir(), "scia-ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	require.NoError(t, os.WriteFile(caFile, caPEM, 0o600))
+
+	client, err := newPullHTTPClient(context.Background(), caFile)
+	require.NoError(t, err)
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary
- network-filter sidecar のみに NET_ADMIN capability を追加
- stock session 採用後の POST /policy で IP/CIDR allowlist の iptables chain を更新可能にする
- initContainer 構成と iptables-restore 経路は変更しない
- main container や他の sidecar には NET_ADMIN を付与しない

## Test plan
- `make lint`
- `env -u KUBERNETES_SERVICE_HOST -u KUBERNETES_SERVICE_PORT -u KUBERNETES_PORT make test`