### PR TITLE
feat: add optional macOS native filesystem sandbox

### DIFF
--- a/cmd/native.go
+++ b/cmd/native.go
@@ -25,10 +25,10 @@ import (
 var NativeCmd = &cobra.Command{Use: "native", Short: "Install and manage a native External Session Manager"}
 
 type nativeManageOptions struct {
-	upstream, publicURL, name, listen, managerID, apiKeyEnv, apiKeyFile, configPath string
-	scope, teamID, drainTimeout                                                     string
-	labels                                                                          []string
-	defaultManager, apiKeyStdin, force, drain, keepRegistration, keepData           bool
+	upstream, publicURL, name, listen, managerID, apiKeyEnv, apiKeyFile, configPath          string
+	scope, teamID, drainTimeout                                                              string
+	labels                                                                                   []string
+	defaultManager, apiKeyStdin, force, drain, keepRegistration, keepData, filesystemSandbox bool
 }
 
 var nativeManageOpts nativeManageOptions
@@ -62,6 +62,7 @@ func init() {
 	f.StringSliceVar(&nativeManageOpts.labels, "label", nil, "allocator label in key=value form")
 	f.BoolVar(&nativeManageOpts.defaultManager, "default", false, "make this the default external session manager")
 	f.BoolVar(&nativeManageOpts.force, "force", false, "install even if the existing state directory contains sessions")
+	f.BoolVar(&nativeManageOpts.filesystemSandbox, "filesystem-sandbox", false, "sandbox native session filesystem access on macOS")
 
 	status := &cobra.Command{Use: "status", Short: "Show daemon and connection status", RunE: runNativeStatus}
 	doctor := &cobra.Command{Use: "doctor", Short: "Validate daemon configuration and connectivity", RunE: runNativeDoctor}
@@ -79,6 +80,9 @@ func init() {
 func runNativeInstall(_ *cobra.Command, _ []string) error {
 	if nativeManageOpts.upstream == "" || nativeManageOpts.publicURL == "" {
 		return errors.New("--upstream and --public-url are required")
+	}
+	if nativeManageOpts.filesystemSandbox && runtime.GOOS != "darwin" {
+		return errors.New("--filesystem-sandbox is only supported on macOS")
 	}
 	hostname, _ := os.Hostname()
 	if nativeManageOpts.name == "" {
@@ -131,7 +135,8 @@ func runNativeInstall(_ *cobra.Command, _ []string) error {
 	cfg := nativeDaemonConfig{Listen: nativeManageOpts.listen, UpstreamURL: strings.TrimRight(nativeManageOpts.upstream, "/"),
 		ConnectionToken: token, PublicURL: strings.TrimRight(nativeManageOpts.publicURL, "/"), StateDir: paths.state,
 		BinaryPath: paths.binary, ManagerID: registration.ID, InstanceID: instanceID, Scope: nativeManageOpts.scope, TeamID: nativeManageOpts.teamID,
-		Labels: labels, Version: nativeBuildVersion()}
+		Labels: labels, Version: nativeBuildVersion(),
+		FilesystemSandbox: nativeFilesystemSandboxConfig{Enabled: nativeManageOpts.filesystemSandbox}}
 	if err := installNativeService(paths, cfg); err != nil {
 		return err
 	}
@@ -252,7 +257,7 @@ func runNativeStatus(_ *cobra.Command, _ []string) error {
 		health = "ok"
 	}
 	active, _ := filepath.Glob(filepath.Join(cfg.StateDir, "sessions", "*"))
-	fmt.Printf("Service: %s\nManager ID: %s\nUpstream: %s\nPublic URL: %s\nLabels: %s\nVersion: %s\nActive sessions: %d\nHealth: %s\nState: %s\n", service, cfg.ManagerID, cfg.UpstreamURL, cfg.PublicURL, formatLabels(cfg.Labels), cfg.Version, len(active), health, cfg.StateDir)
+	fmt.Printf("Service: %s\nManager ID: %s\nUpstream: %s\nPublic URL: %s\nLabels: %s\nVersion: %s\nFilesystem sandbox: %t\nActive sessions: %d\nHealth: %s\nState: %s\n", service, cfg.ManagerID, cfg.UpstreamURL, cfg.PublicURL, formatLabels(cfg.Labels), cfg.Version, cfg.FilesystemSandbox.Enabled, len(active), health, cfg.StateDir)
 	return nil
 }
 
@@ -273,6 +278,14 @@ func runNativeDoctor(_ *cobra.Command, _ []string) error {
 	cfg, err := readNativeConfig(paths.config)
 	if err != nil {
 		return err
+	}
+	if cfg.FilesystemSandbox.Enabled {
+		if runtime.GOOS != "darwin" {
+			return errors.New("filesystem sandbox is enabled but this host is not macOS")
+		}
+		if _, err := os.Stat("/usr/bin/sandbox-exec"); err != nil {
+			return fmt.Errorf("filesystem sandbox executable: %w", err)
+		}
 	}
 	if err := nativeHealth(cfg.Listen); err != nil {
 		return fmt.Errorf("local health: %w", err)

--- a/cmd/native_session_manager.go
+++ b/cmd/native_session_manager.go
@@ -34,23 +34,29 @@ var NativeSessionManagerCmd = &cobra.Command{
 
 var nativeSessionManagerOptions struct {
 	listen, upstreamURL, connectionToken, upstreamAuthToken, publicURL, stateDir, binaryPath, managerID, configPath string
+	filesystemSandbox                                                                                               bool
+}
+
+type nativeFilesystemSandboxConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 type nativeDaemonConfig struct {
-	Listen            string            `json:"listen"`
-	UpstreamURL       string            `json:"upstream_url"`
-	ConnectionToken   string            `json:"connection_token"`
-	CredentialsPath   string            `json:"credentials_path,omitempty"`
-	UpstreamAuthToken string            `json:"upstream_auth_token,omitempty"`
-	PublicURL         string            `json:"public_url"`
-	StateDir          string            `json:"state_dir"`
-	BinaryPath        string            `json:"binary_path,omitempty"`
-	ManagerID         string            `json:"manager_id,omitempty"`
-	InstanceID        string            `json:"instance_id,omitempty"`
-	Scope             string            `json:"scope,omitempty"`
-	TeamID            string            `json:"team_id,omitempty"`
-	Labels            map[string]string `json:"labels,omitempty"`
-	Version           string            `json:"version,omitempty"`
+	Listen            string                        `json:"listen"`
+	UpstreamURL       string                        `json:"upstream_url"`
+	ConnectionToken   string                        `json:"connection_token"`
+	CredentialsPath   string                        `json:"credentials_path,omitempty"`
+	UpstreamAuthToken string                        `json:"upstream_auth_token,omitempty"`
+	PublicURL         string                        `json:"public_url"`
+	StateDir          string                        `json:"state_dir"`
+	BinaryPath        string                        `json:"binary_path,omitempty"`
+	ManagerID         string                        `json:"manager_id,omitempty"`
+	InstanceID        string                        `json:"instance_id,omitempty"`
+	Scope             string                        `json:"scope,omitempty"`
+	TeamID            string                        `json:"team_id,omitempty"`
+	Labels            map[string]string             `json:"labels,omitempty"`
+	Version           string                        `json:"version,omitempty"`
+	FilesystemSandbox nativeFilesystemSandboxConfig `json:"filesystem_sandbox,omitempty"`
 }
 
 func init() {
@@ -64,6 +70,7 @@ func init() {
 	f.StringVar(&nativeSessionManagerOptions.binaryPath, "binary", "", "agentapi-proxy binary used for provisioners")
 	f.StringVar(&nativeSessionManagerOptions.managerID, "manager-id", "", "registered external session manager ID")
 	f.StringVar(&nativeSessionManagerOptions.configPath, "config", "", "JSON daemon configuration file")
+	f.BoolVar(&nativeSessionManagerOptions.filesystemSandbox, "filesystem-sandbox", false, "sandbox native session filesystem access on macOS")
 }
 
 func runNativeSessionManager(command *cobra.Command, _ []string) error {
@@ -97,11 +104,14 @@ func runNativeSessionManager(command *cobra.Command, _ []string) error {
 		if !command.Flags().Changed("manager-id") {
 			o.managerID = cfg.ManagerID
 		}
+		if !command.Flags().Changed("filesystem-sandbox") {
+			o.filesystemSandbox = cfg.FilesystemSandbox.Enabled
+		}
 	}
 	if o.upstreamURL == "" || o.connectionToken == "" || o.publicURL == "" {
 		return fmt.Errorf("--upstream-url, --connection-token and --public-url are required")
 	}
-	manager, err := services.NewNativeSessionManager(o.stateDir, o.upstreamURL, o.connectionToken, o.upstreamAuthToken, o.binaryPath)
+	manager, err := services.NewNativeSessionManager(o.stateDir, o.upstreamURL, o.connectionToken, o.upstreamAuthToken, o.binaryPath, o.filesystemSandbox)
 	if err != nil {
 		return err
 	}

--- a/cmd/native_test.go
+++ b/cmd/native_test.go
@@ -33,7 +33,8 @@ func TestNativeConfigPersistsSeparateInstanceID(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 	credentialsPath := filepath.Join(dir, "credentials.json")
-	want := nativeDaemonConfig{ManagerID: "manager-1", InstanceID: "machine-1", ConnectionToken: "secret", CredentialsPath: credentialsPath}
+	want := nativeDaemonConfig{ManagerID: "manager-1", InstanceID: "machine-1", ConnectionToken: "secret", CredentialsPath: credentialsPath,
+		FilesystemSandbox: nativeFilesystemSandboxConfig{Enabled: true}}
 	data, err := json.Marshal(want)
 	require.NoError(t, err)
 	var stored nativeDaemonConfig

--- a/docs/external-session-manager.md
+++ b/docs/external-session-manager.md
@@ -202,6 +202,42 @@ curl -X POST "$PARENT_PROXY_URL/start" \
 If the manager is registered with `"default": true`, omit `manager_id` to route
 new sessions to that ESM by default.
 
+## macOS Native Filesystem Sandbox
+
+Native ESM installations on macOS can wrap every session provisioner and its
+descendant processes with the built-in Seatbelt `sandbox-exec` utility. Enable
+it when installing the manager:
+
+```bash
+agentapi-proxy native install \
+  --upstream "https://parent-proxy.example.com" \
+  --public-url "https://native-mac.example.com" \
+  --filesystem-sandbox
+```
+
+The generated daemon configuration contains a single switch:
+
+```json
+{
+  "filesystem_sandbox": {
+    "enabled": true
+  }
+}
+```
+
+When omitted or set to `false`, native sessions retain their existing
+unsandboxed behavior. When enabled, the session can read and write its own
+`home`, `workdir`, `build`, `tmp`, and `runtime` directories, while the rest of
+the host user's home and sibling native sessions are inaccessible. macOS and
+Xcode services remain available so `xcodebuild` and Simulator workflows can
+run. Build output should be directed to `$AGENTAPI_BUILD_DIR`.
+
+The option is fail-closed: the daemon refuses to start on non-macOS hosts or
+when `/usr/bin/sandbox-exec` is unavailable, and a session is not launched if
+its generated Seatbelt profile fails validation. Because `sandbox-exec` is a
+deprecated macOS facility, this backend should be treated as best-effort host
+protection rather than a VM-strength isolation boundary.
+
 ## Verification
 
 After creating a session, verify the route and live status.

--- a/docs/external-session-manager.md
+++ b/docs/external-session-manager.md
@@ -180,6 +180,79 @@ In dev, the working configuration was:
 - The same token used as `SESSION_MANAGER_CONNECTION_TOKEN` and
   `SESSION_MANAGER_HMAC_SECRET`
 
+## Registering a Native Manager
+
+Use `native install` on the machine that will run native sessions. The command
+registers the manager with the parent proxy, stores the returned connection
+token, installs the host service, starts it, and sends the first heartbeat.
+
+Before registering, prepare:
+
+- An API key for the parent proxy with permission to create sessions.
+- An upstream URL for the parent proxy.
+- A public URL through which the parent proxy can reach the native manager.
+  The parent must be able to request `<public-url>/healthz` and proxy session
+  traffic through the same URL. A VPN, Tailscale, or reverse tunnel can be used
+  when the native machine is not directly reachable from the cluster.
+
+For a user-scoped macOS manager with the filesystem sandbox enabled:
+
+```bash
+export AGENTAPI_KEY="<parent-proxy-api-key>"
+
+agentapi-proxy native install \
+  --upstream "https://parent-proxy.example.com" \
+  --public-url "https://native-mac.example.com" \
+  --name "ios-builder" \
+  --label purpose=ios \
+  --filesystem-sandbox
+```
+
+Add `--default` to select this manager when a session does not specify a
+manager. To register it for a team instead of the current user:
+
+```bash
+agentapi-proxy native install \
+  --upstream "https://parent-proxy.example.com" \
+  --public-url "https://native-mac.example.com" \
+  --name "team-ios-builder" \
+  --scope team \
+  --team-id "my-org/ios-team" \
+  --label purpose=ios \
+  --filesystem-sandbox
+```
+
+The registration flow is:
+
+```text
+native install
+  -> POST /external-session-managers
+  -> receive manager ID and one-time connection token
+  -> install and start the native host service
+  -> POST the manager heartbeat
+  -> parent proxy verifies <public-url>/healthz
+```
+
+On macOS, configuration and credentials are stored under:
+
+```text
+~/Library/Application Support/agentapi-native/config.json
+~/Library/Application Support/agentapi-native/credentials.json
+```
+
+Check the installed service and end-to-end parent connectivity:
+
+```bash
+agentapi-proxy native status
+agentapi-proxy native doctor
+```
+
+`native status` reports the manager ID, upstream and public URLs, active
+sessions, and whether the filesystem sandbox is enabled. `native doctor`
+checks local configuration permissions, service health, and the parent
+heartbeat. If registration must retain an existing identity, pass the existing
+ID with `--manager-id`.
+
 ## Starting a Session Through an ESM
 
 Specify the manager explicitly:

--- a/internal/infrastructure/services/native_filesystem_sandbox.go
+++ b/internal/infrastructure/services/native_filesystem_sandbox.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const nativeSandboxExecPath = "/usr/bin/sandbox-exec"
+
+const nativeFilesystemSandboxPolicy = `(version 1)
+
+; Keep macOS and Xcode services available, but prevent the session from reading
+; or modifying the host user's files outside its own session root.
+(allow default)
+
+(deny file-read*
+  (require-all
+    (subpath (param "HOST_HOME"))
+    (require-not (literal (param "SESSION_ROOT")))
+    (require-not (subpath (param "SESSION_ROOT")))
+    (require-not (literal (param "BINARY_PATH")))))
+
+(deny file-write*
+  (require-all
+    (subpath (param "HOST_HOME"))
+    (require-not (literal (param "SESSION_ROOT")))
+    (require-not (subpath (param "SESSION_ROOT")))))
+
+; Protect sibling native sessions when a custom state directory is outside HOME.
+(deny file-read*
+  (require-all
+    (subpath (param "SESSIONS_ROOT"))
+    (require-not (literal (param "SESSION_ROOT")))
+    (require-not (subpath (param "SESSION_ROOT")))
+    (require-not (literal (param "BINARY_PATH")))))
+
+(deny file-write*
+  (require-all
+    (subpath (param "SESSIONS_ROOT"))
+    (require-not (literal (param "SESSION_ROOT")))
+    (require-not (subpath (param "SESSION_ROOT")))))
+`
+
+func (m *NativeSessionManager) newProvisionerCommand(ctx context.Context, root, runtimeDir string, provisionerPort int) (*exec.Cmd, error) {
+	args := []string{"agent-provisioner", "--port", strconv.Itoa(provisionerPort)}
+	if !m.filesystemSandbox {
+		return exec.CommandContext(ctx, m.binaryPath, args...), nil
+	}
+
+	profilePath := filepath.Join(runtimeDir, "filesystem-sandbox.sb")
+	if err := os.WriteFile(profilePath, []byte(nativeFilesystemSandboxPolicy), 0o600); err != nil {
+		return nil, fmt.Errorf("write native filesystem sandbox policy: %w", err)
+	}
+	hostHome, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve host home for native filesystem sandbox: %w", err)
+	}
+	definitions, err := nativeSandboxDefinitions(root, hostHome, filepath.Join(m.stateDir, "sessions"), m.binaryPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateNativeSandboxProfile(profilePath, definitions); err != nil {
+		return nil, err
+	}
+
+	sandboxArgs := []string{"-f", profilePath}
+	sandboxArgs = append(sandboxArgs, definitions...)
+	sandboxArgs = append(sandboxArgs, "--", m.binaryPath)
+	sandboxArgs = append(sandboxArgs, args...)
+	return exec.CommandContext(ctx, nativeSandboxExecPath, sandboxArgs...), nil
+}
+
+func nativeSandboxDefinitions(sessionRoot, hostHome, sessionsRoot, binaryPath string) ([]string, error) {
+	paths := map[string]string{
+		"SESSION_ROOT":  sessionRoot,
+		"HOST_HOME":     hostHome,
+		"SESSIONS_ROOT": sessionsRoot,
+		"BINARY_PATH":   binaryPath,
+	}
+	definitions := make([]string, 0, len(paths))
+	for _, name := range []string{"SESSION_ROOT", "HOST_HOME", "SESSIONS_ROOT", "BINARY_PATH"} {
+		path, err := filepath.EvalSymlinks(filepath.Clean(paths[name]))
+		if err != nil {
+			return nil, fmt.Errorf("resolve native filesystem sandbox %s: %w", name, err)
+		}
+		if !filepath.IsAbs(path) {
+			return nil, fmt.Errorf("native filesystem sandbox %s must be absolute: %s", name, path)
+		}
+		paths[name] = path
+		definitions = append(definitions, "-D"+name+"="+path)
+	}
+	if !strings.HasPrefix(paths["SESSION_ROOT"], paths["SESSIONS_ROOT"]+string(filepath.Separator)) {
+		return nil, fmt.Errorf("native filesystem sandbox session root %s is outside %s", paths["SESSION_ROOT"], paths["SESSIONS_ROOT"])
+	}
+	return definitions, nil
+}
+
+func validateNativeSandboxProfile(profilePath string, definitions []string) error {
+	args := []string{"-f", profilePath}
+	args = append(args, definitions...)
+	args = append(args, "--", "/usr/bin/true")
+	output, err := exec.Command(nativeSandboxExecPath, args...).CombinedOutput()
+	if err != nil {
+		message := string(output)
+		if message == "" {
+			message = err.Error()
+		}
+		return fmt.Errorf("validate native filesystem sandbox policy: %w", errors.New(message))
+	}
+	return nil
+}

--- a/internal/infrastructure/services/native_filesystem_sandbox_test.go
+++ b/internal/infrastructure/services/native_filesystem_sandbox_test.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestNativeSandboxDefinitions(t *testing.T) {
+	root := t.TempDir()
+	hostHome := filepath.Join(root, "home")
+	sessionsRoot := filepath.Join(hostHome, "native", "sessions")
+	sessionRoot := filepath.Join(sessionsRoot, "one")
+	binaryPath := filepath.Join(hostHome, "native", "bin", "agentapi-proxy")
+	for _, path := range []string{hostHome, sessionsRoot, sessionRoot} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definitions, err := nativeSandboxDefinitions(sessionRoot, hostHome, sessionsRoot, binaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalHostHome, _ := filepath.EvalSymlinks(hostHome)
+	canonicalSessionsRoot, _ := filepath.EvalSymlinks(sessionsRoot)
+	canonicalSessionRoot, _ := filepath.EvalSymlinks(sessionRoot)
+	canonicalBinaryPath, _ := filepath.EvalSymlinks(binaryPath)
+	want := []string{
+		"-DSESSION_ROOT=" + canonicalSessionRoot,
+		"-DHOST_HOME=" + canonicalHostHome,
+		"-DSESSIONS_ROOT=" + canonicalSessionsRoot,
+		"-DBINARY_PATH=" + canonicalBinaryPath,
+	}
+	if len(definitions) != len(want) {
+		t.Fatalf("definitions = %#v", definitions)
+	}
+	for i := range want {
+		if definitions[i] != want[i] {
+			t.Fatalf("definitions[%d] = %q, want %q", i, definitions[i], want[i])
+		}
+	}
+}
+
+func TestNativeSandboxDefinitionsRejectRelativePath(t *testing.T) {
+	if _, err := nativeSandboxDefinitions("relative", "also-relative", "sessions", "binary"); err == nil {
+		t.Fatal("expected relative path to be rejected")
+	}
+}
+
+func TestNativeSandboxDefinitionsRejectSessionOutsideState(t *testing.T) {
+	root := t.TempDir()
+	hostHome := filepath.Join(root, "home")
+	sessionsRoot := filepath.Join(root, "sessions")
+	sessionRoot := filepath.Join(root, "outside")
+	binaryPath := filepath.Join(root, "binary")
+	for _, path := range []string{hostHome, sessionsRoot, sessionRoot} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nativeSandboxDefinitions(sessionRoot, hostHome, sessionsRoot, binaryPath); err == nil {
+		t.Fatal("expected session root outside sessions directory to be rejected")
+	}
+}
+
+func TestNativeProvisionerCommandWithoutSandbox(t *testing.T) {
+	m := &NativeSessionManager{binaryPath: "/opt/agentapi-proxy"}
+	cmd, err := m.newProvisionerCommand(context.Background(), "/state/sessions/one", filepath.Join("/state/sessions/one", "runtime"), 4321)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Path != "/opt/agentapi-proxy" {
+		t.Fatalf("command path = %q", cmd.Path)
+	}
+}
+
+func TestNativeFilesystemSandboxPolicyOnMacOS(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is only available on macOS")
+	}
+	root := t.TempDir()
+	hostHome := filepath.Join(root, "home")
+	sessionsRoot := filepath.Join(hostHome, "native", "sessions")
+	sessionRoot := filepath.Join(sessionsRoot, "one")
+	runtimeDir := filepath.Join(sessionRoot, "runtime")
+	binaryPath := filepath.Join(hostHome, "native", "bin", "agentapi-proxy")
+	for _, path := range []string{hostHome, sessionsRoot, sessionRoot, runtimeDir} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secretPath := filepath.Join(hostHome, "secret")
+	allowedPath := filepath.Join(sessionRoot, "allowed")
+	if err := os.WriteFile(secretPath, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(allowedPath, []byte("allowed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profilePath := filepath.Join(runtimeDir, "filesystem-sandbox.sb")
+	if err := os.WriteFile(profilePath, []byte(nativeFilesystemSandboxPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	definitions, err := nativeSandboxDefinitions(sessionRoot, hostHome, sessionsRoot, binaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := append([]string{"-f", profilePath}, definitions...)
+	if output, err := exec.Command(nativeSandboxExecPath, append(args, "--", "/bin/cat", allowedPath)...).CombinedOutput(); err != nil {
+		t.Fatalf("read session file: %v: %s", err, output)
+	}
+	if output, err := exec.Command(nativeSandboxExecPath, append(args, "--", "/bin/cat", binaryPath)...).CombinedOutput(); err != nil {
+		t.Fatalf("read daemon binary: %v: %s", err, output)
+	}
+	if err := exec.Command(nativeSandboxExecPath, append(args, "--", "/bin/cat", secretPath)...).Run(); err == nil {
+		t.Fatal("expected host home file read to be denied")
+	}
+	if err := exec.Command(nativeSandboxExecPath, append(args, "--", "/usr/bin/touch", binaryPath)...).Run(); err == nil {
+		t.Fatal("expected daemon binary write to be denied")
+	}
+}

--- a/internal/infrastructure/services/native_session_manager.go
+++ b/internal/infrastructure/services/native_session_manager.go
@@ -35,6 +35,7 @@ type NativeSessionManager struct {
 	provisionerToken  string
 	upstreamAuthToken string
 	binaryPath        string
+	filesystemSandbox bool
 	httpClient        *http.Client
 }
 
@@ -56,20 +57,21 @@ type NativeSession struct {
 }
 
 type nativeSessionState struct {
-	ID              string                     `json:"id"`
-	Request         *entities.RunServerRequest `json:"request"`
-	RootDir         string                     `json:"root_dir"`
-	AgentPort       int                        `json:"agent_port"`
-	ProvisionerPort int                        `json:"provisioner_port"`
-	PID             int                        `json:"pid"`
-	StartedAt       time.Time                  `json:"started_at"`
-	UpdatedAt       time.Time                  `json:"updated_at"`
-	LastMessageAt   time.Time                  `json:"last_message_at"`
-	Status          string                     `json:"status"`
-	Description     string                     `json:"description,omitempty"`
+	ID                string                     `json:"id"`
+	Request           *entities.RunServerRequest `json:"request"`
+	RootDir           string                     `json:"root_dir"`
+	AgentPort         int                        `json:"agent_port"`
+	ProvisionerPort   int                        `json:"provisioner_port"`
+	PID               int                        `json:"pid"`
+	StartedAt         time.Time                  `json:"started_at"`
+	UpdatedAt         time.Time                  `json:"updated_at"`
+	LastMessageAt     time.Time                  `json:"last_message_at"`
+	Status            string                     `json:"status"`
+	Description       string                     `json:"description,omitempty"`
+	FilesystemSandbox bool                       `json:"filesystem_sandbox,omitempty"`
 }
 
-func NewNativeSessionManager(stateDir, proxyURL, provisionerToken, upstreamAuthToken, binaryPath string) (*NativeSessionManager, error) {
+func NewNativeSessionManager(stateDir, proxyURL, provisionerToken, upstreamAuthToken, binaryPath string, filesystemSandbox bool) (*NativeSessionManager, error) {
 	if stateDir == "" {
 		return nil, errors.New("native state directory is required")
 	}
@@ -86,6 +88,14 @@ func NewNativeSessionManager(stateDir, proxyURL, provisionerToken, upstreamAuthT
 			return nil, fmt.Errorf("resolve executable: %w", err)
 		}
 	}
+	if filesystemSandbox && runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("native filesystem sandbox is only supported on macOS")
+	}
+	if filesystemSandbox {
+		if _, err := os.Stat(nativeSandboxExecPath); err != nil {
+			return nil, fmt.Errorf("native filesystem sandbox requires %s: %w", nativeSandboxExecPath, err)
+		}
+	}
 	if err := os.MkdirAll(filepath.Join(stateDir, "sessions"), 0o700); err != nil {
 		return nil, fmt.Errorf("create native state directory: %w", err)
 	}
@@ -97,6 +107,7 @@ func NewNativeSessionManager(stateDir, proxyURL, provisionerToken, upstreamAuthT
 		provisionerToken:  provisionerToken,
 		upstreamAuthToken: upstreamAuthToken,
 		binaryPath:        binaryPath,
+		filesystemSandbox: filesystemSandbox,
 		httpClient:        &http.Client{Timeout: 30 * time.Second},
 	}
 	if err := m.restoreSessions(); err != nil {
@@ -124,7 +135,9 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 	home := filepath.Join(root, "home")
 	workdir := filepath.Join(root, "workdir")
 	runtimeDir := filepath.Join(root, "runtime")
-	for _, dir := range []string{home, workdir, runtimeDir} {
+	buildDir := filepath.Join(root, "build")
+	tmpDir := filepath.Join(root, "tmp")
+	for _, dir := range []string{home, workdir, runtimeDir, buildDir, tmpDir} {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return nil, fmt.Errorf("create session directory %s: %w", dir, err)
 		}
@@ -156,12 +169,20 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 		cancel()
 		return nil, fmt.Errorf("open provisioner log: %w", err)
 	}
-	cmd := exec.CommandContext(sessionCtx, m.binaryPath, "agent-provisioner", "--port", strconv.Itoa(provisionerPort))
+	cmd, err := m.newProvisionerCommand(sessionCtx, root, runtimeDir, provisionerPort)
+	if err != nil {
+		_ = logFile.Close()
+		cancel()
+		return nil, err
+	}
 	cmd.Dir = workdir
 	cmd.Env = append(os.Environ(),
 		"HOME="+home,
+		"TMPDIR="+tmpDir,
+		"CFFIXED_USER_HOME="+home,
 		"AGENTAPI_NATIVE_SESSION_ROOT="+root,
 		"AGENTAPI_WORKDIR="+workdir,
+		"AGENTAPI_BUILD_DIR="+buildDir,
 		"AGENTAPI_REPO_DIR="+filepath.Join(workdir, "repo"),
 		"AGENTAPI_SESSION_ID="+id,
 		"AGENTAPI_PORT="+strconv.Itoa(agentPort),
@@ -485,7 +506,8 @@ func (m *NativeSessionManager) persistSession(s *NativeSession) error {
 	s.mu.RLock()
 	state := nativeSessionState{ID: s.id, Request: s.request, RootDir: s.rootDir, AgentPort: s.agentPort,
 		ProvisionerPort: s.provisionerPort, PID: s.pid, StartedAt: s.startedAt, UpdatedAt: s.updatedAt,
-		LastMessageAt: s.lastMessageAt, Status: s.status, Description: s.description}
+		LastMessageAt: s.lastMessageAt, Status: s.status, Description: s.description,
+		FilesystemSandbox: m.filesystemSandbox}
 	s.mu.RUnlock()
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -532,6 +554,9 @@ func (m *NativeSessionManager) restoreSessions() error {
 		}
 		var state nativeSessionState
 		if json.Unmarshal(data, &state) != nil || state.ID == "" || state.PID <= 0 {
+			continue
+		}
+		if state.FilesystemSandbox != m.filesystemSandbox {
 			continue
 		}
 		if err := syscall.Kill(state.PID, 0); err != nil || !nativeProcessMatchesSession(state.PID, state.RootDir) {

--- a/internal/infrastructure/services/native_session_manager_test.go
+++ b/internal/infrastructure/services/native_session_manager_test.go
@@ -37,12 +37,12 @@ func TestNativeSessionManagerRestoresLiveSessionState(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = process.Process.Kill() })
 	now := time.Now().UTC().Truncate(time.Second)
-	state := nativeSessionState{ID: "native-1", Request: &entities.RunServerRequest{UserID: "user-1", Tags: map[string]string{"allocator.os": "linux"}}, RootDir: root, AgentPort: port, ProvisionerPort: 42001, PID: process.Process.Pid, StartedAt: now, UpdatedAt: now, LastMessageAt: now, Status: "running"}
+	state := nativeSessionState{ID: "native-1", Request: &entities.RunServerRequest{UserID: "user-1", Tags: map[string]string{"allocator.os": "linux"}}, RootDir: root, AgentPort: port, ProvisionerPort: 42001, PID: process.Process.Pid, StartedAt: now, UpdatedAt: now, LastMessageAt: now, Status: "running", FilesystemSandbox: false}
 	data, _ := json.Marshal(state)
 	if err := os.WriteFile(filepath.Join(root, "runtime", "state.json"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	m, err := NewNativeSessionManager(stateDir, "http://127.0.0.1:8080", "token", "", os.Args[0])
+	m, err := NewNativeSessionManager(stateDir, "http://127.0.0.1:8080", "token", "", os.Args[0], false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestNativeSessionManagerRestoresLiveSessionState(t *testing.T) {
 }
 
 func TestNativeProvisionRequestPullLifecycle(t *testing.T) {
-	m, err := NewNativeSessionManager(t.TempDir(), "http://127.0.0.1:8080", "token", "", os.Args[0])
+	m, err := NewNativeSessionManager(t.TempDir(), "http://127.0.0.1:8080", "token", "", os.Args[0], false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- add `filesystem_sandbox.enabled` to native daemon configuration and `--filesystem-sandbox` install/runtime flags
- wrap macOS native provisioners with `/usr/bin/sandbox-exec` using a per-session Seatbelt profile
- isolate the host home and sibling sessions while keeping the current session and daemon binary usable
- add fail-closed validation, session-state tracking, status/doctor output, tests, and documentation

## Testing
- `make lint`
- `make test` (Go 1.25.12; Zig used as the temporary C compiler with external linking because this runner has no gcc)
- targeted changed-package race tests after the final policy adjustment

## Note
A final uncached full race rerun also exposed a pre-existing race between `TestRunProxyWithInvalidConfig` and `TestRunProxyGracefulShutdown` in `cmd/server_test.go`; the native sandbox tests pass under the race detector.