### PR TITLE
chore: update nfa to v0.12.2

### DIFF
--- a/helm/agentapi-proxy/values.yaml
+++ b/helm/agentapi-proxy/values.yaml
@@ -491,7 +491,7 @@ kubernetesSession:
   image: ""
 
   # Container image for the network-filter sidecar and initContainer (sandbox feature)
-  networkFilterImage: "ghcr.io/takutakahashi/nfa:0.12.1"
+  networkFilterImage: "ghcr.io/takutakahashi/nfa:0.12.2"
 
   # Deprecated: networkFilterImage is used to restore sandbox iptables rules.
   sandboxInitImage: "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a"

--- a/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
+++ b/internal/infrastructure/services/kubernetes_session_manager_sandbox_test.go
@@ -19,7 +19,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 		k8sConfig: &config.KubernetesSessionConfig{
 			Image:                          "session-image:latest",
 			ImagePullPolicy:                "IfNotPresent",
-			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.1",
+			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.2",
 			SandboxInitImage:               "gcr.io/istio-release/iptables:latest",
 			NetworkFilterCPURequest:        "250m",
 			NetworkFilterCPULimit:          "1000m",
@@ -42,7 +42,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 
 	generate := initContainers[0]
 	assert.Equal(t, "network-filter-generate-iptables", generate.Name)
-	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.1", generate.Image)
+	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.2", generate.Image)
 	assert.Equal(t, "/bin/sh", generate.Command[0])
 	assert.Contains(t, generate.Command[2], "nfa setup-iptables --output /etc/iptables/rules.v4 --config /tmp/nfa-config.yaml")
 	assert.Contains(t, generate.Env, corev1.EnvVar{
@@ -70,7 +70,7 @@ func TestBuildSandboxContainersGeneratesIPAllowlistRulesThenRestoresWithIptables
 
 	restore := initContainers[1]
 	assert.Equal(t, "network-filter-setup", restore.Name)
-	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.1", restore.Image)
+	assert.Equal(t, "ghcr.io/takutakahashi/nfa:0.12.2", restore.Image)
 	assert.Equal(t, []string{"iptables-restore", "/etc/iptables/rules.v4"}, restore.Command)
 	assert.Equal(t, generate.Resources, restore.Resources)
 	assert.Equal(t, []corev1.VolumeMount{{
@@ -155,7 +155,7 @@ func TestBuildDeploymentAddsSciaSidecarAndChainsThroughNFA(t *testing.T) {
 			CPULimit:                       "1",
 			MemoryRequest:                  "128Mi",
 			MemoryLimit:                    "512Mi",
-			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.1",
+			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.2",
 			SandboxInitImage:               "gcr.io/istio-release/iptables:latest",
 			NetworkFilterInitMemoryRequest: "32Mi",
 			NetworkFilterInitMemoryLimit:   "64Mi",
@@ -326,7 +326,7 @@ func newSciaSidecarTestManager(sessionSidecarEnabled bool) *KubernetesSessionMan
 			CPULimit:                       "1",
 			MemoryRequest:                  "128Mi",
 			MemoryLimit:                    "512Mi",
-			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.1",
+			NetworkFilterImage:             "ghcr.io/takutakahashi/nfa:0.12.2",
 			SandboxInitImage:               "gcr.io/istio-release/iptables:latest",
 			NetworkFilterInitMemoryRequest: "32Mi",
 			NetworkFilterInitMemoryLimit:   "64Mi",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -375,7 +375,7 @@ type KubernetesSessionConfig struct {
 	SandboxIptablesConfigMapName string `json:"sandbox_iptables_configmap_name" mapstructure:"sandbox_iptables_configmap_name"`
 
 	// NetworkFilterImage is the container image for the iptables rule generation init
-	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:0.12.1.
+	// container and the network-filter sidecar. Defaults to ghcr.io/takutakahashi/nfa:0.12.2.
 	// The init container reads the generated policy config and runs "nfa setup-iptables --output";
 	// the sidecar runs "nfa proxy --deferred-policy".
 	NetworkFilterImage string `json:"network_filter_image" mapstructure:"network_filter_image"`
@@ -1258,7 +1258,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("kubernetes_session.init_container_image", "")
 	v.SetDefault("kubernetes_session.sandbox_init_image", "gcr.io/istio-release/iptables@sha256:88626c33372697bd006bbfc61d1e0d7b60ae9a988d1a7cac07cc834b13e5c21a")
 	v.SetDefault("kubernetes_session.sandbox_iptables_configmap_name", "")
-	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.12.1")
+	v.SetDefault("kubernetes_session.network_filter_image", "ghcr.io/takutakahashi/nfa:0.12.2")
 	v.SetDefault("kubernetes_session.network_filter_cpu_request", "250m")
 	v.SetDefault("kubernetes_session.network_filter_cpu_limit", "1000m")
 	v.SetDefault("kubernetes_session.network_filter_memory_request", "256Mi")


### PR DESCRIPTION
## Summary
- update the default nfa image from v0.12.1 to v0.12.2
- update Helm values and sandbox test fixtures

## Testing
- `make lint` (0 issues)
- targeted nfa/sandbox tests with race detector (pass)
- `make test` (fails in two unrelated existing tests: `TestRunProxyGracefulShutdown` and `TestNativeSessionWithNilRepositorySettingsDerivesPathsFromVirtualHome`)