### PR TITLE
feat: configure MCP servers in session profiles

### DIFF
--- a/docs/session-profile-mcp-servers.md
+++ b/docs/session-profile-mcp-servers.md
@@ -1,0 +1,40 @@
+# Session profile MCP servers
+
+## API design
+
+`SessionProfileConfig` accepts an optional `mcp_servers` map. Its keys are stable server names and its values use the same shape as `Settings.mcp_servers` (`type`, `url`, `command`, `args`, `env`, and `headers`).
+
+```json
+{
+  "name": "repository tools",
+  "config": {
+    "mcp_servers": {
+      "github": {
+        "type": "http",
+        "url": "https://mcp.example.com/github",
+        "headers": { "Authorization": "Bearer ${GITHUB_MCP_TOKEN}" }
+      }
+    }
+  }
+}
+```
+
+The settings layers are resolved from lowest to highest priority:
+
+`base → team → user → session profile → oneshot`
+
+MCP maps merge by server name. A profile replaces a same-named tenant server as one atomic configuration and inherits servers with other names. The selected profile is propagated to direct, scheduled, webhook, SlackBot, and External Session Manager launches.
+
+Profiles are stored in Kubernetes Secrets, like the rest of the profile configuration. Environment variables and headers may contain credentials and must not be logged.
+
+## agentapi-ui design
+
+Reuse `src/components/settings/MCPServerSettings.tsx` in `SessionProfileFormModal` instead of creating a second MCP editor. Move the reusable editor's value type to a shared module, then:
+
+1. Add `mcp_servers?: Record<string, APIMCPServerConfig>` to `SessionProfileConfig`.
+2. Keep an `mcpServers` form state initialized from `editingProfile.config?.mcp_servers ?? {}`.
+3. Add an “MCP servers” section under advanced settings using the shared editor.
+4. Include `mcp_servers` in the submitted profile config when non-empty.
+5. Explain in the form that tenant servers are inherited and same-named entries are overridden.
+
+The list card should show only the number and names of configured profile overrides; details remain in the edit modal. The existing session-profile selection UI requires no changes because resolution happens server-side.

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -901,6 +901,7 @@ func (s *Server) CreateSession(sessionID string, startReq entities.StartRequest,
 		SessionTTL:               sessionTTL,
 		UnsyncedFilePaths:        unsyncedFilePaths,
 		CredentialSource:         credentialSource,
+		ProfileMCPServers:        startReq.ProfileMCPServers,
 	})
 	if err != nil {
 		return nil, err
@@ -951,6 +952,7 @@ func (s *Server) createRemoteSession(ctx context.Context, sessionID string, star
 		AuthProxy:         authProxy,
 		UnsyncedFilePaths: unsyncedFilePaths,
 		CredentialSource:  credentialSource,
+		ProfileMCPServers: startReq.ProfileMCPServers,
 	}
 
 	// Try to build fully-resolved settings (env vars, Bedrock, MCP servers, OAuth token, etc.)

--- a/internal/domain/entities/session.go
+++ b/internal/domain/entities/session.go
@@ -159,6 +159,8 @@ type StartRequest struct {
 	// SessionProfileID is an optional reference to a SessionProfile.
 	// When set, the profile's config is used as a base; explicit fields override it.
 	SessionProfileID string `json:"session_profile_id,omitempty"`
+	// ProfileMCPServers is resolved from SessionProfileID and is never accepted from the API.
+	ProfileMCPServers *MCPServersSettings `json:"-"`
 }
 
 // RepositoryInfo contains repository information extracted from tags
@@ -205,6 +207,8 @@ type RunServerRequest struct {
 	UnsyncedFilePaths []string
 	// CredentialSource selects the owner of managed credential files.
 	CredentialSource string
+	// ProfileMCPServers is applied as a settings layer above user/team settings.
+	ProfileMCPServers *MCPServersSettings
 }
 
 // Session represents a running agentapi session

--- a/internal/domain/entities/session_profile.go
+++ b/internal/domain/entities/session_profile.go
@@ -36,6 +36,7 @@ type SessionProfileConfig struct {
 	// Empty string means the global cleanup worker TTL is used.
 	sessionTTL        string
 	unsyncedFilePaths []string
+	mcpServers        *MCPServersSettings
 }
 
 // NewSessionProfile creates a new SessionProfile
@@ -256,6 +257,12 @@ func (c *SessionProfileConfig) UnsyncedFilePaths() []string {
 func (c *SessionProfileConfig) SetUnsyncedFilePaths(paths []string) {
 	c.unsyncedFilePaths = copyStringSlice(paths)
 }
+
+// MCPServers returns the MCP servers contributed by this profile.
+func (c *SessionProfileConfig) MCPServers() *MCPServersSettings { return c.mcpServers }
+
+// SetMCPServers sets the MCP servers contributed by this profile.
+func (c *SessionProfileConfig) SetMCPServers(servers *MCPServersSettings) { c.mcpServers = servers }
 
 // --- Error types ---
 

--- a/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
+++ b/internal/infrastructure/repositories/kubernetes_session_profile_repository.go
@@ -48,16 +48,17 @@ type sessionProfileJSON struct {
 }
 
 type sessionProfileConfigJSON struct {
-	Environment            map[string]string       `json:"environment,omitempty"`
-	Tags                   map[string]string       `json:"tags,omitempty"`
-	InitialMessageTemplate string                  `json:"initial_message_template,omitempty"`
-	ReuseMessageTemplate   string                  `json:"reuse_message_template,omitempty"`
-	Params                 *entities.SessionParams `json:"params,omitempty"`
-	ReuseSession           bool                    `json:"reuse_session,omitempty"`
-	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
-	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
-	SessionTTL             string                  `json:"session_ttl,omitempty"`
-	UnsyncedFilePaths      []string                `json:"unsynced_file_paths,omitempty"`
+	Environment            map[string]string         `json:"environment,omitempty"`
+	Tags                   map[string]string         `json:"tags,omitempty"`
+	InitialMessageTemplate string                    `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                    `json:"reuse_message_template,omitempty"`
+	Params                 *entities.SessionParams   `json:"params,omitempty"`
+	ReuseSession           bool                      `json:"reuse_session,omitempty"`
+	MemoryKey              map[string]string         `json:"memory_key,omitempty"`
+	SandboxPolicyID        string                    `json:"sandbox_policy_id,omitempty"`
+	SessionTTL             string                    `json:"session_ttl,omitempty"`
+	UnsyncedFilePaths      []string                  `json:"unsynced_file_paths,omitempty"`
+	MCPServers             map[string]*mcpServerJSON `json:"mcp_servers,omitempty"`
 }
 
 // KubernetesSessionProfileRepository implements SessionProfileRepository using Kubernetes Secrets
@@ -323,6 +324,22 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 	cfg.SetSandboxPolicyID(pj.Config.SandboxPolicyID)
 	cfg.SetSessionTTL(pj.Config.SessionTTL)
 	cfg.SetUnsyncedFilePaths(pj.Config.UnsyncedFilePaths)
+	if pj.Config.MCPServers != nil {
+		servers := entities.NewMCPServersSettings()
+		for name, item := range pj.Config.MCPServers {
+			if item == nil {
+				continue
+			}
+			server := entities.NewMCPServer(name, item.Type)
+			server.SetURL(item.URL)
+			server.SetCommand(item.Command)
+			server.SetArgs(item.Args)
+			server.SetEnv(item.Env)
+			server.SetHeaders(item.Headers)
+			servers.SetServer(name, server)
+		}
+		cfg.SetMCPServers(servers)
+	}
 	profile.SetConfig(cfg)
 
 	return profile
@@ -330,6 +347,12 @@ func (r *KubernetesSessionProfileRepository) jsonToEntity(pj *sessionProfileJSON
 
 func (r *KubernetesSessionProfileRepository) entityToJSON(profile *entities.SessionProfile) *sessionProfileJSON {
 	cfg := profile.Config()
+	mcpServers := make(map[string]*mcpServerJSON)
+	if cfg.MCPServers() != nil {
+		for name, server := range cfg.MCPServers().Servers() {
+			mcpServers[name] = &mcpServerJSON{Type: server.Type(), URL: server.URL(), Command: server.Command(), Args: server.Args(), Env: server.Env(), Headers: server.Headers()}
+		}
+	}
 	return &sessionProfileJSON{
 		ID:           profile.ID(),
 		Name:         profile.Name(),
@@ -350,6 +373,7 @@ func (r *KubernetesSessionProfileRepository) entityToJSON(profile *entities.Sess
 			SandboxPolicyID:        cfg.SandboxPolicyID(),
 			SessionTTL:             cfg.SessionTTL(),
 			UnsyncedFilePaths:      cfg.UnsyncedFilePaths(),
+			MCPServers:             mcpServers,
 		},
 		CreatedAt: profile.CreatedAt(),
 		UpdatedAt: profile.UpdatedAt(),

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -5858,7 +5858,12 @@ func (m *KubernetesSessionManager) resolveSettings(
 		}
 	}
 
-	// 4. oneshot (highest priority)
+	// 4. session profile
+	if req.ProfileMCPServers != nil && !req.ProfileMCPServers.IsEmpty() {
+		layers = append(layers, settingsToMCPProfilePatch(req.ProfileMCPServers))
+	}
+
+	// 5. oneshot (highest priority)
 	if req.Oneshot {
 		appendIfExists(fmt.Sprintf("%s-oneshot-settings", session.ServiceName()))
 	}
@@ -5869,6 +5874,29 @@ func (m *KubernetesSessionManager) resolveSettings(
 		log.Printf("[K8S_SESSION] Warning: failed to materialize settings: %v", err)
 	}
 	return materialized
+}
+
+func settingsToMCPProfilePatch(servers *entities.MCPServersSettings) settingspatch.SettingsPatch {
+	patch := settingspatch.SettingsPatch{MCPServers: make(map[string]*settingspatch.MCPServerPatch)}
+	for name, server := range servers.Servers() {
+		patch.MCPServers[name] = &settingspatch.MCPServerPatch{
+			Type: server.Type(), URL: server.URL(), Command: server.Command(),
+			Args: append([]string(nil), server.Args()...), Env: cloneMCPStringMap(server.Env()),
+			Headers: cloneMCPStringMap(server.Headers()),
+		}
+	}
+	return patch
+}
+
+func cloneMCPStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
 }
 
 // resolvePreferredTeamID reads the user's personal settings to determine if a preferred team

--- a/internal/interfaces/controllers/session_controller.go
+++ b/internal/interfaces/controllers/session_controller.go
@@ -190,6 +190,7 @@ func (c *SessionController) StartSession(ctx echo.Context) error {
 		profile := c.resolveSessionProfile(ctx.Request().Context(), startReq.SessionProfileID, userID, startReq.Scope, startReq.TeamID, startReq.Tags)
 		if profile != nil {
 			cfg := profile.Config()
+			startReq.ProfileMCPServers = cfg.MCPServers()
 
 			// Environment: profile is base, request keys override
 			if len(cfg.Environment()) > 0 {

--- a/internal/interfaces/controllers/session_profile_controller.go
+++ b/internal/interfaces/controllers/session_profile_controller.go
@@ -31,16 +31,17 @@ func (c *SessionProfileController) GetName() string {
 
 // SessionProfileConfigRequest represents session profile config in requests
 type SessionProfileConfigRequest struct {
-	Environment            map[string]string       `json:"environment,omitempty"`
-	Tags                   map[string]string       `json:"tags,omitempty"`
-	InitialMessageTemplate string                  `json:"initial_message_template,omitempty"`
-	ReuseMessageTemplate   string                  `json:"reuse_message_template,omitempty"`
-	Params                 *entities.SessionParams `json:"params,omitempty"`
-	ReuseSession           bool                    `json:"reuse_session,omitempty"`
-	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
-	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
-	SessionTTL             string                  `json:"session_ttl,omitempty"`
-	UnsyncedFilePaths      []string                `json:"unsynced_file_paths,omitempty"`
+	Environment            map[string]string            `json:"environment,omitempty"`
+	Tags                   map[string]string            `json:"tags,omitempty"`
+	InitialMessageTemplate string                       `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                       `json:"reuse_message_template,omitempty"`
+	Params                 *entities.SessionParams      `json:"params,omitempty"`
+	ReuseSession           bool                         `json:"reuse_session,omitempty"`
+	MemoryKey              map[string]string            `json:"memory_key,omitempty"`
+	SandboxPolicyID        string                       `json:"sandbox_policy_id,omitempty"`
+	SessionTTL             string                       `json:"session_ttl,omitempty"`
+	UnsyncedFilePaths      []string                     `json:"unsynced_file_paths,omitempty"`
+	MCPServers             map[string]*MCPServerRequest `json:"mcp_servers,omitempty"`
 }
 
 // CreateSessionProfileRequest is the request body for creating a session profile
@@ -80,16 +81,17 @@ type SessionProfileResponse struct {
 
 // SessionProfileConfigResponse represents session profile config in responses
 type SessionProfileConfigResponse struct {
-	Environment            map[string]string       `json:"environment,omitempty"`
-	Tags                   map[string]string       `json:"tags,omitempty"`
-	InitialMessageTemplate string                  `json:"initial_message_template,omitempty"`
-	ReuseMessageTemplate   string                  `json:"reuse_message_template,omitempty"`
-	Params                 *entities.SessionParams `json:"params,omitempty"`
-	ReuseSession           bool                    `json:"reuse_session,omitempty"`
-	MemoryKey              map[string]string       `json:"memory_key,omitempty"`
-	SandboxPolicyID        string                  `json:"sandbox_policy_id,omitempty"`
-	SessionTTL             string                  `json:"session_ttl,omitempty"`
-	UnsyncedFilePaths      []string                `json:"unsynced_file_paths,omitempty"`
+	Environment            map[string]string            `json:"environment,omitempty"`
+	Tags                   map[string]string            `json:"tags,omitempty"`
+	InitialMessageTemplate string                       `json:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                       `json:"reuse_message_template,omitempty"`
+	Params                 *entities.SessionParams      `json:"params,omitempty"`
+	ReuseSession           bool                         `json:"reuse_session,omitempty"`
+	MemoryKey              map[string]string            `json:"memory_key,omitempty"`
+	SandboxPolicyID        string                       `json:"sandbox_policy_id,omitempty"`
+	SessionTTL             string                       `json:"session_ttl,omitempty"`
+	UnsyncedFilePaths      []string                     `json:"unsynced_file_paths,omitempty"`
+	MCPServers             map[string]*MCPServerRequest `json:"mcp_servers,omitempty"`
 }
 
 // --- Handlers ---
@@ -131,7 +133,11 @@ func (c *SessionProfileController) CreateSessionProfile(ctx echo.Context) error 
 	profile.SetTeamID(req.TeamID)
 	profile.SetIsDefault(req.IsDefault)
 	profile.SetSelectorTags(req.SelectorTags)
-	profile.SetConfig(c.requestToConfig(req.Config))
+	config := c.requestToConfig(req.Config)
+	if err := validateSessionProfileConfig(config); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	profile.SetConfig(config)
 
 	if err := c.repo.Create(ctx.Request().Context(), profile); err != nil {
 		log.Printf("Failed to create session profile: %v", err)
@@ -252,7 +258,11 @@ func (c *SessionProfileController) UpdateSessionProfile(ctx echo.Context) error 
 		profile.SetSelectorTags(req.SelectorTags)
 	}
 	if req.Config != nil {
-		profile.SetConfig(c.requestToConfig(*req.Config))
+		config := c.requestToConfig(*req.Config)
+		if err := validateSessionProfileConfig(config); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		profile.SetConfig(config)
 	}
 
 	if err := c.repo.Update(ctx.Request().Context(), profile); err != nil {
@@ -261,6 +271,13 @@ func (c *SessionProfileController) UpdateSessionProfile(ctx echo.Context) error 
 	}
 
 	return ctx.JSON(http.StatusOK, c.toResponse(profile))
+}
+
+func validateSessionProfileConfig(config entities.SessionProfileConfig) error {
+	if config.MCPServers() != nil {
+		return config.MCPServers().Validate()
+	}
+	return nil
 }
 
 // DeleteSessionProfile handles DELETE /session-profiles/:id
@@ -331,11 +348,33 @@ func (c *SessionProfileController) requestToConfig(req SessionProfileConfigReque
 	cfg.SetSandboxPolicyID(req.SandboxPolicyID)
 	cfg.SetSessionTTL(req.SessionTTL)
 	cfg.SetUnsyncedFilePaths(req.UnsyncedFilePaths)
+	if req.MCPServers != nil {
+		servers := entities.NewMCPServersSettings()
+		for name, item := range req.MCPServers {
+			if item == nil {
+				continue
+			}
+			server := entities.NewMCPServer(name, item.Type)
+			server.SetURL(item.URL)
+			server.SetCommand(item.Command)
+			server.SetArgs(item.Args)
+			server.SetEnv(item.Env)
+			server.SetHeaders(item.Headers)
+			servers.SetServer(name, server)
+		}
+		cfg.SetMCPServers(servers)
+	}
 	return cfg
 }
 
 func (c *SessionProfileController) toResponse(p *entities.SessionProfile) SessionProfileResponse {
 	cfg := p.Config()
+	mcpServers := make(map[string]*MCPServerRequest)
+	if cfg.MCPServers() != nil {
+		for name, server := range cfg.MCPServers().Servers() {
+			mcpServers[name] = &MCPServerRequest{Type: server.Type(), URL: server.URL(), Command: server.Command(), Args: server.Args(), Env: server.Env(), Headers: server.Headers()}
+		}
+	}
 	return SessionProfileResponse{
 		ID:           p.ID(),
 		Name:         p.Name(),
@@ -356,6 +395,7 @@ func (c *SessionProfileController) toResponse(p *entities.SessionProfile) Sessio
 			SandboxPolicyID:        cfg.SandboxPolicyID(),
 			SessionTTL:             cfg.SessionTTL(),
 			UnsyncedFilePaths:      cfg.UnsyncedFilePaths(),
+			MCPServers:             mcpServers,
 		},
 		CreatedAt: p.CreatedAt().Format(time.RFC3339),
 		UpdatedAt: p.UpdatedAt().Format(time.RFC3339),

--- a/internal/usecases/session/launch.go
+++ b/internal/usecases/session/launch.go
@@ -42,6 +42,7 @@ type LaunchRequest struct {
 	SessionTTL               string
 	UnsyncedFilePaths        []string
 	CredentialSource         string
+	ProfileMCPServers        *entities.MCPServersSettings
 
 	// Webhook payload to mount in the session filesystem (optional)
 	WebhookPayload []byte
@@ -210,6 +211,7 @@ func (uc *LaunchUseCase) Launch(ctx context.Context, sessionID string, req Launc
 		SessionTTL:               req.SessionTTL,
 		UnsyncedFilePaths:        req.UnsyncedFilePaths,
 		CredentialSource:         req.CredentialSource,
+		ProfileMCPServers:        req.ProfileMCPServers,
 	}
 
 	session, err := uc.sessionManager.CreateSession(ctx, sessionID, runReq, req.WebhookPayload)
@@ -337,6 +339,9 @@ func selectProfileByTags(profiles []*entities.SessionProfile, tags map[string]st
 // applyProfileToLaunchRequest merges a SessionProfileConfig into a LaunchRequest.
 // The profile provides the base; explicit request fields override.
 func applyProfileToLaunchRequest(cfg entities.SessionProfileConfig, req *LaunchRequest) {
+	if cfg.MCPServers() != nil {
+		req.ProfileMCPServers = cfg.MCPServers()
+	}
 	// Environment: profile is base, request overrides key-by-key
 	if len(cfg.Environment()) > 0 {
 		merged := make(map[string]string, len(cfg.Environment()))

--- a/internal/usecases/session/launch_test.go
+++ b/internal/usecases/session/launch_test.go
@@ -134,6 +134,36 @@ func TestLaunchAppliesDefaultProfileDocker(t *testing.T) {
 	}
 }
 
+func TestLaunchPropagatesProfileMCPServers(t *testing.T) {
+	sessionManager := &recordingSessionManager{}
+	profile := entities.NewSessionProfile("profile-1", "mcp", "user-1")
+	profile.SetIsDefault(true)
+	servers := entities.NewMCPServersSettings()
+	github := entities.NewMCPServer("github", "http")
+	github.SetURL("https://mcp.example.com/github")
+	github.SetHeaders(map[string]string{"Authorization": "Bearer token"})
+	servers.SetServer("github", github)
+	cfg := entities.NewSessionProfileConfig()
+	cfg.SetMCPServers(servers)
+	profile.SetConfig(cfg)
+
+	launcher := NewLaunchUseCase(sessionManager).WithSessionProfileRepository(
+		&fakeSessionProfileRepo{profiles: []*entities.SessionProfile{profile}},
+	)
+	if _, err := launcher.Launch(context.Background(), "session-1", LaunchRequest{
+		UserID: "user-1", Scope: entities.ScopeUser,
+	}); err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if sessionManager.req == nil || sessionManager.req.ProfileMCPServers == nil {
+		t.Fatal("profile MCP servers were not propagated")
+	}
+	got := sessionManager.req.ProfileMCPServers.GetServer("github")
+	if got == nil || got.URL() != "https://mcp.example.com/github" || got.Headers()["Authorization"] != "Bearer token" {
+		t.Fatalf("unexpected MCP server: %#v", got)
+	}
+}
+
 func TestLaunchAppliesDefaultProfileSandbox(t *testing.T) {
 	sessionManager := &recordingSessionManager{}
 	profile := entities.NewSessionProfile("profile-1", "default", "user-1")

--- a/pkg/github_sync/syncer.go
+++ b/pkg/github_sync/syncer.go
@@ -1411,26 +1411,36 @@ func sanitizeFilename(name string) string {
 
 // sessionProfileRecord is the YAML on-disk representation of a SessionProfile.
 type sessionProfileRecord struct {
-	ID                     string                      `yaml:"id"`
-	Name                   string                      `yaml:"name"`
-	Description            string                      `yaml:"description,omitempty"`
-	UserID                 string                      `yaml:"user_id"`
-	Scope                  string                      `yaml:"scope"`
-	TeamID                 string                      `yaml:"team_id,omitempty"`
-	IsDefault              bool                        `yaml:"is_default,omitempty"`
-	SelectorTags           map[string]string           `yaml:"selector_tags,omitempty"`
-	Environment            map[string]string           `yaml:"environment,omitempty"`
-	Tags                   map[string]string           `yaml:"tags,omitempty"`
-	InitialMessageTemplate string                      `yaml:"initial_message_template,omitempty"`
-	ReuseMessageTemplate   string                      `yaml:"reuse_message_template,omitempty"`
-	ReuseSession           bool                        `yaml:"reuse_session,omitempty"`
-	MemoryKey              map[string]string           `yaml:"memory_key,omitempty"`
-	UnsyncedFilePaths      []string                    `yaml:"unsynced_file_paths,omitempty"`
-	Params                 *sessionProfileParamsRecord `yaml:"params,omitempty"`
-	GitHubToken            string                      `yaml:"github_token,omitempty"`
-	InitialMessage         string                      `yaml:"initial_message,omitempty"`
-	CreatedAt              string                      `yaml:"created_at,omitempty"`
-	UpdatedAt              string                      `yaml:"updated_at,omitempty"`
+	ID                     string                                    `yaml:"id"`
+	Name                   string                                    `yaml:"name"`
+	Description            string                                    `yaml:"description,omitempty"`
+	UserID                 string                                    `yaml:"user_id"`
+	Scope                  string                                    `yaml:"scope"`
+	TeamID                 string                                    `yaml:"team_id,omitempty"`
+	IsDefault              bool                                      `yaml:"is_default,omitempty"`
+	SelectorTags           map[string]string                         `yaml:"selector_tags,omitempty"`
+	Environment            map[string]string                         `yaml:"environment,omitempty"`
+	Tags                   map[string]string                         `yaml:"tags,omitempty"`
+	InitialMessageTemplate string                                    `yaml:"initial_message_template,omitempty"`
+	ReuseMessageTemplate   string                                    `yaml:"reuse_message_template,omitempty"`
+	ReuseSession           bool                                      `yaml:"reuse_session,omitempty"`
+	MemoryKey              map[string]string                         `yaml:"memory_key,omitempty"`
+	UnsyncedFilePaths      []string                                  `yaml:"unsynced_file_paths,omitempty"`
+	MCPServers             map[string]*sessionProfileMCPServerRecord `yaml:"mcp_servers,omitempty"`
+	Params                 *sessionProfileParamsRecord               `yaml:"params,omitempty"`
+	GitHubToken            string                                    `yaml:"github_token,omitempty"`
+	InitialMessage         string                                    `yaml:"initial_message,omitempty"`
+	CreatedAt              string                                    `yaml:"created_at,omitempty"`
+	UpdatedAt              string                                    `yaml:"updated_at,omitempty"`
+}
+
+type sessionProfileMCPServerRecord struct {
+	Type    string            `yaml:"type"`
+	URL     string            `yaml:"url,omitempty"`
+	Command string            `yaml:"command,omitempty"`
+	Args    []string          `yaml:"args,omitempty"`
+	Env     map[string]string `yaml:"env,omitempty"`
+	Headers map[string]string `yaml:"headers,omitempty"`
 }
 
 type sessionProfileParamsRecord struct {
@@ -1495,6 +1505,20 @@ func sessionProfileToRecord(p *entities.SessionProfile, dek []byte) (sessionProf
 		CreatedAt:              p.CreatedAt().Format(time.RFC3339),
 		UpdatedAt:              p.UpdatedAt().Format(time.RFC3339),
 	}
+	if servers := cfg.MCPServers(); servers != nil && !servers.IsEmpty() {
+		rec.MCPServers = make(map[string]*sessionProfileMCPServerRecord, len(servers.Servers()))
+		for name, server := range servers.Servers() {
+			env, err := encryptSessionProfileMCPMap(dek, server.Env(), "mcp_servers."+name+".env")
+			if err != nil {
+				return sessionProfileRecord{}, err
+			}
+			headers, err := encryptSessionProfileMCPMap(dek, server.Headers(), "mcp_servers."+name+".headers")
+			if err != nil {
+				return sessionProfileRecord{}, err
+			}
+			rec.MCPServers[name] = &sessionProfileMCPServerRecord{Type: server.Type(), URL: server.URL(), Command: server.Command(), Args: server.Args(), Env: env, Headers: headers}
+		}
+	}
 	if params := cfg.Params(); params != nil {
 		paramsRec := sessionParamsToRecord(params)
 		if paramsRec.GitHubToken != "" && !IsEncrypted(paramsRec.GitHubToken) {
@@ -1507,6 +1531,22 @@ func sessionProfileToRecord(p *entities.SessionProfile, dek []byte) (sessionProf
 		rec.Params = paramsRec
 	}
 	return rec, nil
+}
+
+func encryptSessionProfileMCPMap(dek []byte, values map[string]string, field string) (map[string]string, error) {
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		if IsEncrypted(value) {
+			result[key] = value
+			continue
+		}
+		encrypted, err := EncryptField(dek, value)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt session profile %s.%s: %w", field, key, err)
+		}
+		result[key] = encrypted
+	}
+	return result, nil
 }
 
 func sessionParamsToRecord(p *entities.SessionParams) *sessionProfileParamsRecord {
@@ -1725,10 +1765,50 @@ func (s *Syncer) importSessionProfileFile(ctx context.Context, data []byte, scop
 	if params != nil {
 		cfg.SetParams(sessionParamsFromRecord(params))
 	}
+	if len(rec.MCPServers) > 0 {
+		servers := entities.NewMCPServersSettings()
+		for name, item := range rec.MCPServers {
+			if item == nil {
+				continue
+			}
+			env, err := decryptSessionProfileMCPMap(dek, item.Env, "mcp_servers."+name+".env")
+			if err != nil {
+				return err
+			}
+			headers, err := decryptSessionProfileMCPMap(dek, item.Headers, "mcp_servers."+name+".headers")
+			if err != nil {
+				return err
+			}
+			server := entities.NewMCPServer(name, item.Type)
+			server.SetURL(item.URL)
+			server.SetCommand(item.Command)
+			server.SetArgs(item.Args)
+			server.SetEnv(env)
+			server.SetHeaders(headers)
+			servers.SetServer(name, server)
+		}
+		cfg.SetMCPServers(servers)
+	}
 	p.SetConfig(cfg)
 
 	if existing != nil {
 		return s.sessionProfileRepo.Update(ctx, p)
 	}
 	return s.sessionProfileRepo.Create(ctx, p)
+}
+
+func decryptSessionProfileMCPMap(dek []byte, values map[string]string, field string) (map[string]string, error) {
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		if !IsEncrypted(value) {
+			result[key] = value
+			continue
+		}
+		plain, err := DecryptField(dek, value)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt session profile %s.%s: %w", field, key, err)
+		}
+		result[key] = plain
+	}
+	return result, nil
 }

--- a/pkg/github_sync/syncer_session_profile_test.go
+++ b/pkg/github_sync/syncer_session_profile_test.go
@@ -17,6 +17,13 @@ func TestSessionProfileToRecordEncryptsAllEnvironmentValues(t *testing.T) {
 		"PUBLIC_VALUE": "not-secret",
 		"API_TOKEN":    "secret-token",
 	})
+	servers := entities.NewMCPServersSettings()
+	mcpServer := entities.NewMCPServer("github", "http")
+	mcpServer.SetURL("https://mcp.example.com")
+	mcpServer.SetEnv(map[string]string{"TOKEN": "mcp-env-secret"})
+	mcpServer.SetHeaders(map[string]string{"Authorization": "mcp-header-secret"})
+	servers.SetServer("github", mcpServer)
+	cfg.SetMCPServers(servers)
 	cfg.SetParams(&entities.SessionParams{
 		Message:      "hello",
 		GithubToken:  "ghp_secret",
@@ -78,6 +85,8 @@ func TestSessionProfileToRecordEncryptsAllEnvironmentValues(t *testing.T) {
 		"not-secret",
 		"secret-token",
 		"ghp_secret",
+		"mcp-env-secret",
+		"mcp-header-secret",
 	} {
 		if strings.Contains(rendered, plaintext) {
 			t.Fatalf("exported YAML contains plaintext %q:\n%s", plaintext, rendered)

--- a/pkg/import/types.go
+++ b/pkg/import/types.go
@@ -259,4 +259,5 @@ type SessionProfileConfigImport struct {
 	ReuseSession           bool                            `yaml:"reuse_session,omitempty" toml:"reuse_session,omitempty" json:"reuse_session,omitempty"`
 	MemoryKey              map[string]string               `yaml:"memory_key,omitempty" toml:"memory_key,omitempty" json:"memory_key,omitempty"`
 	UnsyncedFilePaths      []string                        `yaml:"unsynced_file_paths,omitempty" toml:"unsynced_file_paths,omitempty" json:"unsynced_file_paths,omitempty"`
+	MCPServers             map[string]*MCPServerImport     `yaml:"mcp_servers,omitempty" toml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7855,6 +7855,13 @@
           "example": [
             "/home/agentapi/.codex/auth.json"
           ]
+        },
+        "mcp_servers": {
+          "type": "object",
+          "description": "MCP servers enabled for sessions using this profile. Entries override tenant settings by server name; unmentioned tenant servers are inherited.",
+          "additionalProperties": {
+            "$ref": "#/components/schemas/MCPServerRequest"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- add `config.mcp_servers` to session profile CRUD and OpenAPI
- apply profile MCP servers as a settings layer (`base → team → user → profile → oneshot`)
- propagate the profile layer across direct, scheduled/webhook/slackbot, and external-manager launches
- persist profile MCP settings and encrypt MCP env/header values during GitHub sync
- document the matching `takutakahashi/agentapi-ui` implementation design and component reuse

## Verification

- `golangci-lint run --timeout=5m` — 0 issues
- targeted Go tests for affected packages — passed
- `jq empty spec/openapi.json` — passed
- `make test` — attempted, but this runtime has no `gcc`, so `CGO_ENABLED=1 go test -race ./...` cannot build `runtime/cgo`
