### PR TITLE
fix: include required ACP session load params

### DIFF
--- a/cmd/acp_server.go
+++ b/cmd/acp_server.go
@@ -141,7 +141,7 @@ func runAcpServer(cmd *cobra.Command, args []string) error {
 		if data, err := os.ReadFile(sessionFile); err == nil {
 			savedID := strings.TrimSpace(string(data))
 			if savedID != "" {
-				if err := acpClient.LoadSession(ctx, savedID); err != nil {
+				if err := acpClient.LoadSession(ctx, savedID, cwd); err != nil {
 					log.Printf("[acp-server] session/load failed (%v), creating new session", err)
 				} else {
 					log.Printf("[acp-server] restored previous session (session=%s)", acpClient.SessionID())

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -299,9 +299,11 @@ func (c *Client) LoadSession(ctx context.Context, sessionId, cwd string) error {
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return fmt.Errorf("acp session/load: parse result: %w", err)
 	}
-	c.setSessionRuntimeInfo(result.SessionId, result.Modes, result.ConfigOptions)
+	// ACP load responses do not repeat the requested session ID. Keep the ID
+	// from the request instead of replacing it with an empty value.
+	c.setSessionRuntimeInfo(sessionId, result.Modes, result.ConfigOptions)
 	if c.verbose {
-		log.Printf("[acp] session loaded: id=%s configOptions=%d", result.SessionId, len(result.ConfigOptions))
+		log.Printf("[acp] session loaded: id=%s configOptions=%d", sessionId, len(result.ConfigOptions))
 	}
 	return nil
 }

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -285,8 +285,12 @@ func (c *Client) SessionRuntimeInfo() SessionRuntimeInfo {
 // Only call this when AgentCaps().SessionLoad is true; otherwise fall back to NewSession.
 // On success the session ID is updated; on failure (session not found, etc.) the caller
 // should call NewSession to start fresh.
-func (c *Client) LoadSession(ctx context.Context, sessionId string) error {
-	params := SessionLoadParams{SessionId: sessionId}
+func (c *Client) LoadSession(ctx context.Context, sessionId, cwd string) error {
+	params := SessionLoadParams{
+		SessionId:  sessionId,
+		Cwd:        cwd,
+		McpServers: []McpServer{},
+	}
 	raw, err := c.rpc.Call(ctx, "session/load", params)
 	if err != nil {
 		return fmt.Errorf("acp session/load: %w", err)

--- a/pkg/acp/client_test.go
+++ b/pkg/acp/client_test.go
@@ -1,6 +1,27 @@
 package acp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionLoadParamsIncludesRequiredFields(t *testing.T) {
+	params := SessionLoadParams{
+		SessionId:  "019fa1af-b421-7a59-9fca-00ec8143f882",
+		Cwd:        "/home/agentapi/workdir/repo",
+		McpServers: []McpServer{},
+	}
+
+	encoded, err := json.Marshal(params)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"sessionId": "019fa1af-b421-7a59-9fca-00ec8143f882",
+		"cwd": "/home/agentapi/workdir/repo",
+		"mcpServers": []
+	}`, string(encoded))
+}
 
 func TestExtractModelFromConfigOptions(t *testing.T) {
 	tests := []struct {

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -155,7 +155,9 @@ type SessionListResult struct {
 // SessionLoadParams is the params for "session/load" (client→agent).
 // Only valid when AgentCapabilities.SessionLoad is true.
 type SessionLoadParams struct {
-	SessionId string `json:"sessionId"`
+	SessionId  string      `json:"sessionId"`
+	Cwd        string      `json:"cwd"`
+	McpServers []McpServer `json:"mcpServers"`
 }
 
 // SessionLoadResult is the response to "session/load".

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -162,7 +162,6 @@ type SessionLoadParams struct {
 
 // SessionLoadResult is the response to "session/load".
 type SessionLoadResult struct {
-	SessionId     string            `json:"sessionId"`
 	Modes         *SessionModeState `json:"modes,omitempty"`
 	ConfigOptions []ConfigOption    `json:"configOptions,omitempty"`
 }


### PR DESCRIPTION
## Summary

- include `cwd` when restoring an ACP session
- send the required empty `mcpServers` array
- retain the requested session ID when the ACP load response omits it
- cover the serialized `session/load` request parameters

Current `acp-server` only sends `sessionId`. Agents implementing the current ACP load-session schema, including `@agentclientprotocol/codex-acp` 1.1.7, reject that request with `-32602 Invalid params`, so the bridge silently creates a fresh session instead of restoring the saved one.

After a successful load, the current ACP response does not repeat `sessionId`. The bridge must retain the ID from its request; otherwise `/session` reports an empty ID even though the underlying Codex thread was restored.

## Verification

- `go test ./pkg/acp/... ./cmd`
- reproduced the invalid-params failure against `@agentclientprotocol/codex-acp@1.1.7`
- verified the complete compatibility path against a real Codex 0.145.0 rollout: the requested thread ID was restored and used for a subsequent prompt
