### PR TITLE
feat(acp): support form elicitation requests

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -357,6 +357,7 @@ func (b *Bridge) Run(ctx context.Context) {
 	b.serverCtx = ctx
 	updates := b.acp.Updates()
 	perms := b.acp.PermissionRequests()
+	elicitations := b.acp.ElicitationRequests()
 
 	for {
 		select {
@@ -374,8 +375,60 @@ func (b *Bridge) Run(ctx context.Context) {
 				return
 			}
 			b.handlePermissionRequest(req)
+
+		case req, ok := <-elicitations:
+			if !ok {
+				return
+			}
+			b.handleElicitationRequest(req)
 		}
 	}
+}
+
+// handleElicitationRequest emits an ACP form elicitation via SSE and waits for
+// the browser client to return accept, decline, or cancel via POST /rpc.
+func (b *Bridge) handleElicitationRequest(req acp.ElicitationRequest) {
+	id, replyCh := b.beginAgentRequest("session/create_elicitation", req.Params)
+
+	go func() {
+		defer b.finishAgentRequest(id)
+
+		select {
+		case <-b.serverCtx.Done():
+			_ = req.Reply(acp.CreateElicitationResult{Action: "cancel"})
+		case raw := <-replyCh:
+			var result acp.CreateElicitationResult
+			if err := json.Unmarshal(raw, &result); err != nil {
+				result = acp.CreateElicitationResult{Action: "cancel"}
+			}
+			_ = req.Reply(result)
+		}
+	}()
+}
+
+func (b *Bridge) beginAgentRequest(method string, params interface{}) (int64, chan json.RawMessage) {
+	id := b.agentReqSeq.Add(1)
+	idRaw, _ := json.Marshal(id)
+	idRawMsg := json.RawMessage(idRaw)
+	replyCh := make(chan json.RawMessage, 1)
+
+	b.pendingReplyMu.Lock()
+	b.pendingReplies[id] = replyCh
+	b.pendingReplyMu.Unlock()
+
+	b.broadcast(jsonRPCMsg{
+		JSONRPC: "2.0",
+		ID:      &idRawMsg,
+		Method:  method,
+		Params:  params,
+	})
+	return id, replyCh
+}
+
+func (b *Bridge) finishAgentRequest(id int64) {
+	b.pendingReplyMu.Lock()
+	delete(b.pendingReplies, id)
+	b.pendingReplyMu.Unlock()
 }
 
 // isChunkKind reports whether kind is a streaming chunk that should be buffered.
@@ -491,30 +544,10 @@ func (b *Bridge) handlePermissionRequest(req acp.PermissionRequest) {
 		return
 	}
 
-	id := b.agentReqSeq.Add(1)
-	idRaw, _ := json.Marshal(id)
-	idRawMsg := json.RawMessage(idRaw)
-
-	replyCh := make(chan json.RawMessage, 1)
-
-	b.pendingReplyMu.Lock()
-	b.pendingReplies[id] = replyCh
-	b.pendingReplyMu.Unlock()
-
-	msg := jsonRPCMsg{
-		JSONRPC: "2.0",
-		ID:      &idRawMsg,
-		Method:  "session/request_permission",
-		Params:  req.Params,
-	}
-	b.broadcast(msg)
+	id, replyCh := b.beginAgentRequest("session/request_permission", req.Params)
 
 	go func() {
-		defer func() {
-			b.pendingReplyMu.Lock()
-			delete(b.pendingReplies, id)
-			b.pendingReplyMu.Unlock()
-		}()
+		defer b.finishAgentRequest(id)
 
 		select {
 		case <-b.serverCtx.Done():

--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -80,9 +80,10 @@ type Bridge struct {
 
 	// Agent-initiated RPCs (e.g. session/request_permission):
 	// We assign local sequential ids, emit them via SSE, and await replies on POST /rpc.
-	agentReqSeq    atomic.Int64
-	pendingReplyMu sync.Mutex
-	pendingReplies map[int64]chan json.RawMessage // local agentReqId → reply channel
+	agentReqSeq     atomic.Int64
+	pendingReplyMu  sync.Mutex
+	pendingReplies  map[int64]chan json.RawMessage // local agentReqId → reply channel
+	pendingRequests map[int64]json.RawMessage      // local agentReqId → JSON-RPC request for reconnect replay
 
 	// Chunk buffer: accumulates consecutive chunk updates of the same kind and
 	// emits them as a single batched session/update when the kind changes or the
@@ -118,6 +119,7 @@ func New(client *acp.Client, sessionId string, verbose bool, outputFile string, 
 		autoApprove:        autoApprove,
 		outputFile:         outputFile,
 		pendingReplies:     make(map[int64]chan json.RawMessage),
+		pendingRequests:    make(map[int64]json.RawMessage),
 		currentStatus:      "stable",
 		lastUserMessageIdx: -1,
 	}
@@ -412,22 +414,27 @@ func (b *Bridge) beginAgentRequest(method string, params interface{}) (int64, ch
 	idRawMsg := json.RawMessage(idRaw)
 	replyCh := make(chan json.RawMessage, 1)
 
-	b.pendingReplyMu.Lock()
-	b.pendingReplies[id] = replyCh
-	b.pendingReplyMu.Unlock()
-
-	b.broadcast(jsonRPCMsg{
+	msg := jsonRPCMsg{
 		JSONRPC: "2.0",
 		ID:      &idRawMsg,
 		Method:  method,
 		Params:  params,
-	})
+	}
+	raw, _ := json.Marshal(msg)
+
+	b.pendingReplyMu.Lock()
+	b.pendingReplies[id] = replyCh
+	b.pendingRequests[id] = raw
+	b.pendingReplyMu.Unlock()
+
+	b.broadcast(msg)
 	return id, replyCh
 }
 
 func (b *Bridge) finishAgentRequest(id int64) {
 	b.pendingReplyMu.Lock()
 	delete(b.pendingReplies, id)
+	delete(b.pendingRequests, id)
 	b.pendingReplyMu.Unlock()
 }
 
@@ -645,6 +652,20 @@ func (b *Bridge) HandleReply(id int64, result json.RawMessage) error {
 	default:
 	}
 	return nil
+}
+
+// PendingAgentRequests returns the unanswered agent-initiated JSON-RPC requests.
+// A newly opened UI connection uses this snapshot to recover prompts that were
+// emitted while no SSE subscriber was connected.
+func (b *Bridge) PendingAgentRequests() []json.RawMessage {
+	b.pendingReplyMu.Lock()
+	defer b.pendingReplyMu.Unlock()
+
+	requests := make([]json.RawMessage, 0, len(b.pendingRequests))
+	for _, raw := range b.pendingRequests {
+		requests = append(requests, append(json.RawMessage(nil), raw...))
+	}
+	return requests
 }
 
 // SetSessionConfigOption forwards a session/set_config_option request to the ACP agent.

--- a/pkg/acp/bridge/bridge_test.go
+++ b/pkg/acp/bridge/bridge_test.go
@@ -1,15 +1,69 @@
 package bridge
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/takutakahashi/agentapi-proxy/pkg/acp"
 )
+
+func TestHandleElicitationRequestBroadcastsAndReturnsReply(t *testing.T) {
+	b := New(nil, "session-1", false, "", false)
+	b.serverCtx = context.Background()
+	replied := make(chan acp.CreateElicitationResult, 1)
+
+	b.handleElicitationRequest(acp.ElicitationRequest{
+		Params: acp.CreateElicitationParams{
+			SessionId: "session-1",
+			Mode:      "form",
+			Message:   "Choose a color",
+			RequestedSchema: map[string]interface{}{
+				"type": "object",
+			},
+		},
+		Reply: func(result acp.CreateElicitationResult) error {
+			replied <- result
+			return nil
+		},
+	})
+
+	if len(b.history) != 1 {
+		t.Fatalf("history length = %d, want 1", len(b.history))
+	}
+	var request jsonRPCMsg
+	if err := json.Unmarshal(b.history[0], &request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Method != "session/create_elicitation" {
+		t.Fatalf("method = %q, want session/create_elicitation", request.Method)
+	}
+
+	raw, err := json.Marshal(acp.CreateElicitationResult{
+		Action:  "accept",
+		Content: map[string]interface{}{"question_0": "Blue"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := b.HandleReply(1, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case result := <-replied:
+		if result.Action != "accept" || result.Content["question_0"] != "Blue" {
+			t.Fatalf("unexpected result: %#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for elicitation reply")
+	}
+}
 
 func TestMessagesReturnsMessagesSinceLastUserMessage(t *testing.T) {
 	b := New(nil, "session-1", false, "", false)

--- a/pkg/acp/bridge/pending_requests_test.go
+++ b/pkg/acp/bridge/pending_requests_test.go
@@ -1,0 +1,35 @@
+package bridge
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPendingAgentRequestsAreAvailableUntilReplyFinishes(t *testing.T) {
+	b := &Bridge{
+		pendingReplies:  make(map[int64]chan json.RawMessage),
+		pendingRequests: make(map[int64]json.RawMessage),
+	}
+
+	id, _ := b.beginAgentRequest("session/request_permission", map[string]string{
+		"sessionId": "session-1",
+	})
+
+	pending := b.PendingAgentRequests()
+	if len(pending) != 1 {
+		t.Fatalf("got %d pending requests, want 1", len(pending))
+	}
+
+	var msg jsonRPCMsg
+	if err := json.Unmarshal(pending[0], &msg); err != nil {
+		t.Fatalf("unmarshal pending request: %v", err)
+	}
+	if msg.Method != "session/request_permission" {
+		t.Fatalf("unexpected pending method: %q", msg.Method)
+	}
+
+	b.finishAgentRequest(id)
+	if pending := b.PendingAgentRequests(); len(pending) != 0 {
+		t.Fatalf("got %d pending requests after finishing, want 0", len(pending))
+	}
+}

--- a/pkg/acp/bridge/server.go
+++ b/pkg/acp/bridge/server.go
@@ -383,6 +383,14 @@ func (s *Server) handleSSE(c echo.Context) error {
 	for i, msg := range history {
 		_, _ = fmt.Fprintf(w, "id: %d\nevent: message\ndata: %s\n\n", historyStartIdx+i, msg)
 	}
+	// A first-time connection has no Last-Event-ID. Replay unanswered
+	// agent-initiated requests without an SSE id so opening the chat after a
+	// prompt was emitted still shows it, without disturbing history resumption.
+	if lastEventIDStr == "" {
+		for _, msg := range s.bridge.PendingAgentRequests() {
+			_, _ = fmt.Fprintf(w, "event: message\ndata: %s\n\n", msg)
+		}
+	}
 	if hasFlusher {
 		flusher.Flush()
 	}

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -24,6 +24,13 @@ type PermissionRequest struct {
 	Reply func(optionId string) error
 }
 
+// ElicitationRequest is an inbound structured form request from the agent.
+type ElicitationRequest struct {
+	Params CreateElicitationParams
+	// Reply must be called exactly once to unblock the agent.
+	Reply func(CreateElicitationResult) error
+}
+
 // Client is a high-level ACP client backed by a JSON-RPC 2.0 connection.
 // It manages the lifecycle of a single ACP session.
 type Client struct {
@@ -39,16 +46,19 @@ type Client struct {
 	updateCh chan SessionUpdate
 	// permCh receives inbound permission requests from the agent.
 	permCh chan PermissionRequest
+	// elicitationCh receives inbound form elicitation requests from the agent.
+	elicitationCh chan ElicitationRequest
 }
 
 // NewClient creates an ACP client using the given reader (agent stdout) and
 // writer (agent stdin).
 func NewClient(r io.Reader, w io.Writer, verbose bool) *Client {
 	c := &Client{
-		rpc:      jsonrpc.New(r, w, verbose),
-		verbose:  verbose,
-		updateCh: make(chan SessionUpdate, 64),
-		permCh:   make(chan PermissionRequest, 8),
+		rpc:           jsonrpc.New(r, w, verbose),
+		verbose:       verbose,
+		updateCh:      make(chan SessionUpdate, 64),
+		permCh:        make(chan PermissionRequest, 8),
+		elicitationCh: make(chan ElicitationRequest, 8),
 	}
 	c.registerHandlers()
 	return c
@@ -70,6 +80,36 @@ func (c *Client) registerHandlers() {
 		case c.updateCh <- n.Update:
 		default:
 			log.Printf("[acp] updateCh full, dropping update kind=%s", n.Update.Kind)
+		}
+	})
+
+	// session/create_elicitation (agent→client, bidirectional RPC)
+	c.rpc.RegisterRequestHandler("session/create_elicitation", func(ctx context.Context, raw json.RawMessage) (interface{}, error) {
+		var p CreateElicitationParams
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("parse create_elicitation: %w", err)
+		}
+
+		replyCh := make(chan CreateElicitationResult, 1)
+		req := ElicitationRequest{
+			Params: p,
+			Reply: func(result CreateElicitationResult) error {
+				replyCh <- result
+				return nil
+			},
+		}
+
+		select {
+		case c.elicitationCh <- req:
+		default:
+			return CreateElicitationResult{Action: "cancel"}, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return CreateElicitationResult{Action: "cancel"}, nil
+		case result := <-replyCh:
+			return result, nil
 		}
 	})
 
@@ -162,7 +202,8 @@ func (c *Client) Initialize(ctx context.Context) error {
 	params := InitializeParams{
 		ProtocolVersion: ProtocolVersion,
 		ClientCapabilities: ClientCapabilities{
-			Filesystem: &FilesystemCapability{Enabled: true},
+			Filesystem:  &FilesystemCapability{Enabled: true},
+			Elicitation: &ElicitationCapability{Form: map[string]interface{}{}},
 		},
 	}
 	raw, err := c.rpc.Call(ctx, "initialize", params)
@@ -437,4 +478,10 @@ func (c *Client) Updates() <-chan SessionUpdate {
 // requests from the agent.
 func (c *Client) PermissionRequests() <-chan PermissionRequest {
 	return c.permCh
+}
+
+// ElicitationRequests returns a channel that receives inbound form elicitation
+// requests from the agent.
+func (c *Client) ElicitationRequests() <-chan ElicitationRequest {
+	return c.elicitationCh
 }

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -76,6 +76,12 @@ func (c *Client) registerHandlers() {
 		if n.Update.Kind == SessionUpdateKindConfigOptionUpdate {
 			c.updateSessionConfigOptions(n.Update.ConfigOptions)
 		}
+		if n.Update.Kind == SessionUpdateKindCurrentModeUpdate {
+			if n.Update.CurrentModeId == "" {
+				n.Update.CurrentModeId = n.Update.Mode
+			}
+			c.updateSessionMode(n.Update.CurrentModeId)
+		}
 		select {
 		case c.updateCh <- n.Update:
 		default:
@@ -360,6 +366,17 @@ func (c *Client) updateSessionConfigOptions(configOptions []ConfigOption) {
 	defer c.mu.Unlock()
 	c.sessionInfo.ConfigOptions = configOptions
 	c.sessionInfo.Model = ExtractModelFromConfigOptions(configOptions)
+}
+
+func (c *Client) updateSessionMode(modeId string) {
+	if modeId == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sessionInfo.Modes != nil {
+		c.sessionInfo.Modes.CurrentModeId = modeId
+	}
 }
 
 // ExtractModelFromConfigOptions returns the most likely active model value from ACP config options.

--- a/pkg/acp/client_test.go
+++ b/pkg/acp/client_test.go
@@ -23,6 +23,33 @@ func TestElicitationCapabilityIncludesEmptyFormObject(t *testing.T) {
 	}
 }
 
+func TestUpdateSessionModeUpdatesRuntimeInfo(t *testing.T) {
+	client := &Client{
+		sessionInfo: SessionRuntimeInfo{
+			Modes: &SessionModeState{CurrentModeId: "default"},
+		},
+	}
+
+	client.updateSessionMode("plan")
+
+	if got := client.SessionRuntimeInfo().Modes.CurrentModeId; got != "plan" {
+		t.Fatalf("current mode = %q, want plan", got)
+	}
+}
+
+func TestSessionUpdateDecodesCurrentModeID(t *testing.T) {
+	var notification SessionUpdateNotification
+	if err := json.Unmarshal([]byte(`{
+		"sessionId":"session-1",
+		"update":{"sessionUpdate":"current_mode_update","currentModeId":"plan"}
+	}`), &notification); err != nil {
+		t.Fatal(err)
+	}
+	if got := notification.Update.CurrentModeId; got != "plan" {
+		t.Fatalf("current mode = %q, want plan", got)
+	}
+}
+
 func TestExtractModelFromConfigOptions(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/acp/client_test.go
+++ b/pkg/acp/client_test.go
@@ -1,6 +1,27 @@
 package acp
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestElicitationCapabilityIncludesEmptyFormObject(t *testing.T) {
+	params := InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		ClientCapabilities: ClientCapabilities{
+			Elicitation: &ElicitationCapability{Form: map[string]interface{}{}},
+		},
+	}
+
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"elicitation":{"form":{}}`) {
+		t.Fatalf("initialize params do not advertise form elicitation: %s", raw)
+	}
+}
 
 func TestExtractModelFromConfigOptions(t *testing.T) {
 	tests := []struct {

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -17,6 +17,8 @@ type ClientCapabilities struct {
 	Filesystem *FilesystemCapability `json:"filesystem,omitempty"`
 	// Terminal management
 	Terminal *TerminalCapability `json:"terminal,omitempty"`
+	// Structured forms initiated by the agent.
+	Elicitation *ElicitationCapability `json:"elicitation,omitempty"`
 }
 
 // AgentCapabilities describes what the agent supports.
@@ -45,6 +47,11 @@ type FilesystemCapability struct {
 // TerminalCapability indicates the client can handle terminal requests.
 type TerminalCapability struct {
 	Enabled bool `json:"enabled"`
+}
+
+// ElicitationCapability indicates which elicitation modes the client supports.
+type ElicitationCapability struct {
+	Form map[string]interface{} `json:"form"`
 }
 
 // ----------------------------------------------------------------------------
@@ -376,6 +383,22 @@ type RequestPermissionOutcome struct {
 // The ACP spec requires: {outcome: {outcome: "selected", optionId: "<id>"}}
 type RequestPermissionResult struct {
 	Outcome RequestPermissionOutcome `json:"outcome"`
+}
+
+// CreateElicitationParams is the params for "session/create_elicitation"
+// (agent→client). RequestedSchema follows ACP's restricted JSON Schema shape.
+type CreateElicitationParams struct {
+	SessionId       string                 `json:"sessionId"`
+	ToolCallId      string                 `json:"toolCallId,omitempty"`
+	Mode            string                 `json:"mode"`
+	Message         string                 `json:"message"`
+	RequestedSchema map[string]interface{} `json:"requestedSchema,omitempty"`
+}
+
+// CreateElicitationResult is the response to "session/create_elicitation".
+type CreateElicitationResult struct {
+	Action  string                 `json:"action"`
+	Content map[string]interface{} `json:"content,omitempty"`
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -364,6 +364,8 @@ type PermissionOption struct {
 type RequestPermissionToolCall struct {
 	ToolCallId string          `json:"toolCallId"`
 	Kind       string          `json:"kind,omitempty"`     // e.g. "switch_mode" for ExitPlanMode
+	Title      string          `json:"title,omitempty"`    // human-readable tool call title
+	Content    json.RawMessage `json:"content,omitempty"`  // structured tool call content
 	RawInput   json.RawMessage `json:"rawInput,omitempty"` // raw tool input JSON
 }
 

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -311,6 +311,8 @@ type SessionUpdate struct {
 	Title string `json:"title,omitempty"`
 
 	// current_mode_update
+	CurrentModeId string `json:"currentModeId,omitempty"`
+	// Mode is accepted for compatibility with older ACP agents.
 	Mode string `json:"mode,omitempty"`
 
 	// config_option_update

--- a/pkg/acp/types_test.go
+++ b/pkg/acp/types_test.go
@@ -1,0 +1,34 @@
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRequestPermissionParamsPreservesExitPlanModeContent(t *testing.T) {
+	var params RequestPermissionParams
+	err := json.Unmarshal([]byte(`{
+		"sessionId":"session-1",
+		"options":[],
+		"toolCall":{
+			"toolCallId":"tool-1",
+			"kind":"switch_mode",
+			"title":"Ready to code?",
+			"content":[{"type":"content","content":{"type":"text","text":"# Plan\n\nImplement it."}}],
+			"rawInput":{"plan":"# Plan\n\nImplement it."}
+		}
+	}`), &params)
+	if err != nil {
+		t.Fatalf("unmarshal request permission params: %v", err)
+	}
+
+	if params.ToolCall.Title != "Ready to code?" {
+		t.Fatalf("unexpected title: %q", params.ToolCall.Title)
+	}
+	if len(params.ToolCall.Content) == 0 {
+		t.Fatal("structured plan content was dropped")
+	}
+	if len(params.ToolCall.RawInput) == 0 {
+		t.Fatal("raw plan input was dropped")
+	}
+}


### PR DESCRIPTION
## Summary
- advertise ACP form elicitation capability during initialization
- relay `session/create_elicitation` requests over the existing SSE/JSON-RPC bridge
- return browser accept/decline/cancel responses to the ACP agent
- decode `current_mode_update.currentModeId` for EnterPlanMode and persist the active mode in session runtime info
- add coverage for capability serialization, elicitation round-trips, and plan-mode updates

## Verification
- `make lint` (0 issues)
- `CGO_ENABLED=0 go test ./...`
- `make test` could not run the race detector because this environment does not provide gcc

Companion UI: https://github.com/takutakahashi/agentapi-ui/pull/586