### PR TITLE
fix: delete stale local session routes

### DIFF
--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -737,7 +737,18 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 func (c *SessionController) deleteLocalSessionAlias(ctx echo.Context, route *repositories.SessionRoute) error {
 	session := c.getSessionManager().GetSession(route.RemoteSessionID)
 	if session == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+		authzCtx := auth.GetAuthorizationContext(ctx)
+		if authzCtx == nil || !authzCtx.CanModifyResource(route.UserID, route.Scope, route.TeamID) {
+			return echo.NewHTTPError(http.StatusForbidden, "You don't have permission to delete this session")
+		}
+		if err := c.sessionRouteRepo.Delete(ctx.Request().Context(), route.SessionID); err != nil {
+			log.Printf("Failed to delete stale session alias %s: %v", route.SessionID, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete session")
+		}
+		log.Printf("Deleted stale session alias %s (missing local session: %s)", route.SessionID, route.RemoteSessionID)
+		return ctx.JSON(http.StatusOK, map[string]interface{}{
+			"message": "Session terminated successfully", "session_id": route.SessionID, "status": "terminated",
+		})
 	}
 	authzCtx := auth.GetAuthorizationContext(ctx)
 	if !authzCtx.CanModifyResource(session.UserID(), string(session.Scope()), session.TeamID()) {

--- a/internal/interfaces/controllers/session_controller_test.go
+++ b/internal/interfaces/controllers/session_controller_test.go
@@ -1,15 +1,110 @@
 package controllers
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
 )
 
 type sessionListTestSession struct {
 	id string
+}
+
+type staleRouteSessionManager struct{}
+
+func (staleRouteSessionManager) CreateSession(context.Context, string, *entities.RunServerRequest, []byte) (entities.Session, error) {
+	return nil, nil
+}
+func (staleRouteSessionManager) GetSession(string) entities.Session { return nil }
+func (staleRouteSessionManager) ListSessions(entities.SessionFilter) []entities.Session {
+	return nil
+}
+func (staleRouteSessionManager) DeleteSession(string) error { return nil }
+func (staleRouteSessionManager) SendMessage(context.Context, string, string) error {
+	return nil
+}
+func (staleRouteSessionManager) StopAgent(context.Context, string) error { return nil }
+func (staleRouteSessionManager) GetMessages(context.Context, string) ([]repositories.Message, error) {
+	return nil, nil
+}
+func (staleRouteSessionManager) Shutdown(time.Duration) error { return nil }
+
+type staleRouteProvider struct{ manager repositories.SessionManager }
+
+func (p staleRouteProvider) GetSessionManager() repositories.SessionManager { return p.manager }
+
+type staleRouteRepository struct {
+	route     *repositories.SessionRoute
+	deletedID string
+}
+
+func (r *staleRouteRepository) Save(context.Context, *repositories.SessionRoute) error { return nil }
+func (r *staleRouteRepository) Get(context.Context, string) (*repositories.SessionRoute, error) {
+	return r.route, nil
+}
+func (r *staleRouteRepository) List(context.Context, string) ([]*repositories.SessionRoute, error) {
+	return []*repositories.SessionRoute{r.route}, nil
+}
+func (r *staleRouteRepository) Delete(_ context.Context, sessionID string) error {
+	r.deletedID = sessionID
+	return nil
+}
+
+func staleRouteDeleteContext(sessionID, userID string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/sessions/"+sessionID, nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetParamNames("sessionId")
+	ctx.SetParamValues(sessionID)
+	ctx.Set("authz_context", &auth.AuthorizationContext{
+		PersonalScope: auth.PersonalScopeAuth{UserID: userID},
+	})
+	return ctx, rec
+}
+
+func TestDeleteSession_RemovesStaleLocalAlias(t *testing.T) {
+	const sessionID = "public-session"
+	repo := &staleRouteRepository{route: &repositories.SessionRoute{
+		SessionID: sessionID, RemoteSessionID: "missing-local-session", UserID: "user-1", Scope: "user",
+	}}
+	controller := NewSessionController(
+		staleRouteProvider{manager: staleRouteSessionManager{}}, nil, WithSessionRouteRepository(repo),
+	)
+	ctx, rec := staleRouteDeleteContext(sessionID, "user-1")
+
+	require.NoError(t, controller.DeleteSession(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, sessionID, repo.deletedID)
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Equal(t, "terminated", response["status"])
+}
+
+func TestDeleteSession_RejectsStaleLocalAliasOwnedByAnotherUser(t *testing.T) {
+	const sessionID = "public-session"
+	repo := &staleRouteRepository{route: &repositories.SessionRoute{
+		SessionID: sessionID, RemoteSessionID: "missing-local-session", UserID: "owner", Scope: "user",
+	}}
+	controller := NewSessionController(
+		staleRouteProvider{manager: staleRouteSessionManager{}}, nil, WithSessionRouteRepository(repo),
+	)
+	ctx, _ := staleRouteDeleteContext(sessionID, "other-user")
+
+	err := controller.DeleteSession(ctx)
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusForbidden, httpErr.Code)
+	require.Empty(t, repo.deletedID)
 }
 
 func (s *sessionListTestSession) ID() string                    { return s.id }


### PR DESCRIPTION
## Summary
- delete a local session route when its allocated session is already gone
- authorize stale-route cleanup using the persisted route ownership metadata
- add regression tests for owner cleanup and cross-user rejection

## Tests
- `make lint`
- `make test` (with Kubernetes environment isolated and Zig CC for the race detector)