### PR TITLE
Hide environment values from session profile responses

### DIFF
--- a/internal/interfaces/controllers/session_profile_controller.go
+++ b/internal/interfaces/controllers/session_profile_controller.go
@@ -80,7 +80,6 @@ type SessionProfileResponse struct {
 
 // SessionProfileConfigResponse represents session profile config in responses
 type SessionProfileConfigResponse struct {
-	Environment            map[string]string       `json:"environment,omitempty"`
 	Tags                   map[string]string       `json:"tags,omitempty"`
 	InitialMessageTemplate string                  `json:"initial_message_template,omitempty"`
 	ReuseMessageTemplate   string                  `json:"reuse_message_template,omitempty"`
@@ -346,7 +345,6 @@ func (c *SessionProfileController) toResponse(p *entities.SessionProfile) Sessio
 		IsDefault:    p.IsDefault(),
 		SelectorTags: p.SelectorTags(),
 		Config: SessionProfileConfigResponse{
-			Environment:            cfg.Environment(),
 			Tags:                   cfg.Tags(),
 			InitialMessageTemplate: cfg.InitialMessageTemplate(),
 			ReuseMessageTemplate:   cfg.ReuseMessageTemplate(),

--- a/internal/interfaces/controllers/session_profile_controller_test.go
+++ b/internal/interfaces/controllers/session_profile_controller_test.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+func TestSessionProfileResponseOmitsEnvironment(t *testing.T) {
+	profile := entities.NewSessionProfile("profile-1", "default", "user-1")
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetEnvironment(map[string]string{"SECRET": "sensitive-value"})
+	cfg.SetTags(map[string]string{"agent": "codex"})
+	profile.SetConfig(cfg)
+
+	controller := NewSessionProfileController(nil)
+	body, err := json.Marshal(controller.toResponse(profile))
+	require.NoError(t, err)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(body, &response))
+	responseConfig, ok := response["config"].(map[string]any)
+	require.True(t, ok)
+	require.NotContains(t, responseConfig, "environment")
+	require.Equal(t, map[string]any{"agent": "codex"}, responseConfig["tags"])
+}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7582,6 +7582,60 @@
         }
       }
     },
+    "SessionProfileConfigResponse": {
+      "type": "object",
+      "description": "Session profile configuration. Environment variable values are omitted from API responses.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Tags to attach to the session"
+        },
+        "initial_message_template": {
+          "type": "string",
+          "description": "Go template for the initial message"
+        },
+        "reuse_message_template": {
+          "type": "string",
+          "description": "Go template for the reuse message when reusing a session"
+        },
+        "reuse_session": {
+          "type": "boolean",
+          "description": "Whether to reuse an existing session instead of creating a new one"
+        },
+        "memory_key": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Memory key mapping for session context"
+        },
+        "params": {
+          "$ref": "#/components/schemas/SessionParams"
+        },
+        "sandbox_policy_id": {
+          "type": "string",
+          "description": "Reference to a SandboxPolicy resource. When set, the sandbox sidecar is enabled automatically with this policy applied. params.sandbox may also be used to enable sandbox without a policy."
+        },
+        "session_ttl": {
+          "type": "string",
+          "description": "Default TTL for sessions created with this profile. Overrides the global cleanup worker TTL. Accepted format: Go duration string (e.g. '48h', '168h'). Can be overridden per-session via params.session_ttl.",
+          "example": "72h"
+        },
+        "unsynced_file_paths": {
+          "type": "array",
+          "description": "Managed file paths that should not be synced back to storage for sessions created with this profile.",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "/home/agentapi/.codex/auth.json"
+          ]
+        }
+      }
+    },
     "CreateSessionProfileRequest": {
       "type": "object",
       "required": [
@@ -7684,7 +7738,7 @@
           "description": "Tag selector used to choose this profile when launching a session"
         },
         "config": {
-          "$ref": "#/components/schemas/SessionProfileConfig"
+          "$ref": "#/components/schemas/SessionProfileConfigResponse"
         },
         "created_at": {
           "type": "string",


### PR DESCRIPTION
## Summary
- omit `config.environment` from session-profiles API responses
- keep environment accepted in create/update requests
- document a response-only config schema in OpenAPI
- add a regression test for response serialization

## Verification
- `make lint`
- `go test ./internal/interfaces/controllers`
- `jq empty spec/openapi.json`
- `make test` could not run with the required race detector because this runner has no C compiler (`gcc` not found)