### PR TITLE
fix: preserve paused status when creating schedules

### DIFF
--- a/internal/modules/schedule/handlers.go
+++ b/internal/modules/schedule/handlers.go
@@ -71,6 +71,7 @@ type CreateScheduleRequest struct {
 	Name          string                 `json:"name"`
 	Scope         entities.ResourceScope `json:"scope,omitempty"`
 	TeamID        string                 `json:"team_id,omitempty"`
+	Status        *ScheduleStatus        `json:"status,omitempty"`
 	ScheduledAt   *time.Time             `json:"scheduled_at,omitempty"`
 	CronExpr      string                 `json:"cron_expr,omitempty"`
 	Timezone      string                 `json:"timezone,omitempty"`
@@ -121,6 +122,9 @@ func (h *Handlers) CreateSchedule(c echo.Context) error {
 	}
 	if req.ScheduledAt == nil && req.CronExpr == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "either scheduled_at or cron_expr must be set")
+	}
+	if req.Status != nil && *req.Status != ScheduleStatusActive && *req.Status != ScheduleStatusPaused {
+		return echo.NewHTTPError(http.StatusBadRequest, "status must be active or paused")
 	}
 
 	// Validate cron expression if provided
@@ -199,6 +203,11 @@ func (h *Handlers) CreateSchedule(c echo.Context) error {
 		}
 	}
 
+	status := ScheduleStatusActive
+	if req.Status != nil {
+		status = *req.Status
+	}
+
 	// Create schedule
 	schedule := &Schedule{
 		ID:            uuid.New().String(),
@@ -207,7 +216,7 @@ func (h *Handlers) CreateSchedule(c echo.Context) error {
 		Scope:         req.Scope,
 		TeamID:        req.TeamID,
 		UserTeams:     userTeams,
-		Status:        ScheduleStatusActive,
+		Status:        status,
 		ScheduledAt:   req.ScheduledAt,
 		CronExpr:      req.CronExpr,
 		Timezone:      timezone,

--- a/internal/modules/schedule/handlers_test.go
+++ b/internal/modules/schedule/handlers_test.go
@@ -49,6 +49,24 @@ func TestHandlers_CreateSchedule(t *testing.T) {
 			wantStatus: http.StatusCreated,
 		},
 		{
+			name: "valid paused schedule",
+			body: CreateScheduleRequest{
+				Name:        "Paused Schedule",
+				Status:      statusPtr(ScheduleStatusPaused),
+				ScheduledAt: timePtr(time.Now().Add(time.Hour)),
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "invalid status",
+			body: CreateScheduleRequest{
+				Name:        "Invalid Status",
+				Status:      statusPtr(ScheduleStatusCompleted),
+				ScheduledAt: timePtr(time.Now().Add(time.Hour)),
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name: "missing name",
 			body: CreateScheduleRequest{
 				ScheduledAt: timePtr(time.Now().Add(time.Hour)),
@@ -103,6 +121,15 @@ func TestHandlers_CreateSchedule(t *testing.T) {
 
 			if rec.Code != tt.wantStatus {
 				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if tt.body.Status != nil {
+				var response ScheduleResponse
+				if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if response.Status != *tt.body.Status {
+					t.Errorf("got schedule status %q, want %q", response.Status, *tt.body.Status)
+				}
 			}
 		})
 	}

--- a/internal/modules/slackbot/controller.go
+++ b/internal/modules/slackbot/controller.go
@@ -25,9 +25,10 @@ func NewSlackBotController(repo repositories.SlackBotRepository) *SlackBotContro
 
 // CreateSlackBotRequest is the request body for creating a SlackBot
 type CreateSlackBotRequest struct {
-	Name   string                 `json:"name"`
-	Scope  entities.ResourceScope `json:"scope,omitempty"`
-	TeamID string                 `json:"team_id,omitempty"`
+	Name   string                  `json:"name"`
+	Scope  entities.ResourceScope  `json:"scope,omitempty"`
+	TeamID string                  `json:"team_id,omitempty"`
+	Status entities.SlackBotStatus `json:"status,omitempty"`
 	// Teams is an explicit list of team IDs (e.g. ["org/team-slug"]) whose settings
 	// (MCP servers, env vars, Bedrock config, etc.) will be merged into sessions
 	// created by this bot. When omitted, the server falls back to the authenticated
@@ -150,6 +151,9 @@ func (c *SlackBotController) CreateSlackBot(ctx echo.Context) error {
 	if req.Name == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
 	}
+	if req.Status != "" && req.Status != entities.SlackBotStatusActive && req.Status != entities.SlackBotStatusPaused {
+		return echo.NewHTTPError(http.StatusBadRequest, "status must be active or paused")
+	}
 
 	userID := getSlackBotUserID(ctx)
 	if userID == "" {
@@ -167,6 +171,9 @@ func (c *SlackBotController) CreateSlackBot(ctx echo.Context) error {
 	id := uuid.New().String()
 	bot := entities.NewSlackBot(id, req.Name, userID)
 
+	if req.Status != "" {
+		bot.SetStatus(req.Status)
+	}
 	if req.Scope != "" {
 		bot.SetScope(req.Scope)
 	}

--- a/internal/modules/slackbot/controller_test.go
+++ b/internal/modules/slackbot/controller_test.go
@@ -208,6 +208,37 @@ func TestCreateSlackBot_Success(t *testing.T) {
 	assert.Equal(t, entities.SlackBotStatusActive, resp.Status)
 }
 
+func TestCreateSlackBot_Paused(t *testing.T) {
+	repo := newMockSlackBotRepository()
+	controller := NewSlackBotController(repo)
+
+	c, rec := makeSlackBotEchoContext(t, http.MethodPost, "/slackbots", CreateSlackBotRequest{
+		Name:   "Paused Bot",
+		Status: entities.SlackBotStatusPaused,
+	}, "user-1")
+
+	err := controller.CreateSlackBot(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp SlackBotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, entities.SlackBotStatusPaused, resp.Status)
+}
+
+func TestCreateSlackBot_InvalidStatus(t *testing.T) {
+	repo := newMockSlackBotRepository()
+	controller := NewSlackBotController(repo)
+
+	c, _ := makeSlackBotEchoContext(t, http.MethodPost, "/slackbots", CreateSlackBotRequest{
+		Name:   "Invalid Bot",
+		Status: entities.SlackBotStatus("invalid"),
+	}, "user-1")
+
+	err := controller.CreateSlackBot(c)
+	assertHTTPError(t, err, http.StatusBadRequest)
+}
+
 func TestCreateSlackBot_MissingName(t *testing.T) {
 	repo := newMockSlackBotRepository()
 	controller := NewSlackBotController(repo)

--- a/internal/modules/webhook/controller.go
+++ b/internal/modules/webhook/controller.go
@@ -43,6 +43,7 @@ type CreateWebhookRequest struct {
 	Name            string                        `json:"name"`
 	Scope           entities.ResourceScope        `json:"scope,omitempty"`
 	TeamID          string                        `json:"team_id,omitempty"`
+	Status          entities.WebhookStatus        `json:"status,omitempty"`
 	Type            entities.WebhookType          `json:"type"`
 	Secret          string                        `json:"secret,omitempty"`
 	SignatureHeader string                        `json:"signature_header,omitempty"`
@@ -253,6 +254,9 @@ func (c *WebhookController) CreateWebhook(ctx echo.Context) error {
 	if req.Type != entities.WebhookTypeGitHub && req.Type != entities.WebhookTypeCustom {
 		return echo.NewHTTPError(http.StatusBadRequest, "type must be 'github' or 'custom'")
 	}
+	if req.Status != "" && req.Status != entities.WebhookStatusActive && req.Status != entities.WebhookStatusPaused {
+		return echo.NewHTTPError(http.StatusBadRequest, "status must be active or paused")
+	}
 	if len(req.Triggers) == 0 {
 		return echo.NewHTTPError(http.StatusBadRequest, "at least one trigger is required")
 	}
@@ -298,6 +302,9 @@ func (c *WebhookController) CreateWebhook(ctx echo.Context) error {
 	webhook := entities.NewWebhook(uuid.New().String(), req.Name, userID, req.Type)
 	webhook.SetScope(req.Scope)
 	webhook.SetTeamID(req.TeamID)
+	if req.Status != "" {
+		webhook.SetStatus(req.Status)
+	}
 	if req.Secret != "" {
 		webhook.SetSecret(req.Secret)
 	}

--- a/internal/modules/webhook/controller_create_status_test.go
+++ b/internal/modules/webhook/controller_create_status_test.go
@@ -1,0 +1,97 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/takutakahashi/agentapi-proxy/internal/domain/entities"
+	"github.com/takutakahashi/agentapi-proxy/internal/usecases/ports/repositories"
+)
+
+type createStatusWebhookRepository struct {
+	created *entities.Webhook
+}
+
+func (r *createStatusWebhookRepository) Create(_ context.Context, webhook *entities.Webhook) error {
+	r.created = webhook
+	return nil
+}
+
+func (r *createStatusWebhookRepository) Get(context.Context, string) (*entities.Webhook, error) {
+	return nil, nil
+}
+
+func (r *createStatusWebhookRepository) List(context.Context, repositories.WebhookFilter) ([]*entities.Webhook, error) {
+	return nil, nil
+}
+
+func (r *createStatusWebhookRepository) Update(context.Context, *entities.Webhook) error {
+	return nil
+}
+
+func (r *createStatusWebhookRepository) Delete(context.Context, string) error {
+	return nil
+}
+
+func (r *createStatusWebhookRepository) FindByGitHubRepository(context.Context, repositories.GitHubMatcher) ([]*entities.Webhook, error) {
+	return nil, nil
+}
+
+func (r *createStatusWebhookRepository) RecordDelivery(context.Context, string, *entities.WebhookDeliveryRecord) error {
+	return nil
+}
+
+func TestCreateWebhook_Paused(t *testing.T) {
+	repo := &createStatusWebhookRepository{}
+	controller := NewWebhookController(repo)
+	body, err := json.Marshal(CreateWebhookRequest{
+		Name:   "Paused Webhook",
+		Status: entities.WebhookStatusPaused,
+		Type:   entities.WebhookTypeCustom,
+		Triggers: []TriggerRequest{
+			{Name: "all"},
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	err = controller.CreateWebhook(e.NewContext(req, rec))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	require.NotNil(t, repo.created)
+	assert.Equal(t, entities.WebhookStatusPaused, repo.created.Status())
+}
+
+func TestCreateWebhook_InvalidStatus(t *testing.T) {
+	controller := NewWebhookController(&createStatusWebhookRepository{})
+	body, err := json.Marshal(CreateWebhookRequest{
+		Name:   "Invalid Webhook",
+		Status: entities.WebhookStatus("invalid"),
+		Type:   entities.WebhookTypeCustom,
+		Triggers: []TriggerRequest{
+			{Name: "all"},
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	err = controller.CreateWebhook(e.NewContext(req, rec))
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+}

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -6033,6 +6033,14 @@
             "type": "string",
             "description": "Team identifier (e.g., 'org/team-slug') when scope is 'team'"
           },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "paused"
+            ],
+            "description": "Initial status of the schedule (default: active)"
+          },
           "scheduled_at": {
             "type": "string",
             "format": "date-time",

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -6274,6 +6274,10 @@
             "type": "string",
             "description": "Team identifier (e.g., 'org/team-slug') when scope is 'team'"
           },
+          "status": {
+            "$ref": "#/components/schemas/WebhookStatus",
+            "description": "Initial status of the webhook (default: active)"
+          },
           "type": {
             "$ref": "#/components/schemas/WebhookType"
           },
@@ -7575,6 +7579,10 @@
           "type": "string",
           "description": "Team ID for team-scoped SlackBots (format: 'org/team-slug')",
           "example": "myorg/backend"
+        },
+        "status": {
+          "$ref": "#/components/schemas/SlackBotStatus",
+          "description": "Initial status of the SlackBot (default: active)"
         },
         "bot_token_secret_name": {
           "type": "string",


### PR DESCRIPTION
## Summary
- preserve an explicitly requested `paused` status when creating schedules
- apply the same fix to webhooks and SlackBots after auditing all active/paused resources
- default to `active` only when status is omitted
- reject invalid create-time statuses
- update OpenAPI and add regression coverage

## Validation
- `make lint` — 0 issues
- `go test ./internal/modules/schedule ./internal/modules/webhook ./internal/modules/slackbot` — passed
- GitHub Actions `ci` (race-enabled) — passed
- GitHub Actions `e2e-tests` — passed
- local `make test` was invoked but could not compile the race runtime because this agent environment has no C compiler (`gcc` not found); the equivalent CI job passed

## Dev deployment
- namespace: `agentapi-ui-dev`
- Helm revision: `1201`
- chart: `0.3.0-dev.20260724143019.89e64a4`
- app version: `dev-89e64a4`
- health endpoint: HTTP 200

## Live API verification
- schedule create: HTTP 201, status `paused`; GET persisted status `paused`
- webhook create: HTTP 201, status `paused`
- SlackBot create: HTTP 201, status `paused`
- all temporary verification resources were deleted after testing