### PR TITLE
fix(acp): preserve prompt token usage

### DIFF
--- a/pkg/acp/bridge/bridge.go
+++ b/pkg/acp/bridge/bridge.go
@@ -570,7 +570,7 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, prompt []acp.ContentBlock)
 	b.setStatus("running")
 
 	go func() {
-		stopReason, err := b.acp.PromptBlocks(promptCtx, prompt)
+		result, err := b.acp.PromptBlocksWithResult(promptCtx, prompt)
 
 		// Flush any chunk that was still buffered when the agent turn ended.
 		b.flushChunkBuffer()
@@ -585,11 +585,11 @@ func (b *Bridge) SendPrompt(clientID json.RawMessage, prompt []acp.ContentBlock)
 			})
 			return
 		}
-		log.Printf("[bridge] Prompt done (session=%s, stopReason=%s)", b.sessionId, stopReason)
+		log.Printf("[bridge] Prompt done (session=%s, stopReason=%s)", b.sessionId, result.StopReason)
 		b.broadcast(jsonRPCMsg{
 			JSONRPC: "2.0",
 			ID:      &clientID,
-			Result:  acp.PromptResult{StopReason: stopReason},
+			Result:  result,
 		})
 	}()
 

--- a/pkg/acp/client.go
+++ b/pkg/acp/client.go
@@ -373,12 +373,29 @@ func (c *Client) Prompt(ctx context.Context, text string) (StopReason, error) {
 // PromptBlocks sends an ordered multimodal prompt and returns when the agent
 // has finished the turn.
 func (c *Client) PromptBlocks(ctx context.Context, prompt []ContentBlock) (StopReason, error) {
+	result, err := c.PromptBlocksWithResult(ctx, prompt)
+	return result.StopReason, err
+}
+
+// PromptWithResult sends a text user message and returns the complete ACP
+// prompt response, including token usage when the agent reports it.
+func (c *Client) PromptWithResult(ctx context.Context, text string) (PromptResult, error) {
+	return c.PromptBlocksWithResult(
+		ctx, []ContentBlock{{Type: ContentBlockTypeText, Text: text}},
+	)
+}
+
+// PromptBlocksWithResult sends an ordered multimodal prompt and returns the
+// complete ACP prompt response.
+func (c *Client) PromptBlocksWithResult(
+	ctx context.Context, prompt []ContentBlock,
+) (PromptResult, error) {
 	sessionId := c.SessionID()
 	if sessionId == "" {
-		return "", fmt.Errorf("acp: no active session; call NewSession first")
+		return PromptResult{}, fmt.Errorf("acp: no active session; call NewSession first")
 	}
 	if len(prompt) == 0 {
-		return "", fmt.Errorf("acp: prompt must contain at least one content block")
+		return PromptResult{}, fmt.Errorf("acp: prompt must contain at least one content block")
 	}
 	params := PromptParams{
 		SessionId: sessionId,
@@ -386,13 +403,14 @@ func (c *Client) PromptBlocks(ctx context.Context, prompt []ContentBlock) (StopR
 	}
 	raw, err := c.rpc.Call(ctx, "session/prompt", params)
 	if err != nil {
-		return StopReasonCancelled, fmt.Errorf("acp session/prompt: %w", err)
+		return PromptResult{StopReason: StopReasonCancelled},
+			fmt.Errorf("acp session/prompt: %w", err)
 	}
 	var result PromptResult
 	if err := json.Unmarshal(raw, &result); err != nil {
-		return "", fmt.Errorf("acp session/prompt: parse result: %w", err)
+		return PromptResult{}, fmt.Errorf("acp session/prompt: parse result: %w", err)
 	}
-	return result.StopReason, nil
+	return result, nil
 }
 
 // SetSessionConfigOption changes a runtime session configuration option.

--- a/pkg/acp/client_test.go
+++ b/pkg/acp/client_test.go
@@ -1,6 +1,49 @@
 package acp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptResultPreservesTokenUsage(t *testing.T) {
+	var result PromptResult
+	err := json.Unmarshal([]byte(`{
+		"stopReason": "end_turn",
+		"usage": {
+			"totalTokens": 5321,
+			"inputTokens": 913,
+			"cachedReadTokens": 4096,
+			"outputTokens": 312,
+			"thoughtTokens": 96
+		},
+		"_meta": {"quota": {"remaining": 42}}
+	}`), &result)
+	require.NoError(t, err)
+	require.Equal(t, StopReasonEndTurn, result.StopReason)
+	require.NotNil(t, result.Usage)
+	require.EqualValues(t, 5321, result.Usage.TotalTokens)
+	require.EqualValues(t, 913, result.Usage.InputTokens)
+	require.EqualValues(t, 4096, *result.Usage.CachedReadTokens)
+	require.EqualValues(t, 312, result.Usage.OutputTokens)
+	require.EqualValues(t, 96, *result.Usage.ThoughtTokens)
+	require.Contains(t, result.Meta, "quota")
+
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"stopReason": "end_turn",
+		"usage": {
+			"totalTokens": 5321,
+			"inputTokens": 913,
+			"cachedReadTokens": 4096,
+			"outputTokens": 312,
+			"thoughtTokens": 96
+		},
+		"_meta": {"quota": {"remaining": 42}}
+	}`, string(encoded))
+}
 
 func TestExtractModelFromConfigOptions(t *testing.T) {
 	tests := []struct {

--- a/pkg/acp/types.go
+++ b/pkg/acp/types.go
@@ -231,9 +231,24 @@ const (
 	StopReasonMaxTurnRequests StopReason = "max_turn_requests"
 )
 
+// PromptUsage reports the tokens consumed by one "session/prompt" turn.
+// InputTokens excludes tokens served from the prompt cache; CachedReadTokens
+// reports those separately.
+type PromptUsage struct {
+	TotalTokens       int64                  `json:"totalTokens"`
+	InputTokens       int64                  `json:"inputTokens"`
+	OutputTokens      int64                  `json:"outputTokens"`
+	ThoughtTokens     *int64                 `json:"thoughtTokens,omitempty"`
+	CachedReadTokens  *int64                 `json:"cachedReadTokens,omitempty"`
+	CachedWriteTokens *int64                 `json:"cachedWriteTokens,omitempty"`
+	Meta              map[string]interface{} `json:"_meta,omitempty"`
+}
+
 // PromptResult is the response to "session/prompt".
 type PromptResult struct {
-	StopReason StopReason `json:"stopReason"`
+	StopReason StopReason             `json:"stopReason"`
+	Usage      *PromptUsage           `json:"usage,omitempty"`
+	Meta       map[string]interface{} `json:"_meta,omitempty"`
 }
 
 // SessionCancelParams is the params for "session/cancel" notification.


### PR DESCRIPTION
## Summary

ACP agents may return a `usage` object from `session/prompt`, but the bridge currently unmarshals only `stopReason` and reconstructs the response. This drops all input/cache/output counters before they reach `/messages`.

- model the ACP prompt usage and `_meta` fields
- add complete-result client methods while preserving the existing `StopReason` API
- broadcast the original prompt result from the bridge
- cover JSON round-trip of token usage

## Validation

- `go test ./pkg/acp/...` passes
- the broader `go test ./...` reached unrelated native-session tests, which fail on this macOS checkout because `/bin/true` does not exist; all ACP packages pass
- `git diff --check` passes