### PR TITLE
feat(kubernetes): persist session home on PVC

### DIFF
--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -2010,6 +2010,9 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	var sandboxEnvVars []corev1.EnvVar
 	effectiveSandbox := m.resolveSandboxParams(ctx, req)
 	initContainers, sandboxSidecar, sandboxEnvVars = m.buildSandboxContainers(effectiveSandbox)
+	if m.isPVCEnabled() {
+		initContainers = append([]corev1.Container{m.buildSessionHomeInitContainer()}, initContainers...)
+	}
 
 	var sciaInitContainer *corev1.Container
 	var sciaSidecar *corev1.Container
@@ -3126,6 +3129,12 @@ func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.D
 			},
 		},
 	}
+	if m.isPVCEnabled() {
+		// The PVC root is the main container's home. DinD only needs the shared
+		// workspace, which the session-home init container creates before app
+		// containers start.
+		sidecar.VolumeMounts[1].SubPath = "workdir"
+	}
 
 	volumes := []corev1.Volume{
 		{
@@ -3173,6 +3182,25 @@ func (m *KubernetesSessionManager) buildDinDContainers(docker *sessionsettings.D
 	return &sidecar, mainEnvVars, volumes
 }
 
+// buildSessionHomeInitContainer prepares directories inside a newly-created
+// session-home PVC before the main and sidecar containers mount it. In
+// particular, Kubernetes requires the DinD workdir subPath to exist before the
+// sidecar starts.
+func (m *KubernetesSessionManager) buildSessionHomeInitContainer() corev1.Container {
+	return corev1.Container{
+		Name:            "session-home-init",
+		Image:           m.k8sConfig.Image,
+		ImagePullPolicy: corev1.PullPolicy(m.k8sConfig.ImagePullPolicy),
+		Command:         []string{"mkdir", "-p", "/home/agentapi/workdir"},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "workdir",
+				MountPath: "/home/agentapi",
+			},
+		},
+	}
+}
+
 func defaultIfEmpty(s, def string) string {
 	if s == "" {
 		return def
@@ -3202,7 +3230,11 @@ func buildResourceRequirements(cpuReq, cpuLim, memReq, memLim string) corev1.Res
 
 // buildVolumes builds the volume configuration for the session pod
 func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []corev1.Volume {
-	// Build workdir volume - use PVC if enabled, otherwise EmptyDir
+	// PVC-backed sessions persist the entire agent home so agent-native session
+	// state (for example ~/.claude and ~/.codex) survives Pod recreation. The
+	// volume keeps the historical "workdir" name to avoid unnecessary template
+	// churn. Ephemeral sessions continue to persist only workdir for the lifetime
+	// of their Pod.
 	var workdirVolume corev1.Volume
 	if m.isPVCEnabled() {
 		workdirVolume = corev1.Volume{
@@ -3228,15 +3260,16 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 	// watches the file and syncs any changes back to the Secret.
 
 	volumes := []corev1.Volume{
-		// Workdir volume (PVC or EmptyDir based on configuration)
 		workdirVolume,
-		// dot-claude EmptyDir – used by main container for Claude Code settings
-		{
+	}
+	if !m.isPVCEnabled() {
+		// Ephemeral sessions keep Claude settings isolated from the image layer.
+		volumes = append(volumes, corev1.Volume{
 			Name: "dot-claude",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
-		},
+		})
 	}
 
 	// Add notification subscription Secret volume (source for init container)
@@ -4234,15 +4267,14 @@ func isPodReady(pod *corev1.Pod) bool {
 
 // buildMainContainerVolumeMounts builds the volume mounts for the main container
 func (m *KubernetesSessionManager) buildMainContainerVolumeMounts(session *KubernetesSession, req *entities.RunServerRequest) []corev1.VolumeMount {
+	homeMountPath := "/home/agentapi/workdir"
+	if m.isPVCEnabled() {
+		homeMountPath = "/home/agentapi"
+	}
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      "workdir",
-			MountPath: "/home/agentapi/workdir",
-		},
-		// dot-claude EmptyDir – used by main container for Claude Code settings
-		{
-			Name:      "dot-claude",
-			MountPath: "/home/agentapi/.claude",
+			MountPath: homeMountPath,
 		},
 		// notification subscriptions source – read by setup on startup
 		{
@@ -4250,6 +4282,12 @@ func (m *KubernetesSessionManager) buildMainContainerVolumeMounts(session *Kuber
 			MountPath: "/notification-subscriptions-source",
 			ReadOnly:  true,
 		},
+	}
+	if !m.isPVCEnabled() {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "dot-claude",
+			MountPath: "/home/agentapi/.claude",
+		})
 	}
 
 	// session-settings Secret – optional mount for Pod restart auto-provisioning.

--- a/internal/infrastructure/services/kubernetes_session_manager_workload_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_workload_test.go
@@ -66,6 +66,39 @@ func assertOwnedByService(t *testing.T, obj metav1.Object, serviceName string) {
 	}
 }
 
+func findVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name string) corev1.VolumeMount {
+	t.Helper()
+	for _, mount := range mounts {
+		if mount.Name == name {
+			return mount
+		}
+	}
+	t.Fatalf("Expected volume mount %q, got %+v", name, mounts)
+	return corev1.VolumeMount{}
+}
+
+func findVolume(t *testing.T, volumes []corev1.Volume, name string) corev1.Volume {
+	t.Helper()
+	for _, volume := range volumes {
+		if volume.Name == name {
+			return volume
+		}
+	}
+	t.Fatalf("Expected volume %q, got %+v", name, volumes)
+	return corev1.Volume{}
+}
+
+func findContainer(t *testing.T, containers []corev1.Container, name string) corev1.Container {
+	t.Helper()
+	for _, container := range containers {
+		if container.Name == name {
+			return container
+		}
+	}
+	t.Fatalf("Expected container %q, got %+v", name, containers)
+	return corev1.Container{}
+}
+
 func TestCreateSessionWorkloadWithoutPVCUsesPodRestartPolicyNever(t *testing.T) {
 	manager := newWorkloadTestManager(t, false)
 	session := newWorkloadTestSession()
@@ -87,6 +120,17 @@ func TestCreateSessionWorkloadWithoutPVCUsesPodRestartPolicyNever(t *testing.T) 
 	if pod.Spec.Volumes[0].EmptyDir == nil {
 		t.Fatal("Expected workdir volume to use EmptyDir when PVC is disabled")
 	}
+	workdirMount := findVolumeMount(t, pod.Spec.Containers[0].VolumeMounts, "workdir")
+	if workdirMount.MountPath != "/home/agentapi/workdir" {
+		t.Fatalf("Expected ephemeral workdir mount, got %s", workdirMount.MountPath)
+	}
+	dotClaudeMount := findVolumeMount(t, pod.Spec.Containers[0].VolumeMounts, "dot-claude")
+	if dotClaudeMount.MountPath != "/home/agentapi/.claude" {
+		t.Fatalf("Expected ephemeral Claude config mount, got %s", dotClaudeMount.MountPath)
+	}
+	if findVolume(t, pod.Spec.Volumes, "dot-claude").EmptyDir == nil {
+		t.Fatal("Expected dot-claude volume to use EmptyDir when PVC is disabled")
+	}
 
 	deployments, err := manager.client.AppsV1().Deployments("test-ns").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -100,6 +144,7 @@ func TestCreateSessionWorkloadWithoutPVCUsesPodRestartPolicyNever(t *testing.T) 
 func TestCreateSessionWorkloadWithPVCUsesDeploymentRestartPolicyAlways(t *testing.T) {
 	manager := newWorkloadTestManager(t, true)
 	session := newWorkloadTestSession()
+	session.Request().Docker = &entities.DockerParams{Enabled: true}
 
 	if err := manager.createSessionWorkload(context.Background(), session, session.Request()); err != nil {
 		t.Fatalf("Failed to create workload: %v", err)
@@ -114,6 +159,36 @@ func TestCreateSessionWorkloadWithPVCUsesDeploymentRestartPolicyAlways(t *testin
 	}
 	if deployment.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim == nil {
 		t.Fatal("Expected workdir volume to mount PVC when PVC is enabled")
+	}
+	homeMount := findVolumeMount(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, "workdir")
+	if homeMount.MountPath != "/home/agentapi" {
+		t.Fatalf("Expected PVC to mount the full agent home, got %s", homeMount.MountPath)
+	}
+	for _, mount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if mount.Name == "dot-claude" {
+			t.Fatal("Expected Claude state to live on the session-home PVC")
+		}
+	}
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.Name == "dot-claude" {
+			t.Fatal("Expected no dot-claude EmptyDir for PVC-backed sessions")
+		}
+	}
+	if len(deployment.Spec.Template.Spec.InitContainers) == 0 {
+		t.Fatal("Expected session-home init container")
+	}
+	homeInit := deployment.Spec.Template.Spec.InitContainers[0]
+	if homeInit.Name != "session-home-init" {
+		t.Fatalf("Expected session-home init container first, got %s", homeInit.Name)
+	}
+	initMount := findVolumeMount(t, homeInit.VolumeMounts, "workdir")
+	if initMount.MountPath != "/home/agentapi" {
+		t.Fatalf("Expected init container to mount session home, got %s", initMount.MountPath)
+	}
+	dind := findContainer(t, deployment.Spec.Template.Spec.Containers, "docker-dind")
+	dindWorkdirMount := findVolumeMount(t, dind.VolumeMounts, "workdir")
+	if dindWorkdirMount.MountPath != "/home/agentapi/workdir" || dindWorkdirMount.SubPath != "workdir" {
+		t.Fatalf("Expected DinD to share the persisted workdir subPath, got %+v", dindWorkdirMount)
 	}
 
 	pods, err := manager.client.CoreV1().Pods("test-ns").List(context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
## Summary

- mount PVC-backed session storage at `/home/agentapi` so agent-native state under `~/.claude` and `~/.codex` survives Pod recreation
- keep ephemeral sessions unchanged with separate EmptyDir mounts for workdir and Claude state
- prepare the persisted `workdir` directory before containers start and share it with DinD through a subPath mount
- extend workload tests for PVC and non-PVC volume layouts

## Validation

- `git diff --cached --check` passed before commit
- `make lint` could not run because the workspace image does not contain the Go toolchain (`go: No such file or directory`)
- `make test` could not run for the same reason