### PR TITLE
feat: support model_reasoning_effort via env for codex custom provider

### DIFF
--- a/pkg/sessionsettings/compile.go
+++ b/pkg/sessionsettings/compile.go
@@ -623,6 +623,14 @@ func codexModelMetadataFromEnv(env map[string]string, modelConfigured bool) []st
 		metadata = append(metadata, fmt.Sprintf("model_supports_reasoning_summaries = %s", supportsReasoningSummaries))
 	}
 
+	reasoningEffort := strings.TrimSpace(env["CODEX_MODEL_REASONING_EFFORT"])
+	if reasoningEffort == "" {
+		reasoningEffort = strings.TrimSpace(env["OPENAI_MODEL_REASONING_EFFORT"])
+	}
+	if reasoningEffort != "" {
+		metadata = append(metadata, fmt.Sprintf("model_reasoning_effort = %s", tomlString(reasoningEffort)))
+	}
+
 	return metadata
 }
 
@@ -635,7 +643,7 @@ func appendCodexConfigSection(base string, section string) string {
 	if topLevelTOMLKeyIsSet(selector, "model") {
 		base = removeTopLevelTOMLKey(base, "model")
 	}
-	for _, key := range []string{"model_context_window", "model_auto_compact_token_limit", "model_supports_reasoning_summaries"} {
+	for _, key := range []string{"model_context_window", "model_auto_compact_token_limit", "model_supports_reasoning_summaries", "model_reasoning_effort"} {
 		if topLevelTOMLKeyIsSet(selector, key) {
 			base = removeTopLevelTOMLKey(base, key)
 		}

--- a/pkg/sessionsettings/compile_test.go
+++ b/pkg/sessionsettings/compile_test.go
@@ -609,9 +609,10 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 				"CODEX_MODEL_CONTEXT_WINDOW":               "65536",
 				"CODEX_MODEL_AUTO_COMPACT_TOKEN_LIMIT":     "32768",
 				"CODEX_MODEL_SUPPORTS_REASONING_SUMMARIES": "false",
+				"CODEX_MODEL_REASONING_EFFORT":             "xhigh",
 			},
 			Codex: CodexConfig{
-				ConfigTOML: "approval-mode = \"full-auto\"\nmodel = \"gpt-5.5\"\nmodel_context_window = 128000\nmodel_auto_compact_token_limit = 64000\nmodel_supports_reasoning_summaries = true\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
+				ConfigTOML: "approval-mode = \"full-auto\"\nmodel = \"gpt-5.5\"\nmodel_context_window = 128000\nmodel_auto_compact_token_limit = 64000\nmodel_supports_reasoning_summaries = true\nmodel_reasoning_effort = \"medium\"\nmodel_provider = \"openai\"\nsandbox_mode = \"danger-full-access\"\n\n[sandbox_workspace_write]\nnetwork_access = true\n",
 			},
 		}
 
@@ -649,10 +650,57 @@ func TestCompile_CodexConfigTOML(t *testing.T) {
 		assert.NotContains(t, content, `model_context_window = 128000`)
 		assert.NotContains(t, content, `model_auto_compact_token_limit = 64000`)
 		assert.NotContains(t, content, `model_supports_reasoning_summaries = true`)
+		assert.Contains(t, content, `model_reasoning_effort = "xhigh"`)
+		assert.NotContains(t, content, `model_reasoning_effort = "medium"`)
 		assert.Less(t, strings.Index(content, `model = "qwen3-coder-next"`), strings.Index(content, "[sandbox_workspace_write]"))
 		assert.Less(t, strings.Index(content, `model_provider = "agentapi_openai_compatible"`), strings.Index(content, "[sandbox_workspace_write]"))
 		assert.Less(t, strings.Index(content, "[sandbox_workspace_write]"), strings.Index(content, "[model_providers.agentapi_openai_compatible]"))
 		assert.NotContains(t, content, "env_key")
+	})
+
+	t.Run("writes model_reasoning_effort from env", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "compile-codex-reasoning-effort-*")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		settings := &SessionSettings{
+			Session: SessionMeta{
+				ID:        "test-codex-reasoning-effort",
+				UserID:    "user-codex-reasoning-effort",
+				Scope:     "user",
+				AgentType: "codex-acp",
+			},
+			Env: map[string]string{
+				"OPENAI_BASE_URL":              "http://proxy.example.com/v1",
+				"CODEX_MODEL":                  "qwen3-coder-next",
+				"CODEX_MODEL_REASONING_EFFORT": "xhigh",
+			},
+		}
+
+		inputPath := filepath.Join(tmpDir, "settings.yaml")
+		yamlData, err := MarshalYAML(settings)
+		require.NoError(t, err)
+		err = os.WriteFile(inputPath, yamlData, 0644)
+		require.NoError(t, err)
+
+		outputDir := filepath.Join(tmpDir, "output")
+		opts := CompileOptions{
+			InputPath:   inputPath,
+			OutputDir:   outputDir,
+			EnvFilePath: filepath.Join(tmpDir, "env"),
+			StartupPath: filepath.Join(tmpDir, "startup.sh"),
+		}
+
+		err = Compile(opts)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(outputDir, ".codex/config.toml")
+		data, err := os.ReadFile(configPath)
+		require.NoError(t, err)
+		content := string(data)
+
+		assert.Contains(t, content, `model_reasoning_effort = "xhigh"`)
+		assert.Less(t, strings.Index(content, `model_reasoning_effort = "xhigh"`), strings.Index(content, "[model_providers.agentapi_openai_compatible]"))
 	})
 
 	t.Run("preserves existing model when model env is not set", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- support `model_reasoning_effort` in the generated Codex custom provider config via the `CODEX_MODEL_REASONING_EFFORT` environment variable (fallback: `OPENAI_MODEL_REASONING_EFFORT`), following the same pattern as the existing model metadata keys (context window, auto compact token limit, reasoning summaries)
- strip a top-level `model_reasoning_effort` from a base ConfigTOML when the custom provider section is appended, so the env-derived value wins consistently with the other generated keys

## Motivation
When `OPENAI_BASE_URL` is set (e.g. pointing Codex at an OpenAI-compatible endpoint such as Bedrock's Responses API), there is currently no way to set Codex CLI's `model_reasoning_effort` because the generated config.toml fully controls the model settings. This adds an env-based knob in line with the existing `CODEX_MODEL_*` variables.

## Validation
- `gofmt` / `go vet`: clean
- `go test ./pkg/sessionsettings/`: ok — added a subtest for the new env var (including its position before the provider section) and extended the ConfigTOML-append test to cover the override behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)