### PR TITLE
fix: derive native session paths from virtual HOME

### DIFF
--- a/internal/infrastructure/services/native_session_manager.go
+++ b/internal/infrastructure/services/native_session_manager.go
@@ -142,7 +142,6 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 			return nil, fmt.Errorf("create session directory %s: %w", dir, err)
 		}
 	}
-	configureNativeRepositoryCloneDir(req, workdir)
 	agentPort, err := reserveTCPPort()
 	if err != nil {
 		return nil, err
@@ -177,14 +176,12 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 		return nil, err
 	}
 	cmd.Dir = workdir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = nativeProvisionerEnvironment(os.Environ(),
 		"HOME="+home,
 		"TMPDIR="+tmpDir,
 		"CFFIXED_USER_HOME="+home,
 		"AGENTAPI_NATIVE_SESSION_ROOT="+root,
-		"AGENTAPI_WORKDIR="+workdir,
 		"AGENTAPI_BUILD_DIR="+buildDir,
-		"AGENTAPI_REPO_DIR="+filepath.Join(workdir, "repo"),
 		"AGENTAPI_SESSION_ID="+id,
 		"AGENTAPI_PORT="+strconv.Itoa(agentPort),
 		"PROVISIONER_PROXY_URL="+m.proxyURL,
@@ -234,14 +231,15 @@ func (m *NativeSessionManager) CreateSessionDirect(_ context.Context, id string,
 	return s, nil
 }
 
-func configureNativeRepositoryCloneDir(req *entities.RunServerRequest, workdir string) {
-	cloneDir := filepath.Join(workdir, "repo")
-	if req.RepoInfo != nil {
-		req.RepoInfo.CloneDir = cloneDir
+func nativeProvisionerEnvironment(base []string, values ...string) []string {
+	env := make([]string, 0, len(base)+len(values))
+	for _, value := range base {
+		if strings.HasPrefix(value, "AGENTAPI_WORKDIR=") || strings.HasPrefix(value, "AGENTAPI_REPO_DIR=") {
+			continue
+		}
+		env = append(env, value)
 	}
-	if req.ProvisionSettings != nil && req.ProvisionSettings.Repository != nil {
-		req.ProvisionSettings.Repository.CloneDir = cloneDir
-	}
+	return append(env, values...)
 }
 
 func reserveTCPPort() (int, error) {

--- a/internal/infrastructure/services/native_session_manager_test.go
+++ b/internal/infrastructure/services/native_session_manager_test.go
@@ -14,32 +14,39 @@ import (
 	"time"
 
 	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
-	"github.com/takutakahashi/agentapi-proxy/pkg/sessionsettings"
 )
 
-func TestConfigureNativeRepositoryCloneDir(t *testing.T) {
-	workdir := filepath.Join(t.TempDir(), "sessions", "native-1", "workdir")
-	req := &entities.RunServerRequest{
-		RepoInfo: &entities.RepositoryInfo{
-			FullName: "owner/repo",
-			CloneDir: "/home/agentapi/workdir/repo",
-		},
-		ProvisionSettings: &sessionsettings.SessionSettings{
-			Repository: &sessionsettings.RepositoryConfig{
-				FullName: "owner/repo",
-				CloneDir: "/home/agentapi/workdir/repo",
-			},
-		},
+func TestNativeSessionWithNilRepositorySettingsDerivesPathsFromVirtualHome(t *testing.T) {
+	req := &entities.RunServerRequest{}
+	stateDir := t.TempDir()
+	t.Setenv("AGENTAPI_WORKDIR", "/inherited/workdir")
+	t.Setenv("AGENTAPI_REPO_DIR", "/inherited/repo")
+	m, err := NewNativeSessionManager(stateDir, "http://127.0.0.1:8080", "token", "", "/bin/true", false)
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	configureNativeRepositoryCloneDir(req, workdir)
-
-	want := filepath.Join(workdir, "repo")
-	if req.RepoInfo.CloneDir != want {
-		t.Fatalf("RepoInfo.CloneDir = %q, want %q", req.RepoInfo.CloneDir, want)
+	session, err := m.CreateSessionDirect(context.Background(), "native-1", req, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if req.ProvisionSettings.Repository.CloneDir != want {
-		t.Fatalf("ProvisionSettings.Repository.CloneDir = %q, want %q", req.ProvisionSettings.Repository.CloneDir, want)
+	t.Cleanup(func() { _ = m.DeleteSession(session.ID()) })
+
+	if req.RepoInfo != nil || req.ProvisionSettings != nil {
+		t.Fatal("empty native request unexpectedly gained repository settings")
+	}
+	native := session.(*NativeSession)
+	wantHome := filepath.Join(stateDir, "sessions", "native-1", "home")
+	foundHome := false
+	for _, value := range native.cmd.Env {
+		if value == "HOME="+wantHome {
+			foundHome = true
+		}
+		if strings.HasPrefix(value, "AGENTAPI_WORKDIR=") || strings.HasPrefix(value, "AGENTAPI_REPO_DIR=") {
+			t.Fatalf("native path override was retained: %q", value)
+		}
+	}
+	if !foundHome {
+		t.Fatalf("virtual HOME %q was not configured", wantHome)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop overriding native workdir and repository paths in NativeSessionManager
- prevent inherited AGENTAPI_WORKDIR and AGENTAPI_REPO_DIR from leaking into native provisioners
- add regression coverage for requests with nil RepoInfo and ProvisionSettings

## Testing
- make lint
- make test

Closes #943