### PR TITLE
fix: use native workdir for repository clone

### DIFF
--- a/internal/infrastructure/services/native_session_manager.go
+++ b/internal/infrastructure/services/native_session_manager.go
@@ -142,6 +142,7 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 			return nil, fmt.Errorf("create session directory %s: %w", dir, err)
 		}
 	}
+	configureNativeRepositoryCloneDir(req, workdir)
 	agentPort, err := reserveTCPPort()
 	if err != nil {
 		return nil, err
@@ -231,6 +232,16 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 		_ = m.persistSession(s)
 	}()
 	return s, nil
+}
+
+func configureNativeRepositoryCloneDir(req *entities.RunServerRequest, workdir string) {
+	cloneDir := filepath.Join(workdir, "repo")
+	if req.RepoInfo != nil {
+		req.RepoInfo.CloneDir = cloneDir
+	}
+	if req.ProvisionSettings != nil && req.ProvisionSettings.Repository != nil {
+		req.ProvisionSettings.Repository.CloneDir = cloneDir
+	}
 }
 
 func reserveTCPPort() (int, error) {

--- a/internal/infrastructure/services/native_session_manager_test.go
+++ b/internal/infrastructure/services/native_session_manager_test.go
@@ -14,7 +14,34 @@ import (
 	"time"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
+
+func TestConfigureNativeRepositoryCloneDir(t *testing.T) {
+	workdir := filepath.Join(t.TempDir(), "sessions", "native-1", "workdir")
+	req := &entities.RunServerRequest{
+		RepoInfo: &entities.RepositoryInfo{
+			FullName: "owner/repo",
+			CloneDir: "/home/agentapi/workdir/repo",
+		},
+		ProvisionSettings: &sessionsettings.SessionSettings{
+			Repository: &sessionsettings.RepositoryConfig{
+				FullName: "owner/repo",
+				CloneDir: "/home/agentapi/workdir/repo",
+			},
+		},
+	}
+
+	configureNativeRepositoryCloneDir(req, workdir)
+
+	want := filepath.Join(workdir, "repo")
+	if req.RepoInfo.CloneDir != want {
+		t.Fatalf("RepoInfo.CloneDir = %q, want %q", req.RepoInfo.CloneDir, want)
+	}
+	if req.ProvisionSettings.Repository.CloneDir != want {
+		t.Fatalf("ProvisionSettings.Repository.CloneDir = %q, want %q", req.ProvisionSettings.Repository.CloneDir, want)
+	}
+}
 
 func TestNativeSessionManagerRestoresLiveSessionState(t *testing.T) {
 	stateDir := t.TempDir()


### PR DESCRIPTION
## Summary
- override repository clone directories with each native session's isolated workdir
- keep RepoInfo and provision settings consistent
- add a regression test for the native clone path

## Verification
- make lint
- make test
- CGO_ENABLED=1 go test -race ./...