### PR TITLE
Fix runtime status for public session IDs

### DIFF
--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -353,6 +353,7 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 	// can be removed from the local list. Only the parent proxy's SessionID is
 	// public; RemoteSessionID is an implementation detail used for routing.
 	var routes []*repositories.SessionRoute
+	allocatedSessions := make(map[string]entities.Session)
 	if c.sessionRouteRepo != nil {
 		var err error
 		routes, err = c.sessionRouteRepo.List(ctx.Request().Context(), userID)
@@ -360,6 +361,7 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 			log.Printf("[SEARCH] Failed to list session routes: %v", err)
 			routes = nil
 		} else {
+			allocatedSessions = indexAllocatedSessions(matchingSessions, routes)
 			matchingSessions = excludeAllocatedSessions(matchingSessions, routes)
 		}
 	}
@@ -442,10 +444,7 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 		if !match {
 			continue
 		}
-		status := "active"
-		if route.RemoteSessionID == "" {
-			status = "creating"
-		}
+		status := routedSessionStatus(route, allocatedSessions)
 		filteredSessions = append(filteredSessions, map[string]interface{}{
 			"session_id":           route.SessionID,
 			"allocated_session_id": route.RemoteSessionID,
@@ -468,6 +467,33 @@ func (c *SessionController) SearchSessions(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, map[string]interface{}{
 		"sessions": filteredSessions,
 	})
+}
+
+func routedSessionStatus(route *repositories.SessionRoute, allocatedSessions map[string]entities.Session) string {
+	if route.RemoteSessionID == "" {
+		return "creating"
+	}
+	if allocatedSession := allocatedSessions[route.RemoteSessionID]; allocatedSession != nil {
+		return allocatedSession.Status()
+	}
+	return "active"
+}
+
+func indexAllocatedSessions(sessions []entities.Session, routes []*repositories.SessionRoute) map[string]entities.Session {
+	allocatedIDs := make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		if route.RemoteSessionID != "" && route.RemoteSessionID != route.SessionID {
+			allocatedIDs[route.RemoteSessionID] = struct{}{}
+		}
+	}
+
+	allocatedSessions := make(map[string]entities.Session, len(allocatedIDs))
+	for _, session := range sessions {
+		if _, allocated := allocatedIDs[session.ID()]; allocated {
+			allocatedSessions[session.ID()] = session
+		}
+	}
+	return allocatedSessions
 }
 
 func excludeAllocatedSessions(sessions []entities.Session, routes []*repositories.SessionRoute) []entities.Session {

--- a/internal/interfaces/controllers/session_controller_test.go
+++ b/internal/interfaces/controllers/session_controller_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 type sessionListTestSession struct {
-	id string
+	id     string
+	status string
 }
 
 func (s *sessionListTestSession) ID() string                    { return s.id }
@@ -18,12 +19,17 @@ func (s *sessionListTestSession) UserID() string                { return "user-1
 func (s *sessionListTestSession) Scope() entities.ResourceScope { return entities.ScopeUser }
 func (s *sessionListTestSession) TeamID() string                { return "" }
 func (s *sessionListTestSession) Tags() map[string]string       { return nil }
-func (s *sessionListTestSession) Status() string                { return "running" }
-func (s *sessionListTestSession) StartedAt() time.Time          { return time.Time{} }
-func (s *sessionListTestSession) UpdatedAt() time.Time          { return time.Time{} }
-func (s *sessionListTestSession) LastMessageAt() time.Time      { return time.Time{} }
-func (s *sessionListTestSession) Description() string           { return "" }
-func (s *sessionListTestSession) Cancel()                       {}
+func (s *sessionListTestSession) Status() string {
+	if s.status == "" {
+		return "running"
+	}
+	return s.status
+}
+func (s *sessionListTestSession) StartedAt() time.Time     { return time.Time{} }
+func (s *sessionListTestSession) UpdatedAt() time.Time     { return time.Time{} }
+func (s *sessionListTestSession) LastMessageAt() time.Time { return time.Time{} }
+func (s *sessionListTestSession) Description() string      { return "" }
+func (s *sessionListTestSession) Cancel()                  {}
 
 func TestExcludeAllocatedSessions(t *testing.T) {
 	sessions := []entities.Session{
@@ -41,5 +47,52 @@ func TestExcludeAllocatedSessions(t *testing.T) {
 	}
 	if got[0].ID() != "public-id" || got[1].ID() != "local-id" {
 		t.Fatalf("excludeAllocatedSessions() returned IDs %q and %q, want public-id and local-id", got[0].ID(), got[1].ID())
+	}
+}
+
+func TestIndexAllocatedSessionsPreservesRuntimeStatus(t *testing.T) {
+	sessions := []entities.Session{
+		&sessionListTestSession{id: "allocated-running", status: "running"},
+		&sessionListTestSession{id: "allocated-stable", status: "stable"},
+		&sessionListTestSession{id: "local-id", status: "active"},
+	}
+	routes := []*repositories.SessionRoute{
+		{SessionID: "public-running", RemoteSessionID: "allocated-running"},
+		{SessionID: "public-stable", RemoteSessionID: "allocated-stable"},
+	}
+
+	got := indexAllocatedSessions(sessions, routes)
+	if len(got) != 2 {
+		t.Fatalf("indexAllocatedSessions() returned %d sessions, want 2", len(got))
+	}
+	if got["allocated-running"].Status() != "running" {
+		t.Fatalf("running session status = %q, want running", got["allocated-running"].Status())
+	}
+	if got["allocated-stable"].Status() != "stable" {
+		t.Fatalf("stable session status = %q, want stable", got["allocated-stable"].Status())
+	}
+	if status := routedSessionStatus(routes[0], got); status != "running" {
+		t.Fatalf("public running session status = %q, want running", status)
+	}
+	if status := routedSessionStatus(routes[1], got); status != "stable" {
+		t.Fatalf("public stable session status = %q, want stable", status)
+	}
+}
+
+func TestRoutedSessionStatusFallbacks(t *testing.T) {
+	tests := []struct {
+		name  string
+		route *repositories.SessionRoute
+		want  string
+	}{
+		{name: "allocation pending", route: &repositories.SessionRoute{SessionID: "public-id"}, want: "creating"},
+		{name: "remote session", route: &repositories.SessionRoute{SessionID: "public-id", RemoteSessionID: "remote-id"}, want: "active"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := routedSessionStatus(tt.route, nil); got != tt.want {
+				t.Fatalf("routedSessionStatus() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- preserve allocated session objects before hiding their implementation IDs
- expose the allocated session runtime status through the public session ID
- retain `creating` and remote-manager `active` fallbacks
- add regression tests for `running` and `stable`

## Validation
- `make lint` ✅ (0 issues)
- controller package tests ✅
- `make test` ⚠️ existing `cmd.TestRunProxyWithInvalidConfig` interrupted the test process (`signal: interrupt`); all tests reached before it, including the changed package, passed

## Deployment
- Dev deployment and live session verification to follow.