### PR TITLE
feat: ACP 画像 ContentBlock を入出力する

### DIFF
--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -41,10 +41,10 @@ Endpoints exposed:
   GET  /health    - health check
   GET  /status    - agent status (running|stable)
   GET  /messages  - conversation history (optional ?userPromptIndex=N for turn-based retrieval)
-  POST /message   - send a user message
+  GET  /session   - ACP session metadata and config options
+  POST /rpc       - send ACP JSON-RPC requests (including text/image prompts and config changes)
+  GET  /sse       - ACP JSON-RPC event stream (including text/image output)
   GET  /events    - SSE event stream (message_update, status_change, agent_error)
-  GET  /action    - list pending actions (permission requests, plan approvals)
-  POST /action    - submit a response to a pending action
 
 Example:
   agentapi-proxy acp-server --port 3284 -- my-acp-agent --model gpt-4`,

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -72,10 +72,11 @@ type Bridge struct {
 
 	// Message history: every broadcast message is appended so that reconnecting
 	// SSE clients can replay missed events via GET /messages.
-	histMu             sync.RWMutex
-	history            []json.RawMessage
-	lastUserMessageIdx int
-	userMessageIndices []int // history indices of each user_message_chunk
+	histMu                  sync.RWMutex
+	history                 []json.RawMessage
+	lastUserMessageIdx      int
+	userMessageIndices      []int // history indices of each user_message_chunk
+	lastHistoryWasUserChunk bool
 
 	// Agent-initiated RPCs (e.g. session/request_permission):
 	// We assign local sequential ids, emit them via SSE, and await replies on POST /rpc.
@@ -390,13 +391,30 @@ func isChunkKind(kind acp.SessionUpdateKind) bool {
 // after the pending chunk buffer is flushed.
 func (b *Bridge) emitUpdate(update acp.SessionUpdate) {
 	if isChunkKind(update.Kind) {
+		// Text chunks are coalesced to reduce UI churn. Binary content blocks
+		// (notably image output) must be relayed intact instead of disappearing
+		// into the text-only buffer.
+		text := acp.ExtractTextContent(update.Content)
+		if text == "" {
+			b.flushChunkBuffer()
+			b.broadcast(jsonRPCMsg{
+				JSONRPC: "2.0",
+				Method:  "session/update",
+				Params: sessionUpdateParams{
+					SessionId: b.sessionId,
+					Update:    update,
+					Time:      time.Now(),
+				},
+			})
+			return
+		}
 		b.chunkMu.Lock()
 		if b.chunkKind != "" && b.chunkKind != update.Kind {
 			// Kind changed – flush the previous buffer before accumulating.
 			b.flushChunkBufferLocked()
 		}
 		b.chunkKind = update.Kind
-		b.chunkText.WriteString(acp.ExtractTextContent(update.Content))
+		b.chunkText.WriteString(text)
 		b.chunkMu.Unlock()
 		return
 	}
@@ -519,35 +537,40 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 // SendPrompt sends a session/prompt request to the ACP agent.
 // clientID is the raw JSON-RPC id from the HTTP client; the result (or error)
 // is emitted via SSE with that same id so the client can correlate the response.
-func (b *Bridge) SendPrompt(clientID json.RawMessage, text string) error {
+func (b *Bridge) SendPrompt(clientID json.RawMessage, prompt []acp.ContentBlock) error {
 	promptCtx := b.serverCtx
 	if promptCtx == nil {
 		promptCtx = context.Background()
 	}
 
-	log.Printf("[bridge] SendPrompt (session=%s, clientID=%s, textLen=%d)", b.sessionId, clientID, len(text))
+	log.Printf("[bridge] SendPrompt (session=%s, clientID=%s, blocks=%d)", b.sessionId, clientID, len(prompt))
 
-	// Broadcast the user's prompt as a synthetic session/update notification.
+	// Broadcast the user's prompt blocks as synthetic session/update notifications.
 	// The ACP server does not echo user messages, so we emit it here to ensure
 	// it appears in both the SSE live stream and GET /messages history.
-	userContentRaw, _ := json.Marshal(acp.ContentBlockText{Type: "text", Text: text})
-	b.broadcast(jsonRPCMsg{
-		JSONRPC: "2.0",
-		Method:  "session/update",
-		Params: sessionUpdateParams{
-			SessionId: b.sessionId,
-			Update: acp.SessionUpdate{
-				Kind:    acp.SessionUpdateKindUserMessageChunk,
-				Content: json.RawMessage(userContentRaw),
+	for _, block := range prompt {
+		userContentRaw, err := json.Marshal(block)
+		if err != nil {
+			return fmt.Errorf("marshal prompt content block: %w", err)
+		}
+		b.broadcast(jsonRPCMsg{
+			JSONRPC: "2.0",
+			Method:  "session/update",
+			Params: sessionUpdateParams{
+				SessionId: b.sessionId,
+				Update: acp.SessionUpdate{
+					Kind:    acp.SessionUpdateKindUserMessageChunk,
+					Content: json.RawMessage(userContentRaw),
+				},
+				Time: time.Now(),
 			},
-			Time: time.Now(),
-		},
-	})
+		})
+	}
 
 	b.setStatus("running")
 
 	go func() {
-		stopReason, err := b.acp.Prompt(promptCtx, text)
+		stopReason, err := b.acp.PromptBlocks(promptCtx, prompt)
 
 		// Flush any chunk that was still buffered when the agent turn ended.
 		b.flushChunkBuffer()
@@ -705,10 +728,12 @@ func (b *Bridge) broadcast(msg jsonRPCMsg) {
 
 	// Persist to history inside subsMu so SubscribeFrom sees a consistent snapshot.
 	b.histMu.Lock()
-	if isUserMessageUpdate(msg) {
+	isUserChunk := isUserMessageUpdate(msg)
+	if isUserChunk && !b.lastHistoryWasUserChunk {
 		b.lastUserMessageIdx = len(b.history)
 		b.userMessageIndices = append(b.userMessageIndices, len(b.history))
 	}
+	b.lastHistoryWasUserChunk = isUserChunk
 	b.history = append(b.history, raw)
 	b.histMu.Unlock()
 

--- a/pkg/acp/bridge/bridge_test.go
+++ b/pkg/acp/bridge/bridge_test.go
@@ -85,6 +85,37 @@ func TestUserPromptInfosIncludePreview(t *testing.T) {
 	}
 }
 
+func TestImageBlockDoesNotCreateAnotherUserPromptTurn(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+	b.broadcast(userPromptUpdate(t, "describe this image"))
+	image, err := json.Marshal(map[string]interface{}{
+		"type":     "image",
+		"mimeType": "image/png",
+		"data":     "iVBORw0KGgo=",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.broadcast(jsonRPCMsg{
+		JSONRPC: "2.0",
+		Method:  "session/update",
+		Params: sessionUpdateParams{
+			SessionId: "session-1",
+			Update: acp.SessionUpdate{
+				Kind:    acp.SessionUpdateKindUserMessageChunk,
+				Content: image,
+			},
+		},
+	})
+
+	if got := b.UserPromptCount(); got != 1 {
+		t.Fatalf("UserPromptCount = %d, want 1", got)
+	}
+	if got := len(b.Messages()); got != 2 {
+		t.Fatalf("Messages length = %d, want 2 content blocks", got)
+	}
+}
+
 func TestHandleGetMessagesUserPromptIndex(t *testing.T) {
 	b := New(nil, "session-1", false, "", false)
 	b.broadcast(userPromptUpdate(t, "turn one"))
@@ -235,6 +266,61 @@ func TestUserPromptPreviewTruncation(t *testing.T) {
 	}
 	if !strings.HasSuffix(preview, "…") {
 		t.Fatalf("preview should be truncated with ellipsis: %q", preview)
+	}
+}
+
+func TestValidatePromptContentAllowsTextAndImage(t *testing.T) {
+	err := validatePromptContent([]acp.ContentBlock{
+		{Type: acp.ContentBlockTypeText, Text: "describe this"},
+		{Type: acp.ContentBlockTypeImage, MimeType: "image/png", Data: "iVBORw0KGgo="},
+	})
+	if err != nil {
+		t.Fatalf("validatePromptContent returned error: %v", err)
+	}
+}
+
+func TestValidatePromptContentRejectsIncompleteImage(t *testing.T) {
+	err := validatePromptContent([]acp.ContentBlock{
+		{Type: acp.ContentBlockTypeImage, MimeType: "image/png"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "base64 data") {
+		t.Fatalf("validatePromptContent error = %v, want missing base64 data", err)
+	}
+}
+
+func TestEmitUpdatePreservesImageContent(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+	content, err := json.Marshal(acp.ContentBlock{
+		Type:     acp.ContentBlockTypeImage,
+		MimeType: "image/png",
+		Data:     "iVBORw0KGgo=",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b.emitUpdate(acp.SessionUpdate{
+		Kind:    acp.SessionUpdateKindAgentMessageChunk,
+		Content: content,
+	})
+
+	msgs := b.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("Messages length = %d, want 1", len(msgs))
+	}
+	var envelope struct {
+		Params struct {
+			Update struct {
+				Content acp.ContentBlock `json:"content"`
+			} `json:"update"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(msgs[0], &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Params.Update.Content.Type != acp.ContentBlockTypeImage ||
+		envelope.Params.Update.Content.Data != "iVBORw0KGgo=" {
+		t.Fatalf("image content was not preserved: %+v", envelope.Params.Update.Content)
 	}
 }
 

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -254,19 +254,11 @@ func (s *Server) handleRPC(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest,
 				rpcErrorResp(env.ID, -32602, "invalid params: "+err.Error()))
 		}
-		// Extract the first text content block.
-		text := ""
-		for _, block := range params.Prompt {
-			if block.Type == acp.ContentBlockTypeText {
-				text = block.Text
-				break
-			}
-		}
-		if text == "" {
+		if err := validatePromptContent(params.Prompt); err != nil {
 			return c.JSON(http.StatusBadRequest,
-				rpcErrorResp(env.ID, -32602, "prompt must contain at least one text content block"))
+				rpcErrorResp(env.ID, -32602, err.Error()))
 		}
-		if err := s.bridge.SendPrompt(*env.ID, text); err != nil {
+		if err := s.bridge.SendPrompt(*env.ID, params.Prompt); err != nil {
 			return c.JSON(http.StatusInternalServerError,
 				rpcErrorResp(env.ID, -32000, err.Error()))
 		}
@@ -315,6 +307,27 @@ func (s *Server) handleRPC(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest,
 			rpcErrorResp(env.ID, -32601, "method not supported: "+env.Method))
 	}
+}
+
+func validatePromptContent(prompt []acp.ContentBlock) error {
+	if len(prompt) == 0 {
+		return fmt.Errorf("prompt must contain at least one content block")
+	}
+	for i, block := range prompt {
+		switch block.Type {
+		case acp.ContentBlockTypeText:
+			if block.Text == "" {
+				return fmt.Errorf("prompt[%d] text must not be empty", i)
+			}
+		case acp.ContentBlockTypeImage:
+			if block.MimeType == "" || block.Data == "" {
+				return fmt.Errorf("prompt[%d] image requires mimeType and base64 data", i)
+			}
+		default:
+			return fmt.Errorf("prompt[%d] has unsupported content type %q", i, block.Type)
+		}
+	}
+	return nil
 }
 
 // GET /sse

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -173,6 +173,15 @@ func (c *Client) Initialize(ctx context.Context) error {
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return fmt.Errorf("acp initialize: parse result: %w", err)
 	}
+	if result.AgentCapabilities.LoadSession {
+		result.AgentCapabilities.SessionLoad = true
+	}
+	if result.AgentCapabilities.PromptCapabilities != nil {
+		result.AgentCapabilities.Image = result.AgentCapabilities.Image ||
+			result.AgentCapabilities.PromptCapabilities.Image
+		result.AgentCapabilities.Audio = result.AgentCapabilities.Audio ||
+			result.AgentCapabilities.PromptCapabilities.Audio
+	}
 	c.agentCaps = result.AgentCapabilities
 	if c.verbose {
 		log.Printf("[acp] initialized: protocol=%d agentCaps=%+v authMethods=%d", result.ProtocolVersion, result.AgentCapabilities, len(result.AuthMethods))
@@ -354,19 +363,26 @@ func modelValueToString(value interface{}) string {
 	return ""
 }
 
-// Prompt sends a user message and returns when the agent has finished the turn.
+// Prompt sends a text user message and returns when the agent has finished the turn.
 // While the agent is working, session/update notifications are dispatched to
 // the channel returned by Updates().
 func (c *Client) Prompt(ctx context.Context, text string) (StopReason, error) {
+	return c.PromptBlocks(ctx, []ContentBlock{{Type: ContentBlockTypeText, Text: text}})
+}
+
+// PromptBlocks sends an ordered multimodal prompt and returns when the agent
+// has finished the turn.
+func (c *Client) PromptBlocks(ctx context.Context, prompt []ContentBlock) (StopReason, error) {
 	sessionId := c.SessionID()
 	if sessionId == "" {
 		return "", fmt.Errorf("acp: no active session; call NewSession first")
 	}
+	if len(prompt) == 0 {
+		return "", fmt.Errorf("acp: prompt must contain at least one content block")
+	}
 	params := PromptParams{
 		SessionId: sessionId,
-		Prompt: []ContentBlock{
-			{Type: ContentBlockTypeText, Text: text},
-		},
+		Prompt:    prompt,
 	}
 	raw, err := c.rpc.Call(ctx, "session/prompt", params)
 	if err != nil {

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -23,9 +23,17 @@ type ClientCapabilities struct {
 type AgentCapabilities struct {
 	// Session restore / load
 	SessionLoad bool `json:"sessionLoad,omitempty"`
+	// ACP v1 uses loadSession and nests prompt media capabilities.
+	LoadSession        bool                `json:"loadSession,omitempty"`
+	PromptCapabilities *PromptCapabilities `json:"promptCapabilities,omitempty"`
 	// Image content blocks in prompts
 	Image bool `json:"image,omitempty"`
 	// Audio content blocks in prompts
+	Audio bool `json:"audio,omitempty"`
+}
+
+type PromptCapabilities struct {
+	Image bool `json:"image,omitempty"`
 	Audio bool `json:"audio,omitempty"`
 }
 

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -914,7 +914,7 @@
     },
     "/{sessionId}/{path}": {
       "summary": "Proxy to session",
-      "description": "All requests to /{sessionId}/* are proxied to the corresponding agentapi server instance.",
+      "description": "All requests to /{sessionId}/* are proxied to the corresponding agentapi server instance. ACP-backed sessions also expose session, messages, sse, and rpc paths through this route; session/prompt RPC requests may contain text and base64-encoded image content blocks.",
       "get": {
         "summary": "Proxy GET request to session",
         "operationId": "proxyGetToSession",
@@ -983,7 +983,7 @@
           }
         ],
         "requestBody": {
-          "description": "Request body to forward to agentapi",
+          "description": "Request body to forward to agentapi. For an ACP session's rpc path, session/prompt accepts ordered content blocks such as {\"type\":\"text\",\"text\":\"...\"} and {\"type\":\"image\",\"mimeType\":\"image/png\",\"data\":\"<base64>\"}.",
           "content": {
             "application/json": {
               "schema": {


### PR DESCRIPTION
## Summary
- `session/prompt` の text/image ContentBlock 配列を ACP agent へそのまま転送
- ACP の image output chunk を SSE と履歴に保持
- 複数 user content block を1ターンとして履歴管理
- ACP v1 の nested prompt capabilities / loadSession を正規化
- OpenAPI の session proxy 説明を更新

## Verification
- `make lint` (0 issues)
- `make test` (race detector、全 package 成功。環境に gcc がないため `CC=zig cc`)
- 実 `@agentclientprotocol/codex-acp` 1.1.7 で reasoning_effort を high に変更
- 実 PNG を ACP 経由で送り、Codex が「ロボット」と認識
- dev Playwright E2E はデプロイ後に追記予定