### PR TITLE
fix: delete oneshot public sessions through upstream proxy

### DIFF
--- a/internal/modules/sessionmanager/allocator_worker.go
+++ b/internal/modules/sessionmanager/allocator_worker.go
@@ -16,6 +16,7 @@ import (
 type AllocatorWorker struct {
 	sessionManager repositories.SessionManager
 	client         sessionallocation.ExternalAllocatorClient
+	upstreamURL    string
 	publicURL      string
 }
 
@@ -24,13 +25,18 @@ type directSessionManager interface {
 }
 
 func NewAllocatorWorker(sessionManager repositories.SessionManager, upstreamURL, token, publicURL string) *AllocatorWorker {
-	return NewAllocatorWorkerWithClient(sessionManager, infrasessionallocation.NewClient(upstreamURL, token), publicURL)
+	return newAllocatorWorkerWithClient(sessionManager, infrasessionallocation.NewClient(upstreamURL, token), upstreamURL, publicURL)
 }
 
 func NewAllocatorWorkerWithClient(sessionManager repositories.SessionManager, client sessionallocation.ExternalAllocatorClient, publicURL string) *AllocatorWorker {
+	return newAllocatorWorkerWithClient(sessionManager, client, "", publicURL)
+}
+
+func newAllocatorWorkerWithClient(sessionManager repositories.SessionManager, client sessionallocation.ExternalAllocatorClient, upstreamURL, publicURL string) *AllocatorWorker {
 	return &AllocatorWorker{
 		sessionManager: sessionManager,
 		client:         client,
+		upstreamURL:    upstreamURL,
 		publicURL:      publicURL,
 	}
 }
@@ -67,6 +73,18 @@ func (w *AllocatorWorker) process(ctx context.Context, allocation *sessionalloca
 			Message: "provision_settings is required",
 		})
 		return
+	}
+
+	// The public session ID belongs to the upstream proxy. Keep the oneshot Stop
+	// hook pointed at that proxy so it deletes both the allocated session and the
+	// public route alias. Without this override, Kubernetes service discovery on
+	// the session-manager cluster sends the public ID to the local proxy, where
+	// only the allocated ID exists.
+	if settings.Session.Oneshot && w.upstreamURL != "" {
+		if settings.Env == nil {
+			settings.Env = map[string]string{}
+		}
+		settings.Env["AGENTAPI_PROXY_ENDPOINT"] = w.upstreamURL
 	}
 
 	sessionID := uuid.New().String()

--- a/internal/modules/sessionmanager/allocator_worker_test.go
+++ b/internal/modules/sessionmanager/allocator_worker_test.go
@@ -49,6 +49,41 @@ func TestAllocatorWorkerCompletesAssignedAllocation(t *testing.T) {
 	}
 }
 
+func TestAllocatorWorkerPointsOneshotDeletionAtUpstreamProxy(t *testing.T) {
+	client := &fakeExternalAllocatorClient{}
+	manager := &fakeAllocatorSessionManager{}
+	worker := newAllocatorWorkerWithClient(manager, client, "https://proxy.example", "https://esm.example")
+	settings := &sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{UserID: "user-1", Scope: string(entities.ScopeUser), Oneshot: true},
+	}
+
+	worker.process(context.Background(), &sessionallocation.AllocationRequest{
+		SessionID:         "public-session",
+		ProvisionSettings: settings,
+	})
+
+	if got := settings.Env["AGENTAPI_PROXY_ENDPOINT"]; got != "https://proxy.example" {
+		t.Fatalf("AGENTAPI_PROXY_ENDPOINT = %q, want upstream proxy URL", got)
+	}
+}
+
+func TestAllocatorWorkerLeavesRegularSessionEndpointUnchanged(t *testing.T) {
+	worker := newAllocatorWorkerWithClient(&fakeAllocatorSessionManager{}, &fakeExternalAllocatorClient{}, "https://proxy.example", "https://esm.example")
+	settings := &sessionsettings.SessionSettings{
+		Session: sessionsettings.SessionMeta{UserID: "user-1", Scope: string(entities.ScopeUser)},
+		Env:     map[string]string{"AGENTAPI_PROXY_ENDPOINT": "https://custom.example"},
+	}
+
+	worker.process(context.Background(), &sessionallocation.AllocationRequest{
+		SessionID:         "public-session",
+		ProvisionSettings: settings,
+	})
+
+	if got := settings.Env["AGENTAPI_PROXY_ENDPOINT"]; got != "https://custom.example" {
+		t.Fatalf("AGENTAPI_PROXY_ENDPOINT = %q, want existing endpoint", got)
+	}
+}
+
 func TestAllocatorWorkerCompletesErrorWhenProvisionSettingsMissing(t *testing.T) {
 	client := &fakeExternalAllocatorClient{}
 	worker := NewAllocatorWorkerWithClient(&fakeAllocatorSessionManager{}, client, "https://esm.example")

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -44,11 +44,15 @@ func EndpointFromEnv() (string, error) {
 
 // buildEndpointFromEnv builds the endpoint URL from environment variables
 func buildEndpointFromEnv() (string, error) {
+	if endpoint := os.Getenv("AGENTAPI_PROXY_ENDPOINT"); endpoint != "" {
+		return endpoint, nil
+	}
+
 	proxyHost := os.Getenv("AGENTAPI_PROXY_SERVICE_HOST")
 	proxyPort := os.Getenv("AGENTAPI_PROXY_SERVICE_PORT_HTTP")
 
 	if proxyHost == "" || proxyPort == "" {
-		return "", fmt.Errorf("AGENTAPI_PROXY_SERVICE_HOST or AGENTAPI_PROXY_SERVICE_PORT_HTTP environment variable is not set")
+		return "", fmt.Errorf("AGENTAPI_PROXY_ENDPOINT or AGENTAPI_PROXY_SERVICE_HOST and AGENTAPI_PROXY_SERVICE_PORT_HTTP environment variables are not set")
 	}
 
 	return fmt.Sprintf("http://%s:%s", proxyHost, proxyPort), nil

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -1,0 +1,31 @@
+package client
+
+import "testing"
+
+func TestEndpointFromEnvPrefersExplicitEndpoint(t *testing.T) {
+	t.Setenv("AGENTAPI_PROXY_ENDPOINT", "https://proxy.example/base")
+	t.Setenv("AGENTAPI_PROXY_SERVICE_HOST", "local-proxy")
+	t.Setenv("AGENTAPI_PROXY_SERVICE_PORT_HTTP", "8080")
+
+	endpoint, err := EndpointFromEnv()
+	if err != nil {
+		t.Fatalf("EndpointFromEnv() error = %v", err)
+	}
+	if endpoint != "https://proxy.example/base" {
+		t.Fatalf("EndpointFromEnv() = %q, want explicit endpoint", endpoint)
+	}
+}
+
+func TestEndpointFromEnvFallsBackToServiceEnvironment(t *testing.T) {
+	t.Setenv("AGENTAPI_PROXY_ENDPOINT", "")
+	t.Setenv("AGENTAPI_PROXY_SERVICE_HOST", "local-proxy")
+	t.Setenv("AGENTAPI_PROXY_SERVICE_PORT_HTTP", "8080")
+
+	endpoint, err := EndpointFromEnv()
+	if err != nil {
+		t.Fatalf("EndpointFromEnv() error = %v", err)
+	}
+	if endpoint != "http://local-proxy:8080" {
+		t.Fatalf("EndpointFromEnv() = %q, want service endpoint", endpoint)
+	}
+}


### PR DESCRIPTION
## Summary
- route external-session-manager oneshot deletion back to the upstream proxy that owns the public session ID
- support an explicit `AGENTAPI_PROXY_ENDPOINT` while preserving Kubernetes service env fallback
- add regression tests for oneshot and regular external sessions

## Verification
- `make lint`
- `make test`