### PR TITLE
fix: 動的サンドボックスポリシーでローカルCIDRを保持

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2686,7 +2686,7 @@ func applySandboxPolicyToProvisioner(ctx context.Context, stockSvc *corev1.Servi
 		Denied    []string `json:"denied,omitempty"`
 		CountMode bool     `json:"count_mode,omitempty"`
 	}{
-		Allowed:   sandbox.AllowedDomains,
+		Allowed:   sessionsettings.SandboxAllowedDomains(sandbox.AllowedDomains, sandbox.DeniedDomains),
 		Denied:    sandbox.DeniedDomains,
 		CountMode: sandbox.CountMode,
 	})
@@ -2860,7 +2860,7 @@ func buildNFAConfig(sandbox *entities.SandboxParams) string {
 		}
 	}
 	if mode == "allowlist" {
-		domains = append(domains, sandboxLocalAddressRanges...)
+		domains = append(domains, sessionsettings.SandboxLocalAddressRanges...)
 	}
 
 	var b strings.Builder
@@ -2871,8 +2871,6 @@ func buildNFAConfig(sandbox *entities.SandboxParams) string {
 	b.WriteString("deferredPolicy: true\n")
 	return b.String()
 }
-
-var sandboxLocalAddressRanges = []string{"127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
 
 const (
 	sciaCAPath       = "/etc/scia/mitm/ca.pem"

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
 func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptablesImage(t *testing.T) {
@@ -94,7 +95,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 func TestBuildNFAConfigPreallowsLocalAddressesInAllowlistMode(t *testing.T) {
 	config := buildNFAConfig(&entities.SandboxParams{Enabled: true})
 
-	for _, addressRange := range sandboxLocalAddressRanges {
+	for _, addressRange := range sessionsettings.SandboxLocalAddressRanges {
 		assert.Contains(t, config, `    - "`+addressRange+`"`)
 	}
 }
@@ -105,7 +106,7 @@ func TestBuildNFAConfigDoesNotAddLocalAddressesToDenylist(t *testing.T) {
 		DeniedDomains: []string{"example.com"},
 	})
 
-	for _, addressRange := range sandboxLocalAddressRanges {
+	for _, addressRange := range sessionsettings.SandboxLocalAddressRanges {
 		assert.NotContains(t, config, addressRange)
 	}
 }

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -1802,7 +1802,7 @@ func configureNetworkFilterPolicy(sandbox *sessionsettings.SandboxConfig) {
 		return
 	}
 	payload := map[string]interface{}{
-		"allowed":    sandbox.AllowedDomains,
+		"allowed":    sessionsettings.SandboxAllowedDomains(sandbox.AllowedDomains, sandbox.DeniedDomains),
 		"denied":     sandbox.DeniedDomains,
 		"count_mode": sandbox.CountMode,
 	}

--- a/pkg/sessionsettings/sandbox_test.go
+++ b/pkg/sessionsettings/sandbox_test.go
@@ -1,0 +1,24 @@
+package sessionsettings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSandboxAllowedDomainsAddsLocalRangesToAllowlist(t *testing.T) {
+	allowed := []string{"example.com"}
+
+	effective := SandboxAllowedDomains(allowed, nil)
+
+	assert.Equal(t, append([]string{"example.com"}, SandboxLocalAddressRanges...), effective)
+	assert.Equal(t, []string{"example.com"}, allowed)
+}
+
+func TestSandboxAllowedDomainsAddsLocalRangesToDefaultAllowlist(t *testing.T) {
+	assert.Equal(t, SandboxLocalAddressRanges, SandboxAllowedDomains(nil, nil))
+}
+
+func TestSandboxAllowedDomainsPreservesDenylistMode(t *testing.T) {
+	assert.Empty(t, SandboxAllowedDomains(nil, []string{"example.com"}))
+}

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -125,6 +125,22 @@ type SandboxConfig struct {
 	CountMode      bool     `yaml:"count_mode,omitempty"      json:"count_mode,omitempty"`
 }
 
+// SandboxLocalAddressRanges are pre-allowed in allowlist mode so that
+// cluster-local services remain reachable through the network-filter proxy.
+var SandboxLocalAddressRanges = []string{"127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+
+// SandboxAllowedDomains returns the effective allowlist sent to the running
+// network filter. Adding an allowlist while in denylist mode would change the
+// policy semantics, so local ranges are added only when no deny-only policy is
+// configured.
+func SandboxAllowedDomains(allowed, denied []string) []string {
+	if len(allowed) == 0 && len(denied) > 0 {
+		return allowed
+	}
+	effective := append([]string(nil), allowed...)
+	return append(effective, SandboxLocalAddressRanges...)
+}
+
 // DockerConfig holds Docker-in-Docker (DinD) configuration for a session Pod.
 // When Enabled is true, a DinD sidecar is added to the session Pod and
 // DOCKER_HOST is set so the main container can communicate with the docker daemon.


### PR DESCRIPTION
## 概要

NFA の動的 allowlist 更新時にもループバックおよび RFC 1918 のローカルCIDRを追加し、HTTP_PROXY 経由のクラスタ内部通信が拒否されないようにします。

- provisioner の起動後ポリシー設定へローカルCIDRを追加
- stock Pod 採用時のポリシー差し替えへローカルCIDRを追加
- denylist モードでは追加せず、既存のポリシー意味を維持
- 起動時iptables設定と動的設定で共通のCIDR定義を利用

## 検証

- `make lint`: 成功
- `go test ./pkg/sessionsettings ./pkg/provisioner ./internal/infrastructure/services`: 成功
- `make test`: 実行環境に gcc がなく race detector のビルド段階で失敗
- `CGO_ENABLED=0 go test ./...`: 既存の cmd テストが interrupt signal で失敗し、その後長時間継続したため中断