### PR TITLE
feat: support team-scoped Codex device auth

### DIFF
--- a/internal/interfaces/controllers/codex_device_auth_controller.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller.go
@@ -32,10 +32,11 @@ var (
 
 // authSession tracks an in-progress codex login --device-auth subprocess.
 type authSession struct {
-	cmd     *exec.Cmd
-	tmpHome string
-	mu      sync.Mutex
-	status  string // "pending", "authorized", "denied"
+	cmd            *exec.Cmd
+	tmpHome        string
+	credentialName string
+	mu             sync.Mutex
+	status         string // "pending", "authorized", "denied"
 }
 
 // CodexDeviceAuthController runs `codex login --device-auth` and proxies
@@ -59,6 +60,13 @@ func (c *CodexDeviceAuthController) GetName() string {
 type StartDeviceAuthResponse struct {
 	UserCode        string `json:"user_code"`
 	VerificationURI string `json:"verification_uri"`
+}
+
+// StartDeviceAuthRequest selects where the generated auth.json is stored.
+// An omitted scope preserves the existing user-scoped behavior.
+type StartDeviceAuthRequest struct {
+	Scope  string `json:"scope,omitempty"`
+	TeamID string `json:"team_id,omitempty"`
 }
 
 // PollDeviceAuthResponse is returned by POST /codex/device-auth/token.
@@ -92,6 +100,16 @@ func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 	}
 
 	userID := string(user.ID())
+	var req StartDeviceAuthRequest
+	if ctx.Request().ContentLength != 0 {
+		if err := ctx.Bind(&req); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Invalid request body")
+		}
+	}
+	credentialName, err := deviceAuthCredentialName(user, req)
+	if err != nil {
+		return err
+	}
 
 	codexPath, err := exec.LookPath("codex")
 	if err != nil {
@@ -139,7 +157,7 @@ func (c *CodexDeviceAuthController) StartDeviceAuth(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to start codex: %v", err))
 	}
 
-	session := &authSession{cmd: cmd, tmpHome: tmpHome, status: "pending"}
+	session := &authSession{cmd: cmd, tmpHome: tmpHome, credentialName: credentialName, status: "pending"}
 	c.sessions.Store(userID, session)
 	log.Printf("[CODEX_AUTH] Session tmpHome for user=%s: %s", userID, tmpHome)
 
@@ -273,7 +291,7 @@ func (c *CodexDeviceAuthController) watchCompletion(userID string, session *auth
 	}
 	log.Printf("[CODEX_AUTH] auth.json found (%d bytes) for user=%s", len(data), userID)
 
-	creds := entities.NewCredentials(userID, json.RawMessage(data))
+	creds := entities.NewCredentials(session.credentialName, json.RawMessage(data))
 	creds.SetFileType(sessionsettings.FileTypeCodexAuth)
 
 	if err := c.repo.Save(context.Background(), creds); err != nil {
@@ -283,7 +301,33 @@ func (c *CodexDeviceAuthController) watchCompletion(userID string, session *auth
 	}
 
 	session.status = "authorized"
-	log.Printf("[CODEX_AUTH] Auth completed and credentials saved for user=%s", userID)
+	log.Printf("[CODEX_AUTH] Auth completed and credentials saved for user=%s target=%s", userID, session.credentialName)
+}
+
+func deviceAuthCredentialName(user *entities.User, req StartDeviceAuthRequest) (string, error) {
+	scope := strings.TrimSpace(req.Scope)
+	teamID := strings.TrimSpace(req.TeamID)
+	if scope == "" {
+		scope = string(entities.ScopeUser)
+	}
+
+	switch scope {
+	case string(entities.ScopeUser):
+		if teamID != "" {
+			return "", echo.NewHTTPError(http.StatusBadRequest, "team_id is only valid when scope is 'team'")
+		}
+		return string(user.ID()), nil
+	case string(entities.ScopeTeam):
+		if teamID == "" {
+			return "", echo.NewHTTPError(http.StatusBadRequest, "team_id is required when scope is 'team'")
+		}
+		if !user.IsAdmin() && !user.IsMemberOfTeam(teamID) {
+			return "", echo.NewHTTPError(http.StatusForbidden, "Access denied: not a member of the specified team")
+		}
+		return teamID, nil
+	default:
+		return "", echo.NewHTTPError(http.StatusBadRequest, "scope must be 'user' or 'team'")
+	}
 }
 
 // listDir returns relative paths of all files under root (best-effort).

--- a/internal/interfaces/controllers/codex_device_auth_controller_test.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller_test.go
@@ -1,0 +1,45 @@
+package controllers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+)
+
+func TestDeviceAuthCredentialName(t *testing.T) {
+	user := entities.NewGitHubUser("alice", "alice", "alice@example.com", nil)
+	user.SetGitHubInfo(entities.NewGitHubUserInfo(1, "alice", "Alice", "alice@example.com", "", "", ""), []entities.GitHubTeamMembership{
+		{Organization: "acme", TeamSlug: "platform"},
+	})
+
+	tests := []struct {
+		name       string
+		req        StartDeviceAuthRequest
+		want       string
+		wantStatus int
+	}{
+		{name: "default user scope", want: "alice"},
+		{name: "explicit user scope", req: StartDeviceAuthRequest{Scope: "user"}, want: "alice"},
+		{name: "team scope", req: StartDeviceAuthRequest{Scope: "team", TeamID: "acme/platform"}, want: "acme/platform"},
+		{name: "team id with user scope", req: StartDeviceAuthRequest{Scope: "user", TeamID: "acme/platform"}, wantStatus: http.StatusBadRequest},
+		{name: "missing team id", req: StartDeviceAuthRequest{Scope: "team"}, wantStatus: http.StatusBadRequest},
+		{name: "unknown team", req: StartDeviceAuthRequest{Scope: "team", TeamID: "acme/security"}, wantStatus: http.StatusForbidden},
+		{name: "invalid scope", req: StartDeviceAuthRequest{Scope: "organization"}, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deviceAuthCredentialName(user, tt.req)
+			if tt.wantStatus != 0 {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), http.StatusText(tt.wantStatus))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/interfaces/controllers/codex_device_auth_controller_test.go
+++ b/internal/interfaces/controllers/codex_device_auth_controller_test.go
@@ -1,9 +1,11 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
@@ -35,7 +37,9 @@ func TestDeviceAuthCredentialName(t *testing.T) {
 			got, err := deviceAuthCredentialName(user, tt.req)
 			if tt.wantStatus != 0 {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), http.StatusText(tt.wantStatus))
+				var httpErr *echo.HTTPError
+				require.True(t, errors.As(err, &httpErr))
+				assert.Equal(t, tt.wantStatus, httpErr.Code)
 				return
 			}
 			require.NoError(t, err)

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4650,6 +4650,31 @@
             "ApiKeyAuth": []
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "type": "string",
+                    "enum": [
+                      "user",
+                      "team"
+                    ],
+                    "default": "user",
+                    "description": "Credential ownership scope"
+                  },
+                  "team_id": {
+                    "type": "string",
+                    "description": "Team ID in org/team-slug format; required when scope is team"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Device authorization started",


### PR DESCRIPTION
## Summary
- accept scope and team_id when starting Codex device auth
- validate team membership before storing generated auth.json
- persist team credentials under the team credential name
- document the request in OpenAPI and add authorization tests

## Validation
- golangci-lint: 0 issues
- go test ./internal/interfaces/controllers: passed
- make test attempted with race detector; full suite exceeded the session execution limit