### PR TITLE
feat: add one-command native ESM installation

### DIFF
--- a/cmd/native.go
+++ b/cmd/native.go
@@ -1,0 +1,695 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var NativeCmd = &cobra.Command{Use: "native", Short: "Install and manage a native External Session Manager"}
+
+type nativeManageOptions struct {
+	upstream, publicURL, name, listen, managerID, apiKeyEnv, apiKeyFile, configPath string
+	scope, teamID, drainTimeout                                                     string
+	labels                                                                          []string
+	defaultManager, apiKeyStdin, force, drain, keepRegistration, keepData           bool
+}
+
+var nativeManageOpts nativeManageOptions
+
+type nativeRegistrationResponse struct {
+	ID              string            `json:"id"`
+	InstanceID      string            `json:"instance_id"`
+	Name            string            `json:"name"`
+	ConnectionToken string            `json:"connection_token"`
+	Labels          map[string]string `json:"labels"`
+	Created         bool              `json:"created"`
+	LastHeartbeatAt *time.Time        `json:"last_heartbeat_at"`
+}
+
+func init() {
+	p := NativeCmd.PersistentFlags()
+	p.StringVar(&nativeManageOpts.configPath, "config", "", "native daemon config path")
+	p.StringVar(&nativeManageOpts.apiKeyEnv, "api-key-env", "AGENTAPI_KEY", "environment variable containing the install API key")
+	p.StringVar(&nativeManageOpts.apiKeyFile, "api-key-file", "", "file containing the install API key")
+	p.BoolVar(&nativeManageOpts.apiKeyStdin, "api-key-stdin", false, "read the install API key from stdin")
+
+	install := &cobra.Command{Use: "install", Short: "Register and install the native ESM daemon", RunE: runNativeInstall}
+	f := install.Flags()
+	f.StringVar(&nativeManageOpts.upstream, "upstream", "", "parent agentapi-proxy URL")
+	f.StringVar(&nativeManageOpts.publicURL, "public-url", "", "parent-reachable URL for this host")
+	f.StringVar(&nativeManageOpts.name, "name", "", "human-readable manager name")
+	f.StringVar(&nativeManageOpts.listen, "listen", ":8080", "native ESM listen address")
+	f.StringVar(&nativeManageOpts.managerID, "manager-id", "", "stable manager ID (also migrates an existing registration)")
+	f.StringVar(&nativeManageOpts.scope, "scope", "user", "registration scope: user or team")
+	f.StringVar(&nativeManageOpts.teamID, "team-id", "", "team ID when --scope=team")
+	f.StringSliceVar(&nativeManageOpts.labels, "label", nil, "allocator label in key=value form")
+	f.BoolVar(&nativeManageOpts.defaultManager, "default", false, "make this the default external session manager")
+	f.BoolVar(&nativeManageOpts.force, "force", false, "install even if the existing state directory contains sessions")
+
+	status := &cobra.Command{Use: "status", Short: "Show daemon and connection status", RunE: runNativeStatus}
+	doctor := &cobra.Command{Use: "doctor", Short: "Validate daemon configuration and connectivity", RunE: runNativeDoctor}
+	restart := &cobra.Command{Use: "restart", Short: "Restart the native ESM daemon", RunE: runNativeRestart}
+	rotate := &cobra.Command{Use: "rotate-token", Short: "Rotate the ESM connection token and restart", RunE: runNativeRotateToken}
+	uninstall := &cobra.Command{Use: "uninstall", Short: "Stop and remove the native ESM daemon", RunE: runNativeUninstall}
+	uninstall.Flags().BoolVar(&nativeManageOpts.force, "force", false, "terminate active sessions")
+	uninstall.Flags().BoolVar(&nativeManageOpts.drain, "drain", false, "wait for active sessions to finish")
+	uninstall.Flags().StringVar(&nativeManageOpts.drainTimeout, "drain-timeout", "30m", "maximum time to wait with --drain")
+	uninstall.Flags().BoolVar(&nativeManageOpts.keepRegistration, "keep-registration", false, "keep the parent registration")
+	uninstall.Flags().BoolVar(&nativeManageOpts.keepData, "keep-data", false, "keep daemon state and configuration")
+	NativeCmd.AddCommand(install, status, doctor, restart, rotate, uninstall)
+}
+
+func runNativeInstall(_ *cobra.Command, _ []string) error {
+	if nativeManageOpts.upstream == "" || nativeManageOpts.publicURL == "" {
+		return errors.New("--upstream and --public-url are required")
+	}
+	hostname, _ := os.Hostname()
+	if nativeManageOpts.name == "" {
+		nativeManageOpts.name = hostname
+	}
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	active, _ := filepath.Glob(filepath.Join(paths.state, "sessions", "*"))
+	if len(active) > 0 && !nativeManageOpts.force {
+		return fmt.Errorf("refusing to replace daemon with %d session(s) in state; drain them first or use --force", len(active))
+	}
+	existing, _ := readNativeConfig(paths.config)
+	instanceID := existing.InstanceID
+	if instanceID == "" {
+		instanceID = nativeManageOpts.managerID
+	}
+	if instanceID == "" {
+		instanceID = stableNativeInstanceID(hostname)
+	}
+	labels := map[string]string{"os": runtime.GOOS, "arch": runtime.GOARCH, "hostname": hostname}
+	for _, raw := range nativeManageOpts.labels {
+		parts := strings.SplitN(raw, "=", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" {
+			return fmt.Errorf("invalid --label %q; expected key=value", raw)
+		}
+		labels[strings.TrimSpace(parts[0])] = parts[1]
+	}
+	apiKey, err := readInstallAPIKey()
+	if err != nil {
+		return err
+	}
+	registration, err := registerNativeManager(nativeManageOpts.upstream, apiKey, map[string]interface{}{
+		"manager_id": nativeManageOpts.managerID, "instance_id": instanceID, "name": nativeManageOpts.name,
+		"scope": nativeManageOpts.scope, "team_id": nativeManageOpts.teamID,
+		"labels": labels, "default": nativeManageOpts.defaultManager, "public_url": nativeManageOpts.publicURL,
+		"version": nativeBuildVersion(), "rotate_token": existing.ConnectionToken == "",
+	})
+	if err != nil {
+		return err
+	}
+	token := registration.ConnectionToken
+	if token == "" {
+		token = existing.ConnectionToken
+	}
+	if token == "" {
+		return errors.New("registration did not return a connection token; run native rotate-token")
+	}
+	cfg := nativeDaemonConfig{Listen: nativeManageOpts.listen, UpstreamURL: strings.TrimRight(nativeManageOpts.upstream, "/"),
+		ConnectionToken: token, PublicURL: strings.TrimRight(nativeManageOpts.publicURL, "/"), StateDir: paths.state,
+		BinaryPath: paths.binary, ManagerID: registration.ID, InstanceID: instanceID, Scope: nativeManageOpts.scope, TeamID: nativeManageOpts.teamID,
+		Labels: labels, Version: nativeBuildVersion()}
+	if err := installNativeService(paths, cfg); err != nil {
+		return err
+	}
+	if err := waitNativeHealth(cfg.Listen, 30*time.Second); err != nil {
+		return err
+	}
+	if err := sendNativeHeartbeat(cfg); err != nil {
+		return fmt.Errorf("daemon installed but parent heartbeat failed: %w", err)
+	}
+	fmt.Printf("Native ESM installed\nManager ID: %s\nService: %s\nLabels: %s\n", registration.ID, nativeServiceName(), formatLabels(labels))
+	return nil
+}
+
+type nativeInstallPaths struct{ config, credentials, state, binary, service, logDir string }
+
+func nativePaths(configOverride string) (nativeInstallPaths, error) {
+	if runtime.GOOS == "linux" {
+		if os.Geteuid() != 0 && configOverride == "" {
+			return nativeInstallPaths{}, errors.New("native install on Linux must run as root (use sudo)")
+		}
+		config := "/etc/agentapi-native/config.json"
+		if configOverride != "" {
+			config = configOverride
+		}
+		return nativeInstallPaths{config: config, credentials: "/etc/agentapi-native/credentials.json", state: "/var/lib/agentapi-native", binary: "/usr/local/libexec/agentapi-proxy/agentapi-proxy", service: "/etc/systemd/system/agentapi-native.service", logDir: "/var/log/agentapi-native"}, nil
+	}
+	if runtime.GOOS == "darwin" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nativeInstallPaths{}, err
+		}
+		base := filepath.Join(home, "Library", "Application Support", "agentapi-native")
+		config := filepath.Join(base, "config.json")
+		if configOverride != "" {
+			config = configOverride
+		}
+		return nativeInstallPaths{config: config, credentials: filepath.Join(base, "credentials.json"), state: filepath.Join(base, "state"), binary: filepath.Join(base, "bin", "agentapi-proxy"), service: filepath.Join(home, "Library", "LaunchAgents", "com.agentapi.native.plist"), logDir: filepath.Join(home, "Library", "Logs", "agentapi-native")}, nil
+	}
+	return nativeInstallPaths{}, fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+}
+
+func installNativeService(paths nativeInstallPaths, cfg nativeDaemonConfig) error {
+	for _, dir := range []string{filepath.Dir(paths.config), paths.state, filepath.Dir(paths.binary), paths.logDir, filepath.Dir(paths.service)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if runtime.GOOS == "linux" {
+		if err := ensureLinuxServiceUser(); err != nil {
+			return err
+		}
+		uid, gid := lookupUID("agentapi"), lookupGID("agentapi")
+		if err := filepath.Walk(paths.state, func(path string, _ os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			return os.Chown(path, uid, gid)
+		}); err != nil {
+			return err
+		}
+	}
+	if err := copyExecutable(paths.binary); err != nil {
+		return err
+	}
+	cfg.CredentialsPath = paths.credentials
+	credentials, _ := json.MarshalIndent(map[string]string{"connection_token": cfg.ConnectionToken}, "", "  ")
+	if err := atomicWriteFile(paths.credentials, append(credentials, '\n'), 0o600); err != nil {
+		return err
+	}
+	cfg.ConnectionToken = ""
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := atomicWriteFile(paths.config, append(data, '\n'), 0o600); err != nil {
+		return err
+	}
+	if runtime.GOOS == "linux" {
+		if err := secureNativeConfig(paths.credentials); err != nil {
+			return err
+		}
+		if err := secureNativeConfig(paths.config); err != nil {
+			return err
+		}
+		unit := fmt.Sprintf("[Unit]\nDescription=agentapi-proxy native external session manager\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nUser=agentapi\nGroup=agentapi\nExecStart=%s native-session-manager --config %s\nRestart=always\nRestartSec=3\nKillMode=process\nTimeoutStopSec=30\nLimitNOFILE=65536\n\n[Install]\nWantedBy=multi-user.target\n", paths.binary, paths.config)
+		if err := atomicWriteFile(paths.service, []byte(unit), 0o644); err != nil {
+			return err
+		}
+		if err := runCommand("systemctl", "daemon-reload"); err != nil {
+			return err
+		}
+		if err := runCommand("systemctl", "enable", "agentapi-native.service"); err != nil {
+			return err
+		}
+		return runCommand("systemctl", "restart", "agentapi-native.service")
+	}
+	plist := fmt.Sprintf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\"><dict><key>Label</key><string>com.agentapi.native</string><key>ProgramArguments</key><array><string>%s</string><string>native-session-manager</string><string>--config</string><string>%s</string></array><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s/native.log</string><key>StandardErrorPath</key><string>%s/native.log</string></dict></plist>\n", xmlEscape(paths.binary), xmlEscape(paths.config), xmlEscape(paths.logDir), xmlEscape(paths.logDir))
+	if err := atomicWriteFile(paths.service, []byte(plist), 0o600); err != nil {
+		return err
+	}
+	domain := "gui/" + strconv.Itoa(os.Getuid())
+	_ = runCommand("launchctl", "bootout", domain+"/com.agentapi.native")
+	return runCommand("launchctl", "bootstrap", domain, paths.service)
+}
+
+func runNativeStatus(_ *cobra.Command, _ []string) error {
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	cfg, err := readNativeConfig(paths.config)
+	if err != nil {
+		return err
+	}
+	service := "stopped"
+	if nativeServiceRunning() {
+		service = "running"
+	}
+	health := "unreachable"
+	if nativeHealth(cfg.Listen) == nil {
+		health = "ok"
+	}
+	active, _ := filepath.Glob(filepath.Join(cfg.StateDir, "sessions", "*"))
+	fmt.Printf("Service: %s\nManager ID: %s\nUpstream: %s\nPublic URL: %s\nLabels: %s\nVersion: %s\nActive sessions: %d\nHealth: %s\nState: %s\n", service, cfg.ManagerID, cfg.UpstreamURL, cfg.PublicURL, formatLabels(cfg.Labels), cfg.Version, len(active), health, cfg.StateDir)
+	return nil
+}
+
+func runNativeDoctor(_ *cobra.Command, _ []string) error {
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	for name, path := range map[string]string{"config": paths.config, "credentials": paths.credentials} {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+		if info.Mode().Perm()&0o037 != 0 {
+			return fmt.Errorf("%s permissions are too open: %o", name, info.Mode().Perm())
+		}
+	}
+	cfg, err := readNativeConfig(paths.config)
+	if err != nil {
+		return err
+	}
+	if err := nativeHealth(cfg.Listen); err != nil {
+		return fmt.Errorf("local health: %w", err)
+	}
+	if err := sendNativeHeartbeat(cfg); err != nil {
+		return fmt.Errorf("parent heartbeat: %w", err)
+	}
+	fmt.Println("OK: service, config permissions, local health, and parent heartbeat")
+	return nil
+}
+
+func runNativeRestart(_ *cobra.Command, _ []string) error { return restartNativeService() }
+
+func runNativeRotateToken(_ *cobra.Command, _ []string) error {
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	cfg, err := readNativeConfig(paths.config)
+	if err != nil {
+		return err
+	}
+	apiKey, err := readInstallAPIKey()
+	if err != nil {
+		return err
+	}
+	query := url.Values{}
+	if cfg.Scope != "" {
+		query.Set("scope", cfg.Scope)
+	}
+	if cfg.TeamID != "" {
+		query.Set("team_id", cfg.TeamID)
+	}
+	endpoint := strings.TrimRight(cfg.UpstreamURL, "/") + "/external-session-managers/" + url.PathEscape(cfg.ManagerID) + "/rotate-token"
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	req, _ := http.NewRequest(http.MethodPost, endpoint, nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return responseError(resp)
+	}
+	var registration nativeRegistrationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&registration); err != nil {
+		return err
+	}
+	cfg.ConnectionToken = registration.ConnectionToken
+	credentials, _ := json.MarshalIndent(map[string]string{"connection_token": cfg.ConnectionToken}, "", "  ")
+	if err := atomicWriteFile(cfg.CredentialsPath, append(credentials, '\n'), 0o600); err != nil {
+		return err
+	}
+	if err := secureNativeConfig(cfg.CredentialsPath); err != nil {
+		return err
+	}
+	if err := restartNativeService(); err != nil {
+		return err
+	}
+	fmt.Println("Connection token rotated and daemon restarted")
+	return nil
+}
+
+func runNativeUninstall(_ *cobra.Command, _ []string) error {
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	cfg, err := readNativeConfig(paths.config)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	active, _ := filepath.Glob(filepath.Join(cfg.StateDir, "sessions", "*"))
+	if len(active) > 0 && nativeManageOpts.drain {
+		timeout, parseErr := time.ParseDuration(nativeManageOpts.drainTimeout)
+		if parseErr != nil {
+			return parseErr
+		}
+		deadline := time.Now().Add(timeout)
+		for len(active) > 0 && time.Now().Before(deadline) {
+			time.Sleep(2 * time.Second)
+			active, _ = filepath.Glob(filepath.Join(cfg.StateDir, "sessions", "*"))
+		}
+	}
+	if len(active) > 0 && !nativeManageOpts.force {
+		return fmt.Errorf("refusing to uninstall: %d active session(s); use --drain or --force", len(active))
+	}
+	if len(active) > 0 && nativeManageOpts.force {
+		terminateNativeSessions(active)
+	}
+	if runtime.GOOS == "linux" {
+		_ = runCommand("systemctl", "disable", "--now", "agentapi-native.service")
+		_ = os.Remove(paths.service)
+		_ = runCommand("systemctl", "daemon-reload")
+	} else {
+		_ = runCommand("launchctl", "bootout", "gui/"+strconv.Itoa(os.Getuid())+"/com.agentapi.native")
+		_ = os.Remove(paths.service)
+	}
+	if !nativeManageOpts.keepRegistration && cfg.ManagerID != "" {
+		apiKey, keyErr := readInstallAPIKey()
+		if keyErr != nil {
+			return fmt.Errorf("service removed; registration not removed: %w", keyErr)
+		}
+		query := url.Values{}
+		if cfg.Scope != "" {
+			query.Set("scope", cfg.Scope)
+		}
+		if cfg.TeamID != "" {
+			query.Set("team_id", cfg.TeamID)
+		}
+		endpoint := strings.TrimRight(cfg.UpstreamURL, "/") + "/external-session-managers/" + url.PathEscape(cfg.ManagerID)
+		if encoded := query.Encode(); encoded != "" {
+			endpoint += "?" + encoded
+		}
+		req, _ := http.NewRequest(http.MethodDelete, endpoint, nil)
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		resp, requestErr := http.DefaultClient.Do(req)
+		if requestErr != nil {
+			return requestErr
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			return fmt.Errorf("registration delete returned HTTP %d", resp.StatusCode)
+		}
+	}
+	if !nativeManageOpts.keepData {
+		_ = os.Remove(paths.binary)
+		_ = os.Remove(paths.config)
+		_ = os.Remove(paths.credentials)
+		if safeNativeStateDir(cfg.StateDir) {
+			_ = os.RemoveAll(cfg.StateDir)
+		}
+	}
+	fmt.Println("Native ESM uninstalled")
+	return nil
+}
+
+func terminateNativeSessions(sessionDirs []string) {
+	for _, dir := range sessionDirs {
+		data, err := os.ReadFile(filepath.Join(dir, "runtime", "state.json"))
+		if err != nil {
+			continue
+		}
+		var state struct {
+			PID int `json:"pid"`
+		}
+		if json.Unmarshal(data, &state) == nil && state.PID > 1 {
+			_ = syscall.Kill(-state.PID, syscall.SIGTERM)
+		}
+	}
+	time.Sleep(time.Second)
+}
+
+func safeNativeStateDir(path string) bool {
+	clean := filepath.Clean(path)
+	return clean != "/" && clean != "." && len(strings.Split(clean, string(filepath.Separator))) >= 3
+}
+
+func registerNativeManager(upstream, apiKey string, payload interface{}) (*nativeRegistrationResponse, error) {
+	body, _ := json.Marshal(payload)
+	req, err := http.NewRequest(http.MethodPost, strings.TrimRight(upstream, "/")+"/external-session-managers", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, responseError(resp)
+	}
+	var result nativeRegistrationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func sendNativeHeartbeat(cfg nativeDaemonConfig) error {
+	body, _ := json.Marshal(map[string]interface{}{"public_url": cfg.PublicURL, "version": nativeBuildVersion()})
+	req, _ := http.NewRequest(http.MethodPost, strings.TrimRight(cfg.UpstreamURL, "/")+"/external-session-managers/"+cfg.ManagerID+"/heartbeat", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+cfg.ConnectionToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return responseError(resp)
+	}
+	return nil
+}
+
+func readInstallAPIKey() (string, error) {
+	var value string
+	if nativeManageOpts.apiKeyStdin {
+		data, err := io.ReadAll(io.LimitReader(os.Stdin, 64*1024))
+		if err != nil {
+			return "", err
+		}
+		value = string(data)
+	} else if nativeManageOpts.apiKeyFile != "" {
+		data, err := os.ReadFile(nativeManageOpts.apiKeyFile)
+		if err != nil {
+			return "", err
+		}
+		value = string(data)
+	} else {
+		value = os.Getenv(nativeManageOpts.apiKeyEnv)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", errors.New("install API key is required; use --api-key-stdin, --api-key-file, or --api-key-env")
+	}
+	return value, nil
+}
+
+func readNativeConfig(path string) (nativeDaemonConfig, error) {
+	var cfg nativeDaemonConfig
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, err
+	}
+	if err = json.Unmarshal(data, &cfg); err != nil {
+		return cfg, err
+	}
+	if cfg.ConnectionToken == "" && cfg.CredentialsPath != "" {
+		credentialsData, readErr := os.ReadFile(cfg.CredentialsPath)
+		if readErr != nil {
+			return cfg, readErr
+		}
+		var credentials struct {
+			ConnectionToken string `json:"connection_token"`
+		}
+		if err = json.Unmarshal(credentialsData, &credentials); err != nil {
+			return cfg, err
+		}
+		cfg.ConnectionToken = credentials.ConnectionToken
+	}
+	return cfg, nil
+}
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".native-*")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer func() { _ = os.Remove(name) }()
+	if err = tmp.Chmod(mode); err == nil {
+		_, err = tmp.Write(data)
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(name, path)
+}
+func copyExecutable(destination string) error {
+	source, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	source, _ = filepath.EvalSymlinks(source)
+	if source == destination {
+		return nil
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	tmp, err := os.CreateTemp(filepath.Dir(destination), ".agentapi-proxy-*")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer func() { _ = os.Remove(name) }()
+	if err = tmp.Chmod(0o755); err == nil {
+		_, err = io.Copy(tmp, in)
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(name, destination)
+}
+func stableNativeInstanceID(hostname string) string {
+	source := hostname
+	if data, err := os.ReadFile("/etc/machine-id"); err == nil {
+		source += string(data)
+	}
+	sum := sha256.Sum256([]byte(source))
+	return "native-" + sanitizeID(hostname) + "-" + hex.EncodeToString(sum[:4])
+}
+func sanitizeID(value string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(value) {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+func formatLabels(labels map[string]string) string {
+	parts := make([]string, 0, len(labels))
+	for k, v := range labels {
+		parts = append(parts, k+"="+v)
+	}
+	return strings.Join(parts, ",")
+}
+func responseError(resp *http.Response) error {
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+}
+func nativeHealth(listen string) error {
+	address := listen
+	if strings.HasPrefix(address, ":") {
+		address = "127.0.0.1" + address
+	}
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get("http://" + address + "/healthz")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+func waitNativeHealth(listen string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if nativeHealth(listen) == nil {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return errors.New("native daemon did not become healthy")
+}
+func runCommand(name string, args ...string) error {
+	command := exec.Command(name, args...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+func nativeServiceName() string {
+	if runtime.GOOS == "linux" {
+		return "agentapi-native.service"
+	}
+	return "com.agentapi.native"
+}
+func nativeServiceRunning() bool {
+	var command *exec.Cmd
+	if runtime.GOOS == "linux" {
+		command = exec.Command("systemctl", "is-active", "--quiet", "agentapi-native.service")
+	} else {
+		command = exec.Command("launchctl", "print", "gui/"+strconv.Itoa(os.Getuid())+"/com.agentapi.native")
+	}
+	return command.Run() == nil
+}
+func restartNativeService() error {
+	if runtime.GOOS == "linux" {
+		return runCommand("systemctl", "restart", "agentapi-native.service")
+	}
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	domain := "gui/" + strconv.Itoa(os.Getuid())
+	_ = runCommand("launchctl", "bootout", domain+"/com.agentapi.native")
+	return runCommand("launchctl", "bootstrap", domain, paths.service)
+}
+func ensureLinuxServiceUser() error {
+	if exec.Command("id", "-u", "agentapi").Run() == nil {
+		return nil
+	}
+	return runCommand("useradd", "--system", "--home-dir", "/var/lib/agentapi-native", "--shell", "/usr/sbin/nologin", "agentapi")
+}
+func lookupUID(name string) int {
+	out, err := exec.Command("id", "-u", name).Output()
+	if err != nil {
+		return -1
+	}
+	value, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	return value
+}
+func lookupGID(name string) int {
+	out, err := exec.Command("id", "-g", name).Output()
+	if err != nil {
+		return -1
+	}
+	value, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	return value
+}
+func secureNativeConfig(path string) error {
+	if runtime.GOOS != "linux" {
+		return os.Chmod(path, 0o600)
+	}
+	if err := os.Chown(path, 0, lookupGID("agentapi")); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o640)
+}
+func xmlEscape(value string) string {
+	replacer := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "\"", "&quot;", "'", "&apos;")
+	return replacer.Replace(value)
+}

--- a/cmd/native_session_manager.go
+++ b/cmd/native_session_manager.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -11,12 +12,14 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/spf13/cobra"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
 	"github.com/takutakahashi/agentapi-proxy/internal/infrastructure/services"
 	"github.com/takutakahashi/agentapi-proxy/internal/interfaces/controllers"
 	"github.com/takutakahashi/agentapi-proxy/internal/modules/sessionmanager"
@@ -30,7 +33,24 @@ var NativeSessionManagerCmd = &cobra.Command{
 }
 
 var nativeSessionManagerOptions struct {
-	listen, upstreamURL, connectionToken, upstreamAuthToken, publicURL, stateDir, binaryPath string
+	listen, upstreamURL, connectionToken, upstreamAuthToken, publicURL, stateDir, binaryPath, managerID, configPath string
+}
+
+type nativeDaemonConfig struct {
+	Listen            string            `json:"listen"`
+	UpstreamURL       string            `json:"upstream_url"`
+	ConnectionToken   string            `json:"connection_token"`
+	CredentialsPath   string            `json:"credentials_path,omitempty"`
+	UpstreamAuthToken string            `json:"upstream_auth_token,omitempty"`
+	PublicURL         string            `json:"public_url"`
+	StateDir          string            `json:"state_dir"`
+	BinaryPath        string            `json:"binary_path,omitempty"`
+	ManagerID         string            `json:"manager_id,omitempty"`
+	InstanceID        string            `json:"instance_id,omitempty"`
+	Scope             string            `json:"scope,omitempty"`
+	TeamID            string            `json:"team_id,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	Version           string            `json:"version,omitempty"`
 }
 
 func init() {
@@ -42,10 +62,42 @@ func init() {
 	f.StringVar(&nativeSessionManagerOptions.publicURL, "public-url", "", "URL used by the parent proxy to route sessions")
 	f.StringVar(&nativeSessionManagerOptions.stateDir, "state-dir", "./native-sessions", "native session state directory")
 	f.StringVar(&nativeSessionManagerOptions.binaryPath, "binary", "", "agentapi-proxy binary used for provisioners")
+	f.StringVar(&nativeSessionManagerOptions.managerID, "manager-id", "", "registered external session manager ID")
+	f.StringVar(&nativeSessionManagerOptions.configPath, "config", "", "JSON daemon configuration file")
 }
 
-func runNativeSessionManager(_ *cobra.Command, _ []string) error {
+func runNativeSessionManager(command *cobra.Command, _ []string) error {
 	o := nativeSessionManagerOptions
+	if o.configPath != "" {
+		cfg, err := readNativeConfig(o.configPath)
+		if err != nil {
+			return fmt.Errorf("read native daemon config: %w", err)
+		}
+		if !command.Flags().Changed("listen") {
+			o.listen = cfg.Listen
+		}
+		if !command.Flags().Changed("upstream-url") {
+			o.upstreamURL = cfg.UpstreamURL
+		}
+		if !command.Flags().Changed("connection-token") {
+			o.connectionToken = cfg.ConnectionToken
+		}
+		if !command.Flags().Changed("upstream-auth-token") {
+			o.upstreamAuthToken = cfg.UpstreamAuthToken
+		}
+		if !command.Flags().Changed("public-url") {
+			o.publicURL = cfg.PublicURL
+		}
+		if !command.Flags().Changed("state-dir") {
+			o.stateDir = cfg.StateDir
+		}
+		if !command.Flags().Changed("binary") {
+			o.binaryPath = cfg.BinaryPath
+		}
+		if !command.Flags().Changed("manager-id") {
+			o.managerID = cfg.ManagerID
+		}
+	}
 	if o.upstreamURL == "" || o.connectionToken == "" || o.publicURL == "" {
 		return fmt.Errorf("--upstream-url, --connection-token and --public-url are required")
 	}
@@ -72,6 +124,9 @@ func runNativeSessionManager(_ *cobra.Command, _ []string) error {
 	defer cancel()
 	worker := sessionmanager.NewAllocatorWorkerWithUpstreamAuth(manager, o.upstreamURL, o.connectionToken, o.upstreamAuthToken, o.publicURL)
 	go worker.Start(ctx)
+	if o.managerID != "" {
+		go runNativeHeartbeat(ctx, o.upstreamURL, o.managerID, o.connectionToken, o.publicURL, manager)
+	}
 	go func() {
 		<-ctx.Done()
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -83,6 +138,48 @@ func runNativeSessionManager(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	return nil
+}
+
+func runNativeHeartbeat(ctx context.Context, upstreamURL, managerID, token, publicURL string, manager *services.NativeSessionManager) {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	send := func() {
+		body, _ := json.Marshal(map[string]interface{}{
+			"public_url": publicURL, "version": nativeBuildVersion(),
+			"active_sessions": len(manager.ListSessions(entities.SessionFilter{})),
+		})
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(upstreamURL, "/")+"/external-session-managers/"+url.PathEscape(managerID)+"/heartbeat", bytes.NewReader(body))
+		if err != nil {
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Printf("[NATIVE_ESM] heartbeat failed: %v", err)
+			return
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			log.Printf("[NATIVE_ESM] heartbeat returned HTTP %d", resp.StatusCode)
+		}
+	}
+	send()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			send()
+		}
+	}
+}
+
+func nativeBuildVersion() string {
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+		return info.Main.Version
+	}
+	return "devel"
 }
 
 func nativeSessionProxy(manager *services.NativeSessionManager, secret []byte) echo.HandlerFunc {

--- a/cmd/native_test.go
+++ b/cmd/native_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterNativeManager(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/external-session-managers", r.URL.Path)
+		require.Equal(t, "Bearer install-key", r.Header.Get("Authorization"))
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "machine-1", body["instance_id"])
+		_ = json.NewEncoder(w).Encode(nativeRegistrationResponse{ID: "manager-1", InstanceID: "machine-1", ConnectionToken: "connection-token", Created: true})
+	}))
+	defer server.Close()
+
+	result, err := registerNativeManager(server.URL, "install-key", map[string]string{"instance_id": "machine-1"})
+	require.NoError(t, err)
+	require.Equal(t, "manager-1", result.ID)
+	require.Equal(t, "connection-token", result.ConnectionToken)
+}
+
+func TestNativeConfigPersistsSeparateInstanceID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	credentialsPath := filepath.Join(dir, "credentials.json")
+	want := nativeDaemonConfig{ManagerID: "manager-1", InstanceID: "machine-1", ConnectionToken: "secret", CredentialsPath: credentialsPath}
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+	var stored nativeDaemonConfig
+	require.NoError(t, json.Unmarshal(data, &stored))
+	stored.ConnectionToken = ""
+	data, err = json.Marshal(stored)
+	require.NoError(t, err)
+	require.NoError(t, atomicWriteFile(path, data, 0o600))
+	credentials, err := json.Marshal(map[string]string{"connection_token": want.ConnectionToken})
+	require.NoError(t, err)
+	require.NoError(t, atomicWriteFile(credentialsPath, credentials, 0o600))
+
+	got, err := readNativeConfig(path)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	configBytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NotContains(t, string(configBytes), "secret")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestSafeNativeStateDir(t *testing.T) {
+	require.False(t, safeNativeStateDir("/"))
+	require.False(t, safeNativeStateDir("."))
+	require.True(t, safeNativeStateDir("/var/lib/agentapi-native"))
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -80,6 +80,12 @@ func init() {
 }
 
 func runProxy(cmd *cobra.Command, args []string) {
+	// Register shutdown handling before initialization so an early SIGTERM is
+	// never delivered with the default (process-terminating) behavior.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(quit)
+
 	if verbose {
 		log.SetFlags(log.LstdFlags | log.Lshortfile)
 	}
@@ -157,8 +163,6 @@ func runProxy(cmd *cobra.Command, args []string) {
 	}()
 
 	// Wait for interrupt signal to gracefully shutdown the server
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
 	<-quit
 
 	log.Println("Shutdown signal received, shutting down gracefully...")

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -158,7 +158,7 @@ func TestRunProxyWithInvalidConfig(t *testing.T) {
 	select {
 	case <-done:
 		// Server shut down successfully
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("Server did not shut down in time")
 	}
 }
@@ -208,7 +208,7 @@ func TestRunProxyGracefulShutdown(t *testing.T) {
 	select {
 	case <-done:
 		// Server shut down successfully
-	case <-time.After(5 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("Server did not shut down gracefully")
 	}
 }

--- a/deploy/native/README.md
+++ b/deploy/native/README.md
@@ -2,6 +2,33 @@
 
 `agentapi-proxy native-session-manager` runs sessions as native process groups on a Linux or macOS host. It does not provide a sandbox; dedicate the host to one user or a mutually trusted team.
 
+## One-command installation
+
+Use the management command to register the machine with the parent proxy, install the daemon, start it, and verify both local health and the parent heartbeat:
+
+```bash
+sudo --preserve-env=AGENTAPI_KEY agentapi-proxy native install \
+  --upstream https://cc-api.example.com \
+  --public-url http://10.0.0.10:8080 \
+  --name native-builder-01 \
+  --label pool=native \
+  --label machine=native-builder-01
+```
+
+On macOS omit `sudo`; the command installs a per-user LaunchAgent. `os`, `arch`, and `hostname` labels are detected automatically. The API key is used only for registration and is never written to daemon configuration. Use `--api-key-stdin` or `--api-key-file` when preserving an environment variable is undesirable.
+
+The command is idempotent. It stores a stable instance ID, updates the existing registration and service definition on repeat runs, and preserves the connection token. Use these lifecycle commands after installation:
+
+```bash
+agentapi-proxy native status
+agentapi-proxy native doctor
+agentapi-proxy native restart
+agentapi-proxy native rotate-token
+agentapi-proxy native uninstall
+```
+
+Linux stores non-secret configuration in `/etc/agentapi-native/config.json`, the connection token in `/etc/agentapi-native/credentials.json`, state in `/var/lib/agentapi-native`, and the managed executable in `/usr/local/libexec/agentapi-proxy/`. macOS uses `~/Library/Application Support/agentapi-native/` and `~/Library/LaunchAgents/com.agentapi.native.plist`.
+
 The daemon needs a parent proxy URL, the External Session Manager connection token registered in that user's settings, a parent-reachable public URL, and a private state directory. Register labels such as `os`, `arch`, and `pool` on the External Session Manager settings entry. A session tag such as `allocator.os=linux` is matched against those labels.
 
 On Linux, copy `agentapi-native.service` to `/etc/systemd/system/`, create the `agentapi` user and `/etc/agentapi-native/environment` with mode `0600`, then enable the unit. On macOS, replace all `REPLACE_*` values in the plist, store it as `~/Library/LaunchAgents/com.agentapi.native.plist`, and load it with `launchctl bootstrap gui/$(id -u) ...`.

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -410,6 +410,13 @@ func (r *Router) registerConditionalRoutes() error {
 	// Add settings routes if settings repository is available (Kubernetes mode only)
 	if r.server.settingsRepo != nil && r.handlers.settingsController != nil {
 		log.Printf("[ROUTES] Registering settings endpoints...")
+		r.echo.POST("/external-session-managers", r.handlers.settingsController.RegisterExternalSessionManager, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.GET("/external-session-managers", r.handlers.settingsController.ListExternalSessionManagers, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.GET("/external-session-managers/:id", r.handlers.settingsController.GetExternalSessionManager, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
+		r.echo.PATCH("/external-session-managers/:id", r.handlers.settingsController.PatchExternalSessionManager, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.DELETE("/external-session-managers/:id", r.handlers.settingsController.DeleteExternalSessionManager, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.POST("/external-session-managers/:id/rotate-token", r.handlers.settingsController.RotateExternalSessionManagerToken, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))
+		r.echo.POST("/external-session-managers/:id/heartbeat", r.handlers.settingsController.HeartbeatExternalSessionManager)
 		r.echo.GET("/settings/managers", r.handlers.settingsController.GetAvailableManagers, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.GET("/settings/:name", r.handlers.settingsController.GetSettings, auth.RequirePermission(entities.PermissionSessionRead, r.server.container.AuthService))
 		r.echo.PUT("/settings/:name", r.handlers.settingsController.UpdateSettings, auth.RequirePermission(entities.PermissionSessionCreate, r.server.container.AuthService))

--- a/internal/domain/entities/settings.go
+++ b/internal/domain/entities/settings.go
@@ -93,10 +93,15 @@ func (b *BedrockSettings) Validate() error {
 
 // ExternalSessionManagerEntry represents a registered external session manager (External Session Manager)
 type ExternalSessionManagerEntry struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name"`
-	HMACSecret string            `json:"hmac_secret,omitempty"`
-	Labels     map[string]string `json:"labels,omitempty"`
+	ID              string            `json:"id"`
+	InstanceID      string            `json:"instance_id,omitempty"`
+	Name            string            `json:"name"`
+	HMACSecret      string            `json:"hmac_secret,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	PublicURL       string            `json:"public_url,omitempty"`
+	Version         string            `json:"version,omitempty"`
+	ActiveSessions  int               `json:"active_sessions,omitempty"`
+	LastHeartbeatAt time.Time         `json:"last_heartbeat_at,omitempty"`
 	// Default indicates this manager is used automatically when no manager_id is specified at session creation.
 	// At most one entry should have Default=true.
 	Default bool `json:"default,omitempty"`

--- a/internal/interfaces/controllers/external_session_manager_controller.go
+++ b/internal/interfaces/controllers/external_session_manager_controller.go
@@ -1,0 +1,339 @@
+package controllers
+
+import (
+	"context"
+	"crypto/subtle"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/auth"
+)
+
+type ESMRegistrationRequest struct {
+	ManagerID   string            `json:"manager_id,omitempty"`
+	InstanceID  string            `json:"instance_id"`
+	Name        string            `json:"name"`
+	Scope       string            `json:"scope,omitempty"`
+	TeamID      string            `json:"team_id,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Default     bool              `json:"default,omitempty"`
+	PublicURL   string            `json:"public_url,omitempty"`
+	Version     string            `json:"version,omitempty"`
+	RotateToken bool              `json:"rotate_token,omitempty"`
+}
+
+type ESMHeartbeatRequest struct {
+	PublicURL      string `json:"public_url,omitempty"`
+	Version        string `json:"version,omitempty"`
+	ActiveSessions int    `json:"active_sessions,omitempty"`
+}
+
+type esmRegistrationResponse struct {
+	ExternalSessionManagerResponse
+	Created bool `json:"created"`
+}
+
+func (c *SettingsController) RegisterExternalSessionManager(ctx echo.Context) error {
+	var req ESMRegistrationRequest
+	if err := ctx.Bind(&req); err != nil || strings.TrimSpace(req.InstanceID) == "" || strings.TrimSpace(req.Name) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "instance_id and name are required")
+	}
+	name, err := c.esmSettingsName(ctx, req.Scope, req.TeamID, true)
+	if err != nil {
+		return err
+	}
+
+	c.esmMu.Lock()
+	defer c.esmMu.Unlock()
+	settings, err := c.findOrCreateSettings(ctx, name)
+	if err != nil {
+		return err
+	}
+	managers := append([]entities.ExternalSessionManagerEntry(nil), settings.ExternalSessionManagers()...)
+	idx := -1
+	for i := range managers {
+		if managers[i].InstanceID == req.InstanceID || (req.ManagerID != "" && managers[i].ID == req.ManagerID) {
+			idx = i
+			break
+		}
+	}
+	created := idx < 0
+	connectionToken := ""
+	if created || req.RotateToken {
+		connectionToken, err = generateSettingsESMSecret(32)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to generate connection token")
+		}
+		if created {
+			managerID := req.ManagerID
+			if managerID == "" {
+				managerID = uuid.NewString()
+			}
+			managers = append(managers, entities.ExternalSessionManagerEntry{ID: managerID, InstanceID: req.InstanceID, HMACSecret: connectionToken})
+			idx = len(managers) - 1
+		} else {
+			managers[idx].HMACSecret = connectionToken
+		}
+	}
+	if req.Default {
+		for i := range managers {
+			managers[i].Default = false
+		}
+	}
+	manager := &managers[idx]
+	manager.InstanceID = req.InstanceID
+	manager.Name = req.Name
+	manager.Labels = req.Labels
+	manager.Default = req.Default
+	manager.PublicURL = req.PublicURL
+	manager.Version = req.Version
+	settings.SetExternalSessionManagers(managers)
+	if err := c.repo.Save(ctx.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save external session manager")
+	}
+	return ctx.JSON(http.StatusOK, esmRegistrationResponse{ExternalSessionManagerResponse: esmResponse(*manager, connectionToken), Created: created})
+}
+
+func (c *SettingsController) ListExternalSessionManagers(ctx echo.Context) error {
+	name, err := c.esmSettingsName(ctx, ctx.QueryParam("scope"), ctx.QueryParam("team_id"), false)
+	if err != nil {
+		return err
+	}
+	settings, err := c.repo.FindByName(ctx.Request().Context(), name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return ctx.JSON(http.StatusOK, map[string]interface{}{"external_session_managers": []interface{}{}})
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to list external session managers")
+	}
+	responses := make([]ExternalSessionManagerResponse, 0, len(settings.ExternalSessionManagers()))
+	for _, manager := range settings.ExternalSessionManagers() {
+		responses = append(responses, esmResponse(manager, ""))
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{"external_session_managers": responses})
+}
+
+func (c *SettingsController) GetExternalSessionManager(ctx echo.Context) error {
+	manager, _, err := c.findAuthorizedESM(ctx, false)
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, esmResponse(*manager, ""))
+}
+
+func (c *SettingsController) PatchExternalSessionManager(ctx echo.Context) error {
+	var req ESMRegistrationRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request")
+	}
+	c.esmMu.Lock()
+	defer c.esmMu.Unlock()
+	manager, settings, err := c.findAuthorizedESM(ctx, true)
+	if err != nil {
+		return err
+	}
+	managers := settings.ExternalSessionManagers()
+	for i := range managers {
+		if managers[i].ID != manager.ID {
+			if req.Default {
+				managers[i].Default = false
+			}
+			continue
+		}
+		if req.Name != "" {
+			managers[i].Name = req.Name
+		}
+		if req.InstanceID != "" {
+			managers[i].InstanceID = req.InstanceID
+		}
+		if req.Labels != nil {
+			managers[i].Labels = req.Labels
+		}
+		if req.PublicURL != "" {
+			managers[i].PublicURL = req.PublicURL
+		}
+		if req.Version != "" {
+			managers[i].Version = req.Version
+		}
+		managers[i].Default = req.Default
+		manager = &managers[i]
+	}
+	settings.SetExternalSessionManagers(managers)
+	if err := c.repo.Save(ctx.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update external session manager")
+	}
+	return ctx.JSON(http.StatusOK, esmResponse(*manager, ""))
+}
+
+func (c *SettingsController) DeleteExternalSessionManager(ctx echo.Context) error {
+	c.esmMu.Lock()
+	defer c.esmMu.Unlock()
+	manager, settings, err := c.findAuthorizedESM(ctx, true)
+	if err != nil {
+		return err
+	}
+	managers := settings.ExternalSessionManagers()
+	updated := make([]entities.ExternalSessionManagerEntry, 0, len(managers)-1)
+	for _, item := range managers {
+		if item.ID != manager.ID {
+			updated = append(updated, item)
+		}
+	}
+	settings.SetExternalSessionManagers(updated)
+	if err := c.repo.Save(ctx.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete external session manager")
+	}
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+func (c *SettingsController) RotateExternalSessionManagerToken(ctx echo.Context) error {
+	c.esmMu.Lock()
+	defer c.esmMu.Unlock()
+	manager, settings, err := c.findAuthorizedESM(ctx, true)
+	if err != nil {
+		return err
+	}
+	token, err := generateSettingsESMSecret(32)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to rotate connection token")
+	}
+	managers := settings.ExternalSessionManagers()
+	for i := range managers {
+		if managers[i].ID == manager.ID {
+			managers[i].HMACSecret = token
+			manager = &managers[i]
+		}
+	}
+	settings.SetExternalSessionManagers(managers)
+	if err := c.repo.Save(ctx.Request().Context(), settings); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save rotated token")
+	}
+	return ctx.JSON(http.StatusOK, esmResponse(*manager, token))
+}
+
+func (c *SettingsController) HeartbeatExternalSessionManager(ctx echo.Context) error {
+	token := strings.TrimPrefix(ctx.Request().Header.Get("Authorization"), "Bearer ")
+	if token == "" {
+		token = ctx.Request().Header.Get("X-Session-Manager-Token")
+	}
+	var req ESMHeartbeatRequest
+	if err := ctx.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid heartbeat")
+	}
+	c.esmMu.Lock()
+	defer c.esmMu.Unlock()
+	settingsList, err := c.repo.List(ctx.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to validate manager")
+	}
+	for _, settings := range settingsList {
+		managers := settings.ExternalSessionManagers()
+		for i := range managers {
+			if managers[i].ID == ctx.Param("id") && subtle.ConstantTimeCompare([]byte(managers[i].HMACSecret), []byte(token)) == 1 {
+				managers[i].LastHeartbeatAt = time.Now().UTC()
+				if req.PublicURL != "" {
+					managers[i].PublicURL = req.PublicURL
+				}
+				if req.Version != "" {
+					managers[i].Version = req.Version
+				}
+				managers[i].ActiveSessions = req.ActiveSessions
+				if managers[i].PublicURL != "" {
+					probeCtx, cancel := context.WithTimeout(ctx.Request().Context(), 3*time.Second)
+					probeReq, _ := http.NewRequestWithContext(probeCtx, http.MethodGet, strings.TrimRight(managers[i].PublicURL, "/")+"/healthz", nil)
+					probeResp, probeErr := http.DefaultClient.Do(probeReq)
+					cancel()
+					if probeErr != nil || probeResp.StatusCode != http.StatusOK {
+						if probeResp != nil {
+							_ = probeResp.Body.Close()
+						}
+						return echo.NewHTTPError(http.StatusFailedDependency, "public_url is not reachable from parent proxy")
+					}
+					_ = probeResp.Body.Close()
+				}
+				settings.SetExternalSessionManagers(managers)
+				if err := c.repo.Save(ctx.Request().Context(), settings); err != nil {
+					return echo.NewHTTPError(http.StatusInternalServerError, "failed to save heartbeat")
+				}
+				return ctx.JSON(http.StatusOK, map[string]interface{}{"status": "ok", "manager_id": managers[i].ID, "server_time": managers[i].LastHeartbeatAt})
+			}
+		}
+	}
+	return echo.NewHTTPError(http.StatusUnauthorized, "invalid connection token")
+}
+
+func (c *SettingsController) esmSettingsName(ctx echo.Context, scope, teamID string, modify bool) (string, error) {
+	user := auth.GetUserFromContext(ctx)
+	if user == nil {
+		return "", echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+	if scope == "" {
+		scope = "user"
+	}
+	if scope != "user" && scope != "team" {
+		return "", echo.NewHTTPError(http.StatusBadRequest, "scope must be user or team")
+	}
+	name := string(user.ID())
+	if scope == "team" {
+		if teamID == "" {
+			return "", echo.NewHTTPError(http.StatusBadRequest, "team_id is required")
+		}
+		name = teamID
+	}
+	allowed := c.canAccess(user, name)
+	if modify {
+		allowed = c.canModify(user, name)
+	}
+	if !allowed {
+		return "", echo.NewHTTPError(http.StatusForbidden, "access denied")
+	}
+	return name, nil
+}
+
+func (c *SettingsController) findOrCreateSettings(ctx echo.Context, name string) (*entities.Settings, error) {
+	settings, err := c.repo.FindByName(ctx.Request().Context(), name)
+	if err == nil {
+		return settings, nil
+	}
+	if strings.Contains(err.Error(), "not found") {
+		return entities.NewSettings(name), nil
+	}
+	return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to load settings")
+}
+
+func (c *SettingsController) findAuthorizedESM(ctx echo.Context, modify bool) (*entities.ExternalSessionManagerEntry, *entities.Settings, error) {
+	name, err := c.esmSettingsName(ctx, ctx.QueryParam("scope"), ctx.QueryParam("team_id"), modify)
+	if err != nil {
+		return nil, nil, err
+	}
+	settings, err := c.repo.FindByName(ctx.Request().Context(), name)
+	if err != nil {
+		return nil, nil, echo.NewHTTPError(http.StatusNotFound, "external session manager not found")
+	}
+	for _, manager := range settings.ExternalSessionManagers() {
+		if manager.ID == ctx.Param("id") {
+			copyManager := manager
+			return &copyManager, settings, nil
+		}
+	}
+	return nil, nil, echo.NewHTTPError(http.StatusNotFound, "external session manager not found")
+}
+
+func esmResponse(manager entities.ExternalSessionManagerEntry, token string) ExternalSessionManagerResponse {
+	return ExternalSessionManagerResponse{ID: manager.ID, InstanceID: manager.InstanceID, Name: manager.Name,
+		HasConnectionToken: manager.HMACSecret != "", ConnectionToken: token, Default: manager.Default,
+		Labels: manager.Labels, PublicURL: manager.PublicURL, Version: manager.Version,
+		ActiveSessions:  manager.ActiveSessions,
+		LastHeartbeatAt: timePtrUnlessZero(manager.LastHeartbeatAt)}
+}
+
+func timePtrUnlessZero(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	return &value
+}

--- a/internal/interfaces/controllers/external_session_manager_controller_test.go
+++ b/internal/interfaces/controllers/external_session_manager_controller_test.go
@@ -1,0 +1,87 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func esmTestContext(e *echo.Echo, method, path string, body interface{}, userID string) (echo.Context, *httptest.ResponseRecorder) {
+	data, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(data))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath(path)
+	ctx.Set("internal_user", createTestUser(userID, false))
+	return ctx, rec
+}
+
+func TestExternalSessionManagerRegistrationIsIdempotentAndHeartbeatUsesToken(t *testing.T) {
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer probe.Close()
+
+	repo := newMockSettingsRepository()
+	controller := NewSettingsController(repo, nil, "", "")
+	e := echo.New()
+	body := ESMRegistrationRequest{InstanceID: "machine-1", Name: "native-1", PublicURL: probe.URL,
+		Labels: map[string]string{"os": "linux", "arch": "amd64"}}
+	ctx, rec := esmTestContext(e, http.MethodPost, "/external-session-managers", body, "user1")
+	require.NoError(t, controller.RegisterExternalSessionManager(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var created esmRegistrationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+	require.True(t, created.Created)
+	require.NotEmpty(t, created.ConnectionToken)
+
+	ctx, rec = esmTestContext(e, http.MethodPost, "/external-session-managers", body, "user1")
+	require.NoError(t, controller.RegisterExternalSessionManager(ctx))
+	var repeated esmRegistrationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &repeated))
+	require.False(t, repeated.Created)
+	require.Equal(t, created.ID, repeated.ID)
+	require.Empty(t, repeated.ConnectionToken)
+	require.Len(t, repo.settings["user1"].ExternalSessionManagers(), 1)
+
+	heartbeat := ESMHeartbeatRequest{PublicURL: probe.URL, Version: "test-version", ActiveSessions: 2}
+	ctx, rec = esmTestContext(e, http.MethodPost, "/external-session-managers/:id/heartbeat", heartbeat, "")
+	ctx.SetParamNames("id")
+	ctx.SetParamValues(created.ID)
+	ctx.Request().Header.Set("Authorization", "Bearer "+created.ConnectionToken)
+	require.NoError(t, controller.HeartbeatExternalSessionManager(ctx))
+	require.Equal(t, http.StatusOK, rec.Code)
+	manager := repo.settings["user1"].ExternalSessionManagers()[0]
+	require.False(t, manager.LastHeartbeatAt.IsZero())
+	require.Equal(t, "test-version", manager.Version)
+	require.Equal(t, 2, manager.ActiveSessions)
+}
+
+func TestExternalSessionManagerHeartbeatRejectsUnreachablePublicURL(t *testing.T) {
+	repo := newMockSettingsRepository()
+	controller := NewSettingsController(repo, nil, "", "")
+	e := echo.New()
+	body := ESMRegistrationRequest{InstanceID: "machine-2", Name: "native-2"}
+	ctx, rec := esmTestContext(e, http.MethodPost, "/external-session-managers", body, "user1")
+	require.NoError(t, controller.RegisterExternalSessionManager(ctx))
+	var created esmRegistrationResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &created))
+
+	heartbeat := ESMHeartbeatRequest{PublicURL: "http://127.0.0.1:1"}
+	ctx, _ = esmTestContext(e, http.MethodPost, "/external-session-managers/:id/heartbeat", heartbeat, "")
+	ctx.SetParamNames("id")
+	ctx.SetParamValues(created.ID)
+	ctx.Request().Header.Set("Authorization", "Bearer "+created.ConnectionToken)
+	err := controller.HeartbeatExternalSessionManager(ctx)
+	require.Error(t, err)
+}

--- a/internal/interfaces/controllers/settings_controller.go
+++ b/internal/interfaces/controllers/settings_controller.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -26,6 +28,7 @@ type SettingsController struct {
 	notificationSvc  *notification.Service // Optional
 	gitSyncKMSKeyARN string                // optional; non-empty when GitHub sync encryption is configured
 	gitSyncAWSRegion string
+	esmMu            sync.Mutex
 }
 
 // NewSettingsController creates new settings controller
@@ -115,6 +118,7 @@ type UpdateSettingsRequest struct {
 // ExternalSessionManagerRequest represents a single external session manager registration
 type ExternalSessionManagerRequest struct {
 	ID         string            `json:"id,omitempty"`          // Auto-generated if empty
+	InstanceID string            `json:"instance_id,omitempty"` // Stable native host installation ID
 	Name       string            `json:"name"`                  // Human-readable name
 	HMACSecret string            `json:"hmac_secret,omitempty"` // Connection token; auto-generated if empty, omit to keep existing
 	Default    bool              `json:"default,omitempty"`     // Use as default manager when no manager_id is specified
@@ -169,11 +173,16 @@ type SettingsResponse struct {
 // ExternalSessionManagerResponse represents a single external session manager in responses
 type ExternalSessionManagerResponse struct {
 	ID                 string            `json:"id"`
+	InstanceID         string            `json:"instance_id,omitempty"`
 	Name               string            `json:"name"`
 	HasConnectionToken bool              `json:"has_connection_token"`       // true if a connection token is configured
 	ConnectionToken    string            `json:"connection_token,omitempty"` // returned only immediately after generation or rotation
 	Default            bool              `json:"default,omitempty"`          // true if this manager is used when no manager_id is specified
 	Labels             map[string]string `json:"labels,omitempty"`
+	PublicURL          string            `json:"public_url,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	ActiveSessions     int               `json:"active_sessions,omitempty"`
+	LastHeartbeatAt    *time.Time        `json:"last_heartbeat_at,omitempty"`
 }
 
 // AvailableManagerEntry represents a single available ESM entry returned by GET /settings/managers
@@ -490,13 +499,23 @@ func (c *SettingsController) UpdateSettings(ctx echo.Context) error {
 				m.HMACSecret = secret
 				generatedESMTokens[m.ID] = secret
 			}
-			updated = append(updated, entities.ExternalSessionManagerEntry{
+			entry := entities.ExternalSessionManagerEntry{
 				ID:         m.ID,
+				InstanceID: m.InstanceID,
 				Name:       m.Name,
 				HMACSecret: m.HMACSecret,
 				Default:    m.Default,
 				Labels:     m.Labels,
-			})
+			}
+			// These fields are owned by the daemon registration/heartbeat API and
+			// must survive a legacy settings update.
+			if prev, ok := existing[m.ID]; ok {
+				entry.PublicURL = prev.PublicURL
+				entry.Version = prev.Version
+				entry.ActiveSessions = prev.ActiveSessions
+				entry.LastHeartbeatAt = prev.LastHeartbeatAt
+			}
+			updated = append(updated, entry)
 		}
 		settings.SetExternalSessionManagers(updated)
 	}
@@ -863,11 +882,16 @@ func (c *SettingsController) toResponseWithESMTokens(settings *entities.Settings
 			}
 			resp.ExternalSessionManagers = append(resp.ExternalSessionManagers, ExternalSessionManagerResponse{
 				ID:                 m.ID,
+				InstanceID:         m.InstanceID,
 				Name:               m.Name,
 				HasConnectionToken: m.HMACSecret != "",
 				ConnectionToken:    connectionToken,
 				Default:            m.Default,
 				Labels:             m.Labels,
+				PublicURL:          m.PublicURL,
+				Version:            m.Version,
+				ActiveSessions:     m.ActiveSessions,
+				LastHeartbeatAt:    timePtrUnlessZero(m.LastHeartbeatAt),
 			})
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(cmd.ClientCmd)
 	rootCmd.AddCommand(cmd.AgentProvisionerCmd)
 	rootCmd.AddCommand(cmd.NativeSessionManagerCmd)
+	rootCmd.AddCommand(cmd.NativeCmd)
 	rootCmd.AddCommand(cmd.OneshotCmd)
 	rootCmd.AddCommand(cmd.AcpServerCmd)
 }

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -69,6 +69,9 @@ func AuthMiddleware(cfg *config.Config, authService services.AuthService) echo.M
 				strings.HasPrefix(path, "/internal/external-session-manager") {
 				return next(c)
 			}
+			if strings.HasPrefix(path, "/external-session-managers/") && strings.HasSuffix(path, "/heartbeat") {
+				return next(c)
+			}
 
 			// Skip auth for HMAC-signed requests from a trusted 親プロキシ
 			// This enables small-cluster mode where 親プロキシ proxies session requests to External Session Manager

--- a/pkg/provisioner/native_paths_test.go
+++ b/pkg/provisioner/native_paths_test.go
@@ -49,3 +49,12 @@ func TestNormalizeNativeSettingsRemapsPathsAndDropsContainerTLS(t *testing.T) {
 		t.Fatalf("native environment was not applied: %#v", settings.Env)
 	}
 }
+
+func TestProvisionSettingsPathIsScopedToNativeSession(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AGENTAPI_NATIVE_SESSION_ROOT", root)
+
+	if got, want := provisionSettingsPath(), filepath.Join(root, "runtime", "provision-settings.yaml"); got != want {
+		t.Fatalf("provision settings path = %q, want %q", got, want)
+	}
+}

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	provisionTempSettings = "/tmp/provision-settings.yaml"
-	piOllamaDefaultModel  = "glm-5"
+	piOllamaDefaultModel = "glm-5"
 	// webhookPayloadPath is the well-known path where the webhook payload JSON
 	// is exposed inside the session container.
 	// For non-stock sessions this file is provided by a read-only Kubernetes
@@ -72,6 +71,10 @@ func nativeRuntimePath(parts ...string) string {
 		return filepath.Join(pathParts...)
 	}
 	return fallback
+}
+
+func provisionSettingsPath() string {
+	return nativeRuntimePath("provision-settings.yaml", filepath.Join(os.TempDir(), fmt.Sprintf("agentapi-provision-settings-%d.yaml", os.Getpid())))
 }
 
 func normalizeNativeSettings(settings *sessionsettings.SessionSettings) {
@@ -160,10 +163,12 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 		s.setStatus(StatusError, fmt.Sprintf("failed to marshal settings: %v", err))
 		return
 	}
+	provisionTempSettings := provisionSettingsPath()
 	if err := os.WriteFile(provisionTempSettings, data, 0o600); err != nil {
 		s.setStatus(StatusError, fmt.Sprintf("failed to write temp settings: %v", err))
 		return
 	}
+	defer func() { _ = os.Remove(provisionTempSettings) }()
 
 	// ── Step 1.5: write webhook payload file ─────────────────────────────────
 	// For stock sessions the pod is pre-created without a webhook-payload

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -2570,6 +2570,37 @@
         }
       }
     },
+    "/external-session-managers": {
+      "post": {
+        "summary": "Idempotently register a native External Session Manager",
+        "operationId": "registerExternalSessionManager",
+        "tags": ["External Session Managers"],
+        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExternalSessionManagerRegistrationRequest"}}}},
+        "responses": {"200": {"description": "Registered or updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExternalSessionManager"}}}}}
+      },
+      "get": {
+        "summary": "List External Session Managers",
+        "operationId": "listExternalSessionManagers",
+        "tags": ["External Session Managers"],
+        "parameters": [
+          {"name": "scope", "in": "query", "schema": {"type": "string", "enum": ["user", "team"]}},
+          {"name": "team_id", "in": "query", "schema": {"type": "string"}}
+        ],
+        "responses": {"200": {"description": "Registered managers"}}
+      }
+    },
+    "/external-session-managers/{id}": {
+      "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+      "get": {"summary": "Get an External Session Manager", "operationId": "getExternalSessionManager", "tags": ["External Session Managers"], "responses": {"200": {"description": "Manager", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExternalSessionManager"}}}}}},
+      "patch": {"summary": "Update an External Session Manager", "operationId": "updateExternalSessionManager", "tags": ["External Session Managers"], "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExternalSessionManagerRegistrationRequest"}}}}, "responses": {"200": {"description": "Updated manager"}}},
+      "delete": {"summary": "Delete an External Session Manager", "operationId": "deleteExternalSessionManager", "tags": ["External Session Managers"], "responses": {"204": {"description": "Deleted"}}}
+    },
+    "/external-session-managers/{id}/rotate-token": {
+      "post": {"summary": "Rotate an External Session Manager connection token", "operationId": "rotateExternalSessionManagerToken", "tags": ["External Session Managers"], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}], "responses": {"200": {"description": "Token rotated; connection_token is returned once"}}}
+    },
+    "/external-session-managers/{id}/heartbeat": {
+      "post": {"summary": "Report native daemon health", "description": "Authenticated with the External Session Manager connection token. The parent verifies that public_url/healthz is reachable before accepting the heartbeat.", "operationId": "heartbeatExternalSessionManager", "tags": ["External Session Managers"], "security": [], "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}], "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExternalSessionManagerHeartbeat"}}}}, "responses": {"200": {"description": "Heartbeat accepted"}, "401": {"description": "Invalid connection token"}, "424": {"description": "public_url is unreachable"}}}
+    },
     "/settings/{name}": {
       "get": {
         "summary": "Get settings",
@@ -7240,6 +7271,47 @@
             }
           }
         }
+      },
+      "ExternalSessionManagerRegistrationRequest": {
+        "type": "object",
+        "required": ["instance_id", "name"],
+        "properties": {
+          "manager_id": {"type": "string", "description": "Optional stable manager ID, also used to migrate a legacy registration"},
+          "instance_id": {"type": "string", "description": "Stable ID persisted on the native host for idempotent registration"},
+          "name": {"type": "string"},
+          "scope": {"type": "string", "enum": ["user", "team"], "default": "user"},
+          "team_id": {"type": "string"},
+          "labels": {"type": "object", "additionalProperties": {"type": "string"}},
+          "default": {"type": "boolean"},
+          "public_url": {"type": "string", "format": "uri"},
+          "version": {"type": "string"},
+          "rotate_token": {"type": "boolean", "description": "Generate and return a new token; used when local credentials are missing"}
+        }
+      },
+      "ExternalSessionManager": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "instance_id": {"type": "string"},
+          "name": {"type": "string"},
+          "has_connection_token": {"type": "boolean"},
+          "connection_token": {"type": "string", "description": "Returned only on creation or rotation"},
+          "labels": {"type": "object", "additionalProperties": {"type": "string"}},
+          "default": {"type": "boolean"},
+          "public_url": {"type": "string", "format": "uri"},
+          "version": {"type": "string"},
+          "active_sessions": {"type": "integer"},
+          "last_heartbeat_at": {"type": "string", "format": "date-time"},
+          "created": {"type": "boolean"}
+        }
+      },
+      "ExternalSessionManagerHeartbeat": {
+        "type": "object",
+        "properties": {
+          "public_url": {"type": "string", "format": "uri"},
+          "version": {"type": "string"},
+          "active_sessions": {"type": "integer"}
+        }
       }
     },
     "SlackBotStatus": {
@@ -7848,6 +7920,10 @@
     {
       "name": "Sessions",
       "description": "Session lifecycle management"
+    },
+    {
+      "name": "External Session Managers",
+      "description": "Idempotent native ESM registration, token rotation, and daemon heartbeat"
     },
     {
       "name": "Session Proxy",


### PR DESCRIPTION
## Summary
- add idempotent dedicated External Session Manager registration, lifecycle, token rotation, and heartbeat APIs
- add `agentapi-proxy native install/status/doctor/restart/rotate-token/uninstall` for systemd and launchd
- persist only the ESM connection token in a permission-restricted credentials file and keep the installer API key ephemeral
- add OpenAPI, operations documentation, Linux tests, and macOS cross-build support

Closes #932

## Verification
- `make lint`
- `make test`
- `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build .`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build .`
