### PR TITLE
feat: select managed credential source from session profiles

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -708,8 +708,12 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 	}
 
 	var unsyncedFilePaths []string
+	var credentialSource string
 	if startReq.Params != nil && len(startReq.Params.UnsyncedFilePaths) > 0 {
 		unsyncedFilePaths = append([]string(nil), startReq.Params.UnsyncedFilePaths...)
+	}
+	if startReq.Params != nil {
+		credentialSource = startReq.Params.CredentialSource
 	}
 
 	launcher := sessionuc.NewLaunchUseCase(s.sessionManager).
@@ -736,6 +740,7 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		AuthProxy:                authProxy,
 		SessionTTL:               sessionTTL,
 		UnsyncedFilePaths:        unsyncedFilePaths,
+		CredentialSource:         credentialSource,
 	})
 	if err != nil {
 		return nil, err
@@ -762,12 +767,14 @@ func (s *Server) createRemoteSession(ctx context.Context, sessionID string, star
 	var oneshot bool
 	var authProxy *bool
 	var unsyncedFilePaths []string
+	var credentialSource string
 	if startReq.Params != nil {
 		initialMessage = startReq.Params.Message
 		agentType = startReq.Params.AgentType
 		oneshot = startReq.Params.Oneshot
 		authProxy = startReq.Params.AuthProxy
 		unsyncedFilePaths = append([]string(nil), startReq.Params.UnsyncedFilePaths...)
+		credentialSource = startReq.Params.CredentialSource
 	}
 	runReq := &entities.RunServerRequest{
 		UserID:            userID,
@@ -783,6 +790,7 @@ func (s *Server) createRemoteSession(ctx context.Context, sessionID string, star
 		RepoInfo:          s.extractRepositoryInfo(sessionID, startReq.Tags),
 		AuthProxy:         authProxy,
 		UnsyncedFilePaths: unsyncedFilePaths,
+		CredentialSource:  credentialSource,
 	}
 
 	// Try to build fully-resolved settings (env vars, Bedrock, MCP servers, OAuth token, etc.)

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -119,6 +119,10 @@ type SessionParams struct {
 	SessionTTL string `json:"session_ttl,omitempty"`
 	// UnsyncedFilePaths excludes managed file paths from syncing changes back to storage.
 	UnsyncedFilePaths []string `json:"unsynced_file_paths,omitempty"`
+	// CredentialSource selects which managed credentials are injected into the session.
+	// Valid values are "session_user", "team", and "none". Empty preserves the
+	// legacy behavior (session user for user scope, none for team scope).
+	CredentialSource string `json:"credential_source,omitempty"`
 }
 
 // SessionAnnotations contains user-managed annotations attached to a session.
@@ -199,6 +203,8 @@ type RunServerRequest struct {
 	SessionTTL string
 	// UnsyncedFilePaths excludes managed file paths from syncing changes back to storage.
 	UnsyncedFilePaths []string
+	// CredentialSource selects the owner of managed credential files.
+	CredentialSource string
 }
 
 // Session represents a running agentapi session

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -5352,12 +5352,28 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		log.Printf("[K8S_SESSION] OtelCollector in-process config embedded for session %s", session.id)
 	}
 
-	// Embed managed files from the user's agentapi-agent-files-{userID} Secret so that
+	// Embed managed files from the selected credential owner so that
 	// stock pool pods (which have no user-specific volume mounts) can restore files
 	// on startup via the provision endpoint payload.
-	// Only applies to user-scoped sessions with a known UserID.
-	if (req.Scope == entities.ScopeUser || req.Scope == "") && req.UserID != "" {
-		filesSecretName := fmt.Sprintf("agentapi-agent-files-%s", sanitizeLabelValue(req.UserID))
+	// Empty CredentialSource preserves the legacy behavior: user-scoped sessions
+	// use the session creator and team-scoped sessions receive no credentials.
+	credentialOwner := ""
+	switch req.CredentialSource {
+	case "session_user":
+		credentialOwner = req.UserID
+	case "team":
+		credentialOwner = req.TeamID
+	case "none":
+		// Explicitly disabled.
+	case "":
+		if req.Scope == entities.ScopeUser || req.Scope == "" {
+			credentialOwner = req.UserID
+		}
+	default:
+		log.Printf("[K8S_SESSION] Warning: unknown credential_source %q for session %s; credentials disabled", req.CredentialSource, session.id)
+	}
+	if credentialOwner != "" {
+		filesSecretName := fmt.Sprintf("agentapi-agent-files-%s", sanitizeLabelValue(credentialOwner))
 		filesSecret, err := m.client.CoreV1().Secrets(m.namespace).Get(ctx, filesSecretName, metav1.GetOptions{})
 		if err == nil && len(filesSecret.Data) > 0 {
 			settings.Files = sessionsettings.SecretDataToFiles(filesSecret.Data)
@@ -5372,8 +5388,11 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			}
 		}
 		// Not found or no data is normal (user hasn't logged in yet); skip silently.
+	}
 
-		// Also embed user-managed files from the agentapi-user-files-{userID} Secret.
+	// User-managed files retain their existing user-scope-only behavior; the
+	// credential selector above controls authentication files only.
+	if (req.Scope == entities.ScopeUser || req.Scope == "") && req.UserID != "" {
 		userFilesSecretName := fmt.Sprintf("agentapi-user-files-%s", sanitizeLabelValue(req.UserID))
 		userFilesSecret, userFilesErr := m.client.CoreV1().Secrets(m.namespace).Get(ctx, userFilesSecretName, metav1.GetOptions{})
 		if userFilesErr == nil && len(userFilesSecret.Data) > 0 {
@@ -5384,7 +5403,6 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 					len(userManagedFiles), userFilesSecretName, session.id)
 			}
 		}
-		// Not found or no data is normal (user has no registered files); skip silently.
 	}
 
 	// When CycleMessage is set, write the message into /tmp/check/CYCLE_ENABLED so

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -13,10 +13,56 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/pkg/config"
 	"github.com/takutakahashi/agentapi-proxy/pkg/logger"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
 type fakeSettingsRepository struct {
 	settings map[string]*entities.Settings
+}
+
+func TestBuildSessionSettings_TeamScopeUsesSessionUserCredentialsWhenSelected(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "agentapi-agent-files-test-user", Namespace: "test-ns"},
+			Data: sessionsettings.FilesToSecretData([]sessionsettings.ManagedFile{{
+				Path:    sessionsettings.ManagedFileTypes[sessionsettings.FileTypeCodexAuth],
+				Content: `{"tokens":{"access_token":"user-token"}}`,
+			}}),
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "agentapi-agent-files-org-team-a", Namespace: "test-ns"},
+			Data: sessionsettings.FilesToSecretData([]sessionsettings.ManagedFile{{
+				Path:    sessionsettings.ManagedFileTypes[sessionsettings.FileTypeCodexAuth],
+				Content: `{"tokens":{"access_token":"team-token"}}`,
+			}}),
+		},
+	)
+	cfg := &config.Config{KubernetesSession: config.KubernetesSessionConfig{
+		Namespace: "test-ns", Image: "test-image:latest", BasePort: 9000,
+		PVCEnabled: boolPtrForTest(false),
+	}}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	manager.namespace = "test-ns"
+	session := NewKubernetesSession("test-session", &entities.RunServerRequest{UserID: "test-user"},
+		"test-deploy", "test-service", "test-pvc", "test-ns", 9000, nil, nil)
+
+	settings := manager.buildSessionSettings(context.Background(), session, &entities.RunServerRequest{
+		UserID:           "test-user",
+		Scope:            entities.ScopeTeam,
+		TeamID:           "org/team-a",
+		CredentialSource: "session_user",
+	}, nil)
+
+	if len(settings.Files) != 1 {
+		t.Fatalf("managed files count = %d, want 1", len(settings.Files))
+	}
+	if got := settings.Files[0].Content; got != `{"tokens":{"access_token":"user-token"}}` {
+		t.Fatalf("credential content = %q, want session user's credentials", got)
+	}
 }
 
 func (r *fakeSettingsRepository) Save(ctx context.Context, settings *entities.Settings) error {

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -1036,6 +1036,9 @@ func mergeSessionParams(base, override *entities.SessionParams) *entities.Sessio
 	if len(override.UnsyncedFilePaths) > 0 {
 		merged.UnsyncedFilePaths = append([]string(nil), override.UnsyncedFilePaths...)
 	}
+	if override.CredentialSource != "" {
+		merged.CredentialSource = override.CredentialSource
+	}
 	return &merged
 }
 

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -41,6 +41,7 @@ type LaunchRequest struct {
 	CycleMaxCount            int
 	SessionTTL               string
 	UnsyncedFilePaths        []string
+	CredentialSource         string
 
 	// Webhook payload to mount in the session filesystem (optional)
 	WebhookPayload []byte
@@ -208,6 +209,7 @@ func (uc *LaunchUseCase) Launch(ctx context.Context, sessionID string, req Launc
 		AuthProxy:                req.AuthProxy,
 		SessionTTL:               req.SessionTTL,
 		UnsyncedFilePaths:        req.UnsyncedFilePaths,
+		CredentialSource:         req.CredentialSource,
 	}
 
 	session, err := uc.sessionManager.CreateSession(ctx, sessionID, runReq, req.WebhookPayload)
@@ -406,6 +408,9 @@ func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchR
 		}
 		if len(req.UnsyncedFilePaths) == 0 && len(cfg.Params().UnsyncedFilePaths) > 0 {
 			req.UnsyncedFilePaths = append([]string(nil), cfg.Params().UnsyncedFilePaths...)
+		}
+		if req.CredentialSource == "" {
+			req.CredentialSource = cfg.Params().CredentialSource
 		}
 	}
 	if cfg.SessionTTL() != "" && req.SessionTTL == "" {

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -233,6 +233,31 @@ func TestLaunchAppliesDefaultProfileUnsyncedFilePaths(t *testing.T) {
 	}
 }
 
+func TestLaunchAppliesProfileCredentialSource(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "team profile", "user-1")
+	profile.SetOwnership(entities.ScopeTeam, "user-1", "org/team-a")
+	profile.SetIsDefault(true)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetParams(&entities.SessionParams{CredentialSource: "session_user"})
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).
+		WithSessionProfileRepository(&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}})
+
+	_, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1",
+		Scope:  entities.ScopeTeam,
+		TeamID: "org/team-a",
+	})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if got := sessionManager.req.CredentialSource; got != "session_user" {
+		t.Fatalf("credential source = %q, want session_user", got)
+	}
+}
+
 func TestLaunchExplicitUnsyncedFilePathsOverrideProfile(t *testing.T) {
 	sessionManager := &recordingSessionManager{}
 	profile := entities.NewSessionProfile("profile-1", "default", "user-1")

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -5510,6 +5510,16 @@
             "example": [
               "/home/agentapi/.codex/auth.json"
             ]
+          },
+          "credential_source": {
+            "type": "string",
+            "enum": [
+              "session_user",
+              "team",
+              "none"
+            ],
+            "description": "Managed credential files to inject. session_user uses the user who created the session, team uses the session team, and none disables credential injection. When omitted, user-scoped sessions use session_user and team-scoped sessions use none.",
+            "example": "session_user"
           }
         }
       },


### PR DESCRIPTION
## Summary
- add `params.credential_source` to session profiles and start requests
- support `session_user`, `team`, and `none` credential sources
- preserve legacy defaults: user scope uses session user; team scope injects no credentials
- inject the session creator's Codex `auth.json` into team sessions when `session_user` is selected
- document the field in OpenAPI and cover profile propagation/credential selection with tests

## Validation
- `make lint` ✅ (0 issues)
- `CGO_ENABLED=0 go test ./internal/usecases/session ./internal/infrastructure/services ./internal/interfaces/controllers` ✅
- `make test` ⚠️ could not run the required race build because this execution image has no C compiler (`cgo: C compiler "gcc" not found`)
