### PR TITLE
Fix stale local session route cleanup

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -516,9 +516,37 @@ func NewServer(cfg *config.Config, verbose bool) *Server {
 		log.Printf("[SERVER] Memory dump handler registered for session deletion")
 	}
 
+	// Local allocation may expose a stable public session ID while running the
+	// workload under an adopted stock-session ID.  A oneshot workload deletes
+	// itself by that runtime ID, so remove the public alias at the same time.
+	// Otherwise /search keeps synthesizing an active session from a route whose
+	// workload no longer exists.
+	if k8sManager, ok := sessionManager.(*services.KubernetesSessionManager); ok && sessionRouteRepo != nil {
+		k8sManager.AddSessionDeletedHandler(func(ctx context.Context, sess entities.Session) {
+			cleanupLocalSessionRoutes(ctx, sessionRouteRepo, sess.ID())
+		})
+		log.Printf("[SERVER] Local session route cleanup handler registered")
+	}
+
 	s.setupRoutes()
 
 	return s
+}
+
+func cleanupLocalSessionRoutes(ctx context.Context, repo portrepos.SessionRouteRepository, runtimeSessionID string) {
+	routes, err := repo.List(ctx, "")
+	if err != nil {
+		log.Printf("[SESSION_ROUTE] Warning: failed to list routes while deleting runtime session %s: %v", runtimeSessionID, err)
+		return
+	}
+	for _, route := range routes {
+		if route.ProxyURL != "" || route.RemoteSessionID != runtimeSessionID {
+			continue
+		}
+		if err := repo.Delete(ctx, route.SessionID); err != nil {
+			log.Printf("[SESSION_ROUTE] Warning: failed to delete local alias %s for runtime session %s: %v", route.SessionID, runtimeSessionID, err)
+		}
+	}
 }
 
 // StartMonitoring starts the session monitoring (called after server is fully initialized)

--- a/internal/app/server_session_route_cleanup_test.go
+++ b/internal/app/server_session_route_cleanup_test.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	portrepos "github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+type cleanupRouteRepository struct {
+	routes  []*portrepos.SessionRoute
+	deleted []string
+}
+
+func (r *cleanupRouteRepository) Save(context.Context, *portrepos.SessionRoute) error { return nil }
+func (r *cleanupRouteRepository) Get(context.Context, string) (*portrepos.SessionRoute, error) {
+	return nil, nil
+}
+func (r *cleanupRouteRepository) List(context.Context, string) ([]*portrepos.SessionRoute, error) {
+	return r.routes, nil
+}
+func (r *cleanupRouteRepository) Delete(_ context.Context, sessionID string) error {
+	r.deleted = append(r.deleted, sessionID)
+	return nil
+}
+
+func TestCleanupLocalSessionRoutes(t *testing.T) {
+	repo := &cleanupRouteRepository{routes: []*portrepos.SessionRoute{
+		{SessionID: "public-local", RemoteSessionID: "runtime-id"},
+		{SessionID: "other-local", RemoteSessionID: "other-runtime"},
+		{SessionID: "public-external", RemoteSessionID: "runtime-id", ProxyURL: "https://esm.example"},
+	}}
+
+	cleanupLocalSessionRoutes(context.Background(), repo, "runtime-id")
+
+	if len(repo.deleted) != 1 || repo.deleted[0] != "public-local" {
+		t.Fatalf("deleted routes = %v, want [public-local]", repo.deleted)
+	}
+}

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -763,7 +763,20 @@ func (c *SessionController) RouteToSession(ctx echo.Context) error {
 func (c *SessionController) deleteLocalSessionAlias(ctx echo.Context, route *repositories.SessionRoute) error {
 	session := c.getSessionManager().GetSession(route.RemoteSessionID)
 	if session == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "Session not found")
+		// The runtime may already have removed itself (for example via a oneshot
+		// Stop hook). Authorize from the persisted route metadata and make DELETE
+		// idempotently clean up the stale public alias.
+		authzCtx := auth.GetAuthorizationContext(ctx)
+		if !authzCtx.CanModifyResource(route.UserID, route.Scope, route.TeamID) {
+			return echo.NewHTTPError(http.StatusForbidden, "You don't have permission to delete this session")
+		}
+		if err := c.sessionRouteRepo.Delete(ctx.Request().Context(), route.SessionID); err != nil {
+			log.Printf("Failed to delete stale session alias %s: %v", route.SessionID, err)
+			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to delete session alias")
+		}
+		return ctx.JSON(http.StatusOK, map[string]interface{}{
+			"message": "Stale session alias removed", "session_id": route.SessionID, "status": "terminated",
+		})
 	}
 	authzCtx := auth.GetAuthorizationContext(ctx)
 	if !authzCtx.CanModifyResource(session.UserID(), string(session.Scope()), session.TeamID()) {


### PR DESCRIPTION
## Summary
- remove local public route aliases when their allocated runtime session is deleted
- make deletion of an already-orphaned local alias idempotent
- add regression coverage for route cleanup matching

## Root cause
A oneshot session adopted stock runtime `197d0fcb-0ea0-4e10-9713-9fa967a40524` behind public ID `2f9be8e6-c014-4cc0-86c4-682f0d056875`. The runtime deleted itself, but the local route Secret was not removed. `/search` therefore synthesized the stale route as active.

## Verification
- `make lint`
- `go test ./...`
- `make test` was started, but the current container has no C compiler required by the race detector