### PR TITLE
feat(native): add session list and logs commands

### DIFF
--- a/cmd/native.go
+++ b/cmd/native.go
@@ -14,9 +14,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -29,6 +31,8 @@ type nativeManageOptions struct {
 	scope, teamID, drainTimeout                                                              string
 	labels                                                                                   []string
 	defaultManager, apiKeyStdin, force, drain, keepRegistration, keepData, filesystemSandbox bool
+	logsFollow, logsDaemon                                                                   bool
+	logsTail                                                                                 int
 }
 
 var nativeManageOpts nativeManageOptions
@@ -74,7 +78,12 @@ func init() {
 	uninstall.Flags().StringVar(&nativeManageOpts.drainTimeout, "drain-timeout", "30m", "maximum time to wait with --drain")
 	uninstall.Flags().BoolVar(&nativeManageOpts.keepRegistration, "keep-registration", false, "keep the parent registration")
 	uninstall.Flags().BoolVar(&nativeManageOpts.keepData, "keep-data", false, "keep daemon state and configuration")
-	NativeCmd.AddCommand(install, status, doctor, restart, rotate, uninstall)
+	sessionList := &cobra.Command{Use: "session-list", Aliases: []string{"sessions"}, Short: "List native sessions on this host", Args: cobra.NoArgs, RunE: runNativeSessionList}
+	logs := &cobra.Command{Use: "logs [session-id]", Short: "Show native daemon or session logs", Args: cobra.MaximumNArgs(1), RunE: runNativeLogs}
+	logs.Flags().BoolVarP(&nativeManageOpts.logsFollow, "follow", "f", false, "follow log output")
+	logs.Flags().IntVarP(&nativeManageOpts.logsTail, "tail", "n", 100, "number of lines to show")
+	logs.Flags().BoolVar(&nativeManageOpts.logsDaemon, "daemon", false, "show the native daemon log")
+	NativeCmd.AddCommand(install, status, doctor, restart, rotate, uninstall, sessionList, logs)
 }
 
 func runNativeInstall(_ *cobra.Command, _ []string) error {
@@ -259,6 +268,114 @@ func runNativeStatus(_ *cobra.Command, _ []string) error {
 	active, _ := filepath.Glob(filepath.Join(cfg.StateDir, "sessions", "*"))
 	fmt.Printf("Service: %s\nManager ID: %s\nUpstream: %s\nPublic URL: %s\nLabels: %s\nVersion: %s\nFilesystem sandbox: %t\nActive sessions: %d\nHealth: %s\nState: %s\n", service, cfg.ManagerID, cfg.UpstreamURL, cfg.PublicURL, formatLabels(cfg.Labels), cfg.Version, cfg.FilesystemSandbox.Enabled, len(active), health, cfg.StateDir)
 	return nil
+}
+
+type nativeSessionListEntry struct {
+	ID        string    `json:"id"`
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at"`
+	Status    string    `json:"status"`
+	LogPath   string    `json:"-"`
+}
+
+func readNativeSessionList(stateDir string) ([]nativeSessionListEntry, error) {
+	sessionDirs, err := filepath.Glob(filepath.Join(stateDir, "sessions", "*"))
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]nativeSessionListEntry, 0, len(sessionDirs))
+	for _, sessionDir := range sessionDirs {
+		data, readErr := os.ReadFile(filepath.Join(sessionDir, "runtime", "state.json"))
+		if readErr != nil {
+			continue
+		}
+		var entry nativeSessionListEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			return nil, fmt.Errorf("read session state %s: %w", filepath.Base(sessionDir), err)
+		}
+		if entry.ID == "" {
+			entry.ID = filepath.Base(sessionDir)
+		}
+		entry.LogPath = filepath.Join(sessionDir, "runtime", "provisioner.log")
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].StartedAt.Before(entries[j].StartedAt) })
+	return entries, nil
+}
+
+func runNativeSessionList(command *cobra.Command, _ []string) error {
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	cfg, err := readNativeConfig(paths.config)
+	if err != nil {
+		return err
+	}
+	entries, err := readNativeSessionList(cfg.StateDir)
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(command.OutOrStdout(), 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "SESSION ID\tSTATUS\tPID\tSTARTED\tLOG")
+	for _, entry := range entries {
+		started := "-"
+		if !entry.StartedAt.IsZero() {
+			started = entry.StartedAt.Local().Format(time.RFC3339)
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", entry.ID, entry.Status, entry.PID, started, entry.LogPath)
+	}
+	return w.Flush()
+}
+
+func nativeLogPath(paths nativeInstallPaths, cfg nativeDaemonConfig, sessionID string, daemon bool) (string, error) {
+	if daemon {
+		if sessionID != "" {
+			return "", errors.New("a session ID cannot be used with --daemon")
+		}
+		return filepath.Join(paths.logDir, "native.log"), nil
+	}
+	if sessionID == "" {
+		return "", errors.New("session ID is required (or use --daemon)")
+	}
+	if sessionID == "." || filepath.Base(sessionID) != sessionID {
+		return "", errors.New("invalid session ID")
+	}
+	return filepath.Join(cfg.StateDir, "sessions", sessionID, "runtime", "provisioner.log"), nil
+}
+
+func runNativeLogs(command *cobra.Command, args []string) error {
+	if nativeManageOpts.logsTail < 0 {
+		return errors.New("--tail must be zero or greater")
+	}
+	paths, err := nativePaths(nativeManageOpts.configPath)
+	if err != nil {
+		return err
+	}
+	cfg, err := readNativeConfig(paths.config)
+	if err != nil {
+		return err
+	}
+	sessionID := ""
+	if len(args) == 1 {
+		sessionID = args[0]
+	}
+	logPath, err := nativeLogPath(paths, cfg, sessionID, nativeManageOpts.logsDaemon)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(logPath); err != nil {
+		return fmt.Errorf("open log %s: %w", logPath, err)
+	}
+	tailArgs := []string{"-n", strconv.Itoa(nativeManageOpts.logsTail)}
+	if nativeManageOpts.logsFollow {
+		tailArgs = append(tailArgs, "-F")
+	}
+	tailArgs = append(tailArgs, logPath)
+	tail := exec.CommandContext(command.Context(), "tail", tailArgs...)
+	tail.Stdout = command.OutOrStdout()
+	tail.Stderr = command.ErrOrStderr()
+	return tail.Run()
 }
 
 func runNativeDoctor(_ *cobra.Command, _ []string) error {

--- a/cmd/native_test.go
+++ b/cmd/native_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -62,4 +63,45 @@ func TestSafeNativeStateDir(t *testing.T) {
 	require.False(t, safeNativeStateDir("/"))
 	require.False(t, safeNativeStateDir("."))
 	require.True(t, safeNativeStateDir("/var/lib/agentapi-native"))
+}
+
+func TestReadNativeSessionList(t *testing.T) {
+	stateDir := t.TempDir()
+	older := time.Date(2026, time.July, 20, 1, 2, 3, 0, time.UTC)
+	newer := older.Add(time.Hour)
+	for _, entry := range []nativeSessionListEntry{
+		{ID: "session-new", PID: 22, Status: "running", StartedAt: newer},
+		{ID: "session-old", PID: 11, Status: "stable", StartedAt: older},
+	} {
+		runtimeDir := filepath.Join(stateDir, "sessions", entry.ID, "runtime")
+		require.NoError(t, os.MkdirAll(runtimeDir, 0o700))
+		data, err := json.Marshal(entry)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(runtimeDir, "state.json"), data, 0o600))
+	}
+
+	entries, err := readNativeSessionList(stateDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	require.Equal(t, "session-old", entries[0].ID)
+	require.Equal(t, filepath.Join(stateDir, "sessions", "session-old", "runtime", "provisioner.log"), entries[0].LogPath)
+	require.Equal(t, "session-new", entries[1].ID)
+}
+
+func TestNativeLogPath(t *testing.T) {
+	paths := nativeInstallPaths{logDir: "/logs"}
+	cfg := nativeDaemonConfig{StateDir: "/state"}
+
+	path, err := nativeLogPath(paths, cfg, "session-1", false)
+	require.NoError(t, err)
+	require.Equal(t, "/state/sessions/session-1/runtime/provisioner.log", path)
+
+	path, err = nativeLogPath(paths, cfg, "", true)
+	require.NoError(t, err)
+	require.Equal(t, "/logs/native.log", path)
+
+	_, err = nativeLogPath(paths, cfg, "../session-1", false)
+	require.EqualError(t, err, "invalid session ID")
+	_, err = nativeLogPath(paths, cfg, "", false)
+	require.EqualError(t, err, "session ID is required (or use --daemon)")
 }

--- a/docs/external-session-manager.md
+++ b/docs/external-session-manager.md
@@ -253,6 +253,18 @@ checks local configuration permissions, service health, and the parent
 heartbeat. If registration must retain an existing identity, pass the existing
 ID with `--manager-id`.
 
+List native sessions and inspect their provisioner logs directly from the host:
+
+```bash
+agentapi-proxy native session-list
+agentapi-proxy native logs <session-id>
+agentapi-proxy native logs --follow --tail 200 <session-id>
+agentapi-proxy native logs --daemon --follow
+```
+
+Session logs live below `<state-dir>/sessions/<session-id>/runtime/provisioner.log`.
+They are removed along with the session directory when the session is deleted.
+
 ## Starting a Session Through an ESM
 
 Specify the manager explicitly:


### PR DESCRIPTION
## Summary
- add `native session-list` to show local native session state and log paths
- add `native logs <session-id>` with `--follow`, `--tail`, and daemon log support
- document the commands and cover state/log path handling with tests

## Verification
- `make lint`
- `make test`