### PR TITLE
feat(native): support manager service environment

### DIFF
--- a/cmd/native.go
+++ b/cmd/native.go
@@ -30,6 +30,7 @@ type nativeManageOptions struct {
 	upstream, publicURL, name, listen, managerID, apiKeyEnv, apiKeyFile, configPath          string
 	scope, teamID, drainTimeout                                                              string
 	labels                                                                                   []string
+	environment                                                                              []string
 	defaultManager, apiKeyStdin, force, drain, keepRegistration, keepData, filesystemSandbox bool
 	logsFollow, logsDaemon                                                                   bool
 	logsTail                                                                                 int
@@ -64,6 +65,7 @@ func init() {
 	f.StringVar(&nativeManageOpts.scope, "scope", "user", "registration scope: user or team")
 	f.StringVar(&nativeManageOpts.teamID, "team-id", "", "team ID when --scope=team")
 	f.StringSliceVar(&nativeManageOpts.labels, "label", nil, "allocator label in key=value form")
+	f.StringArrayVar(&nativeManageOpts.environment, "manager-env", nil, "native manager environment variable in KEY=VALUE form (repeatable)")
 	f.BoolVar(&nativeManageOpts.defaultManager, "default", false, "make this the default external session manager")
 	f.BoolVar(&nativeManageOpts.force, "force", false, "install even if the existing state directory contains sessions")
 	f.BoolVar(&nativeManageOpts.filesystemSandbox, "filesystem-sandbox", false, "sandbox native session filesystem access on macOS")
@@ -121,6 +123,17 @@ func runNativeInstall(_ *cobra.Command, _ []string) error {
 		}
 		labels[strings.TrimSpace(parts[0])] = parts[1]
 	}
+	environment := make(map[string]string, len(existing.ManagerEnvironment)+len(nativeManageOpts.environment))
+	for key, value := range existing.ManagerEnvironment {
+		environment[key] = value
+	}
+	for _, raw := range nativeManageOpts.environment {
+		key, value, parseErr := parseNativeManagerEnvironment(raw)
+		if parseErr != nil {
+			return parseErr
+		}
+		environment[key] = value
+	}
 	apiKey, err := readInstallAPIKey()
 	if err != nil {
 		return err
@@ -144,7 +157,7 @@ func runNativeInstall(_ *cobra.Command, _ []string) error {
 	cfg := nativeDaemonConfig{Listen: nativeManageOpts.listen, UpstreamURL: strings.TrimRight(nativeManageOpts.upstream, "/"),
 		ConnectionToken: token, PublicURL: strings.TrimRight(nativeManageOpts.publicURL, "/"), StateDir: paths.state,
 		BinaryPath: paths.binary, ManagerID: registration.ID, InstanceID: instanceID, Scope: nativeManageOpts.scope, TeamID: nativeManageOpts.teamID,
-		Labels: labels, Version: nativeBuildVersion(),
+		Labels: labels, ManagerEnvironment: environment, Version: nativeBuildVersion(),
 		FilesystemSandbox: nativeFilesystemSandboxConfig{Enabled: nativeManageOpts.filesystemSandbox}}
 	if err := installNativeService(paths, cfg); err != nil {
 		return err
@@ -227,7 +240,7 @@ func installNativeService(paths nativeInstallPaths, cfg nativeDaemonConfig) erro
 		if err := secureNativeConfig(paths.config); err != nil {
 			return err
 		}
-		unit := fmt.Sprintf("[Unit]\nDescription=agentapi-proxy native external session manager\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nUser=agentapi\nGroup=agentapi\nExecStart=%s native-session-manager --config %s\nRestart=always\nRestartSec=3\nKillMode=process\nTimeoutStopSec=30\nLimitNOFILE=65536\n\n[Install]\nWantedBy=multi-user.target\n", paths.binary, paths.config)
+		unit := renderNativeSystemdUnit(paths, cfg.ManagerEnvironment)
 		if err := atomicWriteFile(paths.service, []byte(unit), 0o644); err != nil {
 			return err
 		}
@@ -239,13 +252,70 @@ func installNativeService(paths nativeInstallPaths, cfg nativeDaemonConfig) erro
 		}
 		return runCommand("systemctl", "restart", "agentapi-native.service")
 	}
-	plist := fmt.Sprintf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\"><dict><key>Label</key><string>com.agentapi.native</string><key>ProgramArguments</key><array><string>%s</string><string>native-session-manager</string><string>--config</string><string>%s</string></array><key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s/native.log</string><key>StandardErrorPath</key><string>%s/native.log</string></dict></plist>\n", xmlEscape(paths.binary), xmlEscape(paths.config), xmlEscape(paths.logDir), xmlEscape(paths.logDir))
+	plist := renderNativeLaunchAgent(paths, cfg.ManagerEnvironment)
 	if err := atomicWriteFile(paths.service, []byte(plist), 0o600); err != nil {
 		return err
 	}
 	domain := "gui/" + strconv.Itoa(os.Getuid())
 	_ = runCommand("launchctl", "bootout", domain+"/com.agentapi.native")
 	return runCommand("launchctl", "bootstrap", domain, paths.service)
+}
+
+func parseNativeManagerEnvironment(raw string) (string, string, error) {
+	key, value, ok := strings.Cut(raw, "=")
+	if !ok || !validEnvironmentKey(key) {
+		return "", "", fmt.Errorf("invalid --manager-env %q; expected KEY=VALUE", raw)
+	}
+	if strings.ContainsAny(value, "\x00\r\n") {
+		return "", "", fmt.Errorf("invalid --manager-env %q; value must not contain NUL or newlines", raw)
+	}
+	return key, value, nil
+}
+
+func validEnvironmentKey(key string) bool {
+	if key == "" || (!asciiLetter(key[0]) && key[0] != '_') {
+		return false
+	}
+	for i := 1; i < len(key); i++ {
+		if !asciiLetter(key[i]) && (key[i] < '0' || key[i] > '9') && key[i] != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiLetter(value byte) bool {
+	return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z')
+}
+
+func sortedEnvironmentKeys(environment map[string]string) []string {
+	keys := make([]string, 0, len(environment))
+	for key := range environment {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func renderNativeSystemdUnit(paths nativeInstallPaths, environment map[string]string) string {
+	var env strings.Builder
+	for _, key := range sortedEnvironmentKeys(environment) {
+		value := strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "%", "%%").Replace(environment[key])
+		fmt.Fprintf(&env, "Environment=\"%s=%s\"\n", key, value)
+	}
+	return fmt.Sprintf("[Unit]\nDescription=agentapi-proxy native external session manager\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nUser=agentapi\nGroup=agentapi\n%sExecStart=%s native-session-manager --config %s\nRestart=always\nRestartSec=3\nKillMode=process\nTimeoutStopSec=30\nLimitNOFILE=65536\n\n[Install]\nWantedBy=multi-user.target\n", env.String(), paths.binary, paths.config)
+}
+
+func renderNativeLaunchAgent(paths nativeInstallPaths, environment map[string]string) string {
+	var env strings.Builder
+	if len(environment) > 0 {
+		env.WriteString("<key>EnvironmentVariables</key><dict>")
+		for _, key := range sortedEnvironmentKeys(environment) {
+			fmt.Fprintf(&env, "<key>%s</key><string>%s</string>", xmlEscape(key), xmlEscape(environment[key]))
+		}
+		env.WriteString("</dict>")
+	}
+	return fmt.Sprintf("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\"><dict><key>Label</key><string>com.agentapi.native</string><key>ProgramArguments</key><array><string>%s</string><string>native-session-manager</string><string>--config</string><string>%s</string></array>%s<key>RunAtLoad</key><true/><key>KeepAlive</key><true/><key>StandardOutPath</key><string>%s/native.log</string><key>StandardErrorPath</key><string>%s/native.log</string></dict></plist>\n", xmlEscape(paths.binary), xmlEscape(paths.config), env.String(), xmlEscape(paths.logDir), xmlEscape(paths.logDir))
 }
 
 func runNativeStatus(_ *cobra.Command, _ []string) error {

--- a/cmd/native_session_manager.go
+++ b/cmd/native_session_manager.go
@@ -42,21 +42,22 @@ type nativeFilesystemSandboxConfig struct {
 }
 
 type nativeDaemonConfig struct {
-	Listen            string                        `json:"listen"`
-	UpstreamURL       string                        `json:"upstream_url"`
-	ConnectionToken   string                        `json:"connection_token"`
-	CredentialsPath   string                        `json:"credentials_path,omitempty"`
-	UpstreamAuthToken string                        `json:"upstream_auth_token,omitempty"`
-	PublicURL         string                        `json:"public_url"`
-	StateDir          string                        `json:"state_dir"`
-	BinaryPath        string                        `json:"binary_path,omitempty"`
-	ManagerID         string                        `json:"manager_id,omitempty"`
-	InstanceID        string                        `json:"instance_id,omitempty"`
-	Scope             string                        `json:"scope,omitempty"`
-	TeamID            string                        `json:"team_id,omitempty"`
-	Labels            map[string]string             `json:"labels,omitempty"`
-	Version           string                        `json:"version,omitempty"`
-	FilesystemSandbox nativeFilesystemSandboxConfig `json:"filesystem_sandbox,omitempty"`
+	Listen             string                        `json:"listen"`
+	UpstreamURL        string                        `json:"upstream_url"`
+	ConnectionToken    string                        `json:"connection_token"`
+	CredentialsPath    string                        `json:"credentials_path,omitempty"`
+	UpstreamAuthToken  string                        `json:"upstream_auth_token,omitempty"`
+	PublicURL          string                        `json:"public_url"`
+	StateDir           string                        `json:"state_dir"`
+	BinaryPath         string                        `json:"binary_path,omitempty"`
+	ManagerID          string                        `json:"manager_id,omitempty"`
+	InstanceID         string                        `json:"instance_id,omitempty"`
+	Scope              string                        `json:"scope,omitempty"`
+	TeamID             string                        `json:"team_id,omitempty"`
+	Labels             map[string]string             `json:"labels,omitempty"`
+	ManagerEnvironment map[string]string             `json:"manager_environment,omitempty"`
+	Version            string                        `json:"version,omitempty"`
+	FilesystemSandbox  nativeFilesystemSandboxConfig `json:"filesystem_sandbox,omitempty"`
 }
 
 func init() {

--- a/cmd/native_test.go
+++ b/cmd/native_test.go
@@ -35,7 +35,7 @@ func TestNativeConfigPersistsSeparateInstanceID(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	credentialsPath := filepath.Join(dir, "credentials.json")
 	want := nativeDaemonConfig{ManagerID: "manager-1", InstanceID: "machine-1", ConnectionToken: "secret", CredentialsPath: credentialsPath,
-		FilesystemSandbox: nativeFilesystemSandboxConfig{Enabled: true}}
+		ManagerEnvironment: map[string]string{"PATH": "/opt/mise/bin:/usr/bin:/bin"}, FilesystemSandbox: nativeFilesystemSandboxConfig{Enabled: true}}
 	data, err := json.Marshal(want)
 	require.NoError(t, err)
 	var stored nativeDaemonConfig
@@ -57,6 +57,34 @@ func TestNativeConfigPersistsSeparateInstanceID(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestParseNativeManagerEnvironment(t *testing.T) {
+	key, value, err := parseNativeManagerEnvironment("PATH=/opt/mise/bin:/usr/bin:/bin")
+	require.NoError(t, err)
+	require.Equal(t, "PATH", key)
+	require.Equal(t, "/opt/mise/bin:/usr/bin:/bin", value)
+
+	_, _, err = parseNativeManagerEnvironment("1INVALID=value")
+	require.EqualError(t, err, `invalid --manager-env "1INVALID=value"; expected KEY=VALUE`)
+	_, _, err = parseNativeManagerEnvironment("MISSING_VALUE")
+	require.EqualError(t, err, `invalid --manager-env "MISSING_VALUE"; expected KEY=VALUE`)
+}
+
+func TestRenderNativeLaunchAgentEnvironment(t *testing.T) {
+	paths := nativeInstallPaths{binary: "/Applications/Agent & API/agentapi-proxy", config: "/tmp/config.json", logDir: "/tmp/logs"}
+	plist := renderNativeLaunchAgent(paths, map[string]string{"PATH": "/opt/mise/bin:/usr/bin", "SPECIAL": "one&two"})
+	require.Contains(t, plist, "<key>EnvironmentVariables</key><dict>")
+	require.Contains(t, plist, "<key>PATH</key><string>/opt/mise/bin:/usr/bin</string>")
+	require.Contains(t, plist, "<key>SPECIAL</key><string>one&amp;two</string>")
+	require.Contains(t, plist, "<string>/Applications/Agent &amp; API/agentapi-proxy</string>")
+}
+
+func TestRenderNativeSystemdEnvironment(t *testing.T) {
+	paths := nativeInstallPaths{binary: "/usr/local/libexec/agentapi-proxy", config: "/etc/agentapi-native/config.json"}
+	unit := renderNativeSystemdUnit(paths, map[string]string{"PATH": "/opt/mise/bin:/usr/bin", "SPECIAL": `quote"slash\percent%`})
+	require.Contains(t, unit, "Environment=\"PATH=/opt/mise/bin:/usr/bin\"")
+	require.Contains(t, unit, `Environment="SPECIAL=quote\"slash\\percent%%"`)
 }
 
 func TestSafeNativeStateDir(t *testing.T) {

--- a/docs/external-session-manager.md
+++ b/docs/external-session-manager.md
@@ -208,6 +208,26 @@ agentapi-proxy native install \
   --filesystem-sandbox
 ```
 
+Use `--manager-env KEY=VALUE` to set an environment variable on the native
+manager service and its child provisioner processes. This is separate from
+session environment settings. The option is repeatable, and values are kept in
+the native configuration across later installs unless the same key is replaced.
+For example, a macOS manager can expose mise-managed Node.js and the installed
+`agentapi-proxy` binary through `PATH`:
+
+```bash
+NODE_BIN="$(dirname "$(mise which node)")"
+NATIVE_BIN="$HOME/Library/Application Support/agentapi-native/bin"
+
+agentapi-proxy native install \
+  --upstream "https://parent-proxy.example.com" \
+  --public-url "https://native-mac.example.com" \
+  --manager-env "PATH=$NODE_BIN:$NATIVE_BIN:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+```
+
+Do not pass secrets through `--manager-env`; service definitions may be
+readable by other local users on some platforms.
+
 Add `--default` to select this manager when a session does not specify a
 manager. To register it for a team instead of the current user:
 


### PR DESCRIPTION
## Summary

- add repeatable `native install --manager-env KEY=VALUE` options
- persist manager service variables in `manager_environment` and preserve them across reinstalls
- render variables into macOS LaunchAgent and Linux systemd service definitions
- document mise/Node.js `PATH` configuration and add validation/rendering tests

## Verification

- `make lint` (pass)
- added native environment tests with race detector (pass)
- `TestRunProxyGracefulShutdown` with race detector in isolation (pass)
- all race tests excluding `TestRunProxyGracefulShutdown` (pass)
- full `make test` reaches one existing flaky failure: `TestRunProxyGracefulShutdown` times out only as part of the complete cmd suite while Kubernetes API calls wait on an unavailable test endpoint