### PR TITLE
fix: ローカルアドレスをサンドボックスで事前許可

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2859,6 +2859,9 @@ func buildNFAConfig(sandbox *entities.SandboxParams) string {
 			mode = "allowlist"
 		}
 	}
+	if mode == "allowlist" {
+		domains = append(domains, sandboxLocalAddressRanges...)
+	}
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "filter:\n  mode: %s\n  countMode: %t\n  domains:\n", mode, countMode)
@@ -2868,6 +2871,8 @@ func buildNFAConfig(sandbox *entities.SandboxParams) string {
 	b.WriteString("deferredPolicy: true\n")
 	return b.String()
 }
+
+var sandboxLocalAddressRanges = []string{"127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
 
 const (
 	sciaCAPath       = "/etc/scia/mitm/ca.pem"

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -48,6 +48,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 		Name: "NFA_CONFIG",
 		Value: "filter:\n  mode: allowlist\n  countMode: true\n  domains:\n" +
 			"    - \"example.com\"\n    - \"192.0.2.10\"\n    - \"198.51.100.0/24\"\n" +
+			"    - \"127.0.0.0/8\"\n    - \"10.0.0.0/8\"\n    - \"172.16.0.0/12\"\n    - \"192.168.0.0/16\"\n" +
 			"deferredPolicy: true\n",
 	})
 	assert.Equal(t, corev1.ResourceRequirements{
@@ -88,6 +89,25 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 	assert.Empty(t, sidecar.VolumeMounts)
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "HTTP_PROXY", Value: "http://127.0.0.1:3128"})
 	assert.Contains(t, proxyEnvVars, corev1.EnvVar{Name: "NO_PROXY", Value: "127.0.0.1,localhost,anthropic.com,*.anthropic.com"})
+}
+
+func TestBuildNFAConfigPreallowsLocalAddressesInAllowlistMode(t *testing.T) {
+	config := buildNFAConfig(&entities.SandboxParams{Enabled: true})
+
+	for _, addressRange := range sandboxLocalAddressRanges {
+		assert.Contains(t, config, `    - "`+addressRange+`"`)
+	}
+}
+
+func TestBuildNFAConfigDoesNotAddLocalAddressesToDenylist(t *testing.T) {
+	config := buildNFAConfig(&entities.SandboxParams{
+		Enabled:       true,
+		DeniedDomains: []string{"example.com"},
+	})
+
+	for _, addressRange := range sandboxLocalAddressRanges {
+		assert.NotContains(t, config, addressRange)
+	}
 }
 
 func TestResolveSandboxParamsPreservesSessionCountModeWithoutPolicy(t *testing.T) {


### PR DESCRIPTION
## 概要

NFA の allowlist モードで、ループバックおよび RFC 1918 のプライベート IPv4 範囲を既定で許可します。

- `127.0.0.0/8`
- `10.0.0.0/8`
- `172.16.0.0/12`
- `192.168.0.0/16`
- denylist モードの拒否設定には追加しません

## 検証

- `make lint`: 成功
- `CGO_ENABLED=0 go test ./internal/infrastructure/services`: 成功
- `make test`: 実行環境に gcc がなく race detector のビルド段階で失敗