### PR TITLE
Keep session allocation IDs routable

### DIFF
--- a/internal/core/sessionallocation/ports.go
+++ b/internal/core/sessionallocation/ports.go
@@ -21,7 +21,7 @@ type ExternalAllocatorClient interface {
 type Queue interface {
 	SubmitExternalSessionAllocation(ctx context.Context, managerID, sessionID string, settings *sessionsettings.SessionSettings, req *entities.RunServerRequest) error
 	NextSessionAllocation(ctx context.Context, wait time.Duration) (*AllocationRequest, bool, error)
-	CompleteSessionAllocation(ctx context.Context, sessionID string, result AllocationResult) error
+	CompleteSessionAllocation(ctx context.Context, sessionID string, result AllocationResult) (*AllocationRequest, error)
 	NextExternalSessionAllocation(ctx context.Context, managerID string, wait time.Duration) (*AllocationRequest, bool, error)
 	CompleteExternalSessionAllocation(ctx context.Context, sessionID string, result AllocationResult) (*AllocationRequest, error)
 }

--- a/internal/infrastructure/services/session_allocator.go
+++ b/internal/infrastructure/services/session_allocator.go
@@ -346,24 +346,24 @@ func (m *KubernetesSessionManager) CompleteExternalSessionAllocation(ctx context
 	return req, nil
 }
 
-func (m *KubernetesSessionManager) CompleteSessionAllocation(ctx context.Context, sessionID string, result sessionallocation.AllocationResult) error {
+func (m *KubernetesSessionManager) CompleteSessionAllocation(ctx context.Context, sessionID string, result sessionallocation.AllocationResult) (*sessionallocation.AllocationRequest, error) {
 	req, err := m.getSessionAllocation(ctx, sessionID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Status = result.Status
 	req.Message = result.Message
 	req.AllocatedSessionID = result.AllocatedSessionID
 	if err := m.saveSessionAllocation(ctx, req); err != nil {
-		return err
+		return nil, err
 	}
 	if err := m.notifySessionAllocation(ctx); err != nil {
-		return err
+		return nil, err
 	}
 	if err := m.deleteSessionAllocation(context.Background(), sessionID); err != nil {
 		log.Printf("[SESSION_ALLOCATOR] Warning: failed to delete completed allocation %s: %v", sessionID, err)
 	}
-	return nil
+	return req, nil
 }
 
 func (m *KubernetesSessionManager) notifySessionAllocation(ctx context.Context) error {

--- a/internal/infrastructure/services/session_allocator_test.go
+++ b/internal/infrastructure/services/session_allocator_test.go
@@ -192,11 +192,15 @@ func TestCompleteSessionAllocationDeletesAllocationSecret(t *testing.T) {
 		t.Fatalf("saveSessionAllocation() error = %v", err)
 	}
 
-	if err := manager.CompleteSessionAllocation(context.Background(), "test-session", sessionallocation.AllocationResult{
+	allocation, err := manager.CompleteSessionAllocation(context.Background(), "test-session", sessionallocation.AllocationResult{
 		Status:             sessionallocation.StatusAssigned,
-		AllocatedSessionID: "test-session",
-	}); err != nil {
+		AllocatedSessionID: "allocated-session",
+	})
+	if err != nil {
 		t.Fatalf("CompleteSessionAllocation() error = %v", err)
+	}
+	if allocation.SessionID != "test-session" || allocation.AllocatedSessionID != "allocated-session" {
+		t.Fatalf("completion did not preserve public-to-allocated ID mapping: %#v", allocation)
 	}
 
 	_, err = manager.client.CoreV1().Secrets("test-ns").Get(context.Background(), sessionAllocationSecretName("test-session"), metav1.GetOptions{})

--- a/internal/interfaces/controllers/provisioner_controller.go
+++ b/internal/interfaces/controllers/provisioner_controller.go
@@ -112,8 +112,26 @@ func (pc *ProvisionerController) CompleteSessionAllocation(c echo.Context) error
 	if result.Status == "" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "status is required"})
 	}
-	if err := pc.allocationQueue.CompleteSessionAllocation(c.Request().Context(), c.Param("sessionId"), result); err != nil {
+	allocation, err := pc.allocationQueue.CompleteSessionAllocation(c.Request().Context(), c.Param("sessionId"), result)
+	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	if result.Status == sessionallocation.StatusAssigned && result.AllocatedSessionID != "" && result.AllocatedSessionID != allocation.SessionID && pc.sessionRouteRepo != nil {
+		route := &repositories.SessionRoute{
+			SessionID:       allocation.SessionID,
+			RemoteSessionID: result.AllocatedSessionID,
+			StartedAt:       time.Now(),
+		}
+		if allocation.Request != nil {
+			route.UserID = allocation.Request.UserID
+			route.Scope = string(allocation.Request.Scope)
+			route.TeamID = allocation.Request.TeamID
+			route.Tags = allocation.Request.Tags
+			route.InitialMessage = allocation.Request.InitialMessage
+		}
+		if err := pc.sessionRouteRepo.Save(c.Request().Context(), route); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		}
 	}
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -437,17 +437,18 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 					status = "creating"
 				}
 				filteredSessions = append(filteredSessions, map[string]interface{}{
-					"session_id":      route.SessionID,
-					"user_id":         route.UserID,
-					"scope":           route.Scope,
-					"team_id":         route.TeamID,
-					"status":          status,
-					"started_at":      route.StartedAt,
-					"updated_at":      route.StartedAt,
-					"last_message_at": route.StartedAt,
-					"addr":            "",
-					"tags":            tags,
-					"annotations":     entities.SessionAnnotations{},
+					"session_id":           route.SessionID,
+					"allocated_session_id": route.RemoteSessionID,
+					"user_id":              route.UserID,
+					"scope":                route.Scope,
+					"team_id":              route.TeamID,
+					"status":               status,
+					"started_at":           route.StartedAt,
+					"updated_at":           route.StartedAt,
+					"last_message_at":      route.StartedAt,
+					"addr":                 "",
+					"tags":                 tags,
+					"annotations":          entities.SessionAnnotations{},
 					"metadata": map[string]interface{}{
 						"description": route.InitialMessage,
 					},
@@ -534,11 +535,16 @@ func (c *SessionController) DeleteSession(ctx echo.Context) error {
 			if err != nil {
 				log.Printf("Delete session: failed to look up route for %s: %v", sessionID, err)
 			} else if route != nil {
+				if route.ProxyURL == "" && route.RemoteSessionID != "" {
+					return c.deleteLocalSessionAlias(ctx, route)
+				}
 				return c.deleteRemoteSession(ctx, route)
 			}
 		}
 		log.Printf("Delete session failed: session %s not found (requested by %s)", sessionID, clientIP)
-		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+		if session == nil {
+			return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+		}
 	}
 
 	// Check authorization using pre-resolved authorization context (guaranteed to be non-nil by AuthMiddleware)
@@ -577,10 +583,21 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 			if err != nil {
 				log.Printf("[ROUTE] Failed to look up session route for %s: %v", sessionID, err)
 			} else if route != nil {
-				return c.routeToRemoteSession(ctx, route)
+				if route.ProxyURL == "" && route.RemoteSessionID != "" {
+					session = c.getSessionManager().GetSession(route.RemoteSessionID)
+					if session != nil {
+						sessionID = route.SessionID
+					} else {
+						return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+					}
+				} else {
+					return c.routeToRemoteSession(ctx, route)
+				}
 			}
 		}
-		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+		if session == nil {
+			return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+		}
 	}
 
 	// Skip auth check for OPTIONS requests
@@ -690,6 +707,26 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 
 	proxy.ServeHTTP(w, req)
 	return nil
+}
+
+func (c *SessionController) deleteLocalSessionAlias(ctx echo.Context, route *repositories.SessionRoute) error {
+	session := c.getSessionManager().GetSession(route.RemoteSessionID)
+	if session == nil {
+		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+	}
+	authzCtx := auth.GetAuthorizationContext(ctx)
+	if !authzCtx.CanModifyResource(session.UserID(), string(session.Scope()), session.TeamID()) {
+		return echo.NewHTTPError(http.StatusForbidden, "You don't have permission to delete this session")
+	}
+	if err := c.sessionCreator.DeleteSessionByID(route.RemoteSessionID); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete session")
+	}
+	if err := c.sessionRouteRepo.Delete(ctx.Request().Context(), route.SessionID); err != nil {
+		log.Printf("Failed to delete session alias %s: %v", route.SessionID, err)
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{
+		"message": "Session terminated successfully", "session_id": route.SessionID, "status": "terminated",
+	})
 }
 
 // routeToRemoteSession proxies a session request to an external session manager (External Session Manager).

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -109,14 +109,15 @@ type StartResponse struct {
 
 // SessionInfo represents information about a session
 type SessionInfo struct {
-	SessionID   string             `json:"session_id"`
-	UserID      string             `json:"user_id"`
-	Status      string             `json:"status"`
-	StartedAt   time.Time          `json:"started_at"`
-	Port        int                `json:"port"`
-	Tags        map[string]string  `json:"tags,omitempty"`
-	Annotations SessionAnnotations `json:"annotations,omitempty"`
-	Metadata    SessionMetadata    `json:"metadata,omitempty"`
+	SessionID          string             `json:"session_id"`
+	AllocatedSessionID string             `json:"allocated_session_id,omitempty"`
+	UserID             string             `json:"user_id"`
+	Status             string             `json:"status"`
+	StartedAt          time.Time          `json:"started_at"`
+	Port               int                `json:"port"`
+	Tags               map[string]string  `json:"tags,omitempty"`
+	Annotations        SessionAnnotations `json:"annotations,omitempty"`
+	Metadata           SessionMetadata    `json:"metadata,omitempty"`
 }
 
 // SearchResponse represents the response from searching sessions

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -47,7 +47,7 @@
     "/start": {
       "post": {
         "summary": "Create a new session",
-        "description": "Creates a new session and starts an agentapi server instance. Returns the session ID for subsequent requests.",
+        "description": "Creates a new session and starts an agentapi server instance. Returns a stable public session ID for subsequent requests. When allocation selects a different concrete session ID, the returned ID remains a routable alias for the lifetime of the session.",
         "operationId": "createSession",
         "tags": [
           "Sessions"
@@ -105,7 +105,7 @@
                   "properties": {
                     "session_id": {
                       "type": "string",
-                      "description": "Unique session identifier (UUID)"
+                      "description": "Stable public session identifier (UUID). This ID remains valid even when the concrete allocated session has a different ID."
                     }
                   },
                   "required": [
@@ -5740,7 +5740,11 @@
         "properties": {
           "session_id": {
             "type": "string",
-            "description": "Unique session identifier"
+            "description": "Stable public session identifier"
+          },
+          "allocated_session_id": {
+            "type": "string",
+            "description": "Concrete allocated session identifier when it differs from session_id. Requests should continue using session_id."
           },
           "user_id": {
             "type": "string",


### PR DESCRIPTION
## Summary
- keep the ID returned by `/start` as the stable public session ID
- persist a public-to-concrete session route when allocation changes the ID
- resolve local and external allocated sessions through the public ID
- expose `allocated_session_id` in `/search` and document the contract in OpenAPI

## Validation
- `make lint`
- `go test ./internal/interfaces/controllers ./internal/infrastructure/services ./pkg/client`
- `go test -run ^'$' ./...`\n- `make test` could not run because the environment has no `gcc` required by CGO/race (`cgo: C compiler "gcc" not found`)\n