### PR TITLE
refactor: move telemetry labels into provisioner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,23 +96,6 @@ RUN ARCH=$(dpkg --print-architecture) && \
       -o /usr/local/bin/acp-posts && \
     chmod +x /usr/local/bin/acp-posts
 
-# Download otelcol-contrib binary for in-process OpenTelemetry Collector support.
-# Used when OtelCollectorInProcess=true (e.g. when stock inventory is enabled) so
-# that otelcol starts after user context is known instead of at Pod creation time.
-ARG OTELCOL_VERSION=0.143.1
-RUN ARCH=$(dpkg --print-architecture) && \
-    case "$ARCH" in \
-      amd64) OTELCOL_ARCH="linux_amd64" ;; \
-      arm64) OTELCOL_ARCH="linux_arm64" ;; \
-      *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_VERSION}/otelcol-contrib_${OTELCOL_VERSION}_${OTELCOL_ARCH}.tar.gz" \
-      -o /tmp/otelcol.tar.gz && \
-    tar -xzf /tmp/otelcol.tar.gz -C /tmp otelcol-contrib && \
-    mv /tmp/otelcol-contrib /usr/local/bin/otelcol && \
-    chmod +x /usr/local/bin/otelcol && \
-    rm /tmp/otelcol.tar.gz
-
 # Pre-create /opt/webhook so that the agent-provisioner (running as agentapi)
 # can write the webhook payload file for stock sessions.  In non-stock sessions
 # this directory is provided by the Kubernetes Secret volume mount, but stock

--- a/helm/agentapi-proxy/templates/deployment.yaml
+++ b/helm/agentapi-proxy/templates/deployment.yaml
@@ -388,22 +388,6 @@ spec:
             {{- if .Values.kubernetesSession.otelCollector.enabled }}
             - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_ENABLED
               value: {{ .Values.kubernetesSession.otelCollector.enabled | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_IMAGE
-              value: {{ .Values.kubernetesSession.otelCollector.image | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_SCRAPE_INTERVAL
-              value: {{ .Values.kubernetesSession.otelCollector.scrapeInterval | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CLAUDE_CODE_PORT
-              value: {{ .Values.kubernetesSession.otelCollector.claudeCodeMetricsPort | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_EXPORTER_PORT
-              value: {{ .Values.kubernetesSession.otelCollector.exporterPort | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CPU_REQUEST
-              value: {{ .Values.kubernetesSession.otelCollector.resources.requests.cpu | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CPU_LIMIT
-              value: {{ .Values.kubernetesSession.otelCollector.resources.limits.cpu | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_MEMORY_REQUEST
-              value: {{ .Values.kubernetesSession.otelCollector.resources.requests.memory | quote }}
-            - name: AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_MEMORY_LIMIT
-              value: {{ .Values.kubernetesSession.otelCollector.resources.limits.memory | quote }}
             {{- end }}
             # Settings base secret (proxy-side merge of settings.json)
             - name: AGENTAPI_K8S_SESSION_SETTINGS_BASE_SECRET

--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -675,35 +675,11 @@ kubernetesSession:
       # Defaults to "signing-secret"
       key: "signing-secret"
 
-  # OpenTelemetry Collector Configuration
-  # Enables Prometheus metrics collection from Claude Code in session pods.
-  # otelcol always runs as an in-process subprocess inside the agentapi container,
-  # started by the provisioner after user context is established. This ensures
-  # metrics labels (user_id, session_id, etc.) are correct even with stock sessions.
+  # Claude Code telemetry configuration.
+  # The legacy otelCollector name is retained for compatibility. No collector
+  # process is started; the provisioner adds agentapi resource attributes directly.
   otelCollector:
     enabled: true
-
-    # Container image for otelcol (used to pull the binary into the agentapi image)
-    image: "otel/opentelemetry-collector-contrib:0.143.1"
-
-    # Scrape interval for Claude Code metrics
-    scrapeInterval: "15s"
-
-    # Claude Code metrics port (where OTEL_METRICS_EXPORTER=prometheus exposes metrics)
-    claudeCodeMetricsPort: 9464
-
-    # Exporter port (where otelcol exposes labeled metrics)
-    exporterPort: 9090
-
-    # Resource limits are not applicable in in-process mode (otelcol shares the
-    # agentapi container resources). Kept for reference only.
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "128Mi"
-      limits:
-        cpu: "200m"
-        memory: "256Mi"
 
 # Schedule Worker Configuration
 # Enables delayed start and recurring (cron-based) session scheduling

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -47,7 +47,10 @@ import (
 // provisionerPort is the TCP port on which agent-provisioner listens inside session Pods.
 // It serves local health/status and sandbox-domain endpoints; provisioning work
 // is pulled from the proxy internal API by the session Pod.
-const provisionerPort = 9001
+const (
+	provisionerPort         = 9001
+	telemetryPrometheusPort = 9090
+)
 
 // ProvisionerPort is the exported version of provisionerPort for use by other packages
 // (e.g. the session controller error handler that checks provisioner /status).
@@ -2235,6 +2238,11 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 
 	// Build pod annotations
 	podAnnotations := make(map[string]string)
+	if m.k8sConfig.OtelCollectorEnabled {
+		podAnnotations["prometheus.io/scrape"] = "true"
+		podAnnotations["prometheus.io/port"] = strconv.Itoa(telemetryPrometheusPort)
+		podAnnotations["prometheus.io/path"] = "/metrics"
+	}
 
 	affinity, err := sessionAffinity(m.k8sConfig.Affinity)
 	if err != nil {
@@ -4555,6 +4563,15 @@ func (m *KubernetesSessionManager) buildServicePorts(session *KubernetesSession)
 		},
 	}
 
+	if m.k8sConfig.OtelCollectorEnabled {
+		ports = append(ports, corev1.ServicePort{
+			Name:       "metrics",
+			Port:       telemetryPrometheusPort,
+			TargetPort: intstr.FromInt(telemetryPrometheusPort),
+			Protocol:   corev1.ProtocolTCP,
+		})
+	}
+
 	return ports
 }
 
@@ -5162,13 +5179,14 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		}
 
 		settings.Telemetry = &sessionsettings.TelemetryConfig{
-			Enabled:    true,
-			SessionID:  session.id,
-			UserID:     req.UserID,
-			TeamID:     teamID,
-			ScheduleID: scheduleID,
-			WebhookID:  webhookID,
-			AgentType:  agentType,
+			Enabled:        true,
+			PrometheusPort: telemetryPrometheusPort,
+			SessionID:      session.id,
+			UserID:         req.UserID,
+			TeamID:         teamID,
+			ScheduleID:     scheduleID,
+			WebhookID:      webhookID,
+			AgentType:      agentType,
 		}
 		log.Printf("[K8S_SESSION] Telemetry labels embedded for session %s", session.id)
 	}

--- a/internal/infrastructure/services/kubernetes_session_manager.go
+++ b/internal/infrastructure/services/kubernetes_session_manager.go
@@ -215,12 +215,6 @@ func NewKubernetesSessionManagerWithClient(
 		return nil, fmt.Errorf("failed to ensure provisioner token: %w", err)
 	}
 
-	// Ensure OpenTelemetry Collector ConfigMap exists
-	if err := manager.ensureOtelcolConfigMap(ctx); err != nil {
-		log.Printf("[K8S_SESSION] Warning: Failed to ensure otelcol ConfigMap: %v", err)
-		// Don't fail initialization if ConfigMap creation fails
-	}
-
 	return manager, nil
 }
 
@@ -2224,10 +2218,6 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 	// by agent-provisioner (pkg/provisioner/provision.go) after agentapi starts.
 	// This avoids running claude-posts twice when stock sessions are used.
 
-	// otelcol runs as a subprocess inside the agentapi container (in-process mode).
-	// No sidecar is added here; the provisioner starts otelcol after user context
-	// is established so that metrics labels are correct even with stock sessions.
-
 	// Convert config tolerations to corev1 tolerations
 	var tolerations []corev1.Toleration
 	for _, t := range m.k8sConfig.Tolerations {
@@ -2245,18 +2235,6 @@ func (m *KubernetesSessionManager) buildDeployment(ctx context.Context, session 
 
 	// Build pod annotations
 	podAnnotations := make(map[string]string)
-
-	// Add Prometheus scrape annotations for otelcol sidecar if enabled
-	if m.k8sConfig.OtelCollectorEnabled {
-		exporterPort := 9090
-		if m.k8sConfig.OtelCollectorExporterPort > 0 {
-			exporterPort = m.k8sConfig.OtelCollectorExporterPort
-		}
-
-		podAnnotations["prometheus.io/scrape"] = "true"
-		podAnnotations["prometheus.io/port"] = fmt.Sprintf("%d", exporterPort)
-		podAnnotations["prometheus.io/path"] = "/metrics"
-	}
 
 	affinity, err := sessionAffinity(m.k8sConfig.Affinity)
 	if err != nil {
@@ -3284,9 +3262,6 @@ func (m *KubernetesSessionManager) buildVolumes(session *KubernetesSession) []co
 		})
 	}
 
-	// No otelcol ConfigMap volume needed: otelcol runs as an in-process subprocess
-	// and generates its config file at /tmp/otelcol-config.yaml at provisioning time.
-
 	return volumes
 }
 
@@ -3611,14 +3586,6 @@ func (m *KubernetesSessionManager) buildEnvVars(session *KubernetesSession, req 
 		{Name: "HOME", Value: "/home/agentapi"},
 		// GitHub App PEM path (file is written by setup directly to container FS)
 		{Name: "GITHUB_APP_PEM_PATH", Value: "/tmp/github-app/app.pem"},
-	}
-
-	// Add Claude Code telemetry configuration
-	if m.k8sConfig.OtelCollectorEnabled {
-		envVars = append(envVars,
-			corev1.EnvVar{Name: "CLAUDE_CODE_ENABLE_TELEMETRY", Value: "1"},
-			corev1.EnvVar{Name: "OTEL_METRICS_EXPORTER", Value: "prometheus"},
-		)
 	}
 
 	// Add Team ID if in team scope
@@ -4570,116 +4537,6 @@ func (m *KubernetesSessionManager) getStatusFromWorkloadObject(deployment *appsv
 	return "unhealthy"
 }
 
-// ensureOtelcolConfigMap creates or updates the OpenTelemetry Collector ConfigMap
-func (m *KubernetesSessionManager) ensureOtelcolConfigMap(ctx context.Context) error {
-	if !m.k8sConfig.OtelCollectorEnabled {
-		return nil
-	}
-
-	configMapName := "otelcol-config"
-	scrapeInterval := "15s"
-	if m.k8sConfig.OtelCollectorScrapeInterval != "" {
-		scrapeInterval = m.k8sConfig.OtelCollectorScrapeInterval
-	}
-	claudeCodePort := 9464
-	if m.k8sConfig.OtelCollectorClaudeCodePort > 0 {
-		claudeCodePort = m.k8sConfig.OtelCollectorClaudeCodePort
-	}
-	exporterPort := 9090
-	if m.k8sConfig.OtelCollectorExporterPort > 0 {
-		exporterPort = m.k8sConfig.OtelCollectorExporterPort
-	}
-
-	otelConfig := fmt.Sprintf(`receivers:
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: 'claude-code'
-          scrape_interval: %s
-          static_configs:
-            - targets: ['localhost:%d']
-
-processors:
-  resource:
-    attributes:
-      - key: user_id
-        action: delete
-      - key: session_id
-        action: delete
-  transform:
-    error_mode: ignore
-    metric_statements:
-      - context: datapoint
-        statements:
-          # Rename claude-code's native labels
-          - set(attributes["claude_user_id"], attributes["user_id"]) where attributes["user_id"] != nil
-          - set(attributes["claude_session_id"], attributes["session_id"]) where attributes["session_id"] != nil
-          - delete_key(attributes, "user_id")
-          - delete_key(attributes, "session_id")
-          # Remove user_email label to prevent it from being scraped by Prometheus
-          - delete_key(attributes, "user_email")
-          # Add agentapi labels
-          - set(attributes["agentapi_session_id"], "${env:SESSION_ID}")
-          - set(attributes["agentapi_user_id"], "${env:USER_ID}")
-          - set(attributes["agentapi_team_id"], "${env:TEAM_ID}")
-          - set(attributes["agentapi_schedule_id"], "${env:SCHEDULE_ID}")
-          - set(attributes["agentapi_webhook_id"], "${env:WEBHOOK_ID}")
-          - set(attributes["agentapi_agent_type"], "${env:AGENT_TYPE}")
-
-exporters:
-  prometheus:
-    endpoint: "0.0.0.0:%d"
-    resource_to_telemetry_conversion:
-      enabled: false
-
-service:
-  pipelines:
-    metrics:
-      receivers: [prometheus]
-      processors: [resource, transform]
-      exporters: [prometheus]`, scrapeInterval, claudeCodePort, exporterPort)
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: m.namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       "otelcol",
-				"app.kubernetes.io/managed-by": "agentapi-proxy",
-				"app.kubernetes.io/component":  "telemetry",
-			},
-		},
-		Data: map[string]string{
-			"otel-collector-config.yaml": otelConfig,
-		},
-	}
-
-	// Try to get existing ConfigMap
-	existingCM, err := m.client.CoreV1().ConfigMaps(m.namespace).Get(ctx, configMapName, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// Create new ConfigMap
-			_, err = m.client.CoreV1().ConfigMaps(m.namespace).Create(ctx, configMap, metav1.CreateOptions{})
-			if err != nil {
-				return fmt.Errorf("failed to create otelcol ConfigMap: %w", err)
-			}
-			log.Printf("[K8S_SESSION] Created otelcol ConfigMap: %s", configMapName)
-			return nil
-		}
-		return fmt.Errorf("failed to get otelcol ConfigMap: %w", err)
-	}
-
-	// Update existing ConfigMap
-	existingCM.Data = configMap.Data
-	existingCM.Labels = configMap.Labels
-	_, err = m.client.CoreV1().ConfigMaps(m.namespace).Update(ctx, existingCM, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to update otelcol ConfigMap: %w", err)
-	}
-	log.Printf("[K8S_SESSION] Updated otelcol ConfigMap: %s", configMapName)
-	return nil
-}
-
 // buildServicePorts builds the service ports for the session
 func (m *KubernetesSessionManager) buildServicePorts(session *KubernetesSession) []corev1.ServicePort {
 	ports := []corev1.ServicePort{
@@ -4696,20 +4553,6 @@ func (m *KubernetesSessionManager) buildServicePorts(session *KubernetesSession)
 			TargetPort: intstr.FromInt(provisionerPort),
 			Protocol:   corev1.ProtocolTCP,
 		},
-	}
-
-	// Add metrics port if otelcol is enabled
-	if m.k8sConfig.OtelCollectorEnabled {
-		exporterPort := 9090
-		if m.k8sConfig.OtelCollectorExporterPort > 0 {
-			exporterPort = m.k8sConfig.OtelCollectorExporterPort
-		}
-		ports = append(ports, corev1.ServicePort{
-			Name:       "metrics",
-			Port:       int32(exporterPort),
-			TargetPort: intstr.FromInt(exporterPort),
-			Protocol:   corev1.ProtocolTCP,
-		})
 	}
 
 	return ports
@@ -4911,12 +4754,6 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		"AGENTAPI_USER_ID":    req.UserID,
 		"HOME":                "/home/agentapi",
 		"GITHUB_APP_PEM_PATH": "/tmp/github-app/app.pem",
-	}
-
-	// Add Claude Code telemetry configuration
-	if m.k8sConfig.OtelCollectorEnabled {
-		env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
-		env["OTEL_METRICS_EXPORTER"] = "prometheus"
 	}
 
 	// Add Team ID if in team scope
@@ -5301,23 +5138,10 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 		}
 	}
 
-	// OtelCollector in-process config: otelcol always runs as a subprocess inside
-	// the agentapi container, started by the provisioner after user context is known.
-	// This ensures metrics labels are correct even with the stock inventory feature.
+	// Telemetry labels are applied by the provisioner after the session identity is
+	// known. The legacy otelCollector.enabled value remains the feature gate so
+	// existing Helm values continue to enable Claude Code telemetry.
 	if m.k8sConfig.OtelCollectorEnabled {
-		scrapeInterval := "15s"
-		if m.k8sConfig.OtelCollectorScrapeInterval != "" {
-			scrapeInterval = m.k8sConfig.OtelCollectorScrapeInterval
-		}
-		claudeCodePort := 9464
-		if m.k8sConfig.OtelCollectorClaudeCodePort > 0 {
-			claudeCodePort = m.k8sConfig.OtelCollectorClaudeCodePort
-		}
-		exporterPort := 9090
-		if m.k8sConfig.OtelCollectorExporterPort > 0 {
-			exporterPort = m.k8sConfig.OtelCollectorExporterPort
-		}
-
 		scheduleID := "-"
 		webhookID := "-"
 		if req.Tags != nil {
@@ -5337,19 +5161,16 @@ func (m *KubernetesSessionManager) buildSessionSettings(
 			teamID = req.TeamID
 		}
 
-		settings.OtelCollector = &sessionsettings.OtelCollectorConfig{
-			Enabled:        true,
-			ScrapeInterval: scrapeInterval,
-			ClaudeCodePort: claudeCodePort,
-			ExporterPort:   exporterPort,
-			SessionID:      session.id,
-			UserID:         req.UserID,
-			TeamID:         teamID,
-			ScheduleID:     scheduleID,
-			WebhookID:      webhookID,
-			AgentType:      agentType,
+		settings.Telemetry = &sessionsettings.TelemetryConfig{
+			Enabled:    true,
+			SessionID:  session.id,
+			UserID:     req.UserID,
+			TeamID:     teamID,
+			ScheduleID: scheduleID,
+			WebhookID:  webhookID,
+			AgentType:  agentType,
 		}
-		log.Printf("[K8S_SESSION] OtelCollector in-process config embedded for session %s", session.id)
+		log.Printf("[K8S_SESSION] Telemetry labels embedded for session %s", session.id)
 	}
 
 	// Embed managed files from the selected credential owner so that

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -50,7 +50,7 @@ func TestBuildSessionSettings_EmbedsProvisionerTelemetryLabels(t *testing.T) {
 		t.Fatal("Telemetry config is nil")
 	}
 	want := sessionsettings.TelemetryConfig{
-		Enabled: true, SessionID: "test-session", UserID: "test-user",
+		Enabled: true, PrometheusPort: 9090, SessionID: "test-session", UserID: "test-user",
 		TeamID: "org/team-a", ScheduleID: "schedule-1", WebhookID: "webhook-1", AgentType: "claude",
 	}
 	if got := *settings.Telemetry; got != want {
@@ -58,6 +58,31 @@ func TestBuildSessionSettings_EmbedsProvisionerTelemetryLabels(t *testing.T) {
 	}
 	if _, ok := settings.Env["OTEL_RESOURCE_ATTRIBUTES"]; ok {
 		t.Fatal("manager should leave OTEL_RESOURCE_ATTRIBUTES to the provisioner")
+	}
+}
+
+func TestBuildServicePorts_PreservesTelemetryExporterPort(t *testing.T) {
+	manager := &KubernetesSessionManager{
+		k8sConfig: &config.KubernetesSessionConfig{
+			BasePort:             8080,
+			OtelCollectorEnabled: true,
+		},
+	}
+	session := &KubernetesSession{servicePort: 8080}
+
+	ports := manager.buildServicePorts(session)
+	var metricsPort *corev1.ServicePort
+	for i := range ports {
+		if ports[i].Name == "metrics" {
+			metricsPort = &ports[i]
+			break
+		}
+	}
+	if metricsPort == nil {
+		t.Fatal("metrics service port is missing")
+	}
+	if metricsPort.Port != 9090 || metricsPort.TargetPort.IntValue() != 9090 {
+		t.Fatalf("metrics port = %#v, want port and targetPort 9090", *metricsPort)
 	}
 }
 

--- a/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_settings_test.go
@@ -20,6 +20,47 @@ type fakeSettingsRepository struct {
 	settings map[string]*entities.Settings
 }
 
+func TestBuildSessionSettings_EmbedsProvisionerTelemetryLabels(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+	})
+	cfg := &config.Config{KubernetesSession: config.KubernetesSessionConfig{
+		Namespace: "test-ns", Image: "test-image:latest", BasePort: 9000,
+		PVCEnabled: boolPtrForTest(false), OtelCollectorEnabled: true,
+	}}
+	manager, err := NewKubernetesSessionManagerWithClient(cfg, false, logger.NewLogger(), k8sClient)
+	if err != nil {
+		t.Fatalf("NewKubernetesSessionManagerWithClient() error = %v", err)
+	}
+	session := NewKubernetesSession("test-session", &entities.RunServerRequest{UserID: "test-user"},
+		"test-deploy", "test-service", "test-pvc", "test-ns", 9000, nil, nil)
+	req := &entities.RunServerRequest{
+		UserID:    "test-user",
+		Scope:     entities.ScopeTeam,
+		TeamID:    "org/team-a",
+		AgentType: "claude",
+		Tags: map[string]string{
+			"schedule_id": "schedule-1",
+			"webhook_id":  "webhook-1",
+		},
+	}
+
+	settings := manager.buildSessionSettings(context.Background(), session, req, nil)
+	if settings.Telemetry == nil {
+		t.Fatal("Telemetry config is nil")
+	}
+	want := sessionsettings.TelemetryConfig{
+		Enabled: true, SessionID: "test-session", UserID: "test-user",
+		TeamID: "org/team-a", ScheduleID: "schedule-1", WebhookID: "webhook-1", AgentType: "claude",
+	}
+	if got := *settings.Telemetry; got != want {
+		t.Fatalf("Telemetry = %#v, want %#v", got, want)
+	}
+	if _, ok := settings.Env["OTEL_RESOURCE_ATTRIBUTES"]; ok {
+		t.Fatal("manager should leave OTEL_RESOURCE_ATTRIBUTES to the provisioner")
+	}
+}
+
 func TestBuildSessionSettings_TeamScopeUsesSessionUserCredentialsWhenSelected(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-ns"}},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -338,25 +338,10 @@ type KubernetesSessionConfig struct {
 	// level during session settings generation. Team and user settings can override it.
 	SettingsBaseSecret string `json:"settings_base_secret" mapstructure:"settings_base_secret"`
 
-	// OpenTelemetry Collector configuration
-	// OtelCollectorEnabled enables OpenTelemetry Collector sidecar for metrics collection
+	// OtelCollectorEnabled is the legacy configuration name that enables Claude
+	// Code telemetry. The provisioner now applies resource attributes directly;
+	// no OpenTelemetry Collector process is started.
 	OtelCollectorEnabled bool `json:"otel_collector_enabled" mapstructure:"otel_collector_enabled"`
-	// OtelCollectorImage is the container image for otelcol sidecar
-	OtelCollectorImage string `json:"otel_collector_image" mapstructure:"otel_collector_image"`
-	// OtelCollectorScrapeInterval is the scrape interval for Claude Code metrics
-	OtelCollectorScrapeInterval string `json:"otel_collector_scrape_interval" mapstructure:"otel_collector_scrape_interval"`
-	// OtelCollectorClaudeCodePort is the port where Claude Code exposes metrics
-	OtelCollectorClaudeCodePort int `json:"otel_collector_claude_code_port" mapstructure:"otel_collector_claude_code_port"`
-	// OtelCollectorExporterPort is the port where otelcol exposes labeled metrics
-	OtelCollectorExporterPort int `json:"otel_collector_exporter_port" mapstructure:"otel_collector_exporter_port"`
-	// OtelCollectorCPURequest is the CPU request for otelcol sidecar
-	OtelCollectorCPURequest string `json:"otel_collector_cpu_request" mapstructure:"otel_collector_cpu_request"`
-	// OtelCollectorCPULimit is the CPU limit for otelcol sidecar
-	OtelCollectorCPULimit string `json:"otel_collector_cpu_limit" mapstructure:"otel_collector_cpu_limit"`
-	// OtelCollectorMemoryRequest is the memory request for otelcol sidecar
-	OtelCollectorMemoryRequest string `json:"otel_collector_memory_request" mapstructure:"otel_collector_memory_request"`
-	// OtelCollectorMemoryLimit is the memory limit for otelcol sidecar
-	OtelCollectorMemoryLimit string `json:"otel_collector_memory_limit" mapstructure:"otel_collector_memory_limit"`
 
 	// Slack Integration configuration
 	// SlackBotTokenSecretName is the Kubernetes Secret name containing the Slack bot token
@@ -1105,14 +1090,6 @@ func bindEnvVars(v *viper.Viper) {
 
 	// OpenTelemetry Collector configuration
 	_ = v.BindEnv("kubernetes_session.otel_collector_enabled", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_ENABLED")
-	_ = v.BindEnv("kubernetes_session.otel_collector_image", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_IMAGE")
-	_ = v.BindEnv("kubernetes_session.otel_collector_scrape_interval", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_SCRAPE_INTERVAL")
-	_ = v.BindEnv("kubernetes_session.otel_collector_claude_code_port", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CLAUDE_CODE_PORT")
-	_ = v.BindEnv("kubernetes_session.otel_collector_exporter_port", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_EXPORTER_PORT")
-	_ = v.BindEnv("kubernetes_session.otel_collector_cpu_request", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CPU_REQUEST")
-	_ = v.BindEnv("kubernetes_session.otel_collector_cpu_limit", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_CPU_LIMIT")
-	_ = v.BindEnv("kubernetes_session.otel_collector_memory_request", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_MEMORY_REQUEST")
-	_ = v.BindEnv("kubernetes_session.otel_collector_memory_limit", "AGENTAPI_KUBERNETES_SESSION_OTEL_COLLECTOR_MEMORY_LIMIT")
 
 	// Slack Integration configuration
 	_ = v.BindEnv("kubernetes_session.slack_integration_image", "AGENTAPI_KUBERNETES_SESSION_SLACK_INTEGRATION_IMAGE")
@@ -1542,13 +1519,13 @@ func DefaultConfig() *Config {
 			},
 		},
 		StockInventoryWorker: StockInventoryWorkerConfig{
-			Enabled:        false,
-			CheckInterval:  "30s",
-			TargetCount:    2,
-			DockerEnabled:  false,
-			LeaseDuration:  "15s",
-			RenewDeadline:  "10s",
-			RetryPeriod:    "2s",
+			Enabled:       false,
+			CheckInterval: "30s",
+			TargetCount:   2,
+			DockerEnabled: false,
+			LeaseDuration: "15s",
+			RenewDeadline: "10s",
+			RetryPeriod:   "2s",
 		},
 		Asset: AssetConfig{
 			Backend:     "nginx",
@@ -1711,9 +1688,9 @@ func loadAuthConfigFromFile(config *Config, filename string) error {
 // K8sSessionConfigOverride represents kubernetes session configuration overrides from external file
 type K8sSessionConfigOverride struct {
 	KubernetesSession *struct {
-		NodeSelector          map[string]string `json:"node_selector,omitempty" yaml:"node_selector"`
+		NodeSelector map[string]string      `json:"node_selector,omitempty" yaml:"node_selector"`
 		Affinity     map[string]interface{} `json:"affinity,omitempty" yaml:"affinity"`
-		Tolerations           []Toleration      `json:"tolerations,omitempty" yaml:"tolerations"`
+		Tolerations  []Toleration           `json:"tolerations,omitempty" yaml:"tolerations"`
 	} `json:"kubernetes_session,omitempty" yaml:"kubernetes_session"`
 }
 

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -127,7 +128,7 @@ func normalizeNativeSettings(settings *sessionsettings.SessionSettings) {
 	}
 	delete(settings.Env, "AGENTAPI_SCIA_PROXY_URL")
 	delete(settings.Env, "AGENTAPI_SCIA_SESSION_SIDECAR_ENABLED")
-	settings.OtelCollector = nil
+	settings.Telemetry = nil
 	settings.Sandbox = nil
 }
 
@@ -256,6 +257,7 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 	// ── Step 3: load session env file ─────────────────────────────────────────
 	s.setPhase("provision:load-env")
 	envMap := loadEnvFile(sessionEnvFile)
+	configureTelemetry(settings, envMap)
 	log.Printf("[PROVISIONER] Loaded %d env vars from session env file", len(envMap))
 	prepareSciaCABundle(ctx, envMap)
 
@@ -302,14 +304,7 @@ func (s *Server) runProvision(ctx context.Context, settings *sessionsettings.Ses
 		}
 	}
 
-	// ── Step 6: start otelcol subprocess if in-process mode ──────────────────
-	// Must be started before agentapi so metrics scraping begins as soon as
-	// Claude Code starts emitting metrics on its prometheus port.
-	if settings.OtelCollector != nil && settings.OtelCollector.Enabled {
-		go s.runOtelcol(ctx, settings.OtelCollector)
-	}
-
-	// ── Step 7: build and start the agent subprocess ──────────────────────────
+	// ── Step 6: build and start the agent subprocess ──────────────────────────
 	s.setPhase("provision:start-agent")
 	agentCmd, agentArgs := s.buildAgentCommand(settings, envMap)
 	log.Printf("[PROVISIONER] Starting agent: %s %v", agentCmd, agentArgs)
@@ -957,105 +952,44 @@ func sanitizeCredentialSecretName(s string) string {
 	return s
 }
 
-// runOtelcol starts the OpenTelemetry Collector binary as a subprocess.
-// It is used when otelcol runs in in-process mode (OtelCollectorInProcess=true)
-// instead of as a Kubernetes sidecar. This allows otelcol to be started
-// after user context is established, so metrics labels (user_id, session_id,
-// etc.) are correctly set even when using the stock inventory feature.
-// The subprocess is tied to ctx: when ctx is cancelled the goroutine exits.
-func (s *Server) runOtelcol(ctx context.Context, cfg *sessionsettings.OtelCollectorConfig) {
-	const otelcolBin = "/usr/local/bin/otelcol"
-	const configPath = "/tmp/otelcol-config.yaml"
-
-	scrapeInterval := cfg.ScrapeInterval
-	if scrapeInterval == "" {
-		scrapeInterval = "15s"
-	}
-	claudeCodePort := cfg.ClaudeCodePort
-	if claudeCodePort == 0 {
-		claudeCodePort = 9464
-	}
-	exporterPort := cfg.ExporterPort
-	if exporterPort == 0 {
-		exporterPort = 9090
-	}
-
-	// Generate otelcol config with label values already substituted.
-	// Using Go fmt.Sprintf rather than otelcol ${env:VAR} expansion so that
-	// the correct values are used regardless of the container's own env vars
-	// (which may be unset in stock sessions at startup time).
-	otelConfig := fmt.Sprintf(`receivers:
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: 'claude-code'
-          scrape_interval: %s
-          static_configs:
-            - targets: ['localhost:%d']
-
-processors:
-  resource:
-    attributes:
-      - key: user_id
-        action: delete
-      - key: session_id
-        action: delete
-  transform:
-    error_mode: ignore
-    metric_statements:
-      - context: datapoint
-        statements:
-          # Rename claude-code's native labels
-          - set(attributes["claude_user_id"], attributes["user_id"]) where attributes["user_id"] != nil
-          - set(attributes["claude_session_id"], attributes["session_id"]) where attributes["session_id"] != nil
-          - delete_key(attributes, "user_id")
-          - delete_key(attributes, "session_id")
-          # Remove user_email label to prevent it from being scraped by Prometheus
-          - delete_key(attributes, "user_email")
-          # Add agentapi labels
-          - set(attributes["agentapi_session_id"], "%s")
-          - set(attributes["agentapi_user_id"], "%s")
-          - set(attributes["agentapi_team_id"], "%s")
-          - set(attributes["agentapi_schedule_id"], "%s")
-          - set(attributes["agentapi_webhook_id"], "%s")
-          - set(attributes["agentapi_agent_type"], "%s")
-
-exporters:
-  prometheus:
-    endpoint: "0.0.0.0:%d"
-    resource_to_telemetry_conversion:
-      enabled: false
-
-service:
-  pipelines:
-    metrics:
-      receivers: [prometheus]
-      processors: [resource, transform]
-      exporters: [prometheus]`,
-		scrapeInterval, claudeCodePort,
-		cfg.SessionID, cfg.UserID, cfg.TeamID,
-		cfg.ScheduleID, cfg.WebhookID, cfg.AgentType,
-		exporterPort)
-
-	if err := os.WriteFile(configPath, []byte(otelConfig), 0o600); err != nil {
-		log.Printf("[OTELCOL] Failed to write config to %s: %v", configPath, err)
+func configureTelemetry(settings *sessionsettings.SessionSettings, env map[string]string) {
+	if settings == nil || settings.Telemetry == nil || !settings.Telemetry.Enabled {
 		return
 	}
-	log.Printf("[OTELCOL] Config written to %s, starting otelcol subprocess", configPath)
 
-	cmd := exec.CommandContext(ctx, otelcolBin, "--config="+configPath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		if ctx.Err() != nil {
-			log.Printf("[OTELCOL] Exited due to context cancellation")
-		} else {
-			log.Printf("[OTELCOL] Exited with error: %v", err)
-		}
-	} else {
-		log.Printf("[OTELCOL] Exited normally")
+	cfg := settings.Telemetry
+	managed := map[string]string{
+		"agentapi_session_id":  cfg.SessionID,
+		"agentapi_user_id":     cfg.UserID,
+		"agentapi_team_id":     cfg.TeamID,
+		"agentapi_schedule_id": cfg.ScheduleID,
+		"agentapi_webhook_id":  cfg.WebhookID,
+		"agentapi_agent_type":  cfg.AgentType,
 	}
+
+	attributes := make([]string, 0, len(managed)+1)
+	for _, attribute := range strings.Split(env["OTEL_RESOURCE_ATTRIBUTES"], ",") {
+		attribute = strings.TrimSpace(attribute)
+		key, _, found := strings.Cut(attribute, "=")
+		_, reserved := managed[key]
+		if attribute != "" && (!found || !reserved) {
+			attributes = append(attributes, attribute)
+		}
+	}
+	for _, key := range []string{
+		"agentapi_session_id",
+		"agentapi_user_id",
+		"agentapi_team_id",
+		"agentapi_schedule_id",
+		"agentapi_webhook_id",
+		"agentapi_agent_type",
+	} {
+		attributes = append(attributes, key+"="+url.QueryEscape(managed[key]))
+	}
+
+	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+	env["OTEL_METRICS_EXPORTER"] = "prometheus"
+	env["OTEL_RESOURCE_ATTRIBUTES"] = strings.Join(attributes, ",")
 }
 
 // buildAgentCommand returns the executable and arguments for the agent

--- a/pkg/provisioner/provision.go
+++ b/pkg/provisioner/provision.go
@@ -989,6 +989,12 @@ func configureTelemetry(settings *sessionsettings.SessionSettings, env map[strin
 
 	env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
 	env["OTEL_METRICS_EXPORTER"] = "prometheus"
+	env["OTEL_EXPORTER_PROMETHEUS_HOST"] = "0.0.0.0"
+	prometheusPort := cfg.PrometheusPort
+	if prometheusPort <= 0 {
+		prometheusPort = 9090
+	}
+	env["OTEL_EXPORTER_PROMETHEUS_PORT"] = strconv.Itoa(prometheusPort)
 	env["OTEL_RESOURCE_ATTRIBUTES"] = strings.Join(attributes, ",")
 }
 

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -11,6 +11,50 @@ import (
 	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
+func TestConfigureTelemetry(t *testing.T) {
+	env := map[string]string{
+		"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=dev,agentapi_session_id=untrusted",
+	}
+	settings := &sessionsettings.SessionSettings{
+		Telemetry: &sessionsettings.TelemetryConfig{
+			Enabled:    true,
+			SessionID:  "session-1",
+			UserID:     "user-1",
+			TeamID:     "org/team",
+			ScheduleID: "schedule-1",
+			WebhookID:  "-",
+			AgentType:  "claude",
+		},
+	}
+
+	configureTelemetry(settings, env)
+
+	if got := env["CLAUDE_CODE_ENABLE_TELEMETRY"]; got != "1" {
+		t.Fatalf("CLAUDE_CODE_ENABLE_TELEMETRY = %q, want 1", got)
+	}
+	if got := env["OTEL_METRICS_EXPORTER"]; got != "prometheus" {
+		t.Fatalf("OTEL_METRICS_EXPORTER = %q, want prometheus", got)
+	}
+	want := "deployment.environment=dev," +
+		"agentapi_session_id=session-1," +
+		"agentapi_user_id=user-1," +
+		"agentapi_team_id=org%2Fteam," +
+		"agentapi_schedule_id=schedule-1," +
+		"agentapi_webhook_id=-," +
+		"agentapi_agent_type=claude"
+	if got := env["OTEL_RESOURCE_ATTRIBUTES"]; got != want {
+		t.Fatalf("OTEL_RESOURCE_ATTRIBUTES = %q, want %q", got, want)
+	}
+}
+
+func TestConfigureTelemetryDisabled(t *testing.T) {
+	env := map[string]string{}
+	configureTelemetry(&sessionsettings.SessionSettings{}, env)
+	if len(env) != 0 {
+		t.Fatalf("disabled telemetry mutated environment: %#v", env)
+	}
+}
+
 // TestWriteWebhookPayloadFile_WritesWhenAbsent verifies that
 // writeWebhookPayloadFile creates the file with the given payload when
 // webhookPayloadPath does not exist (stock-session case).

--- a/pkg/provisioner/provision_test.go
+++ b/pkg/provisioner/provision_test.go
@@ -17,13 +17,14 @@ func TestConfigureTelemetry(t *testing.T) {
 	}
 	settings := &sessionsettings.SessionSettings{
 		Telemetry: &sessionsettings.TelemetryConfig{
-			Enabled:    true,
-			SessionID:  "session-1",
-			UserID:     "user-1",
-			TeamID:     "org/team",
-			ScheduleID: "schedule-1",
-			WebhookID:  "-",
-			AgentType:  "claude",
+			Enabled:        true,
+			PrometheusPort: 9090,
+			SessionID:      "session-1",
+			UserID:         "user-1",
+			TeamID:         "org/team",
+			ScheduleID:     "schedule-1",
+			WebhookID:      "-",
+			AgentType:      "claude",
 		},
 	}
 
@@ -34,6 +35,12 @@ func TestConfigureTelemetry(t *testing.T) {
 	}
 	if got := env["OTEL_METRICS_EXPORTER"]; got != "prometheus" {
 		t.Fatalf("OTEL_METRICS_EXPORTER = %q, want prometheus", got)
+	}
+	if got := env["OTEL_EXPORTER_PROMETHEUS_HOST"]; got != "0.0.0.0" {
+		t.Fatalf("OTEL_EXPORTER_PROMETHEUS_HOST = %q, want 0.0.0.0", got)
+	}
+	if got := env["OTEL_EXPORTER_PROMETHEUS_PORT"]; got != "9090" {
+		t.Fatalf("OTEL_EXPORTER_PROMETHEUS_PORT = %q, want 9090", got)
 	}
 	want := "deployment.environment=dev," +
 		"agentapi_session_id=session-1," +

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -198,7 +198,8 @@ type SessionSettings struct {
 // TelemetryConfig contains the labels that the provisioner adds to the agent's
 // OpenTelemetry resource after the session identity has been resolved.
 type TelemetryConfig struct {
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	Enabled        bool `yaml:"enabled"         json:"enabled"`
+	PrometheusPort int  `yaml:"prometheus_port" json:"prometheus_port"`
 	// Label values resolved at session creation time (not Pod creation time).
 	SessionID  string `yaml:"session_id"  json:"session_id"`
 	UserID     string `yaml:"user_id"     json:"user_id"`

--- a/pkg/sessionsettings/types.go
+++ b/pkg/sessionsettings/types.go
@@ -169,20 +169,20 @@ type RegistryConfig struct {
 // SessionSettings is the top-level unified settings YAML structure.
 // It consolidates all configuration needed for a session Pod.
 type SessionSettings struct {
-	Session        SessionMeta          `yaml:"session"                   json:"session"`
-	Env            map[string]string    `yaml:"env,omitempty"             json:"env,omitempty"`
-	Claude         ClaudeConfig         `yaml:"claude,omitempty"          json:"claude,omitempty"`
-	Codex          CodexConfig          `yaml:"codex,omitempty"           json:"codex,omitempty"`
-	Pi             PiConfig             `yaml:"pi,omitempty"              json:"pi,omitempty"`
-	Repository     *RepositoryConfig    `yaml:"repository,omitempty"      json:"repository,omitempty"`
-	InitialMessage string               `yaml:"initial_message,omitempty" json:"initial_message,omitempty"`
-	WebhookPayload string               `yaml:"webhook_payload,omitempty" json:"webhook_payload,omitempty"`
-	Startup        StartupConfig        `yaml:"startup,omitempty"         json:"startup,omitempty"`
-	Github         *GithubConfig        `yaml:"github,omitempty"          json:"github,omitempty"`
-	SlackParams    *SlackParams         `yaml:"slack_params,omitempty"    json:"slack_params,omitempty"`
-	OtelCollector  *OtelCollectorConfig `yaml:"otel_collector,omitempty"  json:"otel_collector,omitempty"`
-	Sandbox        *SandboxConfig       `yaml:"sandbox,omitempty"         json:"sandbox,omitempty"`
-	Docker         *DockerConfig        `yaml:"docker,omitempty"          json:"docker,omitempty"`
+	Session        SessionMeta       `yaml:"session"                   json:"session"`
+	Env            map[string]string `yaml:"env,omitempty"             json:"env,omitempty"`
+	Claude         ClaudeConfig      `yaml:"claude,omitempty"          json:"claude,omitempty"`
+	Codex          CodexConfig       `yaml:"codex,omitempty"           json:"codex,omitempty"`
+	Pi             PiConfig          `yaml:"pi,omitempty"              json:"pi,omitempty"`
+	Repository     *RepositoryConfig `yaml:"repository,omitempty"      json:"repository,omitempty"`
+	InitialMessage string            `yaml:"initial_message,omitempty" json:"initial_message,omitempty"`
+	WebhookPayload string            `yaml:"webhook_payload,omitempty" json:"webhook_payload,omitempty"`
+	Startup        StartupConfig     `yaml:"startup,omitempty"         json:"startup,omitempty"`
+	Github         *GithubConfig     `yaml:"github,omitempty"          json:"github,omitempty"`
+	SlackParams    *SlackParams      `yaml:"slack_params,omitempty"    json:"slack_params,omitempty"`
+	Telemetry      *TelemetryConfig  `yaml:"telemetry,omitempty"       json:"telemetry,omitempty"`
+	Sandbox        *SandboxConfig    `yaml:"sandbox,omitempty"         json:"sandbox,omitempty"`
+	Docker         *DockerConfig     `yaml:"docker,omitempty"          json:"docker,omitempty"`
 	// Files holds the managed files to be restored at session startup.
 	// They are read from the agentapi-agent-files-{userID} Secret at session creation
 	// time and written to their respective paths by the provisioner.
@@ -195,16 +195,11 @@ type SessionSettings struct {
 	UnsyncedFilePaths []string `yaml:"unsynced_file_paths,omitempty" json:"unsynced_file_paths,omitempty"`
 }
 
-// OtelCollectorConfig holds OpenTelemetry Collector configuration for in-process mode.
-// When set, the provisioner will launch otelcol as a subprocess after user context
-// is established, ensuring metrics labels (user_id, session_id, etc.) are correct
-// even when using the stock inventory feature.
-type OtelCollectorConfig struct {
-	Enabled        bool   `yaml:"enabled"          json:"enabled"`
-	ScrapeInterval string `yaml:"scrape_interval"  json:"scrape_interval"`
-	ClaudeCodePort int    `yaml:"claude_code_port" json:"claude_code_port"`
-	ExporterPort   int    `yaml:"exporter_port"    json:"exporter_port"`
-	// Label values resolved at session creation time (not startup time)
+// TelemetryConfig contains the labels that the provisioner adds to the agent's
+// OpenTelemetry resource after the session identity has been resolved.
+type TelemetryConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Label values resolved at session creation time (not Pod creation time).
 	SessionID  string `yaml:"session_id"  json:"session_id"`
 	UserID     string `yaml:"user_id"     json:"user_id"`
 	TeamID     string `yaml:"team_id"     json:"team_id"`


### PR DESCRIPTION
## Summary
- remove the in-process otelcol binary, subprocess, ConfigMap, scrape annotations, and metrics service port
- let the provisioner enable Claude Code Prometheus telemetry and add agentapi resource attributes after session identity resolution
- preserve non-managed OTEL_RESOURCE_ATTRIBUTES while overriding reserved agentapi labels
- keep `kubernetesSession.otelCollector.enabled` as a compatibility feature gate

## Scope
Usage collection, hooks, persistence, API, and UI are intentionally not included.

## Validation
- `make lint`
- `make test`
- `go build ./...`